### PR TITLE
add appendicitis using generic module framework

### DIFF
--- a/lib/generic/modules/appendicitis.json
+++ b/lib/generic/modules/appendicitis.json
@@ -1,0 +1,195 @@
+{
+  "name": "Appendicitis",
+  "states": {
+    "Initial" : {
+      "type" : "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Gender",
+            "gender": "M" 
+          },
+          "transition": "Male"
+        },
+        {
+          "condition": {
+            "condition_type": "Gender",
+            "gender": "F" 
+          },
+          "transition": "Female"
+        },
+        {
+          "transition" : "Terminal"
+        }
+      ]
+    },
+
+    "Male" : {
+      "type" : "Simple",
+      "distributed_transition": [
+        {
+          "distribution": 0.086,
+          "transition": "Pre_appendicitis"
+        },
+        {
+          "distribution": 0.914,
+          "transition": "Terminal"
+        }
+      ],
+      "remarks" : "Men have an approx lifetime risk of appendicitis of 8.6%. Ref: http://www.ncbi.nlm.nih.gov/pubmed/2239906"
+    },
+
+    "Female" : {
+      "type" : "Simple",
+      "distributed_transition": [
+        {
+          "distribution": 0.067,
+          "transition": "Pre_appendicitis"
+        },
+        {
+          "distribution": 0.933,
+          "transition": "Terminal"
+        }
+      ],
+      "remarks" : "Women have an approx lifetime risk of appendicitis of 6.7%. Ref: http://www.ncbi.nlm.nih.gov/pubmed/2239906"
+    },
+
+    "Pre_appendicitis" : {
+      "type" : "Simple",
+      "distributed_transition": [
+        {
+          "distribution": 0.263,
+          "transition": "Ages_1_17"
+        },
+        {
+          "distribution": 0.423,
+          "transition": "Ages_18_44"
+        },
+        {
+          "distribution": 0.221,
+          "transition": "Ages_45_64"
+        },
+        {
+          "distribution": 0.093,
+          "transition": "Ages_65_Plus"
+        }
+      ],
+      "remarks" : "Age distribution of appendicitis from https://www.ncbi.nlm.nih.gov/books/NBK169006/ , Table 1"
+    },
+
+    "Ages_1_17": {
+      "type": "Delay",
+      "range": {
+        "low": 1,
+        "high": 17,
+        "unit": "years"
+      },
+      "direct_transition": "Appendicitis" 
+    },
+
+    "Ages_18_44": {
+      "type": "Delay",
+      "range": {
+        "low": 18,
+        "high": 44,
+        "unit": "years"
+      },
+      "direct_transition": "Appendicitis" 
+    },
+
+    "Ages_45_64": {
+      "type": "Delay",
+      "range": {
+        "low": 45,
+        "high": 64,
+        "unit": "years"
+      },
+      "direct_transition": "Appendicitis" 
+    },
+
+    "Ages_65_Plus": {
+      "type": "Delay",
+      "range": {
+        "low": 65,
+        "high": 99,
+        "unit": "years"
+      },
+      "direct_transition": "Appendicitis" 
+    },
+
+    "Appendicitis": {
+      "type": "ConditionOnset",
+      "target_encounter" : "Appendicitis_Encounter",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "74400008",
+        "display": "Appendicitis"
+      }],
+      "distributed_transition": [
+        {
+          "distribution": 0.7,
+          "transition": "Appendicitis_Encounter"
+        },
+        {
+          "distribution": 0.3,
+          "transition": "Rupture"
+        }
+      ],
+      "remarks" : ["The rate of perforation varies from 16% to 40%, with a higher frequency occurring in younger age groups (40-57%)",
+                   "and in patients older than 50 years (55-70%), in whom misdiagnosis and delayed diagnosis are common.",
+                   "(ref: http://emedicine.medscape.com/article/773895-overview#a7 )",
+                   "From table 1 here: https://www.ncbi.nlm.nih.gov/books/NBK169006/ it's about 30%",
+                   "For simplicity here I just round to 30% for all age groups."]
+    },
+
+    "Rupture": {
+      "type": "ConditionOnset",
+      "target_encounter": "Appendicitis_Encounter",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "47693006",
+        "display": "Rupture of appendix"
+      }],
+      "direct_transition": "Appendicitis_Encounter"
+    },
+
+    "Appendicitis_Encounter": {
+      "type": "Encounter",
+      "wellness": false,
+      "direct_transition": "Appendectomy_Encounter",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "50849002",
+        "display" : "Emergency Room Admission"
+      }],
+      "remarks" : "Currently the GMF does not include Vital Signs, if we decide to add that then there are some lab tests we could add at this Encounter."
+    },
+
+    "Appendectomy_Encounter": {
+      "type": "Encounter",
+      "class": "daytime",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "183452005",
+        "display": "Encounter Inpatient"
+      }],
+      "direct_transition": "Appendectomy"
+    },
+    "Appendectomy": {
+      "type": "Procedure",
+      "target_encounter": "Appendectomy_Encounter",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "80146002",
+        "display": "Appendectomy"
+      }],
+      "reason": "Appendicitis",
+      "direct_transition": "Terminal"
+    },
+
+
+    "Terminal" : {
+      "type" : "Terminal"
+    }
+  }
+}

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -69,6 +69,13 @@ module Synthea
         end
       end
 
+      class Simple < State
+        def process(time, entity)
+          # simple state always goes to next
+          true
+        end
+      end
+
       class Terminal < State
         def process(time, entity)
           # never pass through the terminal state

--- a/test/unit/generic/appendicitis_test.rb
+++ b/test/unit/generic/appendicitis_test.rb
@@ -1,0 +1,63 @@
+require_relative '../../test_helper'
+
+class AppendicitisTest < Minitest::Test
+  def setup
+    @time = Time.now
+    @patient = Synthea::Person.new
+    @patient[:gender] = 'F'
+    @patient.events.create(@time - 35.years, :birth, :birth)
+    @patient[:age] = 35
+    @patient[:is_alive] = true
+    # Setup a mock to track calls to the patient record
+    @patient.record_synthea = MiniTest::Mock.new
+
+    cfg = JSON.parse(File.read(File.join(File.expand_path("../../../../lib/generic/modules", __FILE__), 'appendicitis.json')))
+    @context = Synthea::Generic::Context.new(cfg)
+  end
+
+  def test_patient_without_appendicitis
+    srand 123
+
+    @context.run(@time, @patient)
+
+    @context.run(@time.advance(years: 65), @patient)
+
+    assert @patient.record_synthea.verify
+  end
+
+  def test_patient_with_appendicitis
+    srand 9
+
+    @context.run(@time, @patient)
+    @time = @time.advance(years: 40)
+
+    @patient.record_synthea.expect(:condition, nil, [:appendicitis, @time])
+
+    @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, :appendicitis])
+    
+    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time])
+    @patient.record_synthea.expect(:encounter, nil, [:encounter_inpatient, @time])
+    
+    @context.run(@time, @patient)
+
+    assert @patient.record_synthea.verify
+  end
+
+  def test_patient_with_rupture
+    srand 8765
+
+    @context.run(@time, @patient)
+    @time = @time.advance(years: 61)
+
+    @patient.record_synthea.expect(:condition, nil, [:appendicitis, @time])
+    @patient.record_synthea.expect(:condition, nil, [:rupture_of_appendix, @time])
+
+    @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, :appendicitis])
+    
+    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time])
+    @patient.record_synthea.expect(:encounter, nil, [:encounter_inpatient, @time])
+    @context.run(@time, @patient)
+
+    assert @patient.record_synthea.verify
+  end
+end


### PR DESCRIPTION
Adds a generic module for Appendicitis. Basic flow is that patients are filtered by gender, and then are assigned to get or not get appendicitis. It picks an age that they will get it with a Delay, and then gives them the Appendicitis condition. There is a chance the appendix will rupture but it leads back into the same sequence of encounters and procedures for an appendectomy. 

Some things not modeled here that could be if we thought it was worthwhile: 
- Appendectomies where they didn't actually have appendicitis
- Complications of surgery
- Lab tests at the appendicitis encounter

This also adds a new State type: Simple. A simple state has no special logic like delay or guard, and doesn't add anything to the patient data, like encounter or procedures. I'm using it here so that we can have a sequence of branches.

![appendicitis](https://cloud.githubusercontent.com/assets/13512036/17771483/2f8b0776-6511-11e6-81d2-b202cac6e360.png)
