### PR TITLE
sequential generator can generate 1 city per thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.5
+  - "2.0.0"
 script:
   - bundle exec rake test
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - "2.0.0"
+  - 2.2.5
 script:
   - bundle exec rake test
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,11 @@ gem 'distribution'
 gem 'pickup'
 gem 'recursive-open-struct'
 gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'master'
-gem 'fhir_models'
+gem 'fhir_models', '~> 0.3' #locked at 0.3 until we implement the 1.6 changes
 gem 'fhir_client' #, path: '../fhir_client' 
 gem 'georuby'
 gem 'net-sftp'
+gem 'concurrent-ruby', require: 'concurrent'
 
 group :test do
   gem "cane", '~> 2.3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'fhir_client' #, path: '../fhir_client'
 gem 'georuby'
 gem 'net-sftp'
 gem 'concurrent-ruby', require: 'concurrent'
+gem 'rack', '~> 1.6' #locked at 1.6 to maintain compatibility with ruby 2.0.0
 
 group :test do
   gem "cane", '~> 2.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,10 +51,13 @@ GEM
     bcp47 (0.3.3)
       i18n
     bson (3.2.6)
+    bson (3.2.6-java)
     builder (3.2.2)
     cane (2.3.0)
       parallel
     coderay (1.1.1)
+    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.2-java)
     connection_pool (2.2.0)
     date_time_precision (0.8.1)
     distribution (0.7.3)
@@ -67,6 +70,7 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
+    ffi (1.9.14-java)
     fhir_client (1.0.2)
       activesupport (>= 3)
       addressable (>= 2.3)
@@ -86,6 +90,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
+    json (1.8.3-java)
     jwt (1.5.4)
     log4r (1.1.10)
     macaddr (1.7.1)
@@ -121,6 +126,7 @@ GEM
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
+    nokogiri (1.6.8-java)
     oauth2 (1.2.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -138,7 +144,12 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.6.4)
+    pry (0.10.4-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      spoon (~> 0.0)
+    rack (2.0.1)
     rake (11.2.2)
     recursive-open-struct (1.0.1)
     rest-client (1.8.0)
@@ -153,27 +164,33 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
+    spoon (0.0.4)
+      ffi
     systemu (2.6.5)
     thread_safe (0.3.5)
+    thread_safe (0.3.5-java)
     tilt (2.0.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
+    unf (0.1.4-java)
     unf_ext (0.0.7.2)
     uuid (2.3.8)
       macaddr (~> 1.0)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
   awesome_print
   cane (~> 2.3.0)
+  concurrent-ruby
   distribution
   faker
   fhir_client
-  fhir_models
+  fhir_models (~> 0.3)
   georuby
   health-data-standards!
   minitest (~> 5.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
       spoon (~> 0.0)
-    rack (2.0.1)
+    rack (1.6.4)
     rake (11.2.2)
     recursive-open-struct (1.0.1)
     rest-client (1.8.0)
@@ -198,6 +198,7 @@ DEPENDENCIES
   net-sftp
   pickup
   pry
+  rack (~> 1.6)
   rake
   recursive-open-struct
   simplecov

--- a/config/synthea.yml
+++ b/config/synthea.yml
@@ -10,7 +10,9 @@ synthea:
   sequential: # sequential population generation... one at a time...
     # population is scaled to accurately represent MA (using a "true" population of 6,794,422)
     population: 1000
+    real_world_population: 6794422 #sum of the jsons in the config folder
     multithreading: false  
+    thread_pool_size: 16 # 16 picked by experimentation to be a good number of threads to use for exporting records
     max_tries: 10 # max number of times it tries to create a person before it gives up (ie, nobody reached the target age)
   schedule:
     variance: 0.1

--- a/config/synthea.yml
+++ b/config/synthea.yml
@@ -1,4 +1,5 @@
 synthea:
+
   start_date: <%= Time.now - 100.years %>
   end_date: <%= Time.now - 1.day %>
   time_step: 7 # days
@@ -7,7 +8,10 @@ synthea:
     birth_variance: 0.01
     daily_births_per_square_mile: <%= (ma_births_per_year = 73000.0)/(ma_square_miles=10554.0)/365.0 %>
   sequential: # sequential population generation... one at a time...
+    # population is scaled to accurately represent MA (using a "true" population of 6,794,422)
     population: 1000
+    multithreading: false  
+    max_tries: 10 # max number of times it tries to create a person before it gives up (ie, nobody reached the target age)
   schedule:
     variance: 0.1
   lifecycle:

--- a/lib/modules/encounters.rb
+++ b/lib/modules/encounters.rb
@@ -38,7 +38,7 @@ module Synthea
                   6.months
               end
             end
-            next_date = time + Distribution::Normal.rng(delta, delta*schedule_variance).call
+            next_date = time + Distribution::Normal.rng(delta*1.0, delta*schedule_variance).call
             entity.events.create(next_date, :encounter, :schedule_encounter)
           end
         end

--- a/lib/modules/lifecycle.rb
+++ b/lib/modules/lifecycle.rb
@@ -11,119 +11,6 @@ module Synthea
         @male_weight = Distribution::Normal.rng(Synthea::Config.lifecycle.weight_gain_male_average,Synthea::Config.lifecycle.weight_gain_male_stddev)
         @female_growth = Distribution::Normal.rng(Synthea::Config.lifecycle.growth_rate_female_average,Synthea::Config.lifecycle.growth_rate_female_stddev)
         @female_weight = Distribution::Normal.rng(Synthea::Config.lifecycle.weight_gain_female_average,Synthea::Config.lifecycle.weight_gain_female_stddev)     
-      
-        # https://en.wikipedia.org/wiki/Demographics_of_Massachusetts#Race.2C_ethnicity.2C_and_ancestry
-        @races = Pickup.new({
-          :white => 75.1,
-          :hispanic => 10.5,
-          :black => 8.1,
-          :asian => 6.0,
-          :native => 0.5,
-          :other => 0.1
-        })
-        @ethnicity = {
-          :white => Pickup.new({
-            :irish => 22.8,
-            :italian => 13.9,
-            :english => 10.7,
-            :french => 7.8,
-            :german => 6.4,
-            :polish => 5.0,
-            :portuguese => 4.7,
-            :american => 4.4,
-            :french_canadian => 3.8,
-            :scottish => 2.4,
-            :russian => 1.9,
-            :swedish => 1.8,
-            :greek => 1.2
-            }),
-          :hispanic => Pickup.new({
-            :puerto_rican => 4.1,
-            :mexican => 1,
-            :central_american => 1,
-            :south_american => 1
-            }),
-          :black => Pickup.new({
-            :african => 1.8,
-            :dominican => 1.8,
-            :west_indian => 1.8
-            }),
-          :asian => Pickup.new({
-            :chinese => 2.0,
-            :asian_indian => 1.1
-            }),
-          :native => Pickup.new({
-            :american_indian => 1
-            }),
-          :other => Pickup.new({
-            :arab => 1
-            })
-        }
-        # blood type data from http://www.redcrossblood.org/learn-about-blood/blood-types
-        # data for :native and :other from https://en.wikipedia.org/wiki/Blood_type_distribution_by_country
-        @blood_types = {
-          :white => Pickup.new({
-            :o_positive => 37,
-            :o_negative => 8,
-            :a_positive => 33,
-            :a_negative => 7,
-            :b_positive => 9,
-            :b_negative => 2,
-            :ab_positive => 3,
-            :ab_negative => 1            
-            }),
-          :hispanic => Pickup.new({
-            :o_positive => 53,
-            :o_negative => 4,
-            :a_positive => 29,
-            :a_negative => 2,
-            :b_positive => 9,
-            :b_negative => 1,
-            :ab_positive => 2,
-            :ab_negative => 1 
-            }),
-          :black => Pickup.new({
-            :o_positive => 47,
-            :o_negative => 4,
-            :a_positive => 24,
-            :a_negative => 2,
-            :b_positive => 18,
-            :b_negative => 1,
-            :ab_positive => 4,
-            :ab_negative => 1
-            }),
-          :asian => Pickup.new({
-            :o_positive => 39,
-            :o_negative => 1,
-            :a_positive => 27,
-            :a_negative => 1,
-            :b_positive => 25,
-            :b_negative => 1,
-            :ab_positive => 7,
-            :ab_negative => 1 
-            }),
-          :native => Pickup.new({
-            :o_positive => 37.4,
-            :o_negative => 6.6,
-            :a_positive => 35.7,
-            :a_negative => 6.3,
-            :b_positive => 8.5,
-            :b_negative => 1.5,
-            :ab_positive => 3.4,
-            :ab_negative => 0.6 
-            }),
-          :other => Pickup.new({
-            :o_positive => 37.4,
-            :o_negative => 6.6,
-            :a_positive => 35.7,
-            :a_negative => 6.3,
-            :b_positive => 8.5,
-            :b_negative => 1.5,
-            :ab_positive => 3.4,
-            :ab_negative => 0.6 
-            })
-        }
-
       end
 
       # People are born
@@ -134,10 +21,10 @@ module Synthea
           entity[:name_first] = "#{entity[:name_first]}#{(entity[:name_first].hash % 999)}"
           entity[:name_last] = Faker::Name.last_name
           entity[:name_last] = "#{entity[:name_last]}#{(entity[:name_last].hash % 999)}"
-          entity[:gender] = gender
-          entity[:race] = @races.pick
-          entity[:ethnicity] = @ethnicity[ entity[:race] ].pick
-          entity[:blood_type] = @blood_types[ entity[:race] ].pick
+          entity[:gender] = gender unless entity[:gender]
+          entity[:race] = Synthea::World::Demographics::RACES.pick unless entity[:race]
+          entity[:ethnicity] = Synthea::World::Demographics::ETHNICITY[ entity[:race] ].pick unless entity[:ethnicity]
+          entity[:blood_type] = Synthea::World::Demographics::BLOOD_TYPES[ entity[:race] ].pick
           # new babies are average weight and length for American newborns
           entity[:height] = 51 # centimeters
           entity[:weight] = 3.5 # kilograms
@@ -146,7 +33,7 @@ module Synthea
           entity.events.create(time, :encounter, :birth)
 
           #determine lat/long coordinates of address within MA
-          location_data = Synthea::Location.selectPoint
+          location_data = Synthea::Location.selectPoint(entity[:city])
           entity[:coordinates_address] = location_data['point']
           zip_code = Synthea::Location.get_zipcode(location_data['city'])
           entity[:address] = {
@@ -156,7 +43,7 @@ module Synthea
             'postalCode' => zip_code
           }
           entity[:address]['line'] << Faker::Address.secondary_address if (rand < 0.5)
-          
+          entity[:city] = location_data['city']
           
           # TODO update awareness
         end

--- a/lib/synthea.rb
+++ b/lib/synthea.rb
@@ -18,6 +18,7 @@ require 'geo_ruby/geojson'
 require 'net/sftp'
 require 'highline/import'
 require 'json'
+require 'concurrent'
 
 root = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
 

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -22,9 +22,17 @@ namespace :synthea do
   end
 
   desc 'sequential generation'
-  task :sequential, [] do |t, args|
+  task :sequential, [:datafile] do |t, args|
+    args.with_defaults(datafile: nil)
+
+    datafile = args.datafile
+    if datafile
+      raise "File not found: #{datafile}" if !File.file?(datafile)
+      datafile = File.read(datafile)
+    end
+
     start = Time.now
-    world = Synthea::World::Sequential.new
+    world = Synthea::World::Sequential.new(datafile)
     world.run
     finish = Time.now
     minutes = ((finish-start)/60)

--- a/lib/world/Location.rb
+++ b/lib/world/Location.rb
@@ -8,21 +8,27 @@ module Synthea
     @@city_zipcode_hash = JSON.parse(File.read(File.expand_path('city_zip.json',File.dirname(File.absolute_path(__FILE__)))))
 
     def self.get_zipcode(city)
-      @@city_zipcode_hash[city].sample
+      zipcode_list = @@city_zipcode_hash[city] || @@city_zipcode_hash[city + " Town"]
+      zipcode_list.sample
     end
 
-    def self.selectPoint
-      #randomly select a city
-      feat_index, city_name = nil, nil
+    def self.selectPoint(city_name=nil)
+      #randomly select a city if not provided
+      feat_index = nil
       rand_num = rand(@@running_total)
-      @@geom.features.each_with_index do |val, index|
-        rand_num -= val.properties["pop"]
-        if rand_num < 0
-          feat_index = index
-          city_name = val.properties["cs_name"]
-          break
+      if city_name
+        feat_index = find_index_of_city(city_name)
+      else
+        @@geom.features.each_with_index do |val, index|
+          rand_num -= val.properties["pop"]
+          if rand_num < 0
+            feat_index = index
+            city_name = val.properties["cs_name"]
+            break
+          end
         end
       end
+
       #determine rough boundaries of city
       city = @@geom.features[feat_index].geometry.geometries[0]
       max_y, max_x = -999, -999
@@ -41,6 +47,14 @@ module Synthea
         point = GeoRuby::SimpleFeatures::Point.from_x_y(x,y)
         return {'point' => point, "city" => city_name} if city.contains_point?(point)
       end
+    end
+
+    def self.find_index_of_city(city_name)
+      @@geom.features.each_with_index do |val, index|
+        name = val.properties["cs_name"]
+        return index if (city_name == name) || (city_name + " Town" == name)
+      end
+      nil
     end
   end
 end

--- a/lib/world/demographics.rb
+++ b/lib/world/demographics.rb
@@ -1,0 +1,121 @@
+module Synthea
+  module World
+    class Demographics
+
+      # https://en.wikipedia.org/wiki/Demographics_of_Massachusetts#Race.2C_ethnicity.2C_and_ancestry
+        RACES = Pickup.new({
+          :white => 75.1,
+          :hispanic => 10.5,
+          :black => 8.1,
+          :asian => 6.0,
+          :native => 0.5,
+          :other => 0.1
+        })
+
+        ETHNICITY = {
+          :white => Pickup.new({
+            :irish => 22.8,
+            :italian => 13.9,
+            :english => 10.7,
+            :french => 7.8,
+            :german => 6.4,
+            :polish => 5.0,
+            :portuguese => 4.7,
+            :american => 4.4,
+            :french_canadian => 3.8,
+            :scottish => 2.4,
+            :russian => 1.9,
+            :swedish => 1.8,
+            :greek => 1.2
+            }),
+          :hispanic => Pickup.new({
+            :puerto_rican => 4.1,
+            :mexican => 1,
+            :central_american => 1,
+            :south_american => 1
+            }),
+          :black => Pickup.new({
+            :african => 1.8,
+            :dominican => 1.8,
+            :west_indian => 1.8
+            }),
+          :asian => Pickup.new({
+            :chinese => 2.0,
+            :asian_indian => 1.1
+            }),
+          :native => Pickup.new({
+            :american_indian => 1
+            }),
+          :other => Pickup.new({
+            :arab => 1
+            })
+        }
+
+        # blood type data from http://www.redcrossblood.org/learn-about-blood/blood-types
+        # data for :native and :other from https://en.wikipedia.org/wiki/Blood_type_distribution_by_country
+        BLOOD_TYPES = {
+          :white => Pickup.new({
+            :o_positive => 37,
+            :o_negative => 8,
+            :a_positive => 33,
+            :a_negative => 7,
+            :b_positive => 9,
+            :b_negative => 2,
+            :ab_positive => 3,
+            :ab_negative => 1            
+            }),
+          :hispanic => Pickup.new({
+            :o_positive => 53,
+            :o_negative => 4,
+            :a_positive => 29,
+            :a_negative => 2,
+            :b_positive => 9,
+            :b_negative => 1,
+            :ab_positive => 2,
+            :ab_negative => 1 
+            }),
+          :black => Pickup.new({
+            :o_positive => 47,
+            :o_negative => 4,
+            :a_positive => 24,
+            :a_negative => 2,
+            :b_positive => 18,
+            :b_negative => 1,
+            :ab_positive => 4,
+            :ab_negative => 1
+            }),
+          :asian => Pickup.new({
+            :o_positive => 39,
+            :o_negative => 1,
+            :a_positive => 27,
+            :a_negative => 1,
+            :b_positive => 25,
+            :b_negative => 1,
+            :ab_positive => 7,
+            :ab_negative => 1 
+            }),
+          :native => Pickup.new({
+            :o_positive => 37.4,
+            :o_negative => 6.6,
+            :a_positive => 35.7,
+            :a_negative => 6.3,
+            :b_positive => 8.5,
+            :b_negative => 1.5,
+            :ab_positive => 3.4,
+            :ab_negative => 0.6 
+            }),
+          :other => Pickup.new({
+            :o_positive => 37.4,
+            :o_negative => 6.6,
+            :a_positive => 35.7,
+            :a_negative => 6.3,
+            :b_positive => 8.5,
+            :b_negative => 1.5,
+            :ab_positive => 3.4,
+            :ab_negative => 0.6 
+            })
+        }
+
+    end
+  end
+end

--- a/lib/world/sequential.rb
+++ b/lib/world/sequential.rb
@@ -4,7 +4,7 @@ module Synthea
 
       attr_reader :stats
         
-      def initialize()
+      def initialize(datafile)
         @start_date = Synthea::Config.start_date
         @end_date = Synthea::Config.end_date
         @time_step = Synthea::Config.time_step
@@ -18,6 +18,12 @@ module Synthea
 
         @population_count = Synthea::Config.sequential.population
 
+        @scaling_factor = @population_count / 6794422.0
+        # 6794422 is the total of all the populations in the towns.json file
+        # towns.collect { |k,v| v['population'] }.inject(0, :+)
+
+        @city_populations = JSON.parse(datafile) if datafile
+
         ['html','fhir','CCDA'].each do |type|
           out_dir = File.join('output',type)
           FileUtils.rm_r out_dir if File.exists? out_dir
@@ -28,19 +34,129 @@ module Synthea
 
       def run
         puts "Generating #{@population_count} patients..."
-        @population_count.times do |i|
-          @date = @start_date + rand(@end_date - @start_date)
-          person = Synthea::Person.new
-          while !person.had_event?(:death) && @date<=@end_date
-            @date += @time_step.days
-            Synthea::Rules.apply(@date,person)
-          end
-          record_stats(person)
-          puts "##{i+1}  #{person[:name_last]}, #{person[:name_first]}. #{person[:race].to_s.capitalize} #{person[:ethnicity].to_s.gsub('_',' ').capitalize}. #{person[:age]} y/o #{person[:gender]}."
-          export(person)
+        @threads = []
+
+        # 16 picked by experimentation to be a good number of threads to use for exporting records
+        # using a cachedthreadpool has no upper bound on the # and if it gets too high then everything grinds to a halt
+        @pool = Concurrent::FixedThreadPool.new(16) if Synthea::Config.sequential.multithreading
+
+        if @city_populations
+          run_with_target_data
+        else
+          run_random
         end
+
+        @threads.each(&:join)
+
+        if @pool
+          puts 'Generation completed, waiting for files to finish exporting...'
+          @pool.shutdown # Tasks already in the queue will be executed, but no new tasks will be accepted.
+          @pool.wait_for_termination
+        end
+
         puts "Generated Demographics:"
         puts JSON.pretty_unparse(@stats)
+      end
+
+      def run_with_target_data
+        @city_populations.each do |city_name,city_stats|
+          if Synthea::Config.sequential.multithreading
+            @threads << Thread.new do
+              process_city(city_name, city_stats)
+            end
+          else
+            process_city(city_name, city_stats)
+          end
+        end
+      end
+
+      def run_random
+        @population_count.times do |i|
+            person = build_person(nil, rand(0..100), nil, nil, nil)
+
+            if @pool
+              @pool.post { export (person) }
+            else
+              export(person)
+            end
+
+            record_stats(person)
+            dead = person.had_event?(:death)
+            
+            puts "##{i+1}#{'(d)' if dead}:  #{person[:name_last]}, #{person[:name_first]}. #{person[:race].to_s.capitalize} #{person[:ethnicity].to_s.gsub('_',' ').capitalize}. #{person[:age]} y/o #{person[:gender]}."
+        end
+      end
+
+      def process_city(city_name, city_stats)
+        population = (city_stats['population'] * @scaling_factor).ceil
+
+        demographics = build_demographics(city_stats, population)            
+
+        puts "Generating #{population} patients within #{city_name}"
+        population.times do |i|
+          target_gender = demographics[:gender][i]
+          target_race = demographics[:race][i]
+          target_ethnicity = Synthea::World::Demographics::ETHNICITY[target_race].pick
+          target_age = demographics[:age][i]
+          try_number = 1
+          loop do
+            person = build_person(city_name, target_age, target_gender, target_race, target_ethnicity)
+
+            if @pool
+              @pool.post { export (person) }
+            else
+              export(person)
+            end
+
+            record_stats(person)
+            dead = person.had_event?(:death)
+            
+            puts "#{city_name} ##{i+1}#{'(d)' if dead}:  #{person[:name_last]}, #{person[:name_first]}. #{person[:race].to_s.capitalize} #{person[:ethnicity].to_s.gsub('_',' ').capitalize}. #{person[:age]} y/o #{person[:gender]}."
+
+            break unless dead
+            break if try_number >= Synthea::Config.sequential.max_tries
+
+            try_number += 1
+            if try_number > (Synthea::Config.sequential.max_tries / 2) && target_age > 90
+              target_age = rand(85..90)
+              # demographics count ages up to 110, which our people never hit
+            end
+          end
+        end
+      end
+
+      def build_demographics(stats, population)
+        gender_ratio = Pickup.new(stats['gender']) { |v| v*100 }
+        race_ratio = Pickup.new(stats['race']) { |v| v*100 }
+        age_ratio = Pickup.new(stats['ages']) { |v| v*100 }
+
+        demographics = Hash.new() { |hsh, key| hsh[key] = Array.new(population) }
+
+        population.times do |i|
+          demographics[:gender][i] = gender_ratio.pick == 'male' ? 'M' : 'F'
+          demographics[:race][i] = race_ratio.pick.to_sym
+          age_group = age_ratio.pick # gives us a string, we need a range
+          demographics[:age][i] = rand( Range.new(*age_group.split('..').map(&:to_i)) )
+        end
+
+        demographics.each_value(&:shuffle)
+
+        demographics
+      end
+
+      def build_person(city, age, gender, race, ethnicity)
+        date = @end_date - age.years
+        person = Synthea::Person.new
+        person[:gender] = gender
+        person[:race] = race
+        person[:ethnicity] = ethnicity
+        person[:city] = city
+        while !person.had_event?(:death) && date<=@end_date
+          date += @time_step.days
+          Synthea::Rules.apply(date,person)
+        end
+
+        person
       end
 
       def record_stats(patient)
@@ -50,6 +166,7 @@ module Synthea
         else
           @stats[:living] += 1
         end
+        @stats[:age_sum] += patient[:age] # useful for tracking the total # of person-years simulated vs real-world clock time
         @stats[:age][ (patient[:age]/10)*10 ] += 1
         @stats[:gender][ patient[:gender] ] += 1
         @stats[:race][ patient[:race] ] += 1
@@ -68,7 +185,7 @@ module Synthea
         out_dir = File.join('output','fhir')
         data = fhir_record.to_json
         File.open(File.join(out_dir, "#{patient.record_synthea.patient_info[:uuid]}.json"), 'w') { |file| file.write(data) }
-        
+
         out_dir = File.join('output','CCDA')
         xml = HealthDataStandards::Export::CCDA.new.export(ccda_record)
         File.open(File.join(out_dir, "#{patient.record_synthea.patient_info[:uuid]}.xml"), 'w') { |file| file.write(xml) }

--- a/lib/world/sequential.rb
+++ b/lib/world/sequential.rb
@@ -18,9 +18,9 @@ module Synthea
 
         @population_count = Synthea::Config.sequential.population
 
-        @scaling_factor = @population_count / 6794422.0
-        # 6794422 is the total of all the populations in the towns.json file
-        # towns.collect { |k,v| v['population'] }.inject(0, :+)
+        @scaling_factor = @population_count.to_f / Synthea::Config.sequential.real_world_population.to_f
+        # if you want to generate a population smaller than 7M but still with accurate ratios,
+        #  you can scale the populations of individual cities down by this amount. 
 
         @city_populations = JSON.parse(datafile) if datafile
 
@@ -36,9 +36,8 @@ module Synthea
         puts "Generating #{@population_count} patients..."
         @threads = []
 
-        # 16 picked by experimentation to be a good number of threads to use for exporting records
         # using a cachedthreadpool has no upper bound on the # and if it gets too high then everything grinds to a halt
-        @pool = Concurrent::FixedThreadPool.new(16) if Synthea::Config.sequential.multithreading
+        @pool = Concurrent::FixedThreadPool.new(Synthea::Config.sequential.thread_pool_size) if Synthea::Config.sequential.multithreading
 
         if @city_populations
           run_with_target_data


### PR DESCRIPTION
Adds the ability to generate 1 city at a time, using real city demographics, to the sequential generator. The generator can now run multithreaded or single-threaded. (Configurable by a synthea.yml property - for fastest performance use JRuby and enable multithreading. Don't enable multithreading on MRI)
Patients are generated in 1 thread per city, and then put into a thread pool to export them.

Adds a new optional parameter to the generate rake task, which accepts a json file of city demographics to use to generate patients. If no file is given it generates pure random patients, as it does today.

Example: 
`bundle exec rake synthea:sequential['./config/Barnstable_County.json']`

Some other changes were needed to accommodate targeting patients to demographics instead of just choosing them completely randomly.

