### PR TITLE
Filter export to past _ years

### DIFF
--- a/config/synthea.yml
+++ b/config/synthea.yml
@@ -1,5 +1,9 @@
 synthea:
-
+  export:
+    ccda: true
+    fhir: true
+    html: true
+    years_of_history: 5
   start_date: <%= Time.now - 100.years %>
   end_date: <%= Time.now - 1.day %>
   time_step: 7 # days

--- a/lib/generic/modules/appendicitis.json
+++ b/lib/generic/modules/appendicitis.json
@@ -156,13 +156,24 @@
     "Appendicitis_Encounter": {
       "type": "Encounter",
       "wellness": false,
-      "direct_transition": "Appendectomy_Encounter",
+      "direct_transition": "History_of_Appendectomy",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "50849002",
         "display" : "Emergency Room Admission"
       }],
       "remarks" : "Currently the GMF does not include Vital Signs, if we decide to add that then there are some lab tests we could add at this Encounter."
+    },
+
+    "History_of_Appendectomy": {
+      "type": "ConditionOnset",
+      "target_encounter": "Appendectomy_Encounter",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "428251008",
+        "display": "History of appendectomy"
+      }],
+      "direct_transition": "Appendectomy_Encounter"
     },
 
     "Appendectomy_Encounter": {
@@ -175,6 +186,7 @@
       }],
       "direct_transition": "Appendectomy"
     },
+
     "Appendectomy": {
       "type": "Procedure",
       "target_encounter": "Appendectomy_Encounter",

--- a/lib/modules/cardiovascular_disease.rb
+++ b/lib/modules/cardiovascular_disease.rb
@@ -464,6 +464,11 @@ module Synthea
           stroke: [:mechanical_thrombectomy],
           cardiac_arrest: [:implant_cardioverter_defib, :catheter_ablation]
         }
+        history_conditions = {
+          myocardial_infarction: [:history_of_myocardial_infarction],
+          stroke: [],
+          cardiac_arrest: [:history_of_cardiac_arrest]
+        }
         time = event.time
         diagnosis = event.type
         patient = entity.record_synthea
@@ -477,6 +482,10 @@ module Synthea
           emergency_procedures[diagnosis].each do |proc|
             reason_code = COND_LOOKUP[diagnosis][:codes]['SNOMED-CT'][0]
             entity.record_synthea.procedure(proc, time, reason_code, :procedure, :procedure) 
+          end
+
+          history_conditions[diagnosis].each do |cond|
+            entity.record_synthea.condition(cond, time) 
           end
         end
       end

--- a/lib/modules/metabolic_syndrome.rb
+++ b/lib/modules/metabolic_syndrome.rb
@@ -494,10 +494,28 @@ module Synthea
 
       def self.process_amputations(amputations, entity, time)
         amputations.each do |amputation|
-          key = "amputation_#{amputation.to_s}".to_sym
+          amp_str = amputation.to_s
+          key = "amputation_#{amp_str}".to_sym
           reason_code = '368581000119106'
           if !entity.record_synthea.present[key]
             entity.record_synthea.procedure(key, time, reason_code, :procedure, :procedure)
+          end
+
+          body_part = amp_str.split('_')[1]
+
+          cond_key =  case body_part
+                      when 'leg' 
+                        :history_of_lower_limb_amputation
+                      when 'foot'
+                        :history_of_amputation_of_foot
+                      when 'hand'
+                        :history_of_disarticulation_at_wrist
+                      when 'arm'
+                        :history_of_upper_limb_amputation
+                      end
+          
+          if !entity.record_synthea.present[cond_key]
+            entity.record_synthea.condition(cond_key, time)
           end
         end
       end

--- a/lib/records/exporter.rb
+++ b/lib/records/exporter.rb
@@ -1,0 +1,79 @@
+module Synthea
+  module Output
+    module Exporter
+      def self.export(patient)
+        patient = filter_for_export(patient) unless Synthea::Config.export.years_of_history <= 0
+
+        if Synthea::Config.export.ccda || Synthea::Config.export.html
+          ccda_record = Synthea::Output::CcdaRecord.convert_to_ccda(patient)
+
+          if Synthea::Config.export.ccda
+            out_dir = File.join('output','CCDA')
+            xml = HealthDataStandards::Export::CCDA.new.export(ccda_record)
+            File.open(File.join(out_dir, "#{patient.record_synthea.patient_info[:uuid]}.xml"), 'w') { |file| file.write(xml) }
+          end
+
+          if Synthea::Config.export.html
+            out_dir = File.join('output','html')
+            html = HealthDataStandards::Export::HTML.new.export(ccda_record)
+            File.open(File.join(out_dir, "#{patient.record_synthea.patient_info[:uuid]}.html"), 'w') { |file| file.write(html) }
+          end
+        end
+
+        if Synthea::Config.export.fhir
+          fhir_record = Synthea::Output::FhirRecord.convert_to_fhir(patient)
+
+          out_dir = File.join('output','fhir')
+          data = fhir_record.to_json
+          File.open(File.join(out_dir, "#{patient.record_synthea.patient_info[:uuid]}.json"), 'w') { |file| file.write(data) }
+        end
+      end
+
+
+      def self.filter_for_export(patient)
+        # filter the patient's history to only the last __ years
+        # but also include relevant history from before that
+
+        cutoff_date = Time.now - Synthea::Config.export.years_of_history.years
+
+        # dup the patient so that we export only the last _ years but the rest still exists, just in case
+        patient = patient.dup
+        patient.record_synthea = patient.record_synthea.dup
+
+        present = patient.record_synthea.present
+
+        [:encounters, :conditions, :observations, :procedures, :immunizations, :careplans, :medications].each do |attribute| 
+          entries = patient.record_synthea.send(attribute).dup
+ 
+          entries.keep_if { |e| should_keep_entry(e, attribute, patient.record_synthea, cutoff_date) }
+          patient.record_synthea.send("#{attribute.to_s}=", entries)
+        end
+
+        patient
+      end
+
+      def self.should_keep_entry(e, attribute, record, cutoff_date)
+        return true if e['time'] > cutoff_date # trivial case, when we're within the last __ years
+
+        # if the entry has a stop time, check if the effective date range overlapped the last __ years
+        return true if e['stop'] && e['stop'] > cutoff_date
+
+        # - encounters, observations, immunizations are single dates and have no "reason"
+        #    so they can only be filtered by the single date
+        # - procedures are always listed in "record.present" so they are only filtered by date. 
+        #    procedures that have "permanent side effects" such as appendectomy, amputation,
+        #    should also add a condition code such as "history of ___" (ex 429280009)
+        case attribute
+        when :medications
+          return record.medication_active?(e['type'])
+        when :careplans
+          return record.careplan_active?(e['type'])
+        when :conditions
+          return record.present[ e['type'] ] || (e['end_time'] && e['end_time'] > cutoff_date)
+        end
+
+        false
+      end
+    end
+  end
+end

--- a/lib/records/lookup.rb
+++ b/lib/records/lookup.rb
@@ -64,7 +64,14 @@ module Synthea
     myocardial_infarction: { description: 'Myocardial Infarction', codes: {'SNOMED-CT' => ['22298006']}},
     cardiac_arrest: {description: 'Cardiac Arrest', codes: {'SNOMED-CT' => ['410429000']}},
     atrial_fibrillation: { description: 'Atrial Fibrillation', codes: {'SNOMED-CT' => ['49436004']} },
-    cardiovascular_disease: { description: 'Disorder of cardiovascular system', codes: {'SNOMED-CT'=>['49601007']}}
+    cardiovascular_disease: { description: 'Disorder of cardiovascular system', codes: {'SNOMED-CT'=>['49601007']}},
+
+    history_of_lower_limb_amputation: { description: 'History of lower limb amputation (situation)', codes: {'SNOMED-CT'=>['161622006']}},
+    history_of_amputation_of_foot: { description: 'History of amputation of foot (situation)', codes: {'SNOMED-CT'=>['429280009']}},
+    history_of_disarticulation_at_wrist: { description: 'History of disarticulation at wrist (situation)', codes: {'SNOMED-CT'=>['698423002']}},
+    history_of_upper_limb_amputation: { description: 'History of upper limb amputation (situation)', codes: {'SNOMED-CT'=>['161621004']}},
+    history_of_myocardial_infarction: { description: 'History of myocardial infarction (situation)', codes: {'SNOMED-CT'=>['399211009']}},
+    history_of_cardiac_arrest: { description: 'History of cardiac arrest (situation)', codes: {'SNOMED-CT'=>['429007001']}},
   }
 
   CAREPLAN_LOOKUP = {

--- a/lib/world/sequential.rb
+++ b/lib/world/sequential.rb
@@ -74,9 +74,9 @@ module Synthea
             person = build_person(nil, rand(0..100), nil, nil, nil)
 
             if @pool
-              @pool.post { export (person) }
+              @pool.post { Synthea::Output::Exporter.export (person) }
             else
-              export(person)
+              Synthea::Output::Exporter.export(person)
             end
 
             record_stats(person)
@@ -102,9 +102,9 @@ module Synthea
             person = build_person(city_name, target_age, target_gender, target_race, target_ethnicity)
 
             if @pool
-              @pool.post { export (person) }
+              @pool.post { Synthea::Output::Exporter.export (person) }
             else
-              export(person)
+              Synthea::Output::Exporter.export(person)
             end
 
             record_stats(person)
@@ -172,24 +172,6 @@ module Synthea
         @stats[:ethnicity][ patient[:ethnicity] ] += 1
         @stats[:blood_type][ patient[:blood_type] ] += 1
       end
-
-      def export(patient)
-        ccda_record = Synthea::Output::CcdaRecord.convert_to_ccda(patient)
-        fhir_record = Synthea::Output::FhirRecord.convert_to_fhir(patient)
-
-        out_dir = File.join('output','html')
-        html = HealthDataStandards::Export::HTML.new.export(ccda_record)
-        File.open(File.join(out_dir, "#{patient.record_synthea.patient_info[:uuid]}.html"), 'w') { |file| file.write(html) }
-        
-        out_dir = File.join('output','fhir')
-        data = fhir_record.to_json
-        File.open(File.join(out_dir, "#{patient.record_synthea.patient_info[:uuid]}.json"), 'w') { |file| file.write(data) }
-
-        out_dir = File.join('output','CCDA')
-        xml = HealthDataStandards::Export::CCDA.new.export(ccda_record)
-        File.open(File.join(out_dir, "#{patient.record_synthea.patient_info[:uuid]}.xml"), 'w') { |file| file.write(xml) }
-      end
-
     end
   end
 end

--- a/test/unit/exporter_test.rb
+++ b/test/unit/exporter_test.rb
@@ -1,0 +1,124 @@
+require_relative '../test_helper'
+
+class ExporterTest < Minitest::Test
+  def setup
+    Synthea::Config.export.years_of_history = 5
+
+    @time = Time.now
+    @patient = Synthea::Person.new
+    @patient[:gender] = 'F'
+    @patient.events.create(@time - 35.years, :birth, :birth)
+    @patient[:age] = 35
+    @patient[:is_alive] = true
+    @record = @patient.record_synthea
+  end
+
+  def test_export_filter_simple_cutoff
+    @record.observation(:height, @time - 8.years, 64)
+    @record.observation(:weight, @time - 4.years, 128)
+
+    # observations should be filtered to the cutoff date
+
+    filtered = Synthea::Output::Exporter.filter_for_export(@patient)
+
+    assert_equal 1, filtered.record_synthea.observations.length
+    assert_equal :weight, filtered.record_synthea.observations[0]['type']
+    assert_equal @time - 4.years, filtered.record_synthea.observations[0]['time']
+    assert_equal 128, filtered.record_synthea.observations[0]['value']
+  end
+
+  def test_export_filter_should_keep_old_active_medication
+    @record.medication_start(:fakeitol, @time - 10.years, [:fake_reason])
+
+    @record.medication_start(:placebitol, @time - 8.years, [:reason2])
+    @record.medication_stop(:placebitol, @time - 6.years, :ineffective)
+    
+    filtered = Synthea::Output::Exporter.filter_for_export(@patient)
+
+    assert_equal 1, filtered.record_synthea.medications.length
+    assert_equal :fakeitol, filtered.record_synthea.medications[0]['type']
+    assert_equal @time - 10.years, filtered.record_synthea.medications[0]['time']
+  end
+
+  def test_export_filter_should_keep_medication_that_ended_during_target
+    @record.medication_start(:dimoxinil, @time - 10.years, [:baldness])
+    @record.medication_stop(:dimoxinil, @time - 9.years, :snake_oil)
+
+    @record.medication_start(:placebitol, @time - 8.years, [:reason2])
+    @record.medication_stop(:placebitol, @time - 4.years, :ineffective)
+    
+    filtered = Synthea::Output::Exporter.filter_for_export(@patient)
+
+    assert_equal 1, filtered.record_synthea.medications.length
+    assert_equal :placebitol, filtered.record_synthea.medications[0]['type']
+    assert_equal @time - 8.years, filtered.record_synthea.medications[0]['time']
+    assert_equal @time - 4.years, filtered.record_synthea.medications[0]['stop']
+  end
+
+  def test_export_filter_should_keep_old_active_careplan
+    @record.careplan_start(:stop_smoking, [:activity1], @time - 10.years, :smoking_is_bad_mkay)
+    @record.careplan_stop(:stop_smoking, @time - 8.years)
+
+    @record.careplan_start(:healthy_diet, [:eat_food_mostly_plants], @time - 12.years, :reason1)
+
+    filtered = Synthea::Output::Exporter.filter_for_export(@patient)
+
+    assert_equal 1, filtered.record_synthea.careplans.length
+    assert_equal :healthy_diet, filtered.record_synthea.careplans[0]['type']
+    assert_equal @time - 12.years, filtered.record_synthea.careplans[0]['time']
+  end
+  
+  def test_export_filter_should_keep_careplan_that_ended_during_target
+    @record.careplan_start(:stop_smoking, [:activity1], @time - 10.years, :smoking_is_bad_mkay)
+    @record.careplan_stop(:stop_smoking, @time - 1.years)
+
+    filtered = Synthea::Output::Exporter.filter_for_export(@patient)
+
+    assert_equal 1, filtered.record_synthea.careplans.length
+    assert_equal :stop_smoking, filtered.record_synthea.careplans[0]['type']
+    assert_equal @time - 10.years, filtered.record_synthea.careplans[0]['time']
+    assert_equal @time - 1.years, filtered.record_synthea.careplans[0]['stop']
+  end
+
+  def test_export_filter_should_keep_old_active_conditions
+    @record.condition(:fakitis, @time - 10.years)
+    @record.end_condition(:fakitis, @time - 8.years)
+
+    @record.condition(:fakosis, @time - 10.years)
+
+    filtered = Synthea::Output::Exporter.filter_for_export(@patient)
+
+    assert_equal 1, filtered.record_synthea.conditions.length
+    assert_equal :fakosis, filtered.record_synthea.conditions[0]['type']
+    assert_equal @time - 10.years, filtered.record_synthea.conditions[0]['time']
+  end
+
+  def test_export_filter_should_keep_condition_that_ended_during_target
+    @record.condition(:boneitis, @time - 10.years)
+    @record.end_condition(:boneitis, @time - 2.years)
+
+    @record.condition(:smallpox, @time - 10.years)
+    @record.end_condition(:smallpox, @time - 9.years)
+
+    filtered = Synthea::Output::Exporter.filter_for_export(@patient)
+
+    assert_equal 1, filtered.record_synthea.conditions.length
+    assert_equal :boneitis, filtered.record_synthea.conditions[0]['type']
+    assert_equal @time - 10.years, filtered.record_synthea.conditions[0]['time']
+  end
+
+  def test_export_filter_should_not_keep_old_stuff
+    @record.procedure(:appendectomy, @time - 20.years, :appendicitis)
+    @record.encounter(:er_visit, @time - 18.years)
+    @record.immunization(:flu_shot, @time - 12.years)
+    @record.observation(:weight, @time - 10.years, 123)
+
+    filtered = Synthea::Output::Exporter.filter_for_export(@patient)
+
+    assert_empty filtered.record_synthea.procedures
+    assert_empty filtered.record_synthea.encounters
+    assert_empty filtered.record_synthea.immunizations
+    assert_empty filtered.record_synthea.observations
+  end
+
+end

--- a/test/unit/generic/appendicitis_test.rb
+++ b/test/unit/generic/appendicitis_test.rb
@@ -34,6 +34,7 @@ class AppendicitisTest < Minitest::Test
     @patient.record_synthea.expect(:condition, nil, [:appendicitis, @time])
 
     @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, :appendicitis])
+    @patient.record_synthea.expect(:condition, nil, [:history_of_appendectomy, @time])
     
     @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time])
     @patient.record_synthea.expect(:encounter, nil, [:encounter_inpatient, @time])
@@ -53,6 +54,7 @@ class AppendicitisTest < Minitest::Test
     @patient.record_synthea.expect(:condition, nil, [:rupture_of_appendix, @time])
 
     @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, :appendicitis])
+    @patient.record_synthea.expect(:condition, nil, [:history_of_appendectomy, @time])
     
     @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time])
     @patient.record_synthea.expect(:encounter, nil, [:encounter_inpatient, @time])


### PR DESCRIPTION
Exported files now contain only the past _ years (configurable) plus old data that is still relevant (active conditions, medications, careplans). Procedures are not kept if old but if they have permanent effects they should add a "History of xyz" condition, a few of which are introduced here. 

Also adds configurable options for exported file formats (fhir, ccda, html)