### PR TITLE
Add support for historical availibility of vaccines

### DIFF
--- a/lib/modules/immunizations.rb
+++ b/lib/modules/immunizations.rb
@@ -25,21 +25,53 @@ module Synthea
         birthdate = entity.event(:birth).time
         age_in_months = Synthea::Modules::Lifecycle.age(time, birthdate, nil, :months)
         IMM_SCHEDULE.each_key do |imm|
-          if immunization_due(imm, age_in_months, entity[:immunizations][imm])
+          if immunization_due(imm, birthdate, age_in_months, time, entity[:immunizations][imm] || [])
             entity[:immunizations][imm] ||= []
             entity[:immunizations][imm] << time
+            # puts "Administering #{IMM_SCHEDULE[imm][:code]['display']} to #{entity[:name_first]} age #{age_in_months/12} in year #{time.year}"
             patient.immunization(imm, time, :immunization, :immunization)
           end
         end
       end
 
-      def self.immunization_due(imm,age_in_months,history)
-        history ||= []
+      def self.immunization_due(imm, birthdate, age_in_months, time, history)
+
         at_months = IMM_SCHEDULE[imm][:at_months]
-        if history.length < at_months.length
-          return age_in_months >= at_months[history.length]
+        first_available = IMM_SCHEDULE[imm][:first_available]
+
+        # Don't administer if the immunization wasn't historically available at the date of the encounter
+        return false if first_available && time.year < first_available
+
+        # Don't administer if all recommended doses have already been given
+        return false if history.length >= at_months.length
+
+        # See if the patient should recieve a dose based on their current age and the recommended dose ages;
+        # we can't just see if greater than the recommended age for the next dose they haven't received
+        # because ie we don't want to administer the HPV vaccine to someone who turns 90 in 2006 when the
+        # vaccine is released; we can't just use a simple test of, say, within 4 years after the recommended
+        # age for the next dose they haven't received because ie PCV13 is given to kids and seniors but was
+        # only available starting in 2010, so a senior in 2012 who has never received a dose should get one,
+        # but only one; what we do is
+
+        # 1) eliminate any recommended doses that are not within 4 years of the patient's age
+        at_months = at_months.reject { |am| age_in_months - am >= 48 }
+
+        # 2) eliminate recommended doses that were actually administered
+        history.each do |date|
+          age_at_date = Synthea::Modules::Lifecycle.age(date, birthdate, nil, :months)
+          # Note: we use drop(1) to non-destructively create a copy of at_months without the first element
+          # so that we don't change the global at_months data
+          at_months = at_months.drop(1) if at_months.size > 0 && age_at_date >= at_months.first && age_at_date - at_months.first < 48
         end
-        return false
+
+        # 3) see if there are any recommended doses remaining that this patient is old enough for
+        return at_months.size > 0 && age_in_months >= at_months.first
+
+        # Note: the approach used here still has some issues, mostly due to odd interactions between
+        # vaccination availability dates and how we schedule adult vaccinations. For example, the PCV13
+        # vaccine is administered to adults over 65, but if the adult is already older than 69 (65 + 4) when
+        # the vaccine is made available in 2012, step 1 above causes the dose to not be administered at all
+
       end
     end
   end

--- a/lib/records/lookup.rb
+++ b/lib/records/lookup.rb
@@ -197,77 +197,93 @@ module Synthea
   IMM_SCHEDULE = {
     :hepb => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'08','display'=>'Hep B, adolescent or pediatric'},
-      :at_months => [0, 1, 6]
+      :at_months => [0, 1, 6],
+      :first_available => 1981
     },
     :rv_mono => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'119','display'=>'rotavirus, monovalent'},
       #  Monovalent (Rotarix) is a 2-dose series, as opposed to pentavalent (RotaTeq) which is a 3-dose series 
-      :at_months => [2, 4]
+      :at_months => [2, 4],
+      :first_available => 2006
     },
     :dtap => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'20','display'=>'DTaP'},
-      :at_months => [2, 4, 6, 15, 48]
+      :at_months => [2, 4, 6, 15, 48],
+      :first_available => 1997 # Note that DTaP is a combined vaccine, and prior to 1997 other DTP vaccines existed
     },
     :hib => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'49','display'=>'Hib (PRP-OMP)'},
       # PRP-OMP (PedvaxHib or COMVAX) is a 2-dose series with a booster at 12-15 months, as opposed to PRP-T
       # (AC-THIB) which is a 3-dose series with a booster at 12-15 months
-      :at_months => [2, 4, 12]
+      :at_months => [2, 4, 12],
+      :first_available => 1977
     },
     :pcv13 => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'133','display'=>'Pneumococcal conjugate PCV 13'},
-      :at_months => [2, 4, 6, 12, 780]
+      :at_months => [2, 4, 6, 12, 780],
+      :first_available => 2010
     },
     :ipv => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'10','display'=>'IPV'},
-      :at_months => [2, 4, 6, 48]
+      :at_months => [2, 4, 6, 48],
+      :first_available => 1955
     },
     :flu => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'140','display'=>'Influenza, seasonal, injectable, preservative free'},
       # This should really only happen Aug - Feb (preferring earlier).  That may take some trickery.
       # Since this is annual administration just populate the array with every 12 months, starting at 6 months.
-      :at_months => (0..100).map {|year| year * 12 + 6 }
+      :at_months => (0..100).map {|year| year * 12 + 6 },
+      :first_available => 1945
     },
     :mmr => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'03','display'=>'MMR'},
-      :at_months => [12, 48]
+      :at_months => [12, 48],
+      :first_available => 1971
     },
     :var => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'21','display'=>'varicella'},
-      :at_months => [12, 48]
+      :at_months => [12, 48],
+      :first_available => 1984
     },
     :hepa => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'83','display'=>'Hep A, ped/adol, 2 dose'},
       # First dose should be 12-23 months, second dose 6-18 months after.  Choosing to do 12 months after.
-      :at_months => [12, 24]
+      :at_months => [12, 24],
+      :first_available => 1995
     },
     :men => {
       # MenACWY can be Menactra (114) or Menveo (136).  Arbitrarily chose Menactra.
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'114','display'=>'meningococcal MCV4P'},
-      :at_months => [132, 192]
+      :at_months => [132, 192],
+      :first_available => 2005 # Other types of meningococcal vaccines were available earlier
     },
     :tdap => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'115','display'=>'Tdap'},
-      :at_months => [132]
+      :at_months => [132],
+      :first_available => 2005
     },
     :hpv => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'62','display'=>'HPV, quadrivalent'},
       # [11 years, boosters 2 months and 6 months later] -- but since we only have encounters scheduled yearly
       # at this age, the boosters will be late.  To be revisited later.
-      :at_months => [132, 134, 138]
+      :at_months => [132, 134, 138],
+      :first_available => 2006
     },
     :td => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'113','display'=>'Td (adult) preservative free'},
       # 21 years and every 10 years after
-      :at_months => [21, 31, 41, 51, 61, 71, 81, 91].map {|year| year * 12 }
+      :at_months => [21, 31, 41, 51, 61, 71, 81, 91].map {|year| year * 12 },
+      :first_available => 1992 # This particular combination of tetanus and diphtheria
     },
     :zoster => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'121','display'=>'zoster'},
-      :at_months => [720]
+      :at_months => [720],
+      :first_available => 2006
     },
     :ppsv23 => {
       :code => {'system'=>'http://hl7.org/fhir/sid/cvx','code'=>'33','display'=>'pneumococcal polysaccharide vaccine, 23 valent'},
-      :at_months => [792]
+      :at_months => [792],
+      :first_available => 1983
     },
   }
 end

--- a/test/unit/immunizations_test.rb
+++ b/test/unit/immunizations_test.rb
@@ -3,43 +3,90 @@ require_relative '../test_helper'
 class ImmunizationsTest < Minitest::Test
 
   def setup
-  	@patient = Synthea::Person.new
-    @patient[:age] = 0
-    @time = Synthea::Config.start_date
-	  @patient.events.create(@time, :birth, :birth, true)
+    # We set up two patients, one born in 1947, before many vaccinations were available, and one born in 2012,
+    # after all vaccinations are available
+    @time_1947 = Time.parse('1947-05-05')
+    @patient_1947 = Synthea::Person.new
+    @patient_1947.events.create(@time_1947, :birth, :birth, true)
+    @patient_1947[:age] = 0
+    @time_2012 = Time.parse('2012-05-05')
+    @patient_2012 = Synthea::Person.new
+    @patient_2012.events.create(@time_2012, :birth, :birth, true)
+    @patient_2012[:age] = 0
   end
 
   def test_birth_immunizations
-  	Synthea::Modules::Immunizations.perform_encounter(@patient, @time)
-  	assert_equal(1, @patient[:immunizations].length)
-  	assert_equal(1, @patient[:immunizations][:hepb].length)
-  	assert_equal(@time, @patient[:immunizations][:hepb][0])
+    Synthea::Modules::Immunizations.perform_encounter(@patient_2012, @time_2012)
+    assert_equal(1, @patient_2012[:immunizations].length)
+    assert_equal(1, @patient_2012[:immunizations][:hepb].length)
+    assert_equal(@time_2012, @patient_2012[:immunizations][:hepb][0])
   end
 
   def test_two_month_immunizations
-  	# birth immunizations
-    Synthea::Modules::Immunizations.perform_encounter(@patient, @time)
-  	# 1-month immunizations
-  	time_1m = @time.advance(:months => 1)
-  	Synthea::Modules::Immunizations.perform_encounter(@patient, time_1m)
-  	# 2-month immunizations
-  	time_2m = @time.advance(:months => 2)
-  	Synthea::Modules::Immunizations.perform_encounter(@patient, time_2m)
+    # birth immunizations
+    Synthea::Modules::Immunizations.perform_encounter(@patient_2012, @time_2012)
+    # 1-month immunizations
+    time_1m = @time_2012.advance(:months => 1)
+    Synthea::Modules::Immunizations.perform_encounter(@patient_2012, time_1m)
+    # 2-month immunizations
+    time_2m = @time_2012.advance(:months => 2)
+    Synthea::Modules::Immunizations.perform_encounter(@patient_2012, time_2m)
 
-  	assert_equal(6, @patient[:immunizations].length)
-  	assert_equal(2, @patient[:immunizations][:hepb].length)
-  	assert_equal(@time, @patient[:immunizations][:hepb][0])
-  	assert_equal(time_1m, @patient[:immunizations][:hepb][1])
-  	assert_equal(1, @patient[:immunizations][:rv_mono].length)
-  	assert_equal(time_2m, @patient[:immunizations][:rv_mono][0])
-  	assert_equal(1, @patient[:immunizations][:dtap].length)
-  	assert_equal(time_2m, @patient[:immunizations][:dtap][0])
-  	assert_equal(1, @patient[:immunizations][:hib].length)
-  	assert_equal(time_2m, @patient[:immunizations][:hib][0])
-  	assert_equal(1, @patient[:immunizations][:pcv13].length)
-  	assert_equal(time_2m, @patient[:immunizations][:pcv13][0])
-  	assert_equal(1, @patient[:immunizations][:ipv].length)
-  	assert_equal(time_2m, @patient[:immunizations][:ipv][0])
+    assert_equal(6, @patient_2012[:immunizations].length)
+    assert_equal(2, @patient_2012[:immunizations][:hepb].length)
+    assert_equal(@time_2012, @patient_2012[:immunizations][:hepb][0])
+    assert_equal(time_1m, @patient_2012[:immunizations][:hepb][1])
+    assert_equal(1, @patient_2012[:immunizations][:rv_mono].length)
+    assert_equal(time_2m, @patient_2012[:immunizations][:rv_mono][0])
+    assert_equal(1, @patient_2012[:immunizations][:dtap].length)
+    assert_equal(time_2m, @patient_2012[:immunizations][:dtap][0])
+    assert_equal(1, @patient_2012[:immunizations][:hib].length)
+    assert_equal(time_2m, @patient_2012[:immunizations][:hib][0])
+    assert_equal(1, @patient_2012[:immunizations][:pcv13].length)
+    assert_equal(time_2m, @patient_2012[:immunizations][:pcv13][0])
+    assert_equal(1, @patient_2012[:immunizations][:ipv].length)
+    assert_equal(time_2m, @patient_2012[:immunizations][:ipv][0])
+  end
+
+  def test_hpv_available
+    # A patient born in 2012 should recieve 3 HPV vaccinations before age of 16
+    (1..16).each do |years|
+      Synthea::Modules::Immunizations.perform_encounter(@patient_2012, @time_2012.advance(:years => years))
+    end
+    assert_equal(3, @patient_2012[:immunizations][:hpv].length)
+  end
+
+  def test_hpv_not_available
+    # A patient born in 1947 should never receive the HPV vaccination, even after it's available in 2006
+    (1..90).each do |years|
+      Synthea::Modules::Immunizations.perform_encounter(@patient_1947, @time_1947.advance(:years => years))
+    end
+    assert_equal(0, (@patient_1947[:immunizations][:hpv] || []).length) # Robust against nil or [] to represent none
+  end
+
+  def test_pcv13_adult
+    # A patient born in 1947 should receive one PCV13 vaccination after it's available 2010
+    (1..90).each do |years|
+      Synthea::Modules::Immunizations.perform_encounter(@patient_1947, @time_1947.advance(:years => years))
+    end
+    assert_equal(1, @patient_1947[:immunizations][:pcv13].length)
+  end
+
+  def test_td_after_available
+    # A patient born in 2012 should receive one Td vaccination at age 21 and every 10 years thereafter
+    (1..45).each do |years|
+      Synthea::Modules::Immunizations.perform_encounter(@patient_2012, @time_2012.advance(:years => years))
+    end
+    assert_equal(3, @patient_2012[:immunizations][:td].length) # Age 21, 31, and 41
+  end
+
+  def test_td_before_available
+    # A patient born in 1947 should receive one Td vaccination on their first scheduled date after 1992 (which
+    # is in 1998) and every 10 years thereafter
+    (1..75).each do |years|
+      Synthea::Modules::Immunizations.perform_encounter(@patient_1947, @time_1947.advance(:years => years))
+    end
+    assert_equal(3, @patient_1947[:immunizations][:td].length) # Year 1998, 2008, 2018
   end
 
 end


### PR DESCRIPTION
It doesn't make sense to provide a patient with a vaccine before that vaccine was actually historically available. For example, the HPV vaccine should not be administered before 2006.

Adding logic for this makes the calculation for when to administer a vaccine more complex.

Additional tests help make sure that this more complex logic is providing reasonable results.