### PR TITLE
new multithreading model for sequential

### DIFF
--- a/config/synthea.yml
+++ b/config/synthea.yml
@@ -23,8 +23,13 @@ synthea:
     # population is scaled to accurately represent MA (using a "true" population of 6,794,422)
     population: 100
     real_world_population: 6794422 #sum of the jsons in the config folder
-    multithreading: false  
-    thread_pool_size: 16 # 16 picked by experimentation to be a good number of threads to use for exporting records
+    multithreading: false
+    thread_pool_size:
+    # numbers picked by experimentation on 2013 i5 mbp, may need to be tweaked on less powerful systems
+    # consider SSD vs HDD, # of cpus/cores, memory usage, etc
+      city_workers: 4
+      generate_workers: 6
+      export_workers: 10
     max_tries: 10 # max number of times it tries to create a person before it gives up (ie, nobody reached the target age)
   schedule:
     variance: 0.1


### PR DESCRIPTION
Currently the multithreading uses 1 thread per city which loops over all the people to generate. This is a significant speedup over single-threading but loses its effectiveness over time when generating large cities.
Consider Suffolk County, where Boston has 600k people and the 2nd most populous city is Revere with 50k people. So once all the people in the smaller cities have been generated, the remaining 500k+ people in Boston will be generated on a single thread and the throughput drops significantly.

The new model uses 1 thread per city and then posts the work of generating people onto another thread pool, so that no matter how many cities are being processed at a time, it should always be generating multiple people at the same time. 