### PR TITLE
Injuries Module, Attributes in GMF, Date logic, and MedicationEnd state

### DIFF
--- a/lib/generic/logic.rb
+++ b/lib/generic/logic.rb
@@ -15,6 +15,10 @@ module Synthea
           self.testAge(condition, context, time, entity)
         when 'Socioeconomic Status'
           self.testSES(condition, context, time, entity)
+        when 'Date'
+          self.testDate(condition, context, time, entity)
+        when 'Attribute'
+          self.testAttribute(condition, context, time, entity)
         when 'True'
           self.testTrue(condition, context, time, entity)
         when 'False'
@@ -62,6 +66,14 @@ module Synthea
         self.compare(ses_category, condition['category'], '==')
       end
 
+      def self.testDate(condition, context, time, entity)
+        self.compare(time.year, condition['year'], condition['operator'])
+      end
+
+      def self.testAttribute(condition, context, time, entity)
+        self.compare(entity[ condition['attribute'] ], condition['value'], condition['operator'])
+      end
+
       def self.testTrue(condition, context, time, entity)
         return true
       end
@@ -84,6 +96,10 @@ module Synthea
           return lhs > rhs
         when '!='
           return lhs != rhs
+        when 'is nil'
+          return lhs.nil?
+        when 'is not nil'
+          return !lhs.nil?
         else
           raise "Unsupported operator: #{operator}"
         end

--- a/lib/generic/modules/opioid_addiction.json
+++ b/lib/generic/modules/opioid_addiction.json
@@ -4,19 +4,30 @@
 
     "Initial" : {
       "type" : "Initial",
-      "direct_transition" : "Age_Guard"
+      "direct_transition" : "Guard"
     },
 
-    "Age_Guard" : {
+    "Guard" : {
       "type" : "Guard",
       "allow" : {
-        "condition_type" : "Age",
-        "operator" : ">=",
-        "quantity" : 14,
-        "unit" : "years"
+        "condition_type" : "And",
+        "conditions" : [
+          {
+            "condition_type" : "Age",
+            "operator" : ">=",
+            "quantity" : 14,
+            "unit" : "years"
+          },
+          {
+            "condition_type" : "Date",
+            "operator" : ">=",
+            "year" : 1990
+          }
+        ]
       },
       "direct_transition" : "General_Population",
-      "remarks" : "Data on specific ages is limited but generally below 15 no source indicates a statistically significant % of opioid addiction"
+      "remarks" : ["Data on specific ages is limited but generally below 15 no source indicates a statistically significant % of opioid addiction.",
+                   "While opioids have been available for decades, the current 'opioid crisis' is generally shown to have begun in the 90s-00s"]
     },
 
     "General_Population" : {
@@ -26,6 +37,19 @@
         "unit" : "days"
       },
       "complex_transition" : [
+        {
+            "condition" : {
+              "condition_type" : "Attribute",
+              "attribute" : "Opioid Prescription",
+              "operator" : "is not nil"
+            },
+            "distributions" : [
+              {
+                "distribution" : 1.0,
+                "transition" : "Directed_Use"
+              }
+            ]
+        },
         {
             "condition": {
               "condition_type": "Socioeconomic Status",
@@ -149,6 +173,7 @@
           "code" : "1310197",
           "display" : "Acetaminophen 300 MG / HYDROcodone Bitartrate 5 MG [Vicodin]"
       }],
+      "assign_to_attribute" : "Opioid Prescription",
       "direct_transition" : "Directed_Use"
     },
 
@@ -182,6 +207,7 @@
           "code" : "1049544",
           "display" : "oxyCODONE Hydrochloride 15 MG [OxyCONTIN]"
       }],
+      "assign_to_attribute" : "Opioid Prescription",
       "direct_transition" : "Directed_Use"
     },
 
@@ -210,6 +236,7 @@
           "code" : "1049639",
           "display" : "Acetaminophen 325 MG / oxyCODONE Hydrochloride 5 MG [Percocet]"
       }],
+      "assign_to_attribute" : "Opioid Prescription",
       "direct_transition" : "Directed_Use"
     },
 
@@ -222,8 +249,7 @@
       "distributed_transition": [
         {
           "distribution": 0.03810,
-          "transition": "General_Population",
-          "remarks" : "TODO the directed use -> gen pop sequence needs to end the prescription"
+          "transition": "End_Prescription_Towards_Gen_Pop"
         },
         {
           "distribution": 0.00004,
@@ -231,8 +257,7 @@
         },
         {
           "distribution": 0.00948,
-          "transition": "Misuse",
-          "remarks" : "TODO the directed use -> misuse sequence should end the prescription"
+          "transition": "End_Prescription_Towards_Misuse"
         },
         {
           "distribution": 0.95238,
@@ -240,6 +265,26 @@
         }
       ]
     }, 
+
+    "End_Prescription_Towards_Gen_Pop" : {
+      "type" : "MedicationEnd",
+      "referenced_by_attribute" : "Opioid Prescription",
+      "direct_transition" : "Reset_Opioid_var_Towards_Gen_Pop"
+    },
+
+    "Reset_Opioid_var_Towards_Gen_Pop" : {
+      "type" : "SetAttribute",
+      "attribute" : "Opioid Prescription",
+      "remarks" : "no value here means the variable is reset to nil",
+      "direct_transition" : "General_Population"
+    },
+
+    "End_Prescription_Towards_Misuse" : {
+      "type" : "MedicationEnd",
+      "referenced_by_attribute" : "Opioid Prescription",
+      "remarks": "Note that the variable is not reset on this sequence, because we still want to know which medication they were on",
+      "direct_transition" : "Misuse"
+    },
 
     "Misuse" : {
       "type" : "Delay", 
@@ -254,7 +299,7 @@
         },
         {
           "distribution": 0.01700,
-          "transition": "General_Population"
+          "transition": "Reset_Opioid_var_Towards_Gen_Pop"
         },
         {
           "distribution": 0.00075,
@@ -476,7 +521,12 @@
     }, 
 
     "Death" : {
-      "type" : "Death"
+      "type" : "Death",
+      "direct_transition" : "Terminal"
+    },
+
+    "Terminal" : {
+      "type" : "Terminal"
     }
 
   }

--- a/test/fixtures/generic/condition_onset.json
+++ b/test/fixtures/generic/condition_onset.json
@@ -40,6 +40,7 @@
                 "code": "47693006",
                 "display": "Rupture of appendix"
             }],
+            "assign_to_attribute" : "Most Recent ED Visit",
             "direct_transition": "Terminal"
         },
         "Terminal": {

--- a/test/fixtures/generic/logic.json
+++ b/test/fixtures/generic/logic.json
@@ -57,6 +57,38 @@
     "condition_type" : "Socioeconomic Status",
     "category" : "Low"
   },
+  "before2016Test" : {
+    "condition_type" : "Date",
+    "operator" : "<",
+    "year" : 2016
+  },
+  "after2000Test" : {
+    "condition_type" : "Date",
+    "operator" : ">=",
+    "year" : 2000
+  },
+  "attributeEqualTo_TestValue_Test" : {
+    "condition_type" : "Attribute",
+    "attribute" : "Test_Attribute_Key",
+    "operator" : "==",
+    "value" : "TestValue"
+  },
+  "attributeGt100Test" : {
+    "condition_type" : "Attribute",
+    "attribute" : "Test_Attribute_Key",
+    "operator" : ">",
+    "value" : 100
+  },
+  "attributeNilTest" : {
+    "condition_type" : "Attribute",
+    "attribute" : "Test_Attribute_Key",
+    "operator" : "is nil"
+  },
+  "attributeNotNilTest" : {
+    "condition_type" : "Attribute",
+    "attribute" : "Test_Attribute_Key",
+    "operator" : "is not nil"
+  },
   "andAllTrueTest": {
     "condition_type": "And",
     "conditions": [

--- a/test/fixtures/generic/medication_end.json
+++ b/test/fixtures/generic/medication_end.json
@@ -1,0 +1,86 @@
+{
+    "name": "MedicationEnd",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Condition"
+        },
+        "Diabetes": {
+            "type": "ConditionOnset",
+            "target_encounter": "Wellness_Encounter",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "73211009",
+                "display": "Diabetes mellitus"
+            }],
+            "direct_transition": "Wellness_Encounter"
+        },
+        "Wellness_Encounter": {
+            "type": "Encounter",
+            "wellness": true,
+            "direct_transition": "Metformin_Start"
+        },
+        "Metformin_Start": {
+            "type": "MedicationOrder",
+            "target_encounter": "Wellness_Encounter",
+            "codes": [{
+                "system": "RxNorm",
+                "code": "860975",
+                "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
+            }],
+            "reason": "Diabetes",
+            "direct_transition": "Insulin_Start"
+        },
+
+        "Insulin_Start": {
+            "type": "MedicationOrder",
+            "target_encounter": "Wellness_Encounter",
+            "codes": [{
+                "system": "RxNorm",
+                "code": "575679",
+                "display": "Insulin, Aspart, Human 100 UNT/ML [NovoLOG]"
+            }],
+            "assign_to_attribute" : "DiabetesMed1",
+            "reason": "Diabetes",
+            "direct_transition": "Bromocriptine_Start"
+        },
+
+        "Bromocriptine_Start": {
+            "type": "MedicationOrder",
+            "target_encounter": "Wellness_Encounter",
+            "codes": [{
+                "system": "RxNorm",
+                "code": "563894",
+                "display": "Bromocriptine 5 MG [Parlodel]"
+            }],
+            "reason": "Diabetes",
+            "direct_transition": "Metformin_End"
+        },
+
+        "Metformin_End": {
+            "type": "MedicationEnd",
+            "codes": [{
+                "system": "RxNorm",
+                "code": "860975",
+                "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
+            }],
+            "direct_transition": "Insulin_End"
+        },
+
+        "Insulin_End": {
+            "type": "MedicationEnd",
+            "referenced_by_attribute" : "DiabetesMed1",
+            "direct_transition": "Bromocriptine_End"
+        },
+
+        "Bromocriptine_End": {
+            "type": "MedicationEnd",
+            "medication_order" : "Bromocriptine_Start",
+            "direct_transition": "Terminal"
+        },
+
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/test/fixtures/generic/medication_order.json
+++ b/test/fixtures/generic/medication_order.json
@@ -28,6 +28,7 @@
                 "code": "860975",
                 "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
             }],
+            "assign_to_attribute" : "Diabetes Medication",
             "reason": "Diabetes",
             "direct_transition": "Terminal"
         },

--- a/test/fixtures/generic/procedure.json
+++ b/test/fixtures/generic/procedure.json
@@ -23,6 +23,7 @@
                 "code": "6025007",
                 "display": "Laparoscopic appendectomy"
             }],
+            "assign_to_attribute" : "Most Recent Surgery",
             "direct_transition": "Terminal"
         },
         "Terminal": {

--- a/test/fixtures/generic/set_attribute.json
+++ b/test/fixtures/generic/set_attribute.json
@@ -1,0 +1,25 @@
+{
+    "name": "SetAttribute",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Set_Attribute_1"
+        },
+        "Set_Attribute_1": {
+            "type": "SetAttribute",
+            "attribute" : "Current Opioid Prescription",
+            "value" : "Vicodin",
+            "direct_transition": "Set_Attribute_2"
+        },
+
+        "Set_Attribute_2": {
+            "type": "SetAttribute",
+            "attribute" : "Current Opioid Prescription",
+            "direct_transition": "Terminal"
+        },
+
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}

--- a/test/unit/generic_logic_test.rb
+++ b/test/unit/generic_logic_test.rb
@@ -111,6 +111,45 @@ class GenericLogicTest < Minitest::Test
     assert(do_test('sesLowTest'))
   end
 
+  def test_date
+    @time = Time.new(2016, 9, 21)
+    refute(do_test('before2016Test'))
+    assert(do_test('after2000Test'))
+
+    @time = Time.new(1981, 4, 28)
+    assert(do_test('before2016Test'))
+    refute(do_test('after2000Test'))
+
+    @time = Time.new(2002, 2, 22)
+    assert(do_test('before2016Test'))
+    assert(do_test('after2000Test'))
+  end
+
+  def test_attribute
+    attribute = 'Test_Attribute_Key'
+
+    @patient[attribute] = nil
+    refute(do_test('attributeEqualTo_TestValue_Test'))
+    assert(do_test('attributeNilTest'))
+    refute(do_test('attributeNotNilTest'))
+
+    @patient[attribute] = "Wrong Value"
+    refute(do_test('attributeEqualTo_TestValue_Test'))
+    refute(do_test('attributeNilTest'))
+    assert(do_test('attributeNotNilTest'))
+
+    @patient[attribute] = "TestValue"
+    assert(do_test('attributeEqualTo_TestValue_Test'))
+    refute(do_test('attributeNilTest'))
+    assert(do_test('attributeNotNilTest'))
+
+    @patient[attribute] = 120
+    refute(do_test('attributeEqualTo_TestValue_Test'))
+    assert(do_test('attributeGt100Test'))
+    refute(do_test('attributeNilTest'))
+    assert(do_test('attributeNotNilTest'))
+  end
+
   def test_and_conditions
     assert(do_test('andAllTrueTest'))
     refute(do_test('andOneFalseTest'))


### PR DESCRIPTION
Adds a generic module for Injuries, and supporting framework changes.  The Injuries model allows patients to be prescribed opioids in certain cases, so in those cases we want the Opioids model to be aware of that. This is accomplished using "Attributes" which are just key/value pairs stored on the patient entity. An Attribute may be a Medication/Procedure/Condition, or an arbitrary string.


For the wiki:

### (add to MedicationOrder/ConditionOnset/etc supported properties)
* **assign_to_attribute**: The name of the attribute this [medication/condition/procedure/etc] should be referred to by. Attributes allow multiple to store, reference, and share medications, conditions, procedures, etc, as well as as arbitrary strings.



(remove "future considerations" from MedicationOrder")


## SetAttribute

The `SetAttribute` state type indicates a point in the module that sets a specified value on the patient entity. In addition to the `assign_to_attribute` property on `MedicationOrder`/`ConditionOnset`/etc states, this state allows for arbitrary text or values to be set on an Attribute, or for the Attribute to be reset.

**Supported Properties**

* **type**: must be "SetAttribute" _(required)_
* **attribute**: the name of the Attribute to set the _value_ for. _(required)_
* **value**: the text or other value to set for this _attribute_. If not provided, the _value_ is set to nil. _(optional)_

**Example**

The following is an example of a SetAttribute that sets the value of Attribute 'Opioid Prescription' to 'Vicodin':

```json
{
  "type": "SetAttribute",
  "attribute": "Opioid Prescription",
  "value": "Vicodin"
}
```

The following is an example of a SetAttribute that sets the value of Attribute 'Opioid Prescription' to nil, or no value:

```json
{
  "type": "SetAttribute",
  "attribute": "Opioid Prescription"
}
```


## MedicationEnd

The `MedicationEnd` state type indicates a point in the module where a currently prescribed medication should be ended. The `MedicationEnd` state supports three ways of specifying the medication to end:
1. By `codes[]`, specifying the code system, code, and display name of the medication to end, or
2. By `medication_order`, specifying the name of the `MedicationOrder` state in which the medication was prescribed, or
3. By `referenced_by_attribute`, specifying the name of the Attribute in which a previous `MedicationOrder` state assigned a medication.

**Supported Properties**

* **type**: must be "MedicationEnd" _(required)_
* **codes[]**: a list of codes indicating the medication _(optional, required if neither `medication_order` nor `referenced_by_attribute` is set)_
  * **system**: the code system.  Currently, only `RxNorm` is allowed. _(required)_
  * **code**: the code _(required)_
  * **display**: the human-readable code description _(required)_
* **medication_order**: the name of the `MedicationOrder` state in which the medication was prescribed _(optional, required if neither `codes[]` nor `referenced_by_attribute` is set)_
* **referenced_by_attribute**: the name of the Attribute in which a previous `MedicationOrder` state assigned a medication _(optional, required if neither `medication_order` nor `codes[]` is set)_
* **reason**:  text reason for why the medication is ended. If not provided, defaults to "prescription expired" _(optional)_

**Example**

The following is an example of a MedicationEnd that ends a prescription for Metformin, specified by code:

```json
{
  "type": "MedicationEnd",
  "codes": [{
    "system": "RxNorm",
    "code": "860975",
    "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
  }]
}
```

The following is an example of a MedicationEnd that ends a prescription for a medication, specified by the name of an attribute where a previous state assigned a value:
```json
{
  "type": "MedicationEnd",
  "referenced_by_attribute" : "InsulinMed1"
},
```

The following is an example of a MedicationEnd that ends a prescription for a medication, specified by the name of the `MedicationOrder` state where the medication was prescribed:
```json
{
  "type": "MedicationEnd",
  "medication_order" : "Bromocriptine_Start"
},
```



## Date

The `Date` condition type tests the current year being simulated.  For example, this may be used to drive different logic depending on the suggested medications or procedures of different time periods, or model different frequency of conditions.

**Supported Properties**

* **condition_type**: must be "Date" _(required)_
* **operator**: indicates how to compare the current year of simulation against the _year_.  Valid _operator_ values are: `<`, `<=`, `==`, `>=`, `>`, and `!=`. _(required)_
* **year**: the year to test the current year of simulation againt against _(required)_

**Example**

The following Date condition will return `true` if the year is 1990 or later.

```json
{
  "condition_type": "Year",
  "operator": ">=",
  "year": 1990
}
```



## Attribute

The `Attribute` condition type tests a named attribute on the patient entity.

**Supported Properties**

* **condition_type**: must be "Attribute" _(required)_
* **attribute**: the name of the attribute to test against _(required)_
* **operator**: indicates how to compare the actual attribute value against the value.  Valid _operator_ values are: `<`, `<=`, `==`, `>=`, `>`, `!=`, `is nil`, and `is not nil`. _(required)_
* **value**: the value to test the _attribute_ value against _(required, unless `operator` is `is nil` or `is not nil`)_

**Example**

The following Attribute condition will return `true` if attribute 'Opioid Prescription' on the patient is set to 'Vicodin'.

```json
{
  "condition_type": "Attribute",
  "attribute": "Opioid Prescription",
  "operator": "==",
  "value": "Vicodin"
}
```

The following Attribute condition will return `true` if attribute 'Opioid Prescription' on the patient has any value that is not nil.

```json
{
  "condition_type": "Attribute",
  "attribute": "Opioid Prescription",
  "operator": "is not nil"
}
```



![injuries](https://cloud.githubusercontent.com/assets/13512036/18723451/94ecdabc-8006-11e6-88ce-1c3208f11c70.png)
