### PR TITLE
adds Symptom state and symptom + priorState logic to GMF

### DIFF
--- a/lib/generic/logic.rb
+++ b/lib/generic/logic.rb
@@ -19,6 +19,10 @@ module Synthea
           self.testDate(condition, context, time, entity)
         when 'Attribute'
           self.testAttribute(condition, context, time, entity)
+        when 'Symptom'
+          self.testSymptom(condition, context, time, entity)
+        when 'PriorState'
+          self.testPriorState(condition, context, time, entity)
         when 'True'
           self.testTrue(condition, context, time, entity)
         when 'False'
@@ -72,6 +76,14 @@ module Synthea
 
       def self.testAttribute(condition, context, time, entity)
         self.compare(entity[ condition['attribute'] ], condition['value'], condition['operator'])
+      end
+
+      def self.testSymptom(condition, context, time, entity)
+        self.compare(entity.get_symptom_value(condition['symptom']), condition['value'], condition['operator'])
+      end
+
+      def self.testPriorState(condition, context, time, entity)
+        !(context.most_recent_by_name(condition['name']).nil?)
       end
 
       def self.testTrue(condition, context, time, entity)

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -291,6 +291,28 @@ module Synthea
         end
       end
 
+      class Symptom < State
+        def initialize (context, name)
+          super
+          cfg = context.state_config(name)
+          @symptom = cfg['symptom']
+          @cause = cfg['cause'] || context.config['name']
+          range = cfg['range']
+          exact = cfg['exact']
+          if range
+            @value = rand(range['low'] .. range['high'])
+          elsif exact
+            @value = exact['quantity']
+          else
+            raise 'Symptom state must specify value using either "range" or "exact"'
+          end
+        end
+
+        def process(time, entity)
+          entity.set_symptom_value(@cause, @symptom, @value)
+        end
+      end
+
       class Death < State
         def process(time, entity)
           entity[:is_alive] = false

--- a/test/fixtures/generic/logic.json
+++ b/test/fixtures/generic/logic.json
@@ -79,6 +79,18 @@
     "operator" : ">",
     "value" : 100
   },
+  "symptomPainLevelGt50" : {
+    "condition_type": "Symptom",
+    "symptom" : "PainLevel",
+    "operator" : ">",
+    "value" : 50
+  },
+  "symptomPainLevelLte80" : {
+    "condition_type": "Symptom",
+    "symptom" : "PainLevel",
+    "operator" : "<=",
+    "value" : 80
+  },
   "attributeNilTest" : {
     "condition_type" : "Attribute",
     "attribute" : "Test_Attribute_Key",
@@ -88,6 +100,10 @@
     "condition_type" : "Attribute",
     "attribute" : "Test_Attribute_Key",
     "operator" : "is not nil"
+  },
+  "priorStateDoctorVisitTest" : {
+    "condition_type": "PriorState",
+    "name" : "DoctorVisit"
   },
   "andAllTrueTest": {
     "condition_type": "And",

--- a/test/fixtures/generic/symptom.json
+++ b/test/fixtures/generic/symptom.json
@@ -1,0 +1,33 @@
+{
+  "name": "Symptom",
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "SymptomOnset"
+    },
+
+    "SymptomOnset" : {
+      "type" : "Symptom",
+      "symptom" : "Chest Pain",
+      "range" : {
+        "low" : 1,
+        "high" : 10
+      },
+      "direct_transition": "SymptomWorsen"
+    },
+
+    "SymptomWorsen" : {
+      "type" : "Symptom",
+      "symptom" : "Chest Pain",
+      "cause" : "Heart Attack",
+      "exact" : {
+        "quantity" : 96
+      },
+      "direct_transition": "Terminal"
+    },
+
+    "Terminal" : {
+      "type" : "Terminal"
+    }
+  }
+}

--- a/test/unit/generic_logic_test.rb
+++ b/test/unit/generic_logic_test.rb
@@ -150,6 +150,35 @@ class GenericLogicTest < Minitest::Test
     assert(do_test('attributeNotNilTest'))
   end
 
+  def test_symptoms
+    @patient.set_symptom_value('Appendicitis', 'PainLevel', 60)
+    assert(do_test('symptomPainLevelGt50'))
+    assert(do_test('symptomPainLevelLte80'))
+
+    @patient.set_symptom_value('Appendicitis', 'LackOfAppetite', 100) # painlevel still 60 here
+    assert(do_test('symptomPainLevelGt50'))
+    assert(do_test('symptomPainLevelLte80'))
+
+    @patient.set_symptom_value('Appendicitis', 'PainLevel', 10)
+    refute(do_test('symptomPainLevelGt50'))
+    assert(do_test('symptomPainLevelLte80'))
+
+    @patient.set_symptom_value('Appendicitis', 'PainLevel', 100)
+    assert(do_test('symptomPainLevelGt50'))
+    refute(do_test('symptomPainLevelLte80'))
+  end
+
+  def test_prior_state
+    # @context.history = [] # can't actually set this here, but we know it's true
+    refute(do_test('priorStateDoctorVisitTest'))
+
+    @context.history << Synthea::Generic::States::Simple.new(@context, "SomeOtherState")
+    refute(do_test('priorStateDoctorVisitTest'))
+
+    @context.history << Synthea::Generic::States::Simple.new(@context, "DoctorVisit")
+    assert(do_test('priorStateDoctorVisitTest'))
+  end
+
   def test_and_conditions
     assert(do_test('andAllTrueTest'))
     refute(do_test('andOneFalseTest'))

--- a/test/unit/generic_states_test.rb
+++ b/test/unit/generic_states_test.rb
@@ -464,6 +464,18 @@ class GenericStatesTest < Minitest::Test
     @patient.record_synthea.verify
   end
 
+  def test_symptoms
+    ctx = get_context('symptom.json')
+
+    symptom1 = Synthea::Generic::States::Symptom.new(ctx, "SymptomOnset")
+    assert(symptom1.process(@time, @patient))
+    assert_includes(1..10, @patient.get_symptom_value('Chest Pain'))
+
+    symptom2 = Synthea::Generic::States::Symptom.new(ctx, "SymptomWorsen")
+    assert(symptom2.process(@time, @patient))
+    assert_equal(96, @patient.get_symptom_value('Chest Pain'))
+  end
+
   def test_death
     # Setup a mock to track calls to the patient record
     @patient.record_synthea = MiniTest::Mock.new


### PR DESCRIPTION
Adds a new state type to add a Symptom to a patient, and logic based on Symptoms and prior states.
Symptoms use the existing Symptom API.  PriorState logic checks if a specific state is in the module's state history.


For the wiki:
(state)
## Symptom

The `Symptom` state type adds or updates a patient's symptom. Synthea tracks symptoms in order to drive a patient's encounters, on a scale of 1-100. A symptom may be tracked for multiple conditions, in these cases only the highest value is considered. See also the Symptom logic. (link here)


**Supported Properties**

* **type**: must be "Symptom" _(required)_
* **symptom**: the name of the symptom being tracked _(required)_
* **cause**: the underlying cause of the symptom. Defaults to the name of the module if not set. _(optional)_
* **exact**: an exact value to score this symptom _(required if `range` is not set)_
  * **quantity**: the score to set (e.g., 4) _(required)_
* **range**: a range indicating the allowable symptom values.  The actual value will be chosen randomly from the range. _(required if `exact` is not set)_
  * **low**: the lowest number (inclusive) allowed (e.g., 5) _(required)_
  * **high**: the highest number (inclusive) allowed (e.g., 7) _(required)_

**Examples**

The following is an example of a Symptom state that sets the symptom value for Chest Pain to be exactly 27.

```json
{
  "type": "Symptom",
  "symptom" : "Chest Pain",
  "cause" : "Asthma",
  "exact": {
    "quantity": 27
  }
}
```

The following is an example of a Symptom state that sets the symptom value for Chest Pain to be between 90 and 100.
```json
{
  "type": "Symptom",
  "symptom" : "Chest Pain",
  "cause" : "Heart Attack",
  "range": {
    "low": 90,
    "high": 100
  }
}
```


(logic)

## Symptom

The `Symptom` condition type tests a patient's current symptoms. Synthea tracks symptoms in order to drive a patient's encounters, on a scale of 1-100. A symptom may be tracked for multiple conditions, in these cases only the highest value is considered. See also the Symptom state. (link here)

**Supported Properties**

* **condition_type**: must be "Symptom" _(required)_
* **symptom**: the name of the symptom to test against. _(required)_
* **operator**: indicates how to compare the current symptom score against the _value_.  Valid _operator_ values are: `<`, `<=`, `==`, `>=`, `>`, and `!=`. _(required)_
* **value**: the value to test the current symptom score against _(required)_

**Example**

The following Symptom condition will return `true` if the patient's symptom score for "Chest Pain" is greater than or equal to 50

```json
{
  "condition_type": "Symptom",
  "symptom" : "Chest Pain",
  "operator": ">=",
  "value": 50
}
```

## PriorState

The `PriorState` condition type tests the progression of the patient through the module, and checks if a specific state has already been processed (in other words, the state is in the module's state history). 

**Supported Properties**

* **condition_type**: must be "PriorState" _(required)_
* **name**: the name of the state to check for in the module's history. _(required)_

**Example**

The following PriorState condition will return `true` if the patient has already passed through a state called 'EmergencyEncounter', false otherwise.

```json
{
  "condition_type" : "PriorState",
  "name" : "EmergencyEncounter"
}
```
