### PR TITLE
Set FHIR Condition status to active

### DIFF
--- a/lib/records/fhir.rb
+++ b/lib/records/fhir.rb
@@ -165,6 +165,7 @@ module Synthea
             }],
           },
           'verificationStatus' => 'confirmed',
+          'clinicalStatus' => 'active',
           'onsetDateTime' => convertFhirDateTime(condition['time'],'time'),
           'context' => {'reference'=>"#{encounter.fullUrl}"}
         })


### PR DESCRIPTION
Minor change that makes sure that exported FHIR Conditions have a clinicalStatus
of active.