### PR TITLE
adds graphviz graph generation as a rake task

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ PATH
       net-sftp
       pickup (~> 0.0.11, >= 0.0.11)
       recursive-open-struct (~> 1.0, >= 1.0.0)
+      ruby-graphviz
 
 GEM
   remote: https://rubygems.org/
@@ -99,6 +100,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
+    json (1.8.3-java)
     jwt (1.5.6)
     log4r (1.1.10)
     macaddr (1.7.1)
@@ -174,6 +176,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-graphviz (1.2.2)
     ruby-progressbar (1.8.1)
     rubyzip (0.9.9)
     simplecov (0.12.0)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ After generating data, upload it to a STU3 server
 bundle exec rake synthea:fhirupload[http://server/fhir/baseDstu3]
 ```
 
+### Synthea GraphViz
+Generate a graphical visualization of Synthea rules. Requires GraphViz to be installed.
+
+```
+brew install graphviz
+bundle exec rake synthea:graphviz
+```
+
 # License
 
 Copyright 2016 The MITRE Corporation

--- a/config/synthea.yml
+++ b/config/synthea.yml
@@ -141,3 +141,5 @@ synthea:
         bs_degree: [0.5, 1.0]
   generic:
     log: false
+  graphviz:
+    output: './output/graphviz/'

--- a/lib/modules/module.rb
+++ b/lib/modules/module.rb
@@ -18,19 +18,21 @@ module Synthea
       modules.each { |r| r.run(time, entity) }
     end
 
+    # rubocop:disable Style/ClassVars
     def self.modules
-      @modules ||= Synthea::Modules.constants.map { |m| "Synthea::Modules::#{m}".constantize.new }
+      @@modules ||= Synthea::Modules.constants.map { |m| "Synthea::Modules::#{m}".constantize.new }
     end
 
     def self.rule(name, inputs, outputs, &block)
-      @metadata ||= {}
-      @metadata[name] = {
+      @@metadata ||= {}
+      @@metadata[name] = {
         inputs: inputs,
         outputs: outputs,
         module_name: to_s.split('::').last
       }
       define_method "#{name}_rule".to_sym, block
     end
+    # rubocop:enable Style/ClassVars
 
     # Let Y be the original period risk (in our example 3650 days) and X be the time-step risk. The chance of an event not happening in 10 years is the
     # probability of the event not occuring every time step. (1-X)^(3650/time_step). Subtract this from 1 to get the

--- a/lib/synthea.rb
+++ b/lib/synthea.rb
@@ -19,6 +19,7 @@ require 'highline/import'
 require 'json'
 require 'concurrent'
 require 'chunky_png'
+require 'graphviz'
 
 root = File.expand_path '..', File.dirname(File.absolute_path(__FILE__))
 
@@ -68,6 +69,6 @@ Dir.glob(File.join(root, 'lib', 'world', '**', '*.rb')).each do |file|
   require file
 end
 
-Dir.glob(File.join(root, 'lib', 'likelihoods', '**', '*.rb')).each do |file|
+Dir.glob(File.join(root, 'lib', 'tasks', '**', '*.rb')).each do |file|
   require file
 end

--- a/lib/tasks/graphviz.rb
+++ b/lib/tasks/graphviz.rb
@@ -1,0 +1,275 @@
+module Synthea
+  module Tasks
+    class Graphviz
+
+      # color (true) or black & white (false)
+      COLOR = true
+
+      def self.generate_graphs
+        folder = Synthea::Config.graphviz.output
+        FileUtils.mkdir_p folder unless File.exists? folder
+
+        puts "Rendering graphs to `#{folder}` folder..."
+        generateRulesBasedGraph()
+        generateWorkflowBasedGraphs()
+        puts 'Done.'
+      end
+
+      def self.generateRulesBasedGraph()
+        # Create a new graph
+        g = GraphViz.new( :G, :type => :digraph )
+
+        # Create the list of items
+        items = []
+        modules = {}
+        Synthea::Rules.metadata.each do |key,rule|
+          items << key
+          items << rule[:inputs]
+          items << rule[:outputs]
+          modules[ rule[:module_name] ] = true
+        end
+        items = items.flatten.uniq
+
+        # Choose a color for each module
+        # available_colors = GraphViz::Utils::Colors::COLORS.keys
+        available_colors = ['palevioletred','orange','lightgoldenrod','palegreen','lightblue','lavender','purple']
+        modules.keys.each_with_index do |key,index|
+          modules[key] = available_colors[index]
+        end
+        attribute_color = 'grey'
+
+        # Create a node for each item
+        nodes = {}
+        items.each{|i|nodes[i]=g.add_node(i.to_s)}
+
+        # Make items that are not rules boxes
+        components = nodes.keys - Synthea::Rules.metadata.keys
+        components.each do |i|
+          nodes[i]['shape']='Box'
+          if COLOR
+            nodes[i]['color']=attribute_color
+            nodes[i]['style']='filled'
+          end
+        end
+
+        # Create the edges
+        edges = []
+
+        Synthea::Rules.metadata.each do |key,rule|
+          node = nodes[key]
+          if COLOR
+            node['color'] = modules[rule[:module_name]]
+            node['style'] = 'filled'
+          end
+          begin
+            rule[:inputs].each do |input|
+              other = nodes[input]
+              if !edges.include?("#{input}:#{key}")
+                g.add_edge( other, node)
+                edges << "#{input}:#{key}"
+              end
+            end
+            rule[:outputs].each do |output|
+              other = nodes[output]
+              if !edges.include?("#{key}:#{output}")
+                g.add_edge( node, other)
+                edges << "#{key}:#{output}"
+              end
+            end
+          rescue Exception => e
+            binding.pry
+          end
+        end
+
+        # Generate output image
+        g.output( :png => File.join(Synthea::Config.graphviz.output, 'synthea_rules.png') )
+      end
+
+      def self.generateWorkflowBasedGraphs()
+        Dir.glob('../synthea/lib/generic/modules/*.json') do |wf_file|
+          # Create a new graph
+          g = GraphViz.new( :G, :type => :digraph )
+          wf = JSON.parse(File.read(wf_file))
+          populate_graph(g, wf)
+
+          # Generate output image
+          g.output( :png => File.join(Synthea::Config.graphviz.output, "#{wf['name']}.png") )
+        end
+      end
+
+      def self.populate_graph(g, wf)
+        # Create nodes based on states
+        nodeMap = {}
+        
+        wf['states'].each do |name, state|
+          node = g.add_nodes(name, {'shape'=> 'record', 'style'=> 'rounded'})
+          details = ''
+          case state['type']
+          when 'Initial', 'Terminal'
+            node['color'] = 'black'
+            node['style'] = 'rounded,filled'
+            node['fontcolor'] = 'white'
+          when 'Guard'
+            details = "Allow if " + logicDetails(state['allow'])
+          when 'Delay', 'Death'
+            if state.has_key? 'range'
+              r = state['range']
+              details = "#{r['low']} - #{r['high']} #{r['unit']}"
+            elsif state.has_key? 'exact'
+              e = state['exact']
+              details = "#{e['quantity']} #{e['unit']}"
+            end 
+          when 'Encounter'
+            if state['wellness']
+              details = 'Wait for regularly scheduled wellness encounter'
+            end
+          when 'SetAttribute'
+            v = state['value']
+            details = "Set '#{state['attribute']}' = #{v ? "'#{v}'" : 'nil'}"
+          when 'Symptom'
+            s = state['symptom']
+            if state.has_key? 'range'
+              r = state['range']
+              details = "#{s}: #{r['low']} - #{r['high']}"
+            elsif state.has_key? 'exact'
+              e = state['exact']
+              details = "#{s}: #{e['quantity']}"
+            end
+          when 'Observation'
+            unit = state['unit']
+            if state.has_key? 'range'
+              r = state['range']
+              details = "#{r['low']} - #{r['high']} #{unit}\\l"
+            elsif state.has_key? 'exact'
+              e = state['exact']
+              details = "#{e['quantity']} #{unit}\\l"
+            end
+          end
+
+          # Things common to many states
+          if state.has_key? 'codes'
+            state['codes'].each do |code|
+              details = details + code['system'] + "[" + code['code'] + "]: " + code['display'] + "\\l"
+            end
+          end
+          if state.has_key? 'target_encounter'
+            verb = 'Perform'
+            case state['type']
+            when 'ConditionOnset'
+              verb = 'Diagnose'
+            when 'MedicationOrder'
+              verb = 'Prescribe'
+            end
+            details = details + verb + " at " + state['target_encounter'] + "\\l"
+          end
+          if state.has_key? 'reason'
+            details = details + "Reason: " + state['reason'] + "\\l"
+          end
+          if state.has_key? 'medication_order'
+            details = details + "Prescribed at: #{state['medication_order']}\\l"
+          end
+          if state.has_key? 'assign_to_attribute'
+            details = details + "Assign to Attribute: '#{state['assign_to_attribute']}'\\l"
+          end
+          if state.has_key? 'referenced_by_attribute'
+            details = details + "Referenced By Attribute: '#{state['referenced_by_attribute']}'\\l"
+          end
+          if details.empty?
+            node['label'] = (name == state['type']) ? name : "{ #{name} | #{state['type']} }"
+          else
+            node['label'] = "{ #{name} | { #{state['type']} | #{details} } }"
+          end
+          nodeMap[name] = node
+        end
+
+        # Create the edges based on the transitions
+        wf['states'].each do |name, state|
+          if state.has_key? 'direct_transition'
+            begin
+              g.add_edges( nodeMap[name], nodeMap[state['direct_transition']] )
+            rescue
+              puts "State '#{name}' is transitioning to an unknown state: '#{state['direct_transition']}'"
+            end
+          elsif state.has_key? 'distributed_transition'
+            state['distributed_transition'].each do |t|
+              pct = t['distribution'] * 100
+              pct = pct.to_i if pct == pct.to_i
+              begin
+                g.add_edges( nodeMap[name], nodeMap[t['transition']], {'label'=> "#{pct}%"})
+              rescue
+                puts "State '#{name}' is transitioning to an unknown state: '#{t['transition']}'"
+              end
+            end
+          elsif state.has_key? 'conditional_transition'
+            state['conditional_transition'].each_with_index do |t,i|
+              cnd = t.has_key?('condition') ? logicDetails(t['condition']) : 'else'
+              begin
+                g.add_edges( nodeMap[name], nodeMap[t['transition']], {'label'=> "#{i+1}. #{cnd}"})
+              rescue
+                puts "State '#{name}' is transitioning to an unknown state: '#{t['transition']}'"
+              end
+            end
+          elsif state.has_key? 'complex_transition'
+            transitions = Hash.new() { |hsh, key| hsh[key] = [] }
+
+            state['complex_transition'].each do |t|
+              cond = t.has_key?('condition') ? logicDetails(t['condition']) : 'else'
+              t['distributions'].each do |dist|
+                pct = dist['distribution'] * 100
+                pct = pct.to_i if pct == pct.to_i
+                nodes = [name, dist['transition']]
+                transitions[nodes] << "#{cond}: #{pct}%"
+              end
+            end
+
+            transitions.each do |nodes, labels|
+              begin
+                g.add_edges( nodeMap[nodes[0]], nodeMap[nodes[1]], {'label'=> labels.join(',\n')})
+              rescue
+                puts "State '#{nodes[0]}' is transitioning to an unknown state: '#{nodes[1]}'"
+              end
+            end
+          end
+        end
+      end
+
+      def self.logicDetails(logic)
+        case logic['condition_type']
+        when 'And', 'Or'
+          subs = logic['conditions'].map do |c|
+            if ['And','Or'].include?(c['condition_type'])
+              "(\\l" + logicDetails(c) + ")\\l"
+            else 
+              logicDetails(c)
+            end
+          end
+          subs.join(logic['condition_type'].downcase + ' ')
+        when 'Not'
+          c = logic['condition']
+          if ['And','Or'].include?(c['condition_type'])
+            "not (\\l" + logicDetails(c) + ")\\l"
+          else
+            "not " + logicDetails(c)
+          end
+        when 'Gender'
+          "gender is '#{logic['gender']}'\\l"
+        when 'Age'
+          "age \\#{logic['operator']} #{logic['quantity']} #{logic['unit']}\\l"
+        when 'Socioeconomic Status'
+          "#{logic['category']} Socioeconomic Status\\l"
+        when 'Date'
+          "Year is \\#{logic['operator']} #{logic['year']}\\l"
+        when 'Symptom'
+          "Symptom: '#{logic['symptom']}' \\#{logic['operator']} #{logic['value']}\\l"
+        when 'PriorState'
+          "state '#{logic['name']}' has been processed\\l"
+        when 'Attribute'
+          "Attribute: '#{logic['attribute']}' \\#{logic['operator']} #{logic['value']}\\l"
+        else
+          "UNSUPPORTED_CONDITION(#{logic['condition_type']})\\l"
+        end
+      end
+
+    end
+  end
+end

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -9,6 +9,11 @@ namespace :synthea do
     fingerprint.save('fingerprint_sample.png')
   end
 
+  desc 'generate rule visualization'
+  task :graphviz, [] do |t, args|
+    Synthea::Tasks::Graphviz.generate_graphs
+  end
+
   desc 'generate'
   task :generate, [] do |_t, _args|
     start = Time.now

--- a/synthea.gemspec
+++ b/synthea.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'highline'
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'chunky_png'
+  s.add_runtime_dependency 'ruby-graphviz'
 end


### PR DESCRIPTION
Migrates synthea_graphviz into synthea proper as a rake task. Graphviz is required to run the new `graphviz` rake task, but not for any other tasks, i.e. `generate` and `sequential` still work without graphviz installed