### PR TITLE
Lung cancer

### DIFF
--- a/lib/entity/entity.rb
+++ b/lib/entity/entity.rb
@@ -34,7 +34,7 @@ module Synthea
     end
 
     def alive?(time=nil)
-      !had_event?(:death,time)
+      event(:birth) && !had_event?(:death,time)
     end
 
     #-----------------------------------------------------------------------

--- a/lib/entity/entity.rb
+++ b/lib/entity/entity.rb
@@ -21,9 +21,9 @@ module Synthea
       @attributes[name] = value
     end
 
-    def had_event?(type,time=nil)
+    def had_event?(type, time = nil)
       if time
-        !@events.before(time,type).empty?
+        !@events.before(time, type).empty?
       else
         @events.events.key?(type)
       end
@@ -33,8 +33,8 @@ module Synthea
       @events.events[type].try(:last)
     end
 
-    def alive?(time=nil)
-      event(:birth) && !had_event?(:death,time)
+    def alive?(time = nil)
+      event(:birth) && !had_event?(:death, time)
     end
 
     #-----------------------------------------------------------------------

--- a/lib/entity/entity.rb
+++ b/lib/entity/entity.rb
@@ -21,12 +21,20 @@ module Synthea
       @attributes[name] = value
     end
 
-    def had_event?(type)
-      @events.events.key?(type)
+    def had_event?(type,time=nil)
+      if time
+        !@events.before(time,type).empty?
+      else
+        @events.events.key?(type)
+      end
     end
 
     def event(type)
       @events.events[type].try(:last)
+    end
+
+    def alive?(time=nil)
+      !had_event?(:death,time)
     end
 
     #-----------------------------------------------------------------------

--- a/lib/generic/logic.rb
+++ b/lib/generic/logic.rb
@@ -71,7 +71,8 @@ module Synthea
       end
 
       def self.test_attribute(condition, _context, _time, entity)
-        compare(entity[condition['attribute']], condition['value'], condition['operator'])
+        attribute = entity[condition['attribute']] || entity[condition['attribute'].to_sym]
+        compare(attribute, condition['value'], condition['operator'])
       end
 
       def self.test_symptom(condition, _context, _time, entity)

--- a/lib/generic/modules/lung_cancer.json
+++ b/lib/generic/modules/lung_cancer.json
@@ -1,0 +1,794 @@
+{
+  "name": "Lung Cancer",
+  "remarks": [
+    "Most of the data for this module was synthesized from two primary sources:",
+    "1. The comprehensive pages starting at http://www.cancer.org/cancer/lungcancer/index",
+    "2. The Cancer Care Ontario Pathway Maps at https://www.cancercare.on.ca/ocs/qpi/dispathmgmt/pathways/lung_cancer_pathway_map/",
+    "Some data statistics came from:",
+    "3. The American Lung Association Lung Cancer Fact Sheet @ http://www.lung.org/lung-health-and-diseases/lung-disease-lookup/lung-cancer/learn-about-lung-cancer/lung-cancer-fact-sheet.html",
+    "4. https://www.verywell.com/what-percentage-of-smokers-get-lung-cancer-2248868",
+    "5. Life Expectancies: http://www.healthcommunities.com/lung-cancer/prognosis.shtml"
+  ],
+  "states": {
+
+    "Initial": {
+      "type" : "Initial",
+      "direct_transition" : "Ages_45_65"
+    },
+
+    "Ages_45_65": {
+      "type": "Delay",
+      "range": {
+        "low": 45,
+        "high": 65,
+        "unit": "years"
+      },
+      "direct_transition": "Lung Cancer Probabilities",
+      "remarks": [
+        "Lung cancer mainly occurs in older people. About 2 out of 3 people diagnosed with lung cancer are 65 or older, while less than 2% are younger than 45. The average age at the time of diagnosis is about 70.",
+        "http://www.cancer.org/cancer/lungcancer-non-smallcell/detailedguide/non-small-cell-lung-cancer-key-statistics"
+      ]
+    },
+
+    "Lung Cancer Probabilities": {
+      "type": "Simple",
+      "complex_transition": [
+        {
+          "condition": {
+            "condition_type": "And",
+            "conditions": [
+              { "condition_type": "Gender", "gender": "M" },
+              { "condition_type": "Attribute", "attribute": "smoker", "operator": "==", "value": false }
+            ]
+          },
+          "distributions": [
+            { "distribution": 0.002, "transition": "Cough" },
+            { "distribution": 0.998, "transition": "Terminal" }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "And",
+            "conditions": [
+              { "condition_type": "Gender", "gender": "M" },
+              { "condition_type": "Attribute", "attribute": "smoker", "operator": "==", "value": true }
+            ]
+          },
+          "distributions": [
+            { "distribution": 0.244, "transition": "Cough" },
+            { "distribution": 0.766, "transition": "Terminal" }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "And",
+            "conditions": [
+              { "condition_type": "Gender", "gender": "F" },
+              { "condition_type": "Attribute", "attribute": "smoker", "operator": "==", "value": false }
+            ]
+          },
+          "distributions": [
+            { "distribution": 0.004, "transition": "Cough" },
+            { "distribution": 0.996, "transition": "Terminal" }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "And",
+            "conditions": [
+              { "condition_type": "Gender", "gender": "F" },
+              { "condition_type": "Attribute", "attribute": "smoker", "operator": "==", "value": true }
+            ]
+          },
+          "distributions": [
+            { "distribution": 0.185, "transition": "Cough" },
+            { "distribution": 0.815, "transition": "Terminal" }
+          ]
+        }
+      ],
+      "remarks": [
+        "Overall, the chance that a man will develop lung cancer in his lifetime is about 1 in 14; for a woman, the risk is about 1 in 17.",
+        "http://www.cancer.org/cancer/lungcancer-non-smallcell/detailedguide/non-small-cell-lung-cancer-key-statistics",
+        "Men who smoke are 23 times more likely to develop lung cancer. Women are 13 times more likely, compared to never smokers.",
+        "http://www.lung.org/lung-health-and-diseases/lung-disease-lookup/lung-cancer/learn-about-lung-cancer/lung-cancer-fact-sheet.html",
+        "In a 2006 European study, the risk of developing lung cancer was: 0.2 percent for men who never smoked (0.4% for women); 5.5 percent of male former smokers (2.6% in women); 15.9 percent of current male smokers (9.5% for women); 24.4 percent for male “heavy smokers” defined as smoking more than 5 cigarettes per day (18.5 percent for women)",
+        "https://www.verywell.com/what-percentage-of-smokers-get-lung-cancer-2248868"
+      ]
+    },
+
+    "Cough": {
+      "type" : "Symptom",
+      "symptom": "Cough",
+      "range": { "low": 50, "high": 100},
+      "direct_transition": "Chest Pain"
+    },
+
+    "Chest Pain": {
+      "type" : "Symptom",
+      "symptom": "Chest Pain",
+      "range": { "low": 50, "high": 100},
+      "direct_transition": "Suspected Lung Cancer"
+    },
+
+    "Suspected Lung Cancer": {
+      "type": "ConditionOnset",
+      "target_encounter": "Diagnosis Encounter I",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "162573006",
+        "display": "Suspected lung cancer (situation)"
+      }],
+      "assign_to_attribute": "Suspected Lung Cancer",
+      "direct_transition": "Diagnosis Encounter I"
+    },
+
+    "Diagnosis Encounter I": {
+      "type": "Encounter",
+      "class": "emergency",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "50849002",
+        "display": "Emergency Room Admission"
+      }],
+      "direct_transition": "Chest X-Ray"
+    },
+
+    "Chest X-Ray": {
+      "type": "Procedure",
+      "target_encounter": "Diagnosis Encounter I",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "399208008",
+        "display": "Plain chest X-ray (procedure)"
+      }],
+      "direct_transition": "Schedule Follow Up I"
+    },
+
+    "Schedule Follow Up I": {
+      "type": "Delay",
+      "range": {
+        "low": 2,
+        "high": 9,
+        "unit": "days"
+      },
+      "direct_transition": "Diagnosis Encounter II"
+    },
+
+    "Diagnosis Encounter II": {
+      "type": "Encounter",
+      "class": "outpatient",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "185347001",
+        "display": "Encounter for problem"
+      }],
+      "direct_transition": "Chest CT Scan"
+    },
+
+    "Chest CT Scan": {
+      "type": "Procedure",
+      "target_encounter": "Diagnosis Encounter II",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "418891003",
+        "display": "Computed tomography of chest and abdomen"
+      }],
+      "reason": "Suspected Lung Cancer",
+      "direct_transition": "Schedule Follow Up II"
+    },
+
+    "Schedule Follow Up II": {
+      "type": "Delay",
+      "range": {
+        "low": 1,
+        "high": 9,
+        "unit": "days"
+      },
+      "distributed_transition": [
+        { "distribution": 0.85, "transition": "Non-Small Cell Lung Cancer"},
+        { "distribution": 0.15, "transition": "Small Cell Lung Cancer"}
+      ],
+      "remarks": [
+        "About 85% of lung cancers are non-small cell lung cancers.",
+        "About 10%-15% of lung cancers are small cell lung cancers.",
+        "http://www.cancer.org/cancer/lungcancer/index"
+      ]
+    },
+
+    "Non-Small Cell Lung Cancer": {
+      "type": "SetAttribute",
+      "attribute": "Lung Cancer Type",
+      "value": "NSCLC",
+      "direct_transition": "NSCLC"
+    },
+
+    "NSCLC": {
+      "type": "ConditionOnset",
+      "target_encounter": "Diagnosis Encounter III",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "254637007",
+        "display": "Non-small cell lung cancer (disorder)"
+      }],
+      "assign_to_attribute": "Lung Cancer",
+      "direct_transition": "Diagnosis Encounter III"
+    },
+
+    "Small Cell Lung Cancer": {
+      "type": "SetAttribute",
+      "attribute": "Lung Cancer Type",
+      "value": "SCLC",
+      "direct_transition": "SCLC"
+    },
+
+    "SCLC": {
+      "type": "ConditionOnset",
+      "target_encounter": "Diagnosis Encounter III",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "254632001",
+        "display": "Small cell carcinoma of lung (disorder)"
+      }],
+      "assign_to_attribute": "Lung Cancer",
+      "direct_transition": "Diagnosis Encounter III"
+    },
+
+    "Diagnosis Encounter III": {
+      "type": "Encounter",
+      "class": "outpatient",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "185347001",
+        "display": "Encounter for problem"
+      }],
+      "distributed_transition": [
+        { "distribution": 0.25, "transition": "Sputum Cytology (Phelgm)"},
+        { "distribution": 0.25, "transition": "Thoracentesis (Fluid)"},
+        { "distribution": 0.25, "transition": "Needle Biopsy (Cells)"},
+        { "distribution": 0.25, "transition": "Bronchoscopy (Tube)"}
+      ]
+    },
+
+    "Sputum Cytology (Phelgm)": {
+      "type": "Procedure",
+      "target_encounter": "Diagnosis Encounter III",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "167995008",
+        "display": "Sputum microscopy (procedure)"
+      }],
+      "reason": "Suspected Lung Cancer",
+      "direct_transition": "Schedule Follow Up III"
+    },
+
+    "Thoracentesis (Fluid)": {
+      "type": "Procedure",
+      "target_encounter": "Diagnosis Encounter III",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "91602002",
+        "display": "Thoracentesis (procedure)"
+      }],
+      "reason": "Suspected Lung Cancer",
+      "direct_transition": "Schedule Follow Up III"
+    },
+
+    "Needle Biopsy (Cells)": {
+      "type": "Procedure",
+      "target_encounter": "Diagnosis Encounter III",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "432231006",
+        "display": "Fine needle aspiration biopsy of lung (procedure)"
+      }],
+      "reason": "Suspected Lung Cancer",
+      "direct_transition": "Schedule Follow Up III"
+    },
+
+    "Bronchoscopy (Tube)": {
+      "type": "Procedure",
+      "target_encounter": "Diagnosis Encounter III",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "173160006",
+        "display": "Diagnostic fiberoptic bronchoscopy (procedure)"
+      }],
+      "reason": "Suspected Lung Cancer",
+      "direct_transition": "Schedule Follow Up III"
+    },
+
+    "Schedule Follow Up III": {
+      "type": "Delay",
+      "range": {
+        "low": 1,
+        "high": 3,
+        "unit": "days"
+      },
+      "complex_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "Lung Cancer Type",
+            "operator": "==",
+            "value": "NSCLC"
+          },
+          "distributions": [
+            { "distribution": 0.19, "transition": "Stage I"},
+            { "distribution": 0.12, "transition": "Stage II"},
+            { "distribution": 0.12, "transition": "Stage III"},
+            { "distribution": 0.55, "transition": "Stage IV"}
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "Lung Cancer Type",
+            "operator": "==",
+            "value": "SCLC"
+          },
+          "distributions": [
+            { "distribution": 0.04, "transition": "Stage I"},
+            { "distribution": 0.10, "transition": "Stage II"},
+            { "distribution": 0.10, "transition": "Stage III"},
+            { "distribution": 0.74, "transition": "Stage IV"}
+          ]
+        }        
+      ],
+      "remarks": [
+        "See Stage Distribution (%) 2006-2012, Case Counts and Percentages",
+        "http://seer.cancer.gov/csr/1975_2013/browse_csr.php?sectionSEL=15&pageSEL=sect_15_table.14.html",
+        "http://seer.cancer.gov/csr/1975_2013/browse_csr.php?sectionSEL=15&pageSEL=sect_15_table.13.html",
+        "only 15 percent of lung cancer cases are diagnosed at an early stage.",
+        "http://www.lung.org/lung-health-and-diseases/lung-disease-lookup/lung-cancer/learn-about-lung-cancer/lung-cancer-fact-sheet.html"
+      ]
+    },
+
+    "Stage I": {
+      "type": "Death",
+      "range": {
+        "low": 2,
+        "high": 6,
+        "unit": "years"
+      },
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "Lung Cancer Type",
+            "operator": "==",
+            "value": "SCLC"
+          },
+          "transition": "SCLC I"
+        },{
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "Lung Cancer Type",
+            "operator": "==",
+            "value": "NSCLC"
+          },
+          "transition": "NSCLC I"
+        }
+      ]
+    },
+
+    "Stage II": {
+      "type": "Death",
+      "range": {
+        "low": 16,
+        "high": 28,
+        "unit": "months"
+      },
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "Lung Cancer Type",
+            "operator": "==",
+            "value": "SCLC"
+          },
+          "transition": "SCLC II"
+        },{
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "Lung Cancer Type",
+            "operator": "==",
+            "value": "NSCLC"
+          },
+          "transition": "NSCLC II"
+        }
+      ]
+    },
+
+    "Stage III": {
+      "type": "Death",
+      "range": {
+        "low": 9,
+        "high": 18,
+        "unit": "months"
+      },
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "Lung Cancer Type",
+            "operator": "==",
+            "value": "SCLC"
+          },
+          "transition": "SCLC III"
+        },{
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "Lung Cancer Type",
+            "operator": "==",
+            "value": "NSCLC"
+          },
+          "transition": "NSCLC III"
+        }
+      ]
+    }, 
+
+    "Stage IV": {
+      "type": "Death",
+      "range": {
+        "low": 6,
+        "high": 10,
+        "unit": "months"
+      },
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "Lung Cancer Type",
+            "operator": "==",
+            "value": "SCLC"
+          },
+          "transition": "SCLC IV"
+        },{
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "Lung Cancer Type",
+            "operator": "==",
+            "value": "NSCLC"
+          },
+          "transition": "NSCLC IV"
+        }
+      ]
+    },
+
+    "NSCLC I": {
+      "type": "ConditionOnset",
+      "target_encounter": "Diagnosis Encounter IV",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "424132000",
+        "display": "Non-small cell carcinoma of lung, TNM stage 1 (disorder)"
+      }],
+      "assign_to_attribute": "Lung Cancer Condition",
+      "direct_transition": "Diagnosis Encounter IV"
+    },
+
+    "NSCLC II": {
+      "type": "ConditionOnset",
+      "target_encounter": "Diagnosis Encounter IV",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "425048006",
+        "display": "Non-small cell carcinoma of lung, TNM stage 2 (disorder)"
+      }],
+      "assign_to_attribute": "Lung Cancer Condition",
+      "direct_transition": "Diagnosis Encounter IV"
+    },
+
+    "NSCLC III": {
+      "type": "ConditionOnset",
+      "target_encounter": "Diagnosis Encounter IV",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "422968005",
+        "display": "Non-small cell carcinoma of lung, TNM stage 3 (disorder)"
+      }],
+      "assign_to_attribute": "Lung Cancer Condition",
+      "direct_transition": "Diagnosis Encounter IV"
+    },
+
+    "NSCLC IV": {
+      "type": "ConditionOnset",
+      "target_encounter": "Diagnosis Encounter IV",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "423121009",
+        "display": "Non-small cell carcinoma of lung, TNM stage 4 (disorder)"
+      }],
+      "assign_to_attribute": "Lung Cancer Condition",
+      "direct_transition": "Diagnosis Encounter IV"
+    },
+
+    "SCLC I": {
+      "type": "ConditionOnset",
+      "target_encounter": "Diagnosis Encounter IV",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "67811000119102",
+        "display": "Primary small cell malignant neoplasm of lung, TNM stage 1 (disorder)"
+      }],
+      "assign_to_attribute": "Lung Cancer Condition",
+      "direct_transition": "Diagnosis Encounter IV"
+    },
+
+    "SCLC II": {
+      "type": "ConditionOnset",
+      "target_encounter": "Diagnosis Encounter IV",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "67821000119109",
+        "display": "Primary small cell malignant neoplasm of lung, TNM stage 2 (disorder)"
+      }],
+      "assign_to_attribute": "Lung Cancer Condition",
+      "direct_transition": "Diagnosis Encounter IV"
+    },
+
+    "SCLC III": {
+      "type": "ConditionOnset",
+      "target_encounter": "Diagnosis Encounter IV",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "67831000119107",
+        "display": "Primary small cell malignant neoplasm of lung, TNM stage 3 (disorder)"
+      }],
+      "assign_to_attribute": "Lung Cancer Condition",
+      "direct_transition": "Diagnosis Encounter IV"
+    },
+
+    "SCLC IV": {
+      "type": "ConditionOnset",
+      "target_encounter": "Diagnosis Encounter IV",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "67841000119103",
+        "display": "Primary small cell malignant neoplasm of lung, TNM stage 4 (disorder)"
+      }],
+      "assign_to_attribute": "Lung Cancer Condition",
+      "direct_transition": "Diagnosis Encounter IV"
+    },
+
+    "Diagnosis Encounter IV": {
+      "type": "Encounter",
+      "class": "outpatient",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "185347001",
+        "display": "Encounter for problem"
+      }],
+      "direct_transition": "MRI Brain"
+    },
+
+    "MRI Brain": {
+      "type": "Procedure",
+      "target_encounter": "Diagnosis Encounter IV",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "698354004",
+        "display": "Magnetic resonance imaging for measurement of brain volume (procedure)"
+      }],
+      "reason": "Lung Cancer Condition",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "Lung Cancer Type",
+            "operator": "==",
+            "value": "SCLC"
+          },
+          "transition": "SCLC Treatment Path"
+        },{
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "Lung Cancer Type",
+            "operator": "==",
+            "value": "NSCLC"
+          },
+          "transition": "NSCLC Treatment Path"
+        }
+      ]
+    },
+
+    "SCLC Treatment Path": {
+      "type": "Simple",
+      "direct_transition": "SCLC Treatment Encounter"
+    },
+
+    "SCLC Treatment Encounter": {
+      "type": "Encounter",
+      "class": "inpatient",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "185347001",
+        "display": "Encounter for problem"
+      }],
+      "direct_transition": "SCLC Chemotheraphy I",
+      "remarks": [
+        "TODO: This inpatient encounter should last 5 days, not the standard 15 minutes."
+      ]   
+    },
+
+    "SCLC Chemotheraphy I": {
+      "type": "MedicationOrder",
+      "target_encounter": "SCLC Treatment Encounter",
+      "codes": [{
+        "system": "RxNorm",
+        "code": "1736854",
+        "display": "Cisplatin 50 MG Injection"
+      }],
+      "reason": "Lung Cancer Condition",
+      "assign_to_attribute": "chemotherapy1",
+      "direct_transition": "SCLC Chemotheraphy IB",
+      "remarks": [
+        "SCLC is generally treated with combinations of chemotherapy drugs. The combinations most often used are: Cisplatin and etoposide",
+        "http://www.cancer.org/cancer/lungcancer-smallcell/detailedguide/small-cell-lung-cancer-treating-chemotherapy"
+      ]
+    },
+
+    "SCLC Chemotheraphy IB": {
+      "type": "MedicationEnd",
+      "referenced_by_attribute": "chemotherapy1",
+      "direct_transition": "SCLC Chemotheraphy II"
+    },
+
+    "SCLC Chemotheraphy II": {
+      "type": "MedicationOrder",
+      "target_encounter": "SCLC Treatment Encounter",
+      "codes": [{
+        "system": "RxNorm",
+        "code": "1734340",
+        "display": "Etoposide 100 MG Injection"
+      }],
+      "reason": "Lung Cancer Condition",
+      "assign_to_attribute": "chemotherapy2",
+      "direct_transition": "SCLC Chemotheraphy IIB",
+      "remarks": [
+        "SCLC is generally treated with combinations of chemotherapy drugs. The combinations most often used are: Cisplatin and etoposide",
+        "http://www.cancer.org/cancer/lungcancer-smallcell/detailedguide/small-cell-lung-cancer-treating-chemotherapy"
+      ]
+    },
+
+    "SCLC Chemotheraphy IIB": {
+      "type": "MedicationEnd",
+      "referenced_by_attribute": "chemotherapy2",
+      "direct_transition": "SCLC Radiation"
+    },
+
+    "SCLC Radiation": {
+      "type": "Procedure",
+      "target_encounter": "SCLC Treatment Encounter",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "703423002",
+        "display": "Combined chemotherapy and radiation therapy (procedure)"
+      }],
+      "reason": "Lung Cancer Condition",
+      "direct_transition": "SCLC Treatment Delay",
+      "remarks": [
+        "The type of radiation therapy most often used to treat SCLC is called external beam radiation therapy (EBRT).",
+        "http://www.cancer.org/cancer/lungcancer-smallcell/detailedguide/small-cell-lung-cancer-treating-radiation-therapy"
+      ]
+    },
+
+    "SCLC Treatment Delay": {
+      "type": "Delay",
+      "range": {
+        "low": 21,
+        "high": 28,
+        "unit": "days"
+      },
+      "direct_transition": "SCLC Treatment Path",
+      "remarks": [
+        "Doctors give chemo in cycles, with a period of treatment (usually 1 to 3 days) followed by a rest period to allow your body time to recover. Each cycle generally lasts about 3 to 4 weeks",
+        "http://www.cancer.org/cancer/lungcancer-smallcell/detailedguide/small-cell-lung-cancer-treating-chemotherapy",
+        "Most often, radiation as part of the initial treatment for SCLC is given once or twice daily, 5 days a week, for 3 to 7 weeks.",
+        "http://www.cancer.org/cancer/lungcancer-smallcell/detailedguide/small-cell-lung-cancer-treating-radiation-therapy"
+      ]
+    },
+
+    "NSCLC Treatment Path": {
+      "type": "Simple",
+      "direct_transition": "NSCLC Treatment Encounter"
+    },
+
+    "NSCLC Treatment Encounter": {
+      "type": "Encounter",
+      "class": "inpatient",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "185347001",
+        "display": "Encounter for problem"
+      }],
+      "direct_transition": "NSCLC Chemotheraphy I",
+      "remarks": [
+        "TODO: This inpatient encounter should last 5 days, not the standard 15 minutes."
+      ]   
+    },
+
+    "NSCLC Chemotheraphy I": {
+      "type": "MedicationOrder",
+      "target_encounter": "NSCLC Treatment Encounter",
+      "codes": [{
+        "system": "RxNorm",
+        "code": "1736854",
+        "display": "Cisplatin 50 MG Injection"
+      }],
+      "reason": "Lung Cancer Condition",
+      "assign_to_attribute": "chemotherapy1",
+      "direct_transition": "NSCLC Chemotheraphy IB",
+      "remarks": [
+        "Most often, treatment for NSCLC uses a combination of 2 chemo drugs.",
+        "If a combination is used, it often includes cisplatin or carboplatin plus one other drug",
+        "http://www.cancer.org/cancer/lungcancer-non-smallcell/detailedguide/non-small-cell-lung-cancer-treating-chemotherapy"
+      ]
+    },
+
+    "NSCLC Chemotheraphy IB": {
+      "type": "MedicationEnd",
+      "referenced_by_attribute": "chemotherapy1",
+      "direct_transition": "NSCLC Chemotheraphy II"
+    },
+
+    "NSCLC Chemotheraphy II": {
+      "type": "MedicationOrder",
+      "target_encounter": "NSCLC Treatment Encounter",
+      "codes": [{
+        "system": "RxNorm",
+        "code": "583214",
+        "display": "PACLitaxel 100 MG Injection"
+      }],
+      "reason": "Lung Cancer Condition",
+      "assign_to_attribute": "chemotherapy2",
+      "direct_transition": "NSCLC Chemotheraphy IIB",
+      "remarks": [
+        "The chemo drugs most often used for NSCLC include ... Paclitaxel (Taxol)",
+        "http://www.cancer.org/cancer/lungcancer-non-smallcell/detailedguide/non-small-cell-lung-cancer-treating-chemotherapy"
+      ]
+    },
+
+    "NSCLC Chemotheraphy IIB": {
+      "type": "MedicationEnd",
+      "referenced_by_attribute": "chemotherapy2",
+      "direct_transition": "NSCLC Radiation"
+    },
+
+    "NSCLC Radiation": {
+      "type": "Procedure",
+      "target_encounter": "NSCLC Treatment Encounter",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "703423002",
+        "display": "Combined chemotherapy and radiation therapy (procedure)"
+      }],
+      "reason": "Lung Cancer Condition",
+      "direct_transition": "NSCLC Treatment Delay",
+      "remarks": [
+        "External beam radiation therapy (EBRT) focuses radiation from outside the body on the cancer. This is the type of radiation therapy most often used to treat NSCLC or its spread to other organs.",
+        "http://www.cancer.org/cancer/lungcancer-non-smallcell/detailedguide/non-small-cell-lung-cancer-treating-radiation-therapy"
+      ]
+    },
+
+    "NSCLC Treatment Delay": {
+      "type": "Delay",
+      "range": {
+        "low": 28,
+        "high": 35,
+        "unit": "days"
+      },
+      "direct_transition": "NSCLC Treatment Path",
+      "remarks": [
+        "Doctors give chemo in cycles, with a period of treatment (usually 1 to 3 days) followed by a rest period to allow the body time to recover. Some chemo drugs, though, are given every day. Chemo cycles generally last about 3 to 4 weeks.",
+        "http://www.cancer.org/cancer/lungcancer-non-smallcell/detailedguide/non-small-cell-lung-cancer-treating-radiation-therapy",
+        "Most often, radiation treatments to the lungs are given 5 days a week for 5 to 7 weeks",
+        "http://www.cancer.org/cancer/lungcancer-non-smallcell/detailedguide/non-small-cell-lung-cancer-treating-radiation-therapy"
+      ]
+    },
+
+    "Terminal": {
+      "type" : "Terminal"
+    }
+  }
+}

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -355,16 +355,14 @@ module Synthea
           super
           cfg = context.state_config(name)
           @range = cfg['range']
-          if @range.nil?
-            @exact = cfg['exact']
-          end
+          @exact = cfg['exact'] if @range.nil?
         end
 
         def process(time, entity)
           if @range
-            value = rand(@range['low'] .. @range['high']).method(@range['unit']).call().since(time)
+            value = rand(@range['low']..@range['high']).method(@range['unit']).call.since(time)
           elsif @exact
-            value = @exact['quantity'].method(@exact['unit']).call().since(time)
+            value = @exact['quantity'].method(@exact['unit']).call.since(time)
           end
           if value
             # Record the future death... if there is a condition with a known life-expectancy
@@ -378,7 +376,6 @@ module Synthea
           true
         end
       end
-
     end
   end
 end

--- a/lib/modules/cardiovascular_disease.rb
+++ b/lib/modules/cardiovascular_disease.rb
@@ -170,7 +170,6 @@ module Synthea
           # survival rate triples if a bystander is present
           survival_rate *= 3 if rand < Synthea::Config.cardiovascular.chd.bystander
           if rand > survival_rate
-            entity[:is_alive] = false
             entity.events.create(time, :death, :coronary_heart_disease, true)
             Synthea::Modules::Lifecycle.record_death(entity, time)
           end
@@ -189,7 +188,6 @@ module Synthea
           survival_rate *= 3 if rand < Synthea::Config.cardiovascular.chd.bystander
           annual_death_risk = 1 - survival_rate
           if rand < Synthea::Rules.convert_risk_to_timestep(annual_death_risk, 365)
-            entity[:is_alive] = false
             entity.events.create(time, :death, :no_coronary_heart_disease, true)
             Synthea::Modules::Lifecycle.record_death(entity, time)
           end
@@ -342,7 +340,6 @@ module Synthea
           entity.events.create(time + 10.minutes, :emergency_encounter, :get_stroke)
           Synthea::Modules::Encounters.emergency_visit(time + 15.minutes, entity)
           if rand < Synthea::Config.cardiovascular.stroke.death
-            entity[:is_alive] = false
             entity.events.create(time, :death, :get_stroke, true)
             Synthea::Modules::Lifecycle.record_death(entity, time)
           end
@@ -433,11 +430,10 @@ module Synthea
 
         if entity[:cardiovascular_procedures]
           entity[:cardiovascular_procedures].each do |reason, procedures|
-            reason_code = COND_LOOKUP[reason][:codes]['SNOMED-CT'][0]
             procedures.each do |proc|
               unless entity.record_synthea.present[proc]
                 # TODO: assumes a procedure will only be performed once, might need to be revisited
-                entity.record_synthea.procedure(proc, time, reason_code, :procedure, :procedure)
+                entity.record_synthea.procedure(proc, time, reason, :procedure, :procedure)
               end
             end
           end
@@ -471,8 +467,7 @@ module Synthea
           end
 
           emergency_procedures[diagnosis].each do |proc|
-            reason_code = COND_LOOKUP[diagnosis][:codes]['SNOMED-CT'][0]
-            entity.record_synthea.procedure(proc, time, reason_code, :procedure, :procedure)
+            entity.record_synthea.procedure(proc, time, diagnosis, :procedure, :procedure)
           end
 
           history_conditions[diagnosis].each do |cond|

--- a/lib/modules/encounters.rb
+++ b/lib/modules/encounters.rb
@@ -3,7 +3,7 @@ module Synthea
     class Encounters < Synthea::Rules
       # People have encounters
       rule :schedule_encounter, [:age], [:encounter] do |time, entity|
-        if entity[:is_alive]
+        if entity.alive?(time)
           unprocessed_events = entity.events.unprocessed_before(time, :encounter_ordered)
           unprocessed_events.each do |event|
             entity.events.process(event)
@@ -42,7 +42,7 @@ module Synthea
       end
 
       rule :encounter, [], [:schedule_encounter, :observations, :lab_results, :diagnoses, :immunizations] do |time, entity|
-        if entity[:is_alive]
+        if entity.alive?(time)
           unprocessed_events = entity.events.unprocessed_before(time, :encounter)
           unprocessed_events.each do |event|
             entity.events.process(event)
@@ -63,7 +63,7 @@ module Synthea
 
       # Sometimes people schedule encounters because they're experiencing symptoms
       rule :symptoms_cause_encounter, [:symptoms, :tracked_symptoms], [:encounter, :symptoms_cause_encounter] do |time, entity|
-        if entity[:is_alive]
+        if entity.alive?(time)
           unprocessed_events = entity.events.unprocessed_before(time, :symptoms_cause_encounter)
           unprocessed_events.each do |event|
             entity.events.process(event)

--- a/lib/modules/generic.rb
+++ b/lib/modules/generic.rb
@@ -25,6 +25,14 @@ module Synthea
 
       #-----------------------------------------------------------------------#
 
+      def self.log_modules(entity)
+        if entity && Synthea::Config.generic.log
+          entity[:generic].each do |key,context|
+            context.log_history if context.logged.nil?
+          end
+        end
+      end
+
       def self.perform_wellness_encounter(entity, time)
         return if entity[:generic].nil?
 

--- a/lib/modules/generic.rb
+++ b/lib/modules/generic.rb
@@ -14,7 +14,7 @@ module Synthea
 
       # this rule loops through the generic modules, processing one at a time
       rule :generic, [:generic], [:generic, :death] do |time, entity|
-        return unless entity[:is_alive]
+        return unless entity.alive?(time)
 
         entity[:generic] ||= {}
         @gmodules.each do |m|

--- a/lib/modules/generic.rb
+++ b/lib/modules/generic.rb
@@ -27,7 +27,7 @@ module Synthea
 
       def self.log_modules(entity)
         if entity && Synthea::Config.generic.log
-          entity[:generic].each do |key,context|
+          entity[:generic].each do |_key, context|
             context.log_history if context.logged.nil?
           end
         end

--- a/lib/modules/metabolic_syndrome.rb
+++ b/lib/modules/metabolic_syndrome.rb
@@ -224,7 +224,6 @@ module Synthea
                                             end
           # see if the disease progresses another stage...
           if rand < (0.0001 * diabetes[:severity])
-            entity[:is_alive] = false
             entity.events.create(time, :death, :end_stage_renal_disease, true)
             Synthea::Modules::Lifecycle.record_death(entity, time)
           end
@@ -511,9 +510,8 @@ module Synthea
         amputations.each do |amputation|
           amp_str = amputation.to_s
           key = "amputation_#{amp_str}".to_sym
-          reason_code = '368581000119106'
           unless entity.record_synthea.present[key]
-            entity.record_synthea.procedure(key, time, reason_code, :procedure, :procedure)
+            entity.record_synthea.procedure(key, time, :neuropathy, :procedure, :procedure)
           end
 
           body_part = amp_str.split('_')[1]

--- a/lib/records/ccda.rb
+++ b/lib/records/ccda.rb
@@ -58,7 +58,7 @@ module Synthea
         # patient.effective_time
         patient.race = { 'name' => entity[:race].to_s.capitalize, 'code' => RACE_ETHNICITY_CODES[entity[:race]] }
         patient.ethnicity = { 'name' => entity[:ethnicity].to_s.capitalize, 'code' => RACE_ETHNICITY_CODES[entity[:ethnicity]] }
-        unless entity[:is_alive]
+        unless entity.alive?
           patient.deathdate = entity.record_synthea.patient_info[:deathdate].to_i
           patient.expired = true
         end

--- a/lib/records/fhir.rb
+++ b/lib/records/fhir.rb
@@ -264,7 +264,7 @@ module Synthea
       def self.procedure(procedure, fhir_record, patient, encounter)
         if procedure['reason']
           reason_code = COND_LOOKUP[procedure['reason']][:codes]['SNOMED-CT'][0]
-          reason = fhir_record.entry.find{ |e| e.resource.is_a?(FHIR::Condition) && e.resource.code.coding.find{ |c| c.code == reason_code } }
+          reason = fhir_record.entry.find { |e| e.resource.is_a?(FHIR::Condition) && e.resource.code.coding.find { |c| c.code == reason_code } }
         end
         proc_data = PROCEDURE_LOOKUP[procedure['type']]
         fhir_procedure = FHIR::Procedure.new('subject' => { 'reference' => patient.fullUrl.to_s },

--- a/lib/world/population.rb
+++ b/lib/world/population.rb
@@ -34,7 +34,7 @@ module Synthea
       end
 
       def handle_time_step
-        died = @people.select { |p| p.had_event?(:death) }
+        died = @people.select { |p| p.had_event?(:death, @data) }
         @people -= died
         @dead += died
         @births += @birth_rate.births

--- a/lib/world/sequential.rb
+++ b/lib/world/sequential.rb
@@ -169,11 +169,10 @@ module Synthea
 
         person = Synthea::Person.new
         options.each { |k, v| person[k] = v }
-        while !person.had_event?(:death) && date <= @end_date
+        while !person.had_event?(:death, date) && date <= @end_date
           date += @time_step.days
           Synthea::Rules.apply(date, person)
         end
-
         person
       end
 
@@ -187,6 +186,7 @@ module Synthea
         conditions << 'Opioid Addict' if addict
         conditions << 'Diabetic' if patient[:diabetes]
         conditions << 'Heart Disease' if patient[:coronary_heart_disease]
+        conditions << 'Lung Cancer' if patient['Lung Cancer Type']
         conditions
       end
 

--- a/lib/world/sequential.rb
+++ b/lib/world/sequential.rb
@@ -173,6 +173,7 @@ module Synthea
           date += @time_step.days
           Synthea::Rules.apply(date, person)
         end
+        Synthea::Modules::Generic.log_modules(person)
         person
       end
 

--- a/test/fixtures/generic/death_life_expectancy.json
+++ b/test/fixtures/generic/death_life_expectancy.json
@@ -1,0 +1,39 @@
+{
+    "name": "Death",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "Death"
+        },
+        "Death": {
+            "type": "Death",
+            "range": {
+                "low": 4,
+                "high": 5,
+                "unit": "months"
+            },
+            "direct_transition": "Continue"
+        },
+        "Continue": {
+            "type": "SetAttribute",
+            "attribute": "processing",
+            "value": true,
+            "direct_transition": "Delay"
+        },
+        "Delay": {
+            "type": "Delay",
+            "range": {
+                "low": 9,
+                "high": 10,
+                "unit": "days"
+            },
+            "direct_transition": "Continue II"
+        },
+        "Continue II": {
+            "type": "SetAttribute",
+            "attribute": "still_processing",
+            "value": true,
+            "direct_transition": "Continue"
+        }
+    }
+}

--- a/test/unit/exporter_test.rb
+++ b/test/unit/exporter_test.rb
@@ -10,7 +10,6 @@ class ExporterTest < Minitest::Test
     @patient[:gender] = 'F'
     @patient.events.create(@time - 35.years, :birth, :birth)
     @patient[:age] = 35
-    @patient[:is_alive] = true
     @patient[:city] = 'Bedford'
     @record = @patient.record_synthea
     @record.patient_info[:uuid] = '1234'

--- a/test/unit/fhir_test.rb
+++ b/test/unit/fhir_test.rb
@@ -16,7 +16,6 @@ class FhirTest < Minitest::Test
     @patient[:birth_place] = { 'city' => 'Bedford','state' => 'MA', }
     @patient[:race] = :white
     @patient[:ethnicity] = :italian
-    @patient[:is_alive] = true
     @patient[:coordinates_address] = GeoRuby::SimpleFeatures::Point.from_x_y(10,15)
     @fhir_record = FHIR::Bundle.new
     @time = Time.now
@@ -32,14 +31,14 @@ class FhirTest < Minitest::Test
     record = @patient.record_synthea
     record.encounter(:age_lt_11, @time)
     record.condition(:prediabetes, @time, :condition, nil)
-    record.procedure(:amputation_left_hand, @time, '46028000', :procedure, nil)
+    record.procedure(:amputation_left_hand, @time, :diabetes, :procedure, nil)
     record.immunization(:rv_mono, @time, :immunization, nil)
     record.observation(:ha1c, @time, 5, :observation, nil)
     record.end_condition(:prediabetes, @time + 10.minutes)
     time_adv = @time + 15.minutes
     record.encounter(:age_lt_11, time_adv)
     record.condition(:diabetes, time_adv, :condition, nil)
-    record.procedure(:amputation_right_leg, time_adv, '79733001', :procedure, nil)
+    record.procedure(:amputation_right_leg, time_adv, :diabetes, :procedure, nil)
     record.immunization(:dtap, time_adv, :immunization, nil)
     record.observation(:height, time_adv, 5, :observation, nil)
 
@@ -222,7 +221,7 @@ class FhirTest < Minitest::Test
   def test_procedure
     condition = {'type' => :nephropathy, 'time' => @time}
     Synthea::Output::FhirRecord.condition(condition, @fhir_record, @patient_entry, @encounter_entry)
-    proc_hash = { 'type' => :amputation_left_arm , 'time' => @time, 'reason' => '368581000119106'}
+    proc_hash = { 'type' => :amputation_left_arm , 'time' => @time, 'reason' => :nephropathy}
     Synthea::Output::FhirRecord.procedure(proc_hash, @fhir_record, @patient_entry, @encounter_entry)
     proc_entry = @fhir_record.entry.reverse.find {|e| e.resource.is_a?(FHIR::Procedure)}
     procedure  = proc_entry.resource

--- a/test/unit/generic/appendicitis_test.rb
+++ b/test/unit/generic/appendicitis_test.rb
@@ -7,7 +7,6 @@ class AppendicitisTest < Minitest::Test
     @patient[:gender] = 'F'
     @patient.events.create(@time - 35.years, :birth, :birth)
     @patient[:age] = 35
-    @patient[:is_alive] = true
     # Setup a mock to track calls to the patient record
     @patient.record_synthea = MiniTest::Mock.new
 

--- a/test/unit/generic_context_test.rb
+++ b/test/unit/generic_context_test.rb
@@ -8,7 +8,6 @@ class GenericContextTest < Minitest::Test
     @patient[:gender] = 'F'
     @patient.events.create(@time - 35.years, :birth, :birth)
     @patient[:age] = 35
-    @patient[:is_alive] = true
   end
 
   def test_direct_transition

--- a/test/unit/generic_logic_test.rb
+++ b/test/unit/generic_logic_test.rb
@@ -6,7 +6,6 @@ class GenericLogicTest < Minitest::Test
     @time = Time.now
     @patient = Synthea::Person.new
     @patient[:gender] = 'F'
-    @patient[:is_alive] = true
     @context = Synthea::Generic::Context.new({
       "name" => "Logic",
       "states" => {


### PR DESCRIPTION
This pull request adds lung cancer to the list of disease's simulated.

I made a number of associated changes, including 

- Altering Procedures so they reference the associated Condition correctly for both generic modules and the original Ruby modules.
- Checking attributes in generic modules will check both strings (e.g. `'foo'`) and symbols (e.g. `:foo`)
- Replaced the `:is_alive` attribute with a more intelligent `alive?(time = nil)` method, so you can see if a patient is alive at a given time. Time `nil` is interpreted as "there has not been a death event in the past or in the future."
- Death state allows future deaths. For example, "you have X months to live given stage IV lung cancer." The patient may continue to receive chemotherapy and radiation treatments in the meantime... but ultimately, they are going to die.

Here is the graphviz rendering of the lung cancer module:

![lung cancer](https://cloud.githubusercontent.com/assets/1054765/18991779/a89ad01c-86e8-11e6-9f86-994037397dc9.png)

Changes required for the wiki:

## Death

The `Death` state type indicates a point in the module at which the patient dies or the patient is given a terminal diagnosis (e.g. "you have 3 months to live").  When the Death state is processed, the patient's death is immediately recorded (e.g. the `alive?` method will return `false`) unless `range` or `exact` attributes are specified, in which case the patient will die sometime in the future.  In either case the module will continue to progress to the next state(s) for the current time-step.  Typically, the Death state should transition to a `Terminal` state.

**Implementation Warning**

If a `Death` state is processed after a `Delay`, it may cause inconsistencies in the record.  This is because the `Delay` implementation must _rewind_ time to correctly honor the requested delay duration.  If it rewinds time, and then the patient dies at the rewinded time, then any modules that were processed before the generic module may have created events and records with a timestamp _after_ the patient's death.

**Supported Properties**

* **type**: must be "Death" _(required)_
* **exact**: an exact amount of time left to live _(optional)_
  * **quantity**: the number of _units_ left to live (e.g., 4) _(required)_
  * **unit**: the unit of time pertaining to the _quantity_ (e.g., "days").  Valid _unit_ values are: `years`, `months`, `weeks`, `days`, `hours`, `minutes`, and `seconds`. _(required)_
* **range**: a range indicating the allowable amounts of remaining life.  The actual time will be chosen randomly from the range. _(optional)_
  * **low**: the lowest number (inclusive) of _units_ to live (e.g., 5) _(required)_
  * **high**: the highest number (inclusive) of _units_ to live (e.g., 7) _(required)_
  * **unit**: the unit of time pertaining to the _range_ (e.g., "days").  Valid _unit_ values are: `years`, `months`, `weeks`, `days`, `hours`, `minutes`, and `seconds`. _(required)_

**Example**

The following example is an immediate death.

```json
{
  "type": "Death"
}
```

This example gives the patient 3 - 5 months to live.

```json
{
    "type": "Death",
    "range": {
        "low": 3,
        "high": 5,
        "unit": "months"
    }
}
```