### PR TITLE
Condition end

### DIFF
--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -197,6 +197,31 @@ module Synthea
         end
       end
 
+      class ConditionEnd < State
+        def initialize(context, name)
+          super
+          cfg = context.state_config(name)
+          @referenced_by = cfg['referenced_by_attribute']
+          @condition_onset = cfg['condition_onset']
+          @codes = cfg['codes']
+        end
+
+        def process(time, entity)
+          if @referenced_by
+            @type = entity[@referenced_by].to_sym
+          elsif @condition_onset
+            @type = @context.most_recent_by_name(@condition_onset).symbol
+          elsif @codes
+            @type = symbol
+          else
+            raise 'Condition End must define the condition to end either by code, a referenced entity attribute, or the name of the original ConditionOnset state'
+          end
+
+          entity.record_synthea.end_condition(@type, time)
+          true
+        end
+      end
+
       class MedicationOrder < State
         attr_reader :prescribed, :target_encounter
 

--- a/test/fixtures/generic/condition_end.json
+++ b/test/fixtures/generic/condition_end.json
@@ -1,0 +1,75 @@
+{
+	"name" : "Condition End",
+  "states" : {
+    "Initial" : {
+      "type" : "Initial",
+      "direct_transition" : "Condition1_Start"
+    },
+
+    "Condition1_Start" : {
+      "type" : "ConditionOnset",
+      "target_encounter" : "DiagnosisEncounter",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "228380004",
+        "display" : "Chases the dragon (finding)"
+      }],
+      "assign_to_attribute" : "Drug Use Behavior",
+      "direct_transition" : "Condition2_Start"
+    },
+
+    "Condition2_Start" : {
+      "type" : "ConditionOnset",
+      "target_encounter" : "DiagnosisEncounter",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "6142004",
+        "display" : "Influenza"
+      }],
+      "direct_transition" : "Condition3_Start"
+    },
+
+    "Condition3_Start" : {
+      "type" : "ConditionOnset",
+      "target_encounter" : "DiagnosisEncounter",
+      "codes": [{
+          "system": "SNOMED-CT",
+          "code": "73211009",
+          "display": "Diabetes mellitus"
+      }],
+      "direct_transition" : "DiagnosisEncounter"
+    },
+
+    "DiagnosisEncounter" : {
+      "type" : "Encounter",
+      "wellness" : true,
+      "direct_transition" : "Condition1_End"
+    },
+
+    "Condition1_End" : {
+      "type" : "ConditionEnd",
+      "referenced_by_attribute" : "Drug Use Behavior",
+      "direct_transition" : "Condition2_End"
+    },
+
+    "Condition2_End" : {
+      "type" : "ConditionEnd",
+      "condition_onset" : "Condition2_Start",
+      "direct_transition" : "Condition3_End"
+    },
+
+    "Condition3_End" : {
+      "type" : "ConditionEnd",
+      "codes": [{
+          "system": "SNOMED-CT",
+          "code": "73211009",
+          "display": "Diabetes mellitus"
+      }],
+      "direct_transition" : "Terminal"
+    },
+
+    "Terminal" : {
+      "type" : "Terminal"
+    }
+  }
+}

--- a/test/unit/graphviz_test.rb
+++ b/test/unit/graphviz_test.rb
@@ -1,0 +1,44 @@
+require_relative '../test_helper'
+
+class GraphvizTest < Minitest::Test
+  def test_all_modules
+    Dir.glob('../synthea/lib/generic/modules/*.json') do |wf_file|
+      wf = JSON.parse(File.read(wf_file))
+
+      wf['states'].each do |name, state|
+        generic_state_test(state)
+      end
+    end
+
+    Dir.glob('../synthea/test/fixtures/generic/*.json') do |wf_file|
+      if wf_file == '../synthea/test/fixtures/generic/logic.json' # logic.json has only conditions, not real states
+        logic = JSON.parse(File.read(wf_file))
+        logic.each do |name, condition|
+          generic_logic_test(condition)
+        end
+      else
+        wf = JSON.parse(File.read(wf_file))
+        wf['states'].each do |name, state|
+          generic_state_test(state)
+        end
+      end
+    end
+  end
+
+  def generic_state_test(state)
+    description = Synthea::Tasks::Graphviz.state_description(state)
+    refute(description.empty?, "Description should not be empty for a #{state['type']} state") unless %w(Simple Initial Terminal Death).include?(state['type'])
+
+    transitions = state['conditional_transition'] || state['complex_transition']
+    return if transitions.nil?
+
+    transitions.each do |t|
+       generic_logic_test(t['condition']) if t.has_key?('condition')
+    end
+  end
+
+  def generic_logic_test(condition)
+    logic = Synthea::Tasks::Graphviz.logicDetails(condition)
+    pass # assertion that the logicDetails didn't raise an exception
+  end
+end


### PR DESCRIPTION
Adds a ConditionEnd state to end conditions, basically identical to the MedicationEnd state in that it can end conditions based on codes, the name of a previous state, or as referenced by an attribute.

Also includes some graphviz changes so it's easier to unit test. The new graphviz test should fail if we add a new state type or condition type somewhere but forget to update graphviz. The test case should not depend on graphviz being installed.

For the Wiki:

## ConditionEnd

The `ConditionEnd` state type indicates a point in the module where a currently active condition should be ended. (ex., if the patient has been cured of a disease) The `ConditionEnd` state supports three ways of specifying the condition to end:
1. By `codes[]`, specifying the code system, code, and display name of the condition to end, or
2. By `condition_onset`, specifying the name of the `ConditionOnset` state in which the condition was onset, or
3. By `referenced_by_attribute`, specifying the name of the Attribute in which a previous `ConditionOnset` state assigned a condition.

**Supported Properties**

* **type**: must be "ConditionEnd" _(required)_
* **codes[]**: a list of codes indicating the condition_(optional, required if neither `condition_onset` nor `referenced_by_attribute` is set)_
  * **system**: the code system.  Currently, only `SNOMED-CT` is allowed. _(required)_
  * **code**: the code _(required)_
  * **display**: the human-readable code description _(required)_
* **condition_onset**: the name of the `ConditionOnset` state in which the condition was acquired_(optional, required if neither `codes[]` nor `referenced_by_attribute` is set)_
* **referenced_by_attribute**: the name of the Attribute in which a previous `ConditionOnset` state assigned a medication _(optional, required if neither `condition_onset` nor `codes[]` is set)_

**Example**

The following is an example of a ConditionEnd that ends the condition Influenza,  specified by code:

```json
{
  "type": "ConditionEnd",
  "codes": [{
      "system" : "SNOMED-CT",
      "code" : "6142004",
      "display" : "Influenza"
  }]
}
```

The following is an example of a ConditionEnd that ends a condition, specified by the name of an attribute where a previous state assigned a value:
```json
{
  "type": "ConditionEnd",
  "referenced_by_attribute" : "Diagnosis3"
},
```

The following is an example of a ConditionEnd that ends a condition, specified by the name of the `ConditionOnset` state where the condition was acquired:
```json
{
  "type": "ConditionEnd",
  "condition_onset" : "Pre_Diabetes"
},
```