### PR TITLE
Observation + condition logic

### DIFF
--- a/lib/generic/logic.rb
+++ b/lib/generic/logic.rb
@@ -81,7 +81,7 @@ module Synthea
         end
       end
 
-      def self.test_condition(condition, _context, _time, entity)
+      def self.test_active_condition(condition, _context, _time, entity)
         # return true if the given condition is currently active
         contype = if condition['codes']
                     # based on state.symbol

--- a/lib/tasks/graphviz.rb
+++ b/lib/tasks/graphviz.rb
@@ -277,6 +277,28 @@ module Synthea
           "state '#{logic['name']}' has been processed\\l"
         when 'Attribute'
           "Attribute: '#{logic['attribute']}' \\#{logic['operator']} #{logic['value']}\\l"
+        when 'Observation'
+          obs = ''
+          if logic['codes']
+            code = logic['codes'].first
+            cond = "'#{code['system']} [#{code['code']}]: #{code['display']}'"
+          elsif logic['referenced_by_attribute']
+            cond = "Referenced By Attribute: '#{logic['referenced_by_attribute']}'"
+          else
+            raise 'Observation condition must be specified by code or attribute'
+          end
+          "Observation #{obs} \\#{logic['operator']} #{logic['value']}\\l"
+        when 'Condition'
+          cond = ''
+          if logic['codes']
+            code = logic['codes'].first
+            cond = "'#{code['system']} [#{code['code']}]: #{code['display']}'"
+          elsif logic['referenced_by_attribute']
+            cond = "Referenced By Attribute: '#{logic['referenced_by_attribute']}'"
+          else
+            raise 'Condition condition must be specified by code or attribute'
+          end
+          "Condition #{cond} is active\\l"
         when 'True', 'False'
           logic['condition_type']
         else

--- a/lib/tasks/graphviz.rb
+++ b/lib/tasks/graphviz.rb
@@ -288,7 +288,7 @@ module Synthea
             raise 'Observation condition must be specified by code or attribute'
           end
           "Observation #{obs} \\#{logic['operator']} #{logic['value']}\\l"
-        when 'Condition'
+        when 'Active Condition'
           cond = ''
           if logic['codes']
             code = logic['codes'].first

--- a/test/fixtures/generic/logic.json
+++ b/test/fixtures/generic/logic.json
@@ -107,7 +107,7 @@
     "operator" : "is not nil"
   },
   "diabetesConditionTest" : {
-    "condition_type" : "Condition",
+    "condition_type" : "Active Condition",
     "codes": [{
         "system": "SNOMED-CT",
         "code": "73211009",
@@ -115,7 +115,7 @@
     }]
   },
   "alzheimersConditionTest" : {
-    "condition_type" : "Condition",
+    "condition_type" : "Active Condition",
     "referenced_by_attribute" : "Alzheimer's Variant"
   },
   "attributeNilTest" : {

--- a/test/fixtures/generic/logic.json
+++ b/test/fixtures/generic/logic.json
@@ -91,6 +91,33 @@
     "operator" : "<=",
     "value" : 80
   },
+  "mmseObservationGt22" : {
+    "condition_type" : "Observation",
+    "codes" : [{
+      "system" : "LOINC",
+      "code" : "72107-6",
+      "display" : "Mini Mental State Examination"
+    }],
+    "operator" : ">",
+    "value" : 22
+  },
+  "hasDiabetesObservation" : {
+    "condition_type" : "Observation",
+    "referenced_by_attribute" : "Diabetes Test Performed",
+    "operator" : "is not nil"
+  },
+  "diabetesConditionTest" : {
+    "condition_type" : "Condition",
+    "codes": [{
+        "system": "SNOMED-CT",
+        "code": "73211009",
+        "display": "Diabetes mellitus"
+    }]
+  },
+  "alzheimersConditionTest" : {
+    "condition_type" : "Condition",
+    "referenced_by_attribute" : "Alzheimer's Variant"
+  },
   "attributeNilTest" : {
     "condition_type" : "Attribute",
     "attribute" : "Test_Attribute_Key",


### PR DESCRIPTION
Adds logic based on Observations (compare the most recent observation of a certain type against a given value) and Conditions (check if a given condition is active)

for the wiki:

## Observation

The `Observation` condition type tests the most recent observation of a given type against a given value. 

**Implementation Warnings**

* Synthea does not support conversion between arbitrary units, so all observations of a given type are expected to be made in the same units. 
* The given observation must have been recorded prior to performing this logical check, unless the `operator` is `is nil` or `is not nil`. Otherwise, the GMF will raise an exception that the observation value cannot be compared as there has been no observation made.

**Supported Properties**

* **condition_type**: must be "Observation" _(required)_
* **codes[]**: a list of codes indicating the observation(optional, required if `referenced_by_attribute` is not set)_
  * **system**: the code system.  Currently, only `LOINC` is allowed. _(required)_
  * **code**: the code _(required)_
  * **display**: the human-readable code description _(required)_
* **referenced_by_attribute**: the name of the Attribute in which a previous `Observation` state recorded an observation _(optional, required if `codes[]` is not set)_
* **operator**: indicates how to compare the actual attribute value against the value.  Valid _operator_ values are: `<`, `<=`, `==`, `>=`, `>`, `!=`, `is nil`, and `is not nil`. _(required)_
* **value**: the value to test the most recent observation value against _(required, unless `operator` is `is nil` or `is not nil`)_

**Example**

The following Observation condition will return `true` if the most recent Observation for LOINC '72107-6' [Mini Mental State Examination] on the patient has a value greater than 22.

```json
{
    "condition_type" : "Observation",
    "codes" : [{
      "system" : "LOINC",
      "code" : "72107-6",
      "display" : "Mini Mental State Examination"
    }],
    "operator" : ">",
    "value" : 22
}
```

The following Observation condition will return `true` if the most recent Observation referenced by the attribute 'Diabetes Test Performed' on the patient has any value that is not nil. In other words, if any observation has been made and stored in attribute 'Diabetes Test Performed', this condition will return `true`.

```json
{
    "condition_type" : "Observation",
    "referenced_by_attribute" : "Diabetes Test Performed",
    "operator" : "is not nil"
}
```



## Active Condition

The `Active Condition` condition type tests whether a given condition is currently diagnosed and active on the patient. 


**Future Implementation Considerations**

Currently to check if a condition has been added but not diagnosed, it is possible to use the [PriorState](#priorstate) condition to check if the state has been processed. In the future it may be preferable to add a distinct "Present Condition" logical condition to clearly specify the intent of looking for a present but not diagnosed condition.

**Supported Properties**

* **condition_type**: must be "Active Condition" _(required)_
* **codes[]**: a list of codes indicating the condition (optional, required if `referenced_by_attribute` is not set)_
  * **system**: the code system.  Currently, only `SNOMED-CT` is allowed. _(required)_
  * **code**: the code _(required)_
  * **display**: the human-readable code description _(required)_
* **referenced_by_attribute**: the name of the Attribute in which a previous `ConditionOnset` state added a condition _(optional, required if `codes[]` is not set)_


**Example**

The following Active Condition condition will return `true` if the patient currently has an active diagnosis of SNOMED-CT 73211009 [Diabetes mellitus].

```json
{
    "condition_type" : "Active Condition",
    "codes": [{
        "system": "SNOMED-CT",
        "code": "73211009",
        "display": "Diabetes mellitus"
    }]
}
```

The following Active Conditon condition will return `true` if the condition referenced by the attribute "Alzheimer's Variant" on the patient is currently active. In other words, if any condition has onset and is stored in attribute "Alzheimer's Variant", this condition will return `true`.

```json
{
    "condition_type" : "Active Condition",
    "referenced_by_attribute" : "Alzheimer's Variant"
}
```