### PR TITLE
new default output folder structure

### DIFF
--- a/config/synthea.yml
+++ b/config/synthea.yml
@@ -10,8 +10,8 @@ synthea:
       export: true
     years_of_history: 5
     location: './output/'  # should either start with . for relative path or / for absolute
-    folder_per_city: true
-    subfolder_by_id: true # if true, creates subfolders based on the patient guid. this reduces the # of files in any single folder
+    folder_per_city: false
+    subfolders_by_id_substring: true # if true, creates subfolders based on the first characters of the patient guid. this reduces the # of files in any single folder
   start_date: <%= Time.now - 100.years %>
   end_date: <%= Time.now - 1.day %>
   time_step: 7 # days

--- a/lib/records/exporter.rb
+++ b/lib/records/exporter.rb
@@ -46,9 +46,13 @@ module Synthea
         if patient
           dirs << patient[:city] if Synthea::Config.exporter.folder_per_city
 
-          # take the first 2 characters of the patient uuid for subfolders
-          # uuid = hex so this gives us 256 subfolders
-          dirs << patient.record_synthea.patient_info[:uuid][0, 2] if Synthea::Config.exporter.subfolder_by_id
+          # take the first 2+3 characters of the patient uuid for subfolders
+          # uuid = hex so this gives us 256 subfolders, each with 16 sub-subfolders
+          if Synthea::Config.exporter.subfolders_by_id_substring
+            uuid = patient.record_synthea.patient_info[:uuid]
+            dirs << uuid[0, 2]
+            dirs << uuid[0, 3]
+          end
         end
 
         folder = File.join(*dirs)

--- a/test/unit/exporter_test.rb
+++ b/test/unit/exporter_test.rb
@@ -125,7 +125,7 @@ class ExporterTest < Minitest::Test
 
   def test_output_file_location_single_dir
     Synthea::Config.exporter.folder_per_city = false
-    Synthea::Config.exporter.subfolder_by_id = false
+    Synthea::Config.exporter.subfolders_by_id_substring = false
 
     assert_equal './output/fhir', Synthea::Output::Exporter.get_output_folder('fhir')
     assert_equal './output/fhir', Synthea::Output::Exporter.get_output_folder('fhir', @patient)
@@ -133,7 +133,7 @@ class ExporterTest < Minitest::Test
 
   def test_output_file_location_cities_single
     Synthea::Config.exporter.folder_per_city = true
-    Synthea::Config.exporter.subfolder_by_id = false
+    Synthea::Config.exporter.subfolders_by_id_substring = false
 
     assert_equal './output/fhir', Synthea::Output::Exporter.get_output_folder('fhir')
     assert_equal './output/fhir/Bedford', Synthea::Output::Exporter.get_output_folder('fhir', @patient)
@@ -141,17 +141,17 @@ class ExporterTest < Minitest::Test
 
   def test_output_file_location_single_split
     Synthea::Config.exporter.folder_per_city = false
-    Synthea::Config.exporter.subfolder_by_id = true
+    Synthea::Config.exporter.subfolders_by_id_substring = true
 
     assert_equal './output/fhir', Synthea::Output::Exporter.get_output_folder('fhir')
-    assert_equal './output/fhir/12', Synthea::Output::Exporter.get_output_folder('fhir', @patient)
+    assert_equal './output/fhir/12/123', Synthea::Output::Exporter.get_output_folder('fhir', @patient)
   end
 
   def test_output_file_location_cities_split
     Synthea::Config.exporter.folder_per_city = true
-    Synthea::Config.exporter.subfolder_by_id = true
+    Synthea::Config.exporter.subfolders_by_id_substring = true
 
     assert_equal './output/fhir', Synthea::Output::Exporter.get_output_folder('fhir')
-    assert_equal './output/fhir/Bedford/12', Synthea::Output::Exporter.get_output_folder('fhir', @patient)
+    assert_equal './output/fhir/Bedford/12/123', Synthea::Output::Exporter.get_output_folder('fhir', @patient)
   end
 end


### PR DESCRIPTION
Changes the default output folder structure from /[type]/[city name]/[first 2 of guid]/ to /[type]/[first 2 of guid]/[first 3 of guid]/ in order to sync up better with syntheticmass bulk loader.  Folders per city is still available as a config setting.