### PR TITLE
add cause of death to patient record

### DIFF
--- a/lib/generic/modules/dementia.json
+++ b/lib/generic/modules/dementia.json
@@ -74,6 +74,7 @@
             "code" : "26929004",
             "display" : "Alzheimer's disease (disorder)"
         }],
+        "assign_to_attribute" : "Type of Alzheimer's",
         "direct_transition" : "NoImpairment"
     },
     
@@ -95,6 +96,7 @@
             "code" : "230265002",
             "display" : "Familial Alzheimer's disease of early onset (disorder)"
         }],
+        "assign_to_attribute" : "Type of Alzheimer's",
         "direct_transition" : "NoImpairment"
     },
 
@@ -571,26 +573,28 @@
         "code" : "34285007",
         "display" : "Hospital admission"
       }],
-      "direct_transition" : "PneumoniaDelay"
+      "direct_transition" : "PneumoniaDeath"
     }, 
 
-    "PneumoniaDelay" : {
-      "type" : "Delay",
+    "PneumoniaDeath" : {
+      "type" : "Death",
       "range" : {
-            "low": 4,
-            "high": 14,
-            "unit": "days"
-        },
-      "direct_transition" : "Death"
+          "low": 4,
+          "high": 14,
+          "unit": "days"
+      },
+      "condition_onset" : "Pneumonia",
+      "direct_transition" : "Terminal"
     },
     
     "Death" : {
-        "type" : "Death",
-        "direct_transition" : "Terminal"
+      "type" : "Death",
+      "referenced_by_attribute" : "Type of Alzheimer's",
+      "direct_transition" : "Terminal"
     },
     
     "Terminal" : {
-        "type" : "Terminal"
+      "type" : "Terminal"
     }
   }
 }

--- a/lib/generic/modules/lung_cancer.json
+++ b/lib/generic/modules/lung_cancer.json
@@ -350,6 +350,7 @@
         "high": 6,
         "unit": "years"
       },
+      "referenced_by_attribute" : "Lung Cancer",
       "conditional_transition": [
         {
           "condition": {
@@ -378,6 +379,7 @@
         "high": 28,
         "unit": "months"
       },
+      "referenced_by_attribute" : "Lung Cancer",
       "conditional_transition": [
         {
           "condition": {
@@ -406,6 +408,7 @@
         "high": 18,
         "unit": "months"
       },
+      "referenced_by_attribute" : "Lung Cancer",
       "conditional_transition": [
         {
           "condition": {
@@ -434,6 +437,7 @@
         "high": 10,
         "unit": "months"
       },
+      "referenced_by_attribute" : "Lung Cancer",
       "conditional_transition": [
         {
           "condition": {

--- a/lib/generic/modules/opioid_addiction.json
+++ b/lib/generic/modules/opioid_addiction.json
@@ -522,6 +522,11 @@
 
     "Death" : {
       "type" : "Death",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "55680006",
+        "display" : "Drug overdose"
+      }],
       "direct_transition" : "Terminal"
     },
 

--- a/lib/modules/lifecycle.rb
+++ b/lib/modules/lifecycle.rb
@@ -320,8 +320,15 @@ module Synthea
       end
 
       #------------------------------------------------------------------------# begin class record functions
-      def self.record_death(entity, time)
+      def self.record_death(entity, time, reason = nil)
         entity.record_synthea.death(time)
+        if reason
+          entity[:cause_of_death] = reason
+          # TODO: once CCDA supports cause of death, change the ccda_method parameter
+          entity.record_synthea.encounter(:death_certification, time)
+          entity.record_synthea.observation(:cause_of_death, time, reason, :observation, :no_action)
+          entity.record_synthea.diagnostic_report(:death_certificate, time, 1) # note: ccda already no action here
+        end
       end
 
       def self.record_height_weight(entity, time)

--- a/lib/modules/metabolic_syndrome.rb
+++ b/lib/modules/metabolic_syndrome.rb
@@ -225,7 +225,7 @@ module Synthea
           # see if the disease progresses another stage...
           if rand < (0.0001 * diabetes[:severity])
             entity.events.create(time, :death, :end_stage_renal_disease, true)
-            Synthea::Modules::Lifecycle.record_death(entity, time)
+            Synthea::Modules::Lifecycle.record_death(entity, time, :end_stage_renal_disease)
           end
         end
       end

--- a/lib/records/ccda.rb
+++ b/lib/records/ccda.rb
@@ -61,6 +61,8 @@ module Synthea
         unless entity.alive?
           patient.deathdate = entity.record_synthea.patient_info[:deathdate].to_i
           patient.expired = true
+          # TODO: would like to put cause of death on the record, though different IGs seem to provide different templates
+          # ex, IHE IG -> "deceased observation"; "Public Health & Emergency Response WG" -> "Cause of Death"
         end
       end
 

--- a/lib/records/fhir.rb
+++ b/lib/records/fhir.rb
@@ -215,8 +215,19 @@ module Synthea
                                                },
                                                'subject' => { 'reference' => patient.fullUrl.to_s },
                                                'encounter' => { 'reference' => encounter.fullUrl.to_s },
-                                               'effectiveDateTime' => convert_fhir_date_time(observation['time'], 'time'),
-                                               'valueQuantity' => { 'value' => observation['value'], 'unit' => obs_data[:unit] })
+                                               'effectiveDateTime' => convert_fhir_date_time(observation['time'], 'time'))
+
+        if obs_data[:value_type] == 'condition'
+          condition_data = COND_LOOKUP[observation['value']]
+          entry.resource.valueCodeableConcept = FHIR::CodeableConcept.new('coding' => [{
+                                                                            'code' => condition_data[:codes]['SNOMED-CT'][0],
+                                                                            'display' => condition_data[:description],
+                                                                            'system' => 'http://snomed.info/sct'
+                                                                          }])
+        else
+          entry.resource.valueQuantity = FHIR::Quantity.new('value' => observation['value'], 'unit' => obs_data[:unit])
+        end
+
         fhir_record.entry << entry
       end
 

--- a/lib/records/lookup.rb
+++ b/lib/records/lookup.rb
@@ -27,6 +27,9 @@ module Synthea
         chloride: { description: 'Chloride', code: '2069-3', unit: 'mmol/L'},
         carbon_dioxide: { description: 'Carbon Dioxide', code: '20565-8', unit: 'mmol/L'},
 
+    death_certificate: { description: 'U.S. standard certificate of death - 2003 revision', code: '69409-1' },
+      cause_of_death: { description: 'Cause of Death [US Standard Certificate of Death]', code: '69453-9', value_type: 'condition' },
+
     microalbumin_creatine_ratio: { description: 'Microalbumin Creatine Ratio', code: '14959-1', unit: 'mg/g'},
     egfr: { description: 'Estimated Glomerular Filtration Rate', code: '33914-3', unit: 'mL/min/{1.73_m2}'}
   }
@@ -187,7 +190,8 @@ module Synthea
     age_lt_39: {description: 'Outpatient Encounter', codes: {"ICD-9-CM" => ['V70.0'], "ICD-10-CM" => ['Z00.00'],  'SNOMED-CT' => ['185349003']}, class: 'outpatient'},
     age_lt_64: {description: 'Outpatient Encounter', codes: {"ICD-9-CM" => ['V70.0'], "ICD-10-CM" => ['Z00.00'],  'SNOMED-CT' => ['185349003']}, class: 'outpatient'},
     age_senior: {description: 'Outpatient Encounter', codes: {"ICD-9-CM" => ['V70.0'], "ICD-10-CM" => ['Z00.00'],  'SNOMED-CT' => ['185349003']}, class: 'outpatient'},
-    emergency: {description: 'Emergency Encounter', codes: {'SNOMED-CT' => ['50849002']}, class: 'emergency'}
+    emergency: {description: 'Emergency Encounter', codes: {'SNOMED-CT' => ['50849002']}, class: 'emergency'},
+    death_certification: {description: 'Death Certification', codes: {'SNOMED-CT' => ['308646001']}, class: 'ambulatory'}
   }
 
 

--- a/lib/world/sequential.rb
+++ b/lib/world/sequential.rb
@@ -196,13 +196,7 @@ module Synthea
         str << options[:city_name] << ' ' if options[:city_name]
         str << options[:number].to_s if options[:number]
         str << '/' << options[:city_pop].to_s if options[:city_pop]
-        if options[:is_dead]
-          if person[:cause_of_death]
-            str << "(d: #{person[:cause_of_death]})"
-          else
-            str << '(d)'
-          end
-        end
+        str << (person[:cause_of_death] ? "(d: #{person[:cause_of_death]})" : '(d)') if options[:is_dead]
         str << ': '
         str << "#{person[:name_last]}, #{person[:name_first]}. #{person[:race].to_s.capitalize} #{person[:ethnicity].to_s.tr('_', ' ').capitalize}. #{person[:age]} y/o #{person[:gender]}"
 

--- a/lib/world/sequential.rb
+++ b/lib/world/sequential.rb
@@ -196,7 +196,13 @@ module Synthea
         str << options[:city_name] << ' ' if options[:city_name]
         str << options[:number].to_s if options[:number]
         str << '/' << options[:city_pop].to_s if options[:city_pop]
-        str << '(d)' if options[:is_dead]
+        if options[:is_dead]
+          if person[:cause_of_death]
+            str << "(d: #{person[:cause_of_death]})"
+          else
+            str << '(d)'
+          end
+        end
         str << ': '
         str << "#{person[:name_last]}, #{person[:name_first]}. #{person[:race].to_s.capitalize} #{person[:ethnicity].to_s.tr('_', ' ').capitalize}. #{person[:age]} y/o #{person[:gender]}"
 

--- a/test/fixtures/generic/death_reason.json
+++ b/test/fixtures/generic/death_reason.json
@@ -1,0 +1,41 @@
+{
+    "name": "Death Reason",
+    "states": {
+        "Initial": {
+            "type": "Initial",
+            "direct_transition": "OnsetDiabetes"
+        },
+        "OnsetDiabetes": {
+            "type": "ConditionOnset",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "73211009",
+                "display": "Diabetes mellitus"
+            }],
+            "assign_to_attribute" : "Cause of Death",
+            "direct_transition": "Terminal"
+        },
+        "Death_by_Code": {
+            "type": "Death",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "73211009",
+                "display": "Diabetes mellitus"
+            }],
+            "direct_transition": "Terminal"
+        },
+        "Death_by_ConditionOnset" : {
+            "type": "Death",
+            "condition_onset" : "OnsetDiabetes",
+            "direct_transition": "Terminal"
+        },
+        "Death_by_Attribute" : {
+            "type": "Death",
+            "referenced_by_attribute" : "Cause of Death",
+            "direct_transition": "Terminal"
+        },
+        "Terminal": {
+            "type": "Terminal"
+        }
+    }
+}


### PR DESCRIPTION
Adds a "Death Certificate" with "Cause of Death" to patient records in FHIR when a cause of death is known. Cause of death may be specified in `Death` state in GMF.  Updates all modules to specify a reason for death.

One note: In the case of a Death state with a specified amount of time to live, the death certificate encounter + observation are added to the patient with future dates. It's theoretically possible that the patient could "die again" of something else before reaching those future dates. I'm thinking about how to fix that & open to suggestions.