### PR TITLE
Run simulation in parallel using JRuby

### DIFF
--- a/lib/world/population.rb
+++ b/lib/world/population.rb
@@ -1,6 +1,4 @@
-if RUBY_PLATFORM == 'java'
-  require 'java'
-end
+require 'java' if RUBY_PLATFORM == 'java'
 
 module Synthea
   module World


### PR DESCRIPTION
**Warning** - This PR makes the assumption that the synthea code, in particular `Synthea::Rules.apply` is thread safe.

This PR allows the simulation to parallelize some of it's execution when running under JRuby. The modifications first check to see what platform the code is running on. If synthea is running in plain old ruby, this should in no way modify the behavior.

When JRuby is detected, the code will use java [Executors](https://docs.oracle.com/javase/8/docs/api/index.html?java/util/concurrent/Executor.html) to parallelize the logic. When synthea runs, it starts at a configured date, and then applies rules to all patients in the simulation (ignoring logic for births at the moment). It then advances the time and applies rules to all patients again. When running in plain old ruby, application of the rules happens in an each loop. So the rules are applied serially to all patients. Now, under JRuby, each call to apply happens in an Runnable that is passed to a fixed thread pool executor. This pool consists of 8 threads that can run the application of synthea rules. This allows the application of rules in parallel.

Testing on my mid-2015 Retina MacBook Pro shows the JRuby code taking 30 seconds to complete the simulation vs 1 minute 8 seconds for plain old ruby.

Potential improvements:

- The thread pool is created and destroyed at each time step. This is the simplest implementation, but it is likely to have better performance if the pool can be reused between time steps. I'm not sure if you would need additional logic to prevent a patient from being evaluated at two different times in parallel on separate threads
- Parallelize export