### PR TITLE
improve ranges to allow for intermediate values

### DIFF
--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -102,10 +102,11 @@ module Synthea
           if @expiration.nil?
             if !@range.nil?
               # choose a random duration within the specified range
-              choice = rand(@range['low']..@range['high'])
-              @expiration = choice.method(@range['unit']).call.since(@start_time)
+              low = @range['low'].send(@range['unit'])
+              high = @range['high'].send(@range['unit'])
+              @expiration = rand(low..high).since(@start_time)
             elsif !@exact.nil?
-              @expiration = @exact['quantity'].method(@exact['unit']).call.since(@start_time)
+              @expiration = @exact['quantity'].send(@exact['unit']).since(@start_time)
             else
               @expiration = @start_time
             end
@@ -388,9 +389,11 @@ module Synthea
 
         def process(time, entity)
           if @range
-            value = rand(@range['low']..@range['high']).method(@range['unit']).call.since(time)
+            low = @range['low'].send(@range['unit'])
+            high = @range['high'].send(@range['unit'])
+            value = rand(low..high).since(time)
           elsif @exact
-            value = @exact['quantity'].method(@exact['unit']).call.since(time)
+            value = @exact['quantity'].send(@exact['unit']).since(time)
           end
 
           # this is the same as the ConditionEnd logic, maybe we want to extract this somewhere

--- a/test/unit/generic/appendicitis_test.rb
+++ b/test/unit/generic/appendicitis_test.rb
@@ -28,7 +28,7 @@ class AppendicitisTest < Minitest::Test
     srand 9
 
     @context.run(@time, @patient)
-    @time = @time.advance(years: 40)
+    @time = @time.advance(years: 19, months: 0, days: 9, hours: 23, minutes: 16, seconds: 8)
 
     @patient.record_synthea.expect(:condition, nil, [:appendicitis, @time])
 
@@ -47,7 +47,7 @@ class AppendicitisTest < Minitest::Test
     srand 8765
 
     @context.run(@time, @patient)
-    @time = @time.advance(years: 61)
+    @time = @time.advance(years: 62, months: 6, days: 12, hours: 15, minutes: 37, seconds: 20)
 
     @patient.record_synthea.expect(:condition, nil, [:appendicitis, @time])
     @patient.record_synthea.expect(:condition, nil, [:rupture_of_appendix, @time])

--- a/test/unit/generic_states_test.rb
+++ b/test/unit/generic_states_test.rb
@@ -106,7 +106,7 @@ class GenericStatesTest < Minitest::Test
     # Re-seed the random generator so we have deterministic outcomes
     srand 12345
 
-    # Seconds (rand(2..10) = 4)
+    # Seconds (rand(2.seconds..10.seconds) = 4s)
     delay = Synthea::Generic::States::Delay.new(ctx, "2_To_10_Second_Delay")
     delay.start_time = @time
     refute(delay.process(@time, @patient))
@@ -114,7 +114,7 @@ class GenericStatesTest < Minitest::Test
     assert(delay.process(@time + 4, @patient))
     assert(delay.process(@time + 5, @patient))
 
-    # Minutes (rand(2..10) = 7)
+    # Minutes (rand(2.minutes..10.minutes) = 405s = 6.75 min)
     delay = Synthea::Generic::States::Delay.new(ctx, "2_To_10_Minute_Delay")
     delay.start_time = @time
     refute(delay.process(@time, @patient))
@@ -122,7 +122,7 @@ class GenericStatesTest < Minitest::Test
     assert(delay.process(@time + 7*60, @patient))
     assert(delay.process(@time + 8*60, @patient))
 
-    # Hours (rand(2..10) = 3)
+    # Hours (rand(2.hours..10.hours) = 9377s = 2.605 hrs)
     delay = Synthea::Generic::States::Delay.new(ctx, "2_To_10_Hour_Delay")
     delay.start_time = @time
     refute(delay.process(@time, @patient))
@@ -130,15 +130,16 @@ class GenericStatesTest < Minitest::Test
     assert(delay.process(@time + 3*60*60, @patient))
     assert(delay.process(@time + 4*60*60, @patient))
 
-    # Days (rand(2..10) = 6)
+    # Days (rand(2.days..10.days) = 520356 s = 6.022 days)
     delay = Synthea::Generic::States::Delay.new(ctx, "2_To_10_Day_Delay")
     delay.start_time = @time
     refute(delay.process(@time, @patient))
-    refute(delay.process(@time.advance(:days => 5), @patient))
-    assert(delay.process(@time.advance(:days => 6), @patient))
+    refute(delay.process(@time.advance(:days => 6), @patient))
     assert(delay.process(@time.advance(:days => 7), @patient))
+    assert(delay.process(@time.advance(:days => 8), @patient))
 
-    # Weeks (rand(2..10) = 7)
+
+    # Weeks (rand(2.weeks..10.weeks) = 4203177 s = 6.95 weeks)
     delay = Synthea::Generic::States::Delay.new(ctx, "2_To_10_Week_Delay")
     delay.start_time = @time
     refute(delay.process(@time, @patient))
@@ -146,21 +147,21 @@ class GenericStatesTest < Minitest::Test
     assert(delay.process(@time.advance(:weeks => 7), @patient))
     assert(delay.process(@time.advance(:weeks => 8), @patient))
 
-    # Months (rand(2..10) = 4)
+    # Months (rand(2.months..10.months) = 11348478 s ~= 4.4 months)
     delay = Synthea::Generic::States::Delay.new(ctx, "2_To_10_Month_Delay")
     delay.start_time = @time
     refute(delay.process(@time, @patient))
-    refute(delay.process(@time.advance(:months => 3), @patient))
-    assert(delay.process(@time.advance(:months => 4), @patient))
+    refute(delay.process(@time.advance(:months => 4), @patient))
     assert(delay.process(@time.advance(:months => 5), @patient))
+    assert(delay.process(@time.advance(:months => 6), @patient))
 
-    # Years (rand(2..10) = 3)
+    # Years (rand(2.years..10.years) = 122970430 s ~= 3.9 years)
     delay = Synthea::Generic::States::Delay.new(ctx, "2_To_10_Year_Delay")
     delay.start_time = @time
     refute(delay.process(@time, @patient))
-    refute(delay.process(@time.advance(:years => 2), @patient))
-    assert(delay.process(@time.advance(:years => 3), @patient))
+    refute(delay.process(@time.advance(:years => 3), @patient))
     assert(delay.process(@time.advance(:years => 4), @patient))
+    assert(delay.process(@time.advance(:years => 5), @patient))
 
     # Re-seed the random generator with a new (random) seed
     srand


### PR DESCRIPTION
Modifies the underlying logic of time-based ranges so that they allow for intermediate values.

Ex. previously a range with units: years,  low: 1,  and high: 4 would always result in a delay of exactly 1, 2, 3, or 4 years. This change results in the ability for intermediate values.

This basically converts `rand(1..4).years` to `rand(1.years..4.years)`