### PR TITLE
Fix geospatial extension to use existing extension on Address.

### DIFF
--- a/lib/records/fhir.rb
+++ b/lib/records/fhir.rb
@@ -75,10 +75,6 @@ module Synthea
                                                    }]
                                                  }
                                                },
-                                               {
-                                                 'url' => "#{SHR_EXT}wkt-geospatialpoint",
-                                                 'valueString' => "POINT (#{entity[:coordinates_address].x} #{entity[:coordinates_address].y})"
-                                               },
                                                # place of birth
                                                {
                                                  'url' => "#{SHR_EXT}placeOfBirth",
@@ -102,6 +98,18 @@ module Synthea
           patient_resource.name << FHIR::HumanName.new('given' => [entity[:name_first]],
                                                        'family' => [entity[:name_maiden]], 'use' => 'maiden')
         end
+        # add geospatial information to address
+        patient_resource.address.first.extension = [FHIR::Extension.new('url' => 'http://hl7.org/fhir/StructureDefinition/geolocation',
+                                                                        'extension' => [
+                                                                          {
+                                                                            'url' => 'latitude',
+                                                                            'valueDecimal' => entity[:coordinates_address].y
+                                                                          },
+                                                                          {
+                                                                            'url' => 'longitude',
+                                                                            'valueDecimal' => entity[:coordinates_address].x
+                                                                          }
+                                                                        ])]
         # add marital status if present
         if entity[:marital_status]
           patient_resource.maritalStatus = FHIR::CodeableConcept.new('coding' => [{ 'system' => 'http://hl7.org/fhir/v3/MaritalStatus', 'code' => entity[:marital_status] }])

--- a/test/unit/fhir_test.rb
+++ b/test/unit/fhir_test.rb
@@ -90,9 +90,10 @@ class FhirTest < Minitest::Test
     assert_equal('Bedford', address.city)
     assert_equal('MA', address.state)
     assert_equal('01730', address.postalCode)
-    coordinates = person.extension[2]
-    assert_equal('http://standardhealthrecord.org/fhir/extensions/wkt-geospatialpoint', coordinates.url)
-    assert_equal('POINT (10 15)', coordinates.valueString)
+    coordinates = address.extension[0]
+    assert_equal('http://hl7.org/fhir/StructureDefinition/geolocation', coordinates.url)
+    assert_equal( 15 , coordinates.latitude)
+    assert_equal( 10 , coordinates.longitude)
     #test race/ethnicity logic
     @patient[:race] = :hispanic
     @patient[:ethnicity] = :mexican


### PR DESCRIPTION
This changes our WKT geospatial extension to use the existing extension defined in FHIR:

http://hl7.org/fhir/2016Sep/extension-geolocation.html

This change will effect downstream systems that rely on our geospatial coordinates, so should be merged in coordination with changes there.