### PR TITLE
Respiratory diseases

### DIFF
--- a/lib/entity/entity.rb
+++ b/lib/entity/entity.rb
@@ -41,9 +41,9 @@ module Synthea
     # Symptom API
     #-----------------------------------------------------------------------
 
-    # Set value for a symptom, providing cause (ie :diabetes), type (ie :fatigue), and value ranging from 1-100
+    # Set value for a symptom, providing cause (ie :diabetes), type (ie :fatigue), and value ranging from 0-100
     def set_symptom_value(cause, type, value)
-      raise 'Symptom value out of range' if value < 1 || value > 100
+      raise 'Symptom value out of range' if value < 0 || value > 100
       @symptoms[type][cause] = value
     end
 

--- a/lib/generic/modules/bronchitis.json
+++ b/lib/generic/modules/bronchitis.json
@@ -101,6 +101,7 @@
 
     "Doctor_Visit" : {
       "type" : "Encounter",
+      "class" : "ambulatory",
       "codes" : [{
         "system": "SNOMED-CT",
         "code": "185345009",

--- a/lib/generic/modules/bronchitis.json
+++ b/lib/generic/modules/bronchitis.json
@@ -78,7 +78,7 @@
     "Bronchitis_Symptom2" : {
       "type" : "Symptom",
       "symptom": "Mucus",
-      "range": { "low" : 50, "high" : 100 },
+      "range": { "low" : 0, "high" : 100 },
       "direct_transition" : "Bronchitis_Symptom3"
     },
     
@@ -111,7 +111,7 @@
         { "distribution" : 0.05, "transition" : "Chest_Xray" },
         { "distribution" : 0.20, "transition" : "Sputum_Test" },
         { "distribution" : 0.50, "transition" : "Lung_Function_Test" },
-        { "distribution" : 0.20, "transition" : "Wait_for_condition_to_resolve" }
+        { "distribution" : 0.20, "transition" : "OTC_Medicine" }
       ],
       "remarks" : ["There are no reliable diagnostic signs or laboratory tests, so the diagnosis of acute bronchitis is essentially a clinical one. ",
                    "The most important condition to rule out is acute pneumonia. "]
@@ -125,7 +125,7 @@
         "code": "399208008",
         "display": "Plain chest X-ray (procedure)"
       }],
-      "direct_transition" : "Wait_for_condition_to_resolve"
+      "direct_transition" : "OTC_Medicine"
     },
 
     "Sputum_Test" : {
@@ -136,7 +136,7 @@
         "code": "269911007",
         "display": "Sputum examination (procedure)"
       }],
-      "direct_transition" : "Wait_for_condition_to_resolve"
+      "direct_transition" : "OTC_Medicine"
     },
 
     "Lung_Function_Test" : {
@@ -146,6 +146,55 @@
         "system": "SNOMED-CT",
         "code": "23426006",
         "display": "Measurement of respiratory function (procedure)"
+      }],
+      "direct_transition" : "OTC_Medicine"
+    },
+
+    "OTC_Medicine" : {
+      "type" : "Simple",
+      "remarks" : ["Up to 95% of bronchitis cases are viral so antibiotics are rarely prescribed",
+                   "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2278319/"],
+      "complex_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Symptom",
+            "symptom" : "Mucus",
+            "operator" : "<",
+            "value" : 20
+          },
+          "distributions" : [
+            { "distribution" : 0.80, "transition" : "Cough_suppressant" },
+            { "distribution" : 0.20, "transition" : "Acetaminophen" }
+          ],
+          "remarks" : "cough suppressants shouldn't be given if the cough brings up mucus"
+        },
+        {
+          "distributions" : [
+            { "distribution" : 0.10, "transition" : "Cough_suppressant" },
+            { "distribution" : 0.90, "transition" : "Acetaminophen" }
+          ]
+        }
+      ]
+    },
+
+    "Cough_suppressant" : {
+      "type" : "MedicationOrder",
+      "target_encounter" : "Doctor_Visit",
+      "codes" : [{
+        "system" : "RxNorm",
+        "code" : "1020137",
+        "display" : "Dextromethorphan Hydrobromide 1 MG/ML"
+      }],
+      "direct_transition" : "Wait_for_condition_to_resolve"
+    },
+
+    "Acetaminophen" : {
+      "type" : "MedicationOrder",
+      "target_encounter" : "Doctor_Visit",
+      "codes" : [{
+        "system" : "RxNorm",
+        "code" : "608680",
+        "display" : "Acetaminophen 160 MG"
       }],
       "direct_transition" : "Wait_for_condition_to_resolve"
     },
@@ -157,8 +206,6 @@
         "high": 3,
         "unit": "weeks"
       },
-      "remarks" : ["Note that there is no prescription here. Up to 95% of bronchitis cases are viral so antibiotics are rarely prescribed",
-                   "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2278319/"],
       "direct_transition" : "Bronchitis_Subsides"
     },
 
@@ -186,6 +233,24 @@
       "type" : "Symptom",
       "symptom": "Shortness of Breath",
       "exact" : { "quantity" : 0 },
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type": "Attribute",
+            "attribute": "OTC_Bronchitis_Med",
+            "operator": "is not nil"
+          },
+          "transition" : "End_OTC_Medication"
+        },
+        {
+          "transition" : "Potential_Infection"
+        }
+      ]
+    },
+
+    "End_OTC_Medication" : {
+      "type" : "MedicationEnd",
+      "referenced_by_attribute" : "OTC_Bronchitis_Med",
       "direct_transition" : "Potential_Infection"
     }
 

--- a/lib/generic/modules/bronchitis.json
+++ b/lib/generic/modules/bronchitis.json
@@ -1,0 +1,192 @@
+{
+  "name": "Bronchitis",
+  "remarks" : ["For now this covers only acute bronchitis. Chronic bronchitis is one of the conditions included in chronic obstructive pulmonary disease (COPD).",
+               "Acute bronchitis is the fifth most common reason why adults see their GP; 5% of the adult population seeks medical advice for bronchitis each year.",
+               "Most of the data here comes from the following sources: ",
+               "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2278319/",
+               "http://www.aafp.org/afp/1998/0315/p1270.html"],
+  "states": {
+
+  "Initial": {
+      "type" : "Initial",
+      "direct_transition" : "Potential_Infection"
+    },
+
+    "Potential_Infection" : {
+      "type" : "Delay",
+      "exact" : {
+        "quantity" : 1,
+        "unit" : "months"
+      },
+      "complex_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Age",
+            "operator" : "<",
+            "quantity" : 18,
+            "unit" : "years"
+          },
+          "distributions" : [
+            {
+              "distribution": 0.005,
+              "transition": "Bronchitis_Infection",
+              "remarks" : ["6% of children get bronchitis each year.",
+                           "6% / year == ~ .5% per month?"]
+            },
+            {
+              "distribution": 0.995,
+              "transition": "Potential_Infection"
+            }
+          ]
+        },
+
+        {
+          "distributions" : [
+            {
+              "distribution": 0.00416,
+              "transition": "Bronchitis_Infection",
+              "remarks" : ["5% of the adult population seeks medical advice for bronchitis each year.",
+                           "5% / year == ~ .42% per month?"]
+            },
+            {
+              "distribution": 0.99584,
+              "transition": "Potential_Infection"
+            }
+          ]
+        }
+      ]
+    },
+
+    "Bronchitis_Infection" : {
+      "type" : "ConditionOnset",
+      "target_encounter" : "Doctor_Visit",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "10509002",
+        "display" : "Acute bronchitis (disorder)"
+      }],
+      "direct_transition" : "Bronchitis_Symptom1"
+    },
+
+    "Bronchitis_Symptom1" : {
+      "type" : "Symptom",
+      "symptom": "Cough",
+      "range": { "low" : 50, "high" : 100 },
+      "direct_transition" : "Bronchitis_Symptom2"
+    },
+
+    "Bronchitis_Symptom2" : {
+      "type" : "Symptom",
+      "symptom": "Mucus",
+      "range": { "low" : 50, "high" : 100 },
+      "direct_transition" : "Bronchitis_Symptom3"
+    },
+    
+    "Bronchitis_Symptom3" : {
+      "type" : "Symptom",
+      "symptom": "Shortness of Breath",
+      "range": { "low" : 50, "high" : 100 },
+      "direct_transition" : "Symptoms_Dont_improve"
+    },
+
+    "Symptoms_Dont_improve" : {
+      "type" : "Delay",
+      "range": {
+        "low": 1,
+        "high": 3,
+        "unit": "days"
+      },
+      "direct_transition" : "Doctor_Visit"
+    },
+
+    "Doctor_Visit" : {
+      "type" : "Encounter",
+      "codes" : [{
+        "system": "SNOMED-CT",
+        "code": "185345009",
+        "display": "Encounter for symptom"
+      }],
+      "distributed_transition" : [
+        { "distribution" : 0.05, "transition" : "Chest_Xray" },
+        { "distribution" : 0.20, "transition" : "Sputum_Test" },
+        { "distribution" : 0.50, "transition" : "Lung_Function_Test" },
+        { "distribution" : 0.20, "transition" : "Wait_for_condition_to_resolve" }
+      ],
+      "remarks" : ["There are no reliable diagnostic signs or laboratory tests, so the diagnosis of acute bronchitis is essentially a clinical one. ",
+                   "The most important condition to rule out is acute pneumonia. "]
+    },
+
+    "Chest_Xray" : {
+      "type" : "Procedure",
+      "target_encounter" : "Doctor_Visit",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "399208008",
+        "display": "Plain chest X-ray (procedure)"
+      }],
+      "direct_transition" : "Wait_for_condition_to_resolve"
+    },
+
+    "Sputum_Test" : {
+      "type" : "Procedure",
+      "target_encounter" : "Doctor_Visit",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "269911007",
+        "display": "Sputum examination (procedure)"
+      }],
+      "direct_transition" : "Wait_for_condition_to_resolve"
+    },
+
+    "Lung_Function_Test" : {
+      "type" : "Procedure",
+      "target_encounter" : "Doctor_Visit",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "23426006",
+        "display": "Measurement of respiratory function (procedure)"
+      }],
+      "direct_transition" : "Wait_for_condition_to_resolve"
+    },
+
+    "Wait_for_condition_to_resolve" : {
+      "type" : "Delay",
+      "range": {
+        "low": 1,
+        "high": 3,
+        "unit": "weeks"
+      },
+      "remarks" : ["Note that there is no prescription here. Up to 95% of bronchitis cases are viral so antibiotics are rarely prescribed",
+                   "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2278319/"],
+      "direct_transition" : "Bronchitis_Subsides"
+    },
+
+    "Bronchitis_Subsides" : {
+      "type" : "ConditionEnd",
+      "condition_onset" : "Bronchitis_Infection",
+      "direct_transition" : "Bronchitis_Symptom1_Subsides"
+    },
+
+    "Bronchitis_Symptom1_Subsides" : {
+      "type" : "Symptom",
+      "symptom": "Cough",
+      "exact" : { "quantity" : 0 },
+      "direct_transition" : "Bronchitis_Symptom2_Subsides"
+    },
+
+    "Bronchitis_Symptom2_Subsides" : {
+      "type" : "Symptom",
+      "symptom": "Mucus",
+      "exact" : { "quantity" : 0 },
+      "direct_transition" : "Bronchitis_Symptom3_Subsides"
+    },
+    
+    "Bronchitis_Symptom3_Subsides" : {
+      "type" : "Symptom",
+      "symptom": "Shortness of Breath",
+      "exact" : { "quantity" : 0 },
+      "direct_transition" : "Potential_Infection"
+    }
+
+  }
+}

--- a/lib/generic/modules/sinusitis.json
+++ b/lib/generic/modules/sinusitis.json
@@ -1,0 +1,305 @@
+{
+  "name": "Sinusitis",
+  "states": {
+
+    "Initial": {
+      "type" : "Initial",
+      "direct_transition" : "Potential_Onset"
+    },
+
+    "Potential_Onset" : {
+      "type" : "Delay",
+      "exact" : {
+        "quantity" : 1,
+        "unit" : "months"
+      },
+      "remarks" : ["Sinusitis, also called rhinosinusitis, affects about 1 in 8 adults annually",
+                   "http://www.entnet.org/content/sinusitis",
+                   "Although sinus infections are the fifth leading reason for antibiotic prescriptions, 90 to 98 percent of cases are caused by viruses,",
+                   "http://www.idsociety.org/2012_Rhinosinusitis_Guidelines/",
+                   "While 15 percent of the population self-reports chronic sinusitis, only an estimated 2 to 3 percent of doctors’ visits are for the disease",
+                   "http://labblog.uofmhealth.org/rounds/chronic-sinusitis-rarer-than-most-providers-and-patients-believe"],
+      "distributed_transition" : [
+        { "distribution" : 0.009, "transition" : "Viral_Infection_Starts" },
+        { "distribution" : 0.0005, "transition" : "Bacterial_Infection_Starts" },
+        { "distribution" : 0.0005, "transition" : "Inflammation_Starts" },
+        { "distribution" : 0.99, "transition" : "Potential_Onset" }
+      ]
+    },
+
+    "Viral_Infection_Starts" : {
+      "type" : "ConditionOnset",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "444814009",
+        "display" : "Viral sinusitis (disorder)"
+      }],
+      "target_encounter" : "Doctor_Visit",
+      "assign_to_attribute" : "Sinusitis Condition",
+      "direct_transition" : "Symptom_of_Infection"
+    },
+
+    "Bacterial_Infection_Starts" : {
+      "type" : "ConditionOnset",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "75498004",
+        "display" : "Acute bacterial sinusitis (disorder)"
+      }],
+      "target_encounter" : "Doctor_Visit",
+      "assign_to_attribute" : "Sinusitis Condition",
+      "direct_transition" : "Symptom_of_Infection"
+    },
+
+    "Symptom_of_Infection" : {
+      "type" : "Symptom",
+      "symptom": "Sinus Pain",
+      "range": { "low" : 40, "high" : 60 },
+      "direct_transition" : "Common_Symptom"
+    },
+
+    "Inflammation_Starts" : {
+      "type" : "ConditionOnset",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "36971009",
+        "display" : "Sinusitis (disorder)"
+      }],
+      "target_encounter" : "Doctor_Visit",
+      "assign_to_attribute" : "Sinusitis Condition",
+      "direct_transition" : "Symptom_of_Inflammation"
+    },
+
+    "Symptom_of_Inflammation" : {
+      "type" : "Symptom",
+      "symptom": "Sinus Pain",
+      "range": { "low" : 20, "high" : 80 },
+      "direct_transition" : "Common_Symptom"
+    },
+
+    "Common_Symptom" : {
+      "type" : "Symptom",
+      "symptom": "Nasal Congestion",
+      "range": { "low" : 60, "high" : 90 },
+      "direct_transition" : "Wait_to_see_Dr"
+    },
+
+    "Wait_to_see_Dr" : {
+      "type" : "Delay",
+      "range": {
+        "low": 5,
+        "high": 10,
+        "unit": "days"
+      },
+      "direct_transition" : "Doctor_Visit"
+    },
+
+    "Doctor_Visit" : {
+      "type" : "Encounter",
+      "codes" : [{
+        "system": "SNOMED-CT",
+        "code": "185345009",
+        "display": "Encounter for symptom"
+      }],
+      "distributed_transition" : [
+        { "distribution" : 0.80, "transition" : "Wait_for_condition_to_resolve" },
+        { "distribution" : 0.20, "transition" : "Prescribe_Antibiotic" }
+      ],
+      "remarks" : "Antibiotics are overprescribed for sinus infections"
+    },
+
+    "Prescribe_Antibiotic" : {
+      "type" : "MedicationOrder",
+      "codes" : [{
+        "system" : "RxNorm",
+        "code" : "824184",
+        "display" : " Amoxicillin 250 MG / Clavulanate 125 MG [Augmentin]"
+      }],
+      "remarks" : "https://www.drugs.com/dosage/amoxicillin.html#Usual_Adult_Dose_for_Sinusitis",
+      "target_encounter" : "Doctor_Visit",
+      "direct_transition" : "Wait_for_condition_to_resolve"
+    },
+
+    "Wait_for_condition_to_resolve" : {
+      "type" : "Delay",
+      "range": {
+        "low": 1,
+        "high": 4,
+        "unit": "weeks"
+      },
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "And",
+            "conditions" : [
+              {
+                "condition_type" : "Active Medication",
+                "codes" : [{
+                  "system" : "RxNorm",
+                  "code" : "824184",
+                  "display" : " Amoxicillin 250 MG / Clavulanate 125 MG [Augmentin]"
+                }]
+              }, 
+              {
+                "condition_type" : "Active Condition",
+                "codes" : [{
+                  "system" : "SNOMED-CT",
+                  "code" : "75498004",
+                  "display" : "Acute bacterial sinusitis (disorder)"
+                }]
+              }
+            ]
+          },
+          "transition" : "Sinusitis_Ends"
+        },
+        {
+          "condition" : {
+            "condition_type" : "Active Condition",
+            "codes" : [{
+              "system" : "SNOMED-CT",
+              "code" : "444814009",
+              "display" : "Viral sinusitis (disorder)"
+            }]
+          },
+          "transition" : "Sinusitis_Ends"
+        },
+        {
+          "transition" : "Chronic_Sinusitis_Continues"
+        }
+      ]
+    },
+
+    "Sinusitis_Ends" : {
+      "type" : "ConditionEnd",
+      "referenced_by_attribute" : "Sinusitis Condition",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Active Medication",
+            "codes" : [{
+              "system" : "RxNorm",
+              "code" : "824184",
+              "display" : " Amoxicillin 250 MG / Clavulanate 125 MG [Augmentin]"
+            }]
+          },
+          "transition" : "End_Antibiotic"  
+        },
+        {
+          "transition" : "Symptom1_Subsides"
+        }
+      ]
+    },
+
+    "End_Antibiotic" : {
+      "type" : "MedicationEnd",
+      "medication_order" : "Prescribe_Antibiotic",
+      "direct_transition" : "Symptom1_Subsides"
+    },
+
+    "Symptom1_Subsides" : {
+      "type" : "Symptom",
+      "symptom": "Sinus Pain",
+      "exact" : { "quantity" : 0 },
+      "direct_transition" : "Symptom2_Subsides"
+    },
+
+    "Symptom2_Subsides" : {
+      "type" : "Symptom",
+      "symptom": "Nasal Congestion",
+      "exact" : { "quantity" : 0 },
+      "direct_transition" : "Potential_Onset"
+    },
+
+    "Chronic_Sinusitis_Continues" : {
+      "type" : "Delay",
+      "exact" : { "quantity" : 1, "unit" : "weeks" },
+      "distributed_transition" : [
+        { "distribution" : 0.10, "transition" : "Sinusitis_Ends" },
+        { "distribution" : 0.75, "transition" : "Chronic_Sinusitis_Continues" },
+        { "distribution" : 0.15, "transition" : "Chronic_Symptoms_Worsen" }
+      ]
+    },
+
+    "Chronic_Symptoms_Worsen" : {
+      "type" : "Symptom",
+      "symptom": "Sinus Pain",
+      "range": { "low" : 60, "high" : 100 },
+      "direct_transition" : "Chronic_Sinusitis_Followup"
+    },
+
+    "Chronic_Sinusitis_Followup" : {
+      "type" : "Encounter",
+      "codes" : [{
+        "system": "SNOMED-CT",
+        "code": "185345009",
+        "display": "Encounter for symptom"
+      }],
+      "complex_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Active Condition",
+            "codes" : [{
+              "system" : "SNOMED-CT",
+              "code" : "40055000",
+              "display" : "Chronic sinusitis (disorder)"
+            }]
+          },
+          "distributions" : [
+            { "distribution" : 0.95, "transition" : "Chronic_Sinusitis_Continues" },
+            { "distribution" : 0.05, "transition" : "Sinus_Surgery" }
+          ]
+        },
+        {
+          "distributions" : [
+            { "distribution" : 0.95, "transition" : "Diagnose_Chronic_Sinusitis" },
+            { "distribution" : 0.05, "transition" : "Sinus_Surgery" }
+          ]
+        }
+      ]
+    },
+
+    "Diagnose_Chronic_Sinusitis" : {
+      "type" : "ConditionOnset",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "40055000",
+        "display" : "Chronic sinusitis (disorder)"
+      }],
+      "target_encounter" : "Chronic_Sinusitis_Followup",
+      "direct_transition" : "Chronic_Sinusitis_Continues"
+    },
+
+    "Sinus_Surgery" : {
+      "type" : "Procedure",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "112790001",
+        "display" : "Nasal sinus endoscopy (procedure)"
+      }],
+      "target_encounter" : "Chronic_Sinusitis_Followup",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Active Condition",
+            "codes" : [{
+              "system" : "SNOMED-CT",
+              "code" : "40055000",
+              "display" : "Chronic sinusitis (disorder)"
+            }]
+          },
+          "transition" : "Chronic_Sinusisitis_Ends"  
+        },
+        {
+          "transition" : "Sinusitis_Ends"
+        }
+      ]
+    },
+
+    "Chronic_Sinusisitis_Ends" : {
+      "type" : "ConditionEnd",
+      "condition_onset" : "Diagnose_Chronic_Sinusitis",
+      "direct_transition" : "Sinusitis_Ends"
+    }
+
+  }
+}

--- a/lib/generic/modules/sinusitis.json
+++ b/lib/generic/modules/sinusitis.json
@@ -96,6 +96,7 @@
 
     "Doctor_Visit" : {
       "type" : "Encounter",
+      "class" : "ambulatory",
       "codes" : [{
         "system": "SNOMED-CT",
         "code": "185345009",
@@ -229,6 +230,7 @@
 
     "Chronic_Sinusitis_Followup" : {
       "type" : "Encounter",
+      "class" : "ambulatory",
       "codes" : [{
         "system": "SNOMED-CT",
         "code": "185345009",

--- a/lib/generic/modules/sore_throat.json
+++ b/lib/generic/modules/sore_throat.json
@@ -50,7 +50,7 @@
         {
           "distributions" : [
             {
-              "distribution": 0.00583,
+              "distribution": 0.005,
               "transition": "Acquire_Viral_Infection"
             },
             {
@@ -59,7 +59,7 @@
               "remarks" : ["[in adults] only about 5%-10% of sore throats are caused by a bacterial infection"]
             },
             {
-              "distribution": 0.9933,
+              "distribution": 0.9942,
               "transition": "Potential_Infection"
             }
           ]

--- a/lib/generic/modules/sore_throat.json
+++ b/lib/generic/modules/sore_throat.json
@@ -147,6 +147,7 @@
 
     "Doctor_Visit" : {
       "type" : "Encounter",
+      "class" : "ambulatory",
       "codes" : [{
         "system": "SNOMED-CT",
         "code": "185345009",

--- a/lib/generic/modules/sore_throat.json
+++ b/lib/generic/modules/sore_throat.json
@@ -1,0 +1,443 @@
+{
+  "name": "Sore Throat",
+  "remarks" : ["Covers both bacterial and viral sore throat. Focuses on strep for bacterial, although gonorrhea and syphilis are also causes.",
+               "Viral sore throats are caused by cold, flu, coxsackie virus, mononucleosis.",
+               "Primary references:",
+               "http://www.medicinenet.com/sore_throat_virus_or_strep/views.htm",
+               "http://emedicine.medscape.com/article/225362-overview"],
+  "states": {
+
+    "Initial": {
+      "type" : "Initial",
+      "direct_transition" : "Potential_Infection"
+    },
+
+    "Potential_Infection" : {
+      "type" : "Delay",
+      "exact" : {
+        "quantity" : 1,
+        "unit" : "months"
+      },
+      "remarks" : ["Each year, pharyngitis is responsible for more than 40 million visits to health care providers. ",
+                   "Most children and adults experience 3-5 viral upper respiratory tract infections (including pharyngitis) per year.",
+                   "Viral pharyngitis affects both children and adults, but it is more common in children.",
+                   "Approximately 10% of children seen by medical care providers each year have pharyngitis, and 25-50% of these children have GABHS pharyngitis.",
+                   "only about 5%-10% of sore throats are caused by a bacterial infection"],
+      "complex_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Age",
+            "operator" : "<",
+            "quantity" : 15,
+            "unit" : "years"
+          },
+          "distributions" : [
+            {
+              "distribution": 0.02,
+              "transition": "Acquire_Viral_Infection"
+            },
+            {
+              "distribution": 0.01,
+              "transition": "Acquire_Bacterial_Infection",
+              "remarks" : ["Bacterial is more common in children than in adults. Assume viral is only 2x as likely as bacterial for children"]
+            },
+            {
+              "distribution": 0.97,
+              "transition": "Potential_Infection"
+            }
+          ]
+        },
+        {
+          "distributions" : [
+            {
+              "distribution": 0.02,
+              "transition": "Acquire_Viral_Infection"
+            },
+            {
+              "distribution": 0.003,
+              "transition": "Acquire_Bacterial_Infection",
+              "remarks" : ["[in adults] only about 5%-10% of sore throats are caused by a bacterial infection"]
+            },
+            {
+              "distribution": 0.977,
+              "transition": "Potential_Infection"
+            }
+          ]
+        }
+      ]
+    },
+
+    "Acquire_Viral_Infection" : {
+      "type" : "ConditionOnset",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "195662009",
+        "display" : "Acute viral pharyngitis (disorder)"
+      }],
+      "assign_to_attribute" : "Sore Throat Condition",
+      "direct_transition" : "Viral_Symptom_1"
+    }, 
+
+    "Viral_Symptom_1" : {
+      "type" : "Symptom",
+      "symptom": "Cough",
+      "range": { "low" : 40, "high" : 100},
+      "direct_transition" : "Viral_Symptom_2"
+    },
+
+    "Viral_Symptom_2" : {
+      "type" : "Symptom",
+      "symptom": "Swollen Lymph Nodes",
+      "range": { "low" : 0, "high" : 60 },
+      "direct_transition" : "Viral_Symptom_3"
+    },
+
+    "Viral_Symptom_3" : {
+      "type" : "Symptom",
+      "symptom": "Swollen Tonsils",
+      "range": { "low": 0, "high": 60},
+      "direct_transition" : "Symptoms_dont_resolve"
+    },
+
+    "Acquire_Bacterial_Infection" : {
+      "type" : "ConditionOnset",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "43878008",
+        "display" : "Streptococcal sore throat (disorder)"
+      }],
+      "assign_to_attribute" : "Sore Throat Condition",
+      "direct_transition" : "Bacterial_Symptom_1"
+    },
+
+    "Bacterial_Symptom_1" : {
+      "type" : "Symptom",
+      "symptom": "Cough",
+      "exact" : { "quantity" : 0 },
+      "remarks" : "Strep generally does not present with cough",
+      "direct_transition" : "Bacterial_Symptom_2"
+    },
+
+    "Bacterial_Symptom_2" : {
+      "type" : "Symptom",
+      "symptom": "Swollen Lymph Nodes",
+      "range": { "low" : 40, "high" : 100 },
+      "remarks" : "Strep generally presents with swollen lymph nodes",
+      "direct_transition" : "Bacterial_Symptom_3"
+    },
+
+    "Bacterial_Symptom_3" : {
+      "type" : "Symptom",
+      "symptom": "Swollen Tonsils",
+      "range": { "low": 40, "high": 100},
+      "direct_transition" : "Symptoms_dont_resolve"
+    },
+
+    "Symptoms_dont_resolve" : {
+      "type" : "Delay",
+      "range" : {
+        "low" : 1,
+        "high" : 5,
+        "unit" : "days"
+      },
+      "direct_transition" : "Doctor_Visit"
+    },
+
+    "Doctor_Visit" : {
+      "type" : "Encounter",
+      "codes" : [{
+        "system": "SNOMED-CT",
+        "code": "185345009",
+        "display": "Encounter for symptom"
+      }],
+      "conditional_transition" : [
+        {
+          "condition": {
+            "condition_type" : "Active Condition",
+            "codes" : [{
+              "system" : "SNOMED-CT",
+              "code" : "43878008",
+              "display" : "Streptococcal sore throat (disorder)"
+            }]
+          },
+          "transition": "Take_Temperature_High",
+          "remarks" : "high fever is a hallmark of strep throat  http://www.webmd.com/cold-and-flu/news/20131104/two-questions-may-rule-out-strep-throat"
+        },
+        {
+          "transition": "Take_Temperature_Low"
+        }
+      ]
+    },
+
+    "Take_Temperature_High" : {
+      "type" : "Observation",
+      "target_encounter" : "Doctor_Visit",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "8331-1",
+        "display" : "Oral temperature"
+      }],
+      "range" : {
+        "low" : 37.2,
+        "high" : 39.4
+      },
+      "remarks" : "37.2 - 39.4 Celsius == 99 - 103 Fahrenheit",
+      "unit" : "Cel",
+      "direct_transition" : "Determine_if_Bacterial"
+    },
+
+    "Take_Temperature_Low" : {
+      "type" : "Observation",
+      "target_encounter" : "Doctor_Visit",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "8331-1",
+        "display" : "Oral temperature"
+      }],
+      "range" : {
+        "low" : 37.0,
+        "high" : 38.0
+      },
+      "remarks" : "37.0 - 38.0 Celsius == 98.6 - 100.4 Fahrenheit",
+      "unit" : "Cel",
+      "direct_transition" : "Determine_if_Bacterial"
+    },
+
+    "Determine_if_Bacterial" : {
+      "type" : "Simple",
+      "remarks" : ["the Centor criteria are used to determine if a sore throat is bacterial",
+                   "http://www.mdcalc.com/modified-centor-score-for-strep-pharyngitis/",
+                   "modified slightly here to account for our simpler logic",
+                   "(we can't do -1 for age > 44 so we do +1 for age <= 44, and require an extra +1)"],
+      "conditional_transition" : [
+        {
+          "condition": {
+            "condition_type" : "At Least",
+            "minimum" : 5,
+            "conditions" : [
+              {
+                "condition_type" : "Symptom",
+                "symptom" : "Cough",
+                "operator" : "<",
+                "value" : 50
+              },
+              {
+                "condition_type" : "Symptom",
+                "symptom" : "Swollen Lymph Nodes",
+                "operator" : ">",
+                "value" : 50
+              },
+              {
+                "condition_type" : "Symptom",
+                "symptom" : "Swollen Tonsils",
+                "operator" : ">",
+                "value" : 50
+              },
+              {
+                "condition_type" : "Observation",
+                "codes" : [{
+                  "system" : "LOINC",
+                  "code" : "8331-1",
+                  "display" : "Oral temperature"
+                }],
+                "operator" : ">",
+                "value" : 38.0
+              },
+              {
+                "condition_type" : "Age",
+                "operator" : "<",
+                "quantity" : 15,
+                "unit" : "years"
+              },
+              {
+                "condition_type" : "Age",
+                "operator" : "<=",
+                "quantity" : 44,
+                "unit" : "years"
+              }
+            ]
+          },
+          "transition": "Prescribe_Antibiotics"
+        },
+        {
+          "condition": {
+            "condition_type" : "At Least",
+            "minimum" : 3,
+            "conditions" : [
+              {
+                "condition_type" : "Symptom",
+                "symptom" : "Cough",
+                "operator" : "<",
+                "value" : 50
+              },
+              {
+                "condition_type" : "Symptom",
+                "symptom" : "Swollen Lymph Nodes",
+                "operator" : ">",
+                "value" : 50
+              },
+              {
+                "condition_type" : "Symptom",
+                "symptom" : "Swollen Tonsils",
+                "operator" : ">",
+                "value" : 50
+              },
+              {
+                "condition_type" : "Observation",
+                "codes" : [{
+                  "system" : "LOINC",
+                  "code" : "8331-1",
+                  "display" : "Oral temperature"
+                }],
+                "operator" : ">",
+                "value" : 38.0
+              },
+              {
+                "condition_type" : "Age",
+                "operator" : "<",
+                "quantity" : 15,
+                "unit" : "years"
+              },
+              {
+                "condition_type" : "Age",
+                "operator" : "<=",
+                "quantity" : 44,
+                "unit" : "years"
+              }
+            ]
+          },
+          "transition": "Throat_Culture"
+        },
+        {
+          "transition": "Time_Passes"
+        }
+      ]
+    },
+
+    "Prescribe_Antibiotics" : {
+      "type" : "Simple",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Age",
+            "operator" : "<",
+            "quantity" : 18,
+            "unit" : "years"
+          },
+          "transition" : "Prescribe_Antibiotics_Child"
+        },
+        {
+          "transition" : "Prescribe_Antibiotics_Adult"
+        }
+      ]
+    },
+
+    "Prescribe_Antibiotics_Child" : {
+      "type" : "MedicationOrder",
+      "codes" : [{
+        "system" : "RxNorm",
+        "code" : "834060",
+        "display" : "Penicillin V Potassium 250 MG"
+      }],
+      "target_encounter" : "Doctor_Visit",
+      "assign_to_attribute" : "Sore Throat Antibiotic",
+      "direct_transition" : "Time_Passes",
+      "remarks" : "if we eventually add Penicillin allergies, we'll need a conditional to prescribe amoxicillin instead"
+    },
+
+    "Prescribe_Antibiotics_Adult" : {
+      "type" : "MedicationOrder",
+      "codes" : [{
+        "system" : "RxNorm",
+        "code" : "834101",
+        "display" : "Penicillin V Potassium 500 MG"
+      }],
+      "target_encounter" : "Doctor_Visit",
+      "assign_to_attribute" : "Sore Throat Antibiotic",
+      "direct_transition" : "Time_Passes"
+    },
+
+    "Throat_Culture" : {
+      "type" : "Procedure",
+      "target_encounter" : "Doctor_Visit",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "117015009",
+        "display" : "Throat culture (procedure) "
+      }],
+      "conditional_transition" : [
+        {
+          "condition": {
+            "condition_type" : "Active Condition",
+            "codes" : [{
+              "system" : "SNOMED-CT",
+              "code" : "43878008",
+              "display" : "Streptococcal sore throat (disorder)"
+            }]
+          },
+          "transition": "Prescribe_Antibiotics",
+          "remarks" : "assuming here for simplicity that the test is 100% accurate. real world it's more like 90-95%"
+        },
+        {
+          "transition": "Time_Passes"
+        }
+      ]
+    },
+
+
+    "Time_Passes" : {
+      "type" : "Delay",
+      "range" : {
+        "low" : 7,
+        "high" : 14,
+        "unit" : "days"
+      },
+      "direct_transition" : "Symptom_1_Ends"
+    },
+
+    "Symptom_1_Ends" : {
+      "type" : "Symptom",
+      "symptom": "Cough",
+      "exact" : { "quantity" : 0 },
+      "direct_transition" : "Symptom_2_Ends"
+    },
+
+    "Symptom_2_Ends" : {
+      "type" : "Symptom",
+      "symptom": "Swollen Lymph Nodes",
+      "exact" : { "quantity" : 0 },
+      "direct_transition" : "Symptom_3_Ends"
+    },
+
+    "Symptom_3_Ends" : {
+      "type" : "Symptom",
+      "symptom": "Swollen Tonsils",
+      "exact" : { "quantity" : 0 },
+      "direct_transition" : "Condition_Resolves"
+    },
+
+    "Condition_Resolves" : {
+      "type" : "ConditionEnd",
+      "referenced_by_attribute" : "Sore Throat Condition",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Active Medication",
+            "referenced_by_attribute" : "Sore Throat Antibiotic"
+          },
+          "transition" : "End_Antibiotics"
+        },
+        {
+          "transition" : "Potential_Infection"
+        }
+      ]
+    },
+
+    "End_Antibiotics" : {
+      "type" : "MedicationEnd",
+      "referenced_by_attribute" : "Sore Throat Antibiotic",
+      "direct_transition" : "Potential_Infection"
+    }
+
+  }
+}

--- a/lib/generic/modules/sore_throat.json
+++ b/lib/generic/modules/sore_throat.json
@@ -33,16 +33,16 @@
           },
           "distributions" : [
             {
-              "distribution": 0.02,
+              "distribution": 0.00583,
               "transition": "Acquire_Viral_Infection"
             },
             {
-              "distribution": 0.01,
+              "distribution": 0.00292,
               "transition": "Acquire_Bacterial_Infection",
               "remarks" : ["Bacterial is more common in children than in adults. Assume viral is only 2x as likely as bacterial for children"]
             },
             {
-              "distribution": 0.97,
+              "distribution": 0.9913,
               "transition": "Potential_Infection"
             }
           ]
@@ -50,16 +50,16 @@
         {
           "distributions" : [
             {
-              "distribution": 0.02,
+              "distribution": 0.00583,
               "transition": "Acquire_Viral_Infection"
             },
             {
-              "distribution": 0.003,
+              "distribution": 0.000875,
               "transition": "Acquire_Bacterial_Infection",
               "remarks" : ["[in adults] only about 5%-10% of sore throats are caused by a bacterial infection"]
             },
             {
-              "distribution": 0.977,
+              "distribution": 0.9933,
               "transition": "Potential_Infection"
             }
           ]
@@ -69,6 +69,7 @@
 
     "Acquire_Viral_Infection" : {
       "type" : "ConditionOnset",
+      "target_encounter" : "Doctor_Visit",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "195662009",
@@ -101,6 +102,7 @@
 
     "Acquire_Bacterial_Infection" : {
       "type" : "ConditionOnset",
+      "target_encounter" : "Doctor_Visit",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "43878008",

--- a/test/fixtures/generic/logic.json
+++ b/test/fixtures/generic/logic.json
@@ -192,6 +192,88 @@
       { "condition_type": "False" }
     ]
   },
+  "atLeast3_AllTrueTest" : {
+    "condition_type": "At Least",
+    "minimum" : 3,
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "True" }
+    ]
+  },
+  "atLeast3_3TrueTest" : {
+    "condition_type": "At Least",
+    "minimum" : 3,
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "False" },
+      { "condition_type": "True" }
+    ]
+  },
+  "atLeast3_2TrueTest" : {
+    "condition_type": "At Least",
+    "minimum" : 3,
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "True" }
+    ]
+  },
+  "atLeast3_NoneTrueTest" : {
+    "condition_type": "At Least",
+    "minimum" : 3,
+    "conditions": [
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "False" }
+    ]
+  },
+
+  "atMost2_AllTrueTest" : {
+    "condition_type": "At Most",
+    "maximum" : 2,
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "True" }
+    ]
+  },
+  "atMost2_3TrueTest" : {
+    "condition_type": "At Most",
+    "maximum" : 2,
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "True" },
+      { "condition_type": "False" },
+      { "condition_type": "True" }
+    ]
+  },
+  "atMost2_2TrueTest" : {
+    "condition_type": "At Most",
+    "maximum" : 2,
+    "conditions": [
+      { "condition_type": "True" },
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "True" }
+    ]
+  },
+  "atMost2_NoneTrueTest" : {
+    "condition_type": "At Most",
+    "maximum" : 2,
+    "conditions": [
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "False" },
+      { "condition_type": "False" }
+    ]
+  },
+
   "notTrueTest": {
     "condition_type": "Not",
     "condition": { "condition_type": "True" }

--- a/test/unit/generic_logic_test.rb
+++ b/test/unit/generic_logic_test.rb
@@ -257,6 +257,20 @@ class GenericLogicTest < Minitest::Test
     refute(do_test('orAllFalseTest'))
   end
 
+  def test_at_least_condition
+    assert(do_test('atLeast3_AllTrueTest'))
+    assert(do_test('atLeast3_3TrueTest'))
+    refute(do_test('atLeast3_2TrueTest'))
+    refute(do_test('atLeast3_NoneTrueTest'))
+  end
+
+  def test_at_most_condition
+    refute(do_test('atMost2_AllTrueTest'))
+    refute(do_test('atMost2_3TrueTest'))
+    assert(do_test('atMost2_2TrueTest'))
+    assert(do_test('atMost2_NoneTrueTest'))
+  end
+
   def test_not_conditions
     refute(do_test('notTrueTest'))
     assert(do_test('notFalseTest'))


### PR DESCRIPTION
Adds new generic modules for some of the most common respiratory diseases, for which people are likely to visit their PCP.
Specifically, Bronchitis (Acute only), Sore Throat (Viral or Strep), and Sinusitis (Acute Viral, Acute Bacterial, and Chronic)

Adds 2 new logical conditions: "At Least" and "At Most". These are grouping conditions that return true based on the number of sub-conditions that return true.

Also includes another minor framework change - complex transitions now allow for a direct transition instead of always requiring a distribution.

**For the wiki** : 
## At Least

The `At Least` condition type tests that a minimum number of conditions from set of sub-conditions are true.  If the _minimum_ number or more sub-conditions are true, it will return `true`, but if less than the minimum are true, it will return `false`. (If the _minimum_ is the same as the number of sub-conditions provided, this is equivalent to the `And` condition. If _minimum_ is 1, this is equivalent to the `Or` condition.)

**Supported Properties**
- **condition_type**: must be "And" _(required)_
- **minimum**: the minimum number of sub-conditions that must return true _(required)_
- **conditions[]**: an array of sub-conditions to test _(required)_

**Example**

The following "At Least" condition will return `true` if 2 or more of the following 3 conditions are met: 1) the patient is male, 2) the patient is at least 40 years old, 3) the patient has an active Diabetes self management plan; `false` otherwise. For example, if the patient is Male, age 46, and does not have a Diabetes self management plan, this condition will return true. If the patient is Female, age 67, and does not have a Diabetes self management plan, this condition will return false.

``` json
{
  "condition_type": "At Least",
  "minimum" : 2,
  "conditions": [
    {
      "condition_type": "Gender",
      "gender": "M" 
    },
    {
      "condition_type": "Age",
      "operator": ">=",
      "quantity": 40,
      "unit": "years"
    },
    {
      "condition_type" : "Active CarePlan",
      "codes": [{
        "system": "SNOMED-CT",
        "code": "698360004",
        "display": "Diabetes self management plan"
      }]
    }
  ]
}
```
## At Most

The `At Most` condition type tests that a maximum number of conditions from set of sub-conditions are true.  If the _maximum_ number or fewer sub-conditions are true, it will return `true`, but if more than the maximum are true, it will return `false`. 

**Example**

The following "At Most" condition will return `true` if 2 or fewer of the following 3 conditions are met: 1) the patient is male, 2) the patient is at least 40 years old, 3) the patient has an active Diabetes self management plan; `false` otherwise. For example, if the patient is Male, age 46, and does not have a Diabetes self management plan, this condition will return true. If the patient is Female, age 67, and does not have a Diabetes self management plan, this condition will return true. If the patient is Male, age 41, and has a Diabetes self management plan, this condition will return false.

``` json
{
  "condition_type": "At Most",
  "maximum" : 2,
  "conditions": [
    {
      "condition_type": "Gender",
      "gender": "M" 
    },
    {
      "condition_type": "Age",
      "operator": ">=",
      "quantity": 40,
      "unit": "years"
    },
    {
      "condition_type" : "Active CarePlan",
      "codes": [{
        "system": "SNOMED-CT",
        "code": "698360004",
        "display": "Diabetes self management plan"
      }]
    }
  ]
}
```
## Complex

`Complex` transitions are a combination of direct, distributed, and conditional transitions.  A `complex_transition` consists of an array of condition/transition pairs which are tested in the order they are defined.  The first condition that evaluates to `true` will result in a transition based on its corresponding `transition` or `distributions`.  If the module defines a `transition`, it will transition directly to that named state. If the module defines `distributions`, it will then transition to one of these according to the same rules as the `distributed_transition`. See [Distributed](#distributed) for more detail. The last element in the `complex_transition` array may omit the `condition` to indicate a fallback transition when all other conditions are `false`.

If none of the `conditions` evaluated to `true`, and no fallback transition was specified, the module will transition to a default `Terminal` state.

Please see the [[Logic|Generic Module Framework: Logic]] section for more information about creating logical conditions.

**Example**

The following example demonstrates a state that for male patients should transition to the "Foo" state with 15% probability and the "Bar" state with 85% probability, and for female patients should transition directly to the "Baz" state.

``` json
{
    "type": "Initial",
    "complex_transition": [
        {
            "condition": {
                "condition_type": "Gender",
                "gender": "M" 
            },
            "distributions" : [
                {
                    "distribution": 0.15,
                    "transition": "Foo"
                },
                {
                    "distribution": 0.85,
                    "transition": "Bar"
                }
            ]
        },
        {
            "condition": {
                "condition_type": "Gender",
                "gender": "F" 
            },
            "transition" : "Baz"
        }
    ]
}
```
# New Modules:

![sore throat](https://cloud.githubusercontent.com/assets/13512036/19772200/77640dbe-9c33-11e6-946f-91ab1e33768a.png)

![sinusitis](https://cloud.githubusercontent.com/assets/13512036/19772201/7a1c0dae-9c33-11e6-9b22-1d23706b2d57.png)

![bronchitis](https://cloud.githubusercontent.com/assets/13512036/19772211/7df1621c-9c33-11e6-8c02-627f85c928a8.png)
