### PR TITLE
fix transition %s by reworking state-loop logic

### DIFF
--- a/lib/generic/context.rb
+++ b/lib/generic/context.rb
@@ -18,13 +18,15 @@ module Synthea
             # looped from a state back to itself, so for perf reasons (memory usage)
             # just stay in the same state and change the dates instead of keeping another object
 
-            if @current_state.exited < time
-              # This must be a delay state that expired between cycles, so temporarily rewind time
-              run(@current_state.exited, entity)
-            end
+            exited = @current_state.exited
 
-            @current_state.start_time = @current_state.exited
+            @current_state.start_time = exited
             @current_state.exited = nil
+
+            if exited < time
+              # This must be a delay state that expired between cycles, so temporarily rewind time
+              run(exited, entity)
+            end
           else
             @history << @current_state
             @current_state = next_state

--- a/test/unit/generic/appendicitis_test.rb
+++ b/test/unit/generic/appendicitis_test.rb
@@ -28,7 +28,8 @@ class AppendicitisTest < Minitest::Test
     srand 9
 
     @context.run(@time, @patient)
-    @time = @time.advance(years: 19, months: 0, days: 9, hours: 23, minutes: 16, seconds: 8)
+    @time = (18.years + 32397368.seconds).since(@time) # seed 9 gives us this delay.
+    # DST means that giving a cleaner number in terms of years/months/days may not always match this # of seconds
 
     @patient.record_synthea.expect(:condition, nil, [:appendicitis, @time])
 
@@ -47,7 +48,8 @@ class AppendicitisTest < Minitest::Test
     srand 8765
 
     @context.run(@time, @patient)
-    @time = @time.advance(years: 62, months: 6, days: 12, hours: 15, minutes: 37, seconds: 20)
+    @time = (45.years + 553275440.seconds).since(@time) # seed 8765 gives us this delay.
+    # DST means that giving a cleaner number in terms of years/months/days may not always match this # of seconds
 
     @patient.record_synthea.expect(:condition, nil, [:appendicitis, @time])
     @patient.record_synthea.expect(:condition, nil, [:rupture_of_appendix, @time])

--- a/test/unit/generic_states_test.rb
+++ b/test/unit/generic_states_test.rb
@@ -134,9 +134,9 @@ class GenericStatesTest < Minitest::Test
     delay = Synthea::Generic::States::Delay.new(ctx, "2_To_10_Day_Delay")
     delay.start_time = @time
     refute(delay.process(@time, @patient))
-    refute(delay.process(@time.advance(:days => 6), @patient))
-    assert(delay.process(@time.advance(:days => 7), @patient))
-    assert(delay.process(@time.advance(:days => 8), @patient))
+    refute(delay.process(@time + 6*24*60*60, @patient))
+    assert(delay.process(@time + 7*24*60*60, @patient))
+    assert(delay.process(@time + 8*24*60*60, @patient))
 
 
     # Weeks (rand(2.weeks..10.weeks) = 4203177 s = 6.95 weeks)


### PR DESCRIPTION
Upon review of some of our transition %s, I discovered that the raw %s were consistent with the defined probabilities, but the overall #s didn't make sense. 
For example, given a module with a 1 year Delay state, a patient should only be able to transition away from that state once per year at most. If a patient were 14 years old, the module should have transitioned from that Delay state 14 times. (Maybe 13-15 but still, in the range of 14.) I observed this patient had 23 transitions away from the state. What was happening is that it was exiting the Delay state, transitioning back to itself, rewinding history, and then the "new" state still had the same enter & exit time so was just immediately exiting and transitioning again. Counting the total # of transitions resulted in %s that matched the defined probabilities, but in effect all the transitions that exited the loop had an extra % chance of triggering. (I suspect roughly double, meaning that if we pull this in it will reduce the frequency of all conditions added by modules with a delay-loop to about half of what they currently are)

This change brings the 2 blocks within Context.run in sync. In both cases the `@current_state` variable should be set to the new state before handling the "delay state that expired between cycles" logic.