### PR TITLE
GMF validator

### DIFF
--- a/lib/generic/components.rb
+++ b/lib/generic/components.rb
@@ -1,0 +1,56 @@
+module Synthea
+  module Generic
+    module Components
+      # generic "Components" that don't fit anywhere else
+      class Component
+        include Synthea::Generic::Metadata
+        include Synthea::Generic::Hashable
+
+        def initialize(hash)
+          from_hash(hash)
+        end
+      end
+
+      class Range < Component
+        attr_accessor :low, :high
+        required_field and: [:low, :high]
+
+        def value
+          rand(low..high)
+        end
+      end
+
+      class RangeWithUnit < Range
+        attr_accessor :unit
+        required_field :unit
+
+        def value
+          rand(low.send(unit)..high.send(unit))
+        end
+      end
+
+      class Exact < Component
+        attr_accessor :quantity
+        required_field :quantity
+
+        def value
+          quantity
+        end
+      end
+
+      class ExactWithUnit < Exact
+        attr_accessor :unit
+        required_field :unit
+
+        def value
+          quantity.send(unit)
+        end
+      end
+
+      class Code < Component
+        attr_accessor :code, :system, :display
+        required_field and: [:code, :system, :display]
+      end
+    end
+  end
+end

--- a/lib/generic/hashable.rb
+++ b/lib/generic/hashable.rb
@@ -1,0 +1,60 @@
+module Synthea
+  module Generic
+    module Hashable
+      # inspired by FHIR::Hashable
+
+      def from_hash(hash)
+        metadata = self.class.class_metadata
+        hash.each do |key, value|
+          next if key == 'remarks' # ignore remarks throughout
+          config = metadata[key]
+          # puts "Config for #{self.class}[#{key}] == #{config}"
+          if config
+            next if config[:ignore]
+            key = config[:store_as] if config[:store_as]
+            value = build_value(value, config)
+          end
+          begin
+            # puts "Setting #{key}=#{value} on #{self}"
+            send("#{key}=", value)
+          rescue
+            raise "Could not set field '#{key}' on #{inspect}.\nHash is #{hash}"
+          end
+        end
+      end
+
+      def build_value(value, config)
+        type = config[:type]
+        polymorphism = config[:polymorphism]
+
+        if type || polymorphism
+          value = if value.is_a?(Array) && (config[:max] || 0) > 1
+                    value.map { |v| construct(v, type, polymorphism) }
+                  else
+                    construct(value, type, polymorphism)
+                  end
+        end
+
+        if value && (config[:max] || 0) > 1 && !value.is_a?(Array)
+          # if there is only one of these, but cardinality allows more, we need to wrap it in an array.
+          value = [value]
+        end
+
+        value
+      end
+
+      def construct(value, type, polymorphism)
+        if polymorphism && value.is_a?(Hash) && value[polymorphism[:key]]
+          type = value[polymorphism[:key]].gsub(/\s+/, '_').camelize
+          type = "#{polymorphism[:package]}::#{type}" if polymorphism[:package]
+        end
+
+        if type
+          Object.const_get("Synthea::Generic::#{type}").new(value)
+        else
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/generic/logic.rb
+++ b/lib/generic/logic.rb
@@ -1,148 +1,227 @@
 module Synthea
   module Generic
     module Logic
-      def self.test(condition, context, time, entity)
-        func = "test_#{condition['condition_type'].gsub(/\s+/, '_').downcase}"
+      class Condition
+        include Synthea::Generic::Metadata
+        include Synthea::Generic::Hashable
 
-        raise "Unsupported condition type: #{condition['condition_type']}" unless respond_to?(func)
+        metadata 'condition_type', ignore: true
 
-        send(func, condition, context, time, entity)
-      end
-
-      def self.test_and(condition, context, time, entity)
-        condition['conditions'].each do |c|
-          return false unless test(c, context, time, entity)
+        def initialize(condition)
+          from_hash(condition)
         end
-        true
-      end
 
-      def self.test_or(condition, context, time, entity)
-        condition['conditions'].each do |c|
-          return true if test(c, context, time, entity)
-        end
-        false
-      end
-
-      def self.test_at_least(condition, context, time, entity)
-        condition['minimum'] <= condition['conditions'].count { |c| test(c, context, time, entity) }
-      end
-
-      def self.test_at_most(condition, context, time, entity)
-        condition['maximum'] >= condition['conditions'].count { |c| test(c, context, time, entity) }
-      end
-
-      def self.test_not(condition, context, time, entity)
-        !test(condition['condition'], context, time, entity)
-      end
-
-      def self.test_gender(condition, _context, _time, entity)
-        condition['gender'] == entity[:gender]
-      end
-
-      def self.test_age(condition, _context, time, entity)
-        birthdate = entity.event(:birth).time
-        age = Synthea::Modules::Lifecycle.age(time, birthdate, nil, condition['unit'].to_sym)
-        compare(age, condition['quantity'], condition['operator'])
-      end
-
-      def self.test_socioeconomic_status(condition, _context, _time, entity)
-        raise "Unsupported category: #{condition['category']}" unless %w(High Middle Low).include?(condition['category'])
-        ses_category = Synthea::Modules::Lifecycle.socioeconomic_category(entity)
-        compare(ses_category, condition['category'], '==')
-      end
-
-      def self.test_date(condition, _context, time, _entity)
-        compare(time.year, condition['year'], condition['operator'])
-      end
-
-      def self.test_attribute(condition, _context, _time, entity)
-        attribute = entity[condition['attribute']] || entity[condition['attribute'].to_sym]
-        compare(attribute, condition['value'], condition['operator'])
-      end
-
-      def self.test_symptom(condition, _context, _time, entity)
-        compare(entity.get_symptom_value(condition['symptom']), condition['value'], condition['operator'])
-      end
-
-      def self.test_observation(condition, _context, _time, entity)
-        # find the most recent instance of the given observation
-        obstype = find_referenced_type(condition, entity, 'Observation')
-
-        obs = entity.record_synthea.observations.select { |o| o['type'] == obstype }
-        operator = condition['operator']
-
-        if obs.empty?
-          if ['is nil', 'is not nil'].include?(operator)
-            compare(nil, condition['value'], operator)
+        def compare(lhs, rhs, operator)
+          case operator
+          when '<'
+            return lhs < rhs
+          when '<='
+            return lhs <= rhs
+          when '=='
+            return lhs == rhs
+          when '>='
+            return lhs >= rhs
+          when '>'
+            return lhs > rhs
+          when '!='
+            return lhs != rhs
+          when 'is nil'
+            return lhs.nil?
+          when 'is not nil'
+            return !lhs.nil?
           else
-            raise "No observations exist for type #{obstype}, cannot compare values"
+            raise "Unsupported operator: #{operator}"
           end
-        else
-          compare(obs.last['value'], condition['value'], operator)
+        end
+
+        def find_referenced_type(entity, name)
+          if codes
+            # based on state.symbol
+            codes.first.display.gsub(/\s+/, '_').downcase.to_sym
+          elsif referenced_by_attribute
+            entity[referenced_by_attribute] || entity[referenced_by_attribute.to_sym]
+          else
+            raise "#{name} condition must be specified by code or attribute"
+          end
         end
       end
 
-      def self.test_active_condition(condition, _context, _time, entity)
-        # return true if the given condition is currently active
-        contype = find_referenced_type(condition, entity, 'Active Condition')
+      class GroupedCondition < Condition
+        attr_accessor :conditions
 
-        entity.record_synthea.present[contype]
+        metadata 'conditions', type: 'Logic::Condition', polymorphism: { key: 'condition_type', package: 'Logic' }, min: 1, max: 999
       end
 
-      def self.test_priorstate(condition, context, _time, _entity)
-        !context.most_recent_by_name(condition['name']).nil?
-      end
-
-      def self.test_active_careplan(condition, _context, _time, entity)
-        # return true if the given careplan is currently active
-        contype = find_referenced_type(condition, entity, 'Active Careplan')
-        entity.record_synthea.careplan_active?(contype)
-      end
-
-      def self.test_active_medication(condition, _context, _time, entity)
-        medtype = find_referenced_type(condition, entity, 'Active Medication')
-        entity.record_synthea.medication_active?(medtype)
-      end
-
-      def self.test_true(_condition, _context, _time, _entity)
-        true
-      end
-
-      def self.test_false(_condition, _context, _time, _entity)
-        false
-      end
-
-      def self.find_referenced_type(condition, entity, name)
-        if condition['codes']
-          # based on state.symbol
-          condition['codes'].first['display'].gsub(/\s+/, '_').downcase.to_sym
-        elsif condition['referenced_by_attribute']
-          entity[condition['referenced_by_attribute']] || entity[condition['referenced_by_attribute'].to_sym]
-        else
-          raise "#{name} condition must be specified by code or attribute"
+      class And < GroupedCondition
+        def test(context, time, entity)
+          conditions.each do |c|
+            return false unless c.test(context, time, entity)
+          end
+          true
         end
       end
 
-      def self.compare(lhs, rhs, operator)
-        case operator
-        when '<'
-          return lhs < rhs
-        when '<='
-          return lhs <= rhs
-        when '=='
-          return lhs == rhs
-        when '>='
-          return lhs >= rhs
-        when '>'
-          return lhs > rhs
-        when '!='
-          return lhs != rhs
-        when 'is nil'
-          return lhs.nil?
-        when 'is not nil'
-          return !lhs.nil?
-        else
-          raise "Unsupported operator: #{operator}"
+      class Or < GroupedCondition
+        def test(context, time, entity)
+          conditions.each do |c|
+            return true if c.test(context, time, entity)
+          end
+          false
+        end
+      end
+
+      class AtLeast < GroupedCondition
+        attr_accessor :minimum
+
+        def test(context, time, entity)
+          minimum <= conditions.count { |c| c.test(context, time, entity) }
+        end
+      end
+
+      class AtMost < GroupedCondition
+        attr_accessor :maximum
+
+        def test(context, time, entity)
+          maximum >= conditions.count { |c| c.test(context, time, entity) }
+        end
+      end
+
+      class Not < Condition
+        attr_accessor :condition
+
+        metadata 'condition', type: 'Logic::Condition', polymorphism: { key: 'condition_type', package: 'Logic' }, min: 1, max: 1
+
+        def test(context, time, entity)
+          !condition.test(context, time, entity)
+        end
+      end
+
+      class Gender < Condition
+        attr_accessor :gender
+
+        def test(_context, _time, entity)
+          gender == entity[:gender]
+        end
+      end
+
+      class Age < Condition
+        attr_accessor :quantity, :unit, :operator
+
+        def test(_context, time, entity)
+          birthdate = entity.event(:birth).time
+          age = Synthea::Modules::Lifecycle.age(time, birthdate, nil, unit.to_sym)
+          compare(age, quantity, operator)
+        end
+      end
+
+      class SocioeconomicStatus < Condition
+        attr_accessor :category
+
+        def test(_context, _time, entity)
+          raise "Unsupported category: #{category}" unless %w(High Middle Low).include?(category)
+          ses_category = Synthea::Modules::Lifecycle.socioeconomic_category(entity)
+          compare(ses_category, category, '==')
+        end
+      end
+
+      class Date < Condition
+        attr_accessor :year, :operator
+
+        def test(_context, time, _entity)
+          compare(time.year, year, operator)
+        end
+      end
+
+      class Attribute < Condition
+        attr_accessor :attribute, :value, :operator
+
+        def test(_context, _time, entity)
+          entity_value = entity[attribute] || entity[attribute.to_sym]
+          compare(entity_value, value, operator)
+        end
+      end
+
+      class Symptom < Condition
+        attr_accessor :symptom, :value, :operator
+
+        def test(_context, _time, entity)
+          compare(entity.get_symptom_value(symptom), value, operator)
+        end
+      end
+
+      class Observation < Condition
+        attr_accessor :codes, :referenced_by_attribute, :operator, :value
+
+        metadata 'codes', type: 'Components::Code', min: 0, max: 999
+
+        def test(_context, _time, entity)
+          # find the most recent instance of the given observation
+          obstype = find_referenced_type(entity, 'Observation')
+
+          obs = entity.record_synthea.observations.select { |o| o['type'] == obstype }
+
+          if obs.empty?
+            if ['is nil', 'is not nil'].include?(operator)
+              compare(nil, value, operator)
+            else
+              raise "No observations exist for type #{obstype}, cannot compare values"
+            end
+          else
+            compare(obs.last['value'], value, operator)
+          end
+        end
+      end
+
+      class ActiveCondition < Condition
+        attr_accessor :codes, :referenced_by_attribute
+
+        metadata 'codes', type: 'Components::Code', min: 0, max: 999
+
+        def test(_context, _time, entity)
+          contype = find_referenced_type(entity, 'Active Condition')
+          entity.record_synthea.present[contype]
+        end
+      end
+
+      class PriorState < Condition
+        attr_accessor :name
+
+        def test(context, _time, _entity)
+          !context.most_recent_by_name(name).nil?
+        end
+      end
+
+      class ActiveCareplan < Condition
+        attr_accessor :codes, :referenced_by_attribute
+
+        metadata 'codes', type: 'Components::Code', min: 0, max: 999
+
+        def test(_context, _time, entity)
+          contype = find_referenced_type(entity, 'Active Careplan')
+          entity.record_synthea.careplan_active?(contype)
+        end
+      end
+
+      class ActiveMedication < Condition
+        attr_accessor :codes, :referenced_by_attribute
+
+        metadata 'codes', type: 'Components::Code', min: 0, max: 999
+
+        def test(_context, _time, entity)
+          medtype = find_referenced_type(entity, 'Active Medication')
+          entity.record_synthea.medication_active?(medtype)
+        end
+      end
+
+      class True < Condition
+        def test(_context, _time, _entity)
+          true
+        end
+      end
+
+      class False < Condition
+        def test(_context, _time, _entity)
+          false
         end
       end
     end

--- a/lib/generic/logic.rb
+++ b/lib/generic/logic.rb
@@ -48,6 +48,7 @@ module Synthea
 
       class GroupedCondition < Condition
         attr_accessor :conditions
+        required_field :conditions
 
         metadata 'conditions', type: 'Logic::Condition', polymorphism: { key: 'condition_type', package: 'Logic' }, min: 1, max: 999
       end
@@ -72,6 +73,7 @@ module Synthea
 
       class AtLeast < GroupedCondition
         attr_accessor :minimum
+        required_field :minimum
 
         def test(context, time, entity)
           minimum <= conditions.count { |c| c.test(context, time, entity) }
@@ -80,6 +82,7 @@ module Synthea
 
       class AtMost < GroupedCondition
         attr_accessor :maximum
+        required_field :maximum
 
         def test(context, time, entity)
           maximum >= conditions.count { |c| c.test(context, time, entity) }
@@ -88,6 +91,7 @@ module Synthea
 
       class Not < Condition
         attr_accessor :condition
+        required_field :condition
 
         metadata 'condition', type: 'Logic::Condition', polymorphism: { key: 'condition_type', package: 'Logic' }, min: 1, max: 1
 
@@ -98,6 +102,7 @@ module Synthea
 
       class Gender < Condition
         attr_accessor :gender
+        required_field :gender
 
         def test(_context, _time, entity)
           gender == entity[:gender]
@@ -106,6 +111,7 @@ module Synthea
 
       class Age < Condition
         attr_accessor :quantity, :unit, :operator
+        required_field and: [:quantity, :unit, :operator]
 
         def test(_context, time, entity)
           birthdate = entity.event(:birth).time
@@ -116,6 +122,7 @@ module Synthea
 
       class SocioeconomicStatus < Condition
         attr_accessor :category
+        required_field :category
 
         def test(_context, _time, entity)
           raise "Unsupported category: #{category}" unless %w(High Middle Low).include?(category)
@@ -126,6 +133,7 @@ module Synthea
 
       class Date < Condition
         attr_accessor :year, :operator
+        required_field and: [:year, :operator]
 
         def test(_context, time, _entity)
           compare(time.year, year, operator)
@@ -134,6 +142,7 @@ module Synthea
 
       class Attribute < Condition
         attr_accessor :attribute, :value, :operator
+        required_field and: [:attribute, :operator] # value is allowed to be omitted if operator is 'is nil'
 
         def test(_context, _time, entity)
           entity_value = entity[attribute] || entity[attribute.to_sym]
@@ -143,6 +152,7 @@ module Synthea
 
       class Symptom < Condition
         attr_accessor :symptom, :value, :operator
+        required_field and: [:symptom, :value, :operator]
 
         def test(_context, _time, entity)
           compare(entity.get_symptom_value(symptom), value, operator)
@@ -151,6 +161,7 @@ module Synthea
 
       class Observation < Condition
         attr_accessor :codes, :referenced_by_attribute, :operator, :value
+        required_field and: [:operator, :value, or: [:codes, :referenced_by_attribute]]
 
         metadata 'codes', type: 'Components::Code', min: 0, max: 999
 
@@ -174,6 +185,7 @@ module Synthea
 
       class ActiveCondition < Condition
         attr_accessor :codes, :referenced_by_attribute
+        required_field or: [:codes, :referenced_by_attribute]
 
         metadata 'codes', type: 'Components::Code', min: 0, max: 999
 
@@ -185,6 +197,7 @@ module Synthea
 
       class PriorState < Condition
         attr_accessor :name
+        required_field :name
 
         def test(context, _time, _entity)
           !context.most_recent_by_name(name).nil?
@@ -193,6 +206,7 @@ module Synthea
 
       class ActiveCareplan < Condition
         attr_accessor :codes, :referenced_by_attribute
+        required_field or: [:codes, :referenced_by_attribute]
 
         metadata 'codes', type: 'Components::Code', min: 0, max: 999
 
@@ -204,6 +218,7 @@ module Synthea
 
       class ActiveMedication < Condition
         attr_accessor :codes, :referenced_by_attribute
+        required_field or: [:codes, :referenced_by_attribute]
 
         metadata 'codes', type: 'Components::Code', min: 0, max: 999
 

--- a/lib/generic/logic.rb
+++ b/lib/generic/logic.rb
@@ -161,7 +161,7 @@ module Synthea
 
       class Observation < Condition
         attr_accessor :codes, :referenced_by_attribute, :operator, :value
-        required_field and: [:operator, :value, or: [:codes, :referenced_by_attribute]]
+        required_field and: [:operator, or: [:codes, :referenced_by_attribute]] # value is allowed to be omitted if operator is 'is nil'
 
         metadata 'codes', type: 'Components::Code', min: 0, max: Float::INFINITY
 

--- a/lib/generic/logic.rb
+++ b/lib/generic/logic.rb
@@ -199,6 +199,8 @@ module Synthea
         attr_accessor :name
         required_field :name
 
+        metadata 'name', reference_to_state_type: 'State', min: 1, max: 1
+
         def test(context, _time, _entity)
           !context.most_recent_by_name(name).nil?
         end

--- a/lib/generic/logic.rb
+++ b/lib/generic/logic.rb
@@ -50,7 +50,7 @@ module Synthea
         attr_accessor :conditions
         required_field :conditions
 
-        metadata 'conditions', type: 'Logic::Condition', polymorphism: { key: 'condition_type', package: 'Logic' }, min: 1, max: 999
+        metadata 'conditions', type: 'Logic::Condition', polymorphism: { key: 'condition_type', package: 'Logic' }, min: 1, max: Float::INFINITY
       end
 
       class And < GroupedCondition
@@ -163,7 +163,7 @@ module Synthea
         attr_accessor :codes, :referenced_by_attribute, :operator, :value
         required_field and: [:operator, :value, or: [:codes, :referenced_by_attribute]]
 
-        metadata 'codes', type: 'Components::Code', min: 0, max: 999
+        metadata 'codes', type: 'Components::Code', min: 0, max: Float::INFINITY
 
         def test(_context, _time, entity)
           # find the most recent instance of the given observation
@@ -187,7 +187,7 @@ module Synthea
         attr_accessor :codes, :referenced_by_attribute
         required_field or: [:codes, :referenced_by_attribute]
 
-        metadata 'codes', type: 'Components::Code', min: 0, max: 999
+        metadata 'codes', type: 'Components::Code', min: 0, max: Float::INFINITY
 
         def test(_context, _time, entity)
           contype = find_referenced_type(entity, 'Active Condition')
@@ -208,7 +208,7 @@ module Synthea
         attr_accessor :codes, :referenced_by_attribute
         required_field or: [:codes, :referenced_by_attribute]
 
-        metadata 'codes', type: 'Components::Code', min: 0, max: 999
+        metadata 'codes', type: 'Components::Code', min: 0, max: Float::INFINITY
 
         def test(_context, _time, entity)
           contype = find_referenced_type(entity, 'Active Careplan')
@@ -220,7 +220,7 @@ module Synthea
         attr_accessor :codes, :referenced_by_attribute
         required_field or: [:codes, :referenced_by_attribute]
 
-        metadata 'codes', type: 'Components::Code', min: 0, max: 999
+        metadata 'codes', type: 'Components::Code', min: 0, max: Float::INFINITY
 
         def test(_context, _time, entity)
           medtype = find_referenced_type(entity, 'Active Medication')

--- a/lib/generic/metadata.rb
+++ b/lib/generic/metadata.rb
@@ -1,6 +1,6 @@
 module Synthea
   module Generic
-    module Validation
+    module Metadata
       def self.included(base)
         base.extend(ClassMethods)
       end
@@ -14,10 +14,19 @@ module Synthea
           required_fields << field
         end
 
+        def class_metadata
+          @class_metadata ||= {}
+        end
+
+        def metadata(field, options)
+          class_metadata[field] = options
+        end
+
         def inherited(klass)
           super
           # this is needed because otherwise the children classes don't get the parent required fields
           klass.required_fields.push(*required_fields)
+          klass.class_metadata.merge!(class_metadata)
         end
       end
 
@@ -54,7 +63,7 @@ module Synthea
 
         if field.is_a?(Symbol)
           valid = send(field)
-          messages << "Required field #{field} is missing on #{self}" unless valid
+          messages << "Required field #{field} is missing on #{inspect}" unless valid
         elsif field.is_a?(Hash)
           valid = validate_field_hash(field, messages)
         else

--- a/lib/generic/metadata.rb
+++ b/lib/generic/metadata.rb
@@ -30,38 +30,51 @@ module Synthea
         end
       end
 
-      def validate
+      # context: the parent context (module) to which this object belongs
+      # path: array of parent objects that lead to this object (ie, state, transition/condition/etc)
+      def validate(context, path)
         messages = []
+        path = path.dup << self
         self.class.required_fields.each do |field|
-          validate_required_field(field, messages)
+          validate_required_field(field, messages, path)
         end
         self.class.class_metadata.each do |field, config|
           next if config[:ignore]
           field = config[:store_as] if config[:store_as]
           value = send(field)
 
+          if value && config[:reference_to_state_type]
+            state = context.config['states'][value]
+            if state.nil?
+              messages << build_message("#{field} references state '#{value}' which does not exist", path)
+            elsif config[:reference_to_state_type] != 'State' && config[:reference_to_state_type] != state['type']
+              messages << build_message("#{field} is expected to refer to a '#{config[:reference_to_state_type]}' but value '#{value}' is actually a '#{state['type']}'", path)
+            end
+          end
+
           if value.is_a?(Array)
-            value.each { |v| messages.push(*v.validate) }
+            value.each { |v| messages.push(*v.validate(context, path)) if v.respond_to?(:validate) }
           elsif value.respond_to?(:validate)
-            messages.push(*value.validate)
+            messages.push(*value.validate(context, path))
           end
         end
         messages.uniq
       end
 
-      def validate_field_hash(field, messages)
-        raise 'Validation hash must have exactly 1 top-level key' if field.size != 1
+      def validate_field_hash(field, messages, path)
+        raise "Validation hash must have exactly 1 top-level key, got (#{field.keys}) on #{self}" if field.size != 1
 
         if field[:or]
-          valid = field[:or].any? { |f| validate_required_field(f, []) }
+          valid = field[:or].any? { |f| validate_required_field(f, [], path) }
+          # messages passed as [] because we don't care about the messages we get back here
           unless valid
-            messages << "At least one of #{to_string(field)} is required on #{self}"
+            messages << build_message("At least one of #{to_string(field)} is required on #{self}", path)
             return false
           end
         elsif field[:and]
-          valid = field[:and].all? { |f| validate_required_field(f, []) }
+          valid = field[:and].all? { |f| validate_required_field(f, [], path) }
           unless valid
-            messages << "All of #{to_string(field)} are required on #{self}"
+            messages << build_message("All of #{to_string(field)} are required on #{self}", path)
             return false
           end
         end
@@ -69,19 +82,23 @@ module Synthea
         true
       end
 
-      def validate_required_field(field, messages)
+      def validate_required_field(field, messages, path)
         valid = true
 
         if field.is_a?(Symbol)
           valid = send(field)
-          messages << "Required '#{field}' is missing on #{inspect}" unless valid
+          messages << build_message("Required '#{field}' is missing on #{self}", path) unless valid
         elsif field.is_a?(Hash)
-          valid = validate_field_hash(field, messages)
+          valid = validate_field_hash(field, messages, path)
         else
-          raise "Unexpected Required Field format. Expected Symbol or Hash, got: #{field}"
+          raise "Unexpected Required Field format. Expected Symbol or Hash, got: #{field} on #{self}"
         end
 
         valid
+      end
+
+      def build_message(msg, path)
+        "#{msg}\n  Path: #{path.join(';')}"
       end
 
       def to_string(field)
@@ -95,7 +112,7 @@ module Synthea
           list = list.map { |f| to_string(f) }
           "(#{list.join(operator)})"
         else
-          raise "Unexpected Required Field format. Expected Symbol or Hash, got: #{field.inspect}"
+          raise "Unexpected Required Field format. Expected Symbol or Hash, got: #{field.inspect} on #{self}"
         end
       end
     end

--- a/lib/generic/modules/allergic_rhinitis.json
+++ b/lib/generic/modules/allergic_rhinitis.json
@@ -118,7 +118,7 @@
 
     "Allergic_Rhinitis_Diagnosis": {
       "type": "Encounter",
-      "class": "outpatient",
+      "encounter_class": "outpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -219,7 +219,7 @@
 
     "Immunotherapy_Consultation": {
       "type": "Encounter",
-      "class": "outpatient",
+      "encounter_class": "outpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -305,7 +305,7 @@
 
     "Immunotherapy_Treatment": {
       "type": "Encounter",
-      "class": "outpatient",
+      "encounter_class": "outpatient",
       "codes": [
         {
           "system": "SNOMED-CT",

--- a/lib/generic/modules/allergic_rhinitis.json
+++ b/lib/generic/modules/allergic_rhinitis.json
@@ -362,6 +362,7 @@
 
     "Immunotherapy_Followup": {
       "type": "Encounter",
+      "encounter_class" : "ambulatory",
       "codes": [
         {
           "system": "SNOMED-CT",

--- a/lib/generic/modules/appendicitis.json
+++ b/lib/generic/modules/appendicitis.json
@@ -156,7 +156,7 @@
     "Appendicitis_Encounter": {
       "type": "Encounter",
       "wellness": false,
-      "class" : "emergency",
+      "encounter_class" : "emergency",
       "direct_transition": "History_of_Appendectomy",
       "codes" : [{
         "system" : "SNOMED-CT",
@@ -179,7 +179,7 @@
 
     "Appendectomy_Encounter": {
       "type": "Encounter",
-      "class": "daytime",
+      "encounter_class": "daytime",
       "codes": [{
         "system": "SNOMED-CT",
         "code": "183452005",

--- a/lib/generic/modules/asthma.json
+++ b/lib/generic/modules/asthma.json
@@ -103,7 +103,7 @@
 
     "Asthma_Diagnosis": {
       "type": "Encounter",
-      "class": "outpatient",
+      "encounter_class": "outpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -248,7 +248,7 @@
 
     "Asthma_ED_Visit": {
       "type": "Encounter",
-      "class": "emergency",
+      "encounter_class": "emergency",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -261,7 +261,7 @@
 
     "Asthma_Attack_Followup": {
       "type": "Encounter",
-      "class": "outpatient",
+      "encounter_class": "outpatient",
       "codes": [
         {
           "system": "SNOMED-CT",

--- a/lib/generic/modules/bronchitis.json
+++ b/lib/generic/modules/bronchitis.json
@@ -101,7 +101,7 @@
 
     "Doctor_Visit" : {
       "type" : "Encounter",
-      "class" : "ambulatory",
+      "encounter_class" : "ambulatory",
       "codes" : [{
         "system": "SNOMED-CT",
         "code": "185345009",

--- a/lib/generic/modules/dementia.json
+++ b/lib/generic/modules/dementia.json
@@ -323,7 +323,7 @@
 
     "ModeratelySevere_Encounter": {
       "type": "Encounter",
-      "class": "ambulatory",
+      "encounter_class": "ambulatory",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -454,7 +454,7 @@
     
     "Severe_Encounter": {
       "type": "Encounter",
-      "class": "ambulatory",
+      "encounter_class": "ambulatory",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -497,7 +497,7 @@
     
     "VerySevere_Encounter": {
       "type": "Encounter",
-      "class": "ambulatory",
+      "encounter_class": "ambulatory",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -567,7 +567,7 @@
 
     "PneumoniaEncounter" : {
       "type" : "Encounter",
-      "class" : "inpatient",
+      "encounter_class" : "inpatient",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "34285007",

--- a/lib/generic/modules/ear_infections.json
+++ b/lib/generic/modules/ear_infections.json
@@ -114,7 +114,7 @@
 
     "Ear_Infection_Encounter": {
       "type": "Encounter",
-      "class": "outpatient",
+      "encounter_class": "outpatient",
       "codes": [
         {
           "system": "SNOMED-CT",

--- a/lib/generic/modules/injuries.json
+++ b/lib/generic/modules/injuries.json
@@ -196,7 +196,7 @@
 
     "RI_Minor_Encounter" : {
       "type" : "Encounter",
-      "class" : "emergency",
+      "encounter_class" : "emergency",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "50849002",
@@ -218,7 +218,7 @@
 
     "RI_Major_Encounter" : {
       "type" : "Encounter",
-      "class" : "emergency",
+      "encounter_class" : "emergency",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "50849002",
@@ -316,7 +316,7 @@
 
     "FI_Minor_Encounter" : {
       "type" : "Encounter",
-      "class" : "emergency",
+      "encounter_class" : "emergency",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "50849002",
@@ -338,7 +338,7 @@
 
     "FI_Major_Encounter" : {
       "type" : "Encounter",
-      "class" : "emergency",
+      "encounter_class" : "emergency",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "50849002",
@@ -430,7 +430,7 @@
 
     "BOI_Minor_Encounter" : {
       "type" : "Encounter",
-      "class" : "emergency",
+      "encounter_class" : "emergency",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "50849002",
@@ -452,7 +452,7 @@
 
     "BOI_Major_Encounter" : {
       "type" : "Encounter",
-      "class" : "emergency",
+      "encounter_class" : "emergency",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "50849002",
@@ -502,7 +502,7 @@
 
     "SOI_Minor_Encounter" : {
       "type" : "Encounter",
-      "class" : "emergency",
+      "encounter_class" : "emergency",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "50849002",
@@ -524,7 +524,7 @@
 
     "SOI_Major_Encounter" : {
       "type" : "Encounter",
-      "class" : "emergency",
+      "encounter_class" : "emergency",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "50849002",

--- a/lib/generic/modules/lung_cancer.json
+++ b/lib/generic/modules/lung_cancer.json
@@ -124,7 +124,7 @@
 
     "Diagnosis Encounter I": {
       "type": "Encounter",
-      "class": "emergency",
+      "encounter_class": "emergency",
       "codes": [{
         "system": "SNOMED-CT",
         "code": "50849002",
@@ -156,7 +156,7 @@
 
     "Diagnosis Encounter II": {
       "type": "Encounter",
-      "class": "outpatient",
+      "encounter_class": "outpatient",
       "codes": [{
         "system": "SNOMED-CT",
         "code": "185347001",
@@ -235,7 +235,7 @@
 
     "Diagnosis Encounter III": {
       "type": "Encounter",
-      "class": "outpatient",
+      "encounter_class": "outpatient",
       "codes": [{
         "system": "SNOMED-CT",
         "code": "185347001",
@@ -557,7 +557,7 @@
 
     "Diagnosis Encounter IV": {
       "type": "Encounter",
-      "class": "outpatient",
+      "encounter_class": "outpatient",
       "codes": [{
         "system": "SNOMED-CT",
         "code": "185347001",
@@ -603,7 +603,7 @@
 
     "SCLC Treatment Encounter": {
       "type": "Encounter",
-      "class": "inpatient",
+      "encounter_class": "inpatient",
       "codes": [{
         "system": "SNOMED-CT",
         "code": "185347001",
@@ -700,7 +700,7 @@
 
     "NSCLC Treatment Encounter": {
       "type": "Encounter",
-      "class": "inpatient",
+      "encounter_class": "inpatient",
       "codes": [{
         "system": "SNOMED-CT",
         "code": "185347001",

--- a/lib/generic/modules/opioid_addiction.json
+++ b/lib/generic/modules/opioid_addiction.json
@@ -145,7 +145,7 @@
 
     "Enter_Directed_Use_Encounter1" : {
       "type" : "Encounter",
-      "class" : "inpatient",
+      "encounter_class" : "inpatient",
       "codes" : [{
           "system": "SNOMED-CT",
           "code": "183452005",
@@ -190,7 +190,7 @@
 
     "Enter_Directed_Use_Encounter2" : {
       "type" : "Encounter",
-      "class" : "inpatient",
+      "encounter_class" : "inpatient",
       "codes" : [{
           "system": "SNOMED-CT",
           "code": "183452005",
@@ -366,7 +366,7 @@
 
     "Enter_Addiction_Treatment" : {
       "type" : "Encounter",
-      "class" : "inpatient",
+      "encounter_class" : "inpatient",
       "codes" : [{
           "system": "SNOMED-CT",
           "code": "56876005",
@@ -399,7 +399,7 @@
 
     "Recovery_Management" : {
       "type" : "Encounter",
-      "class" : "outpatient",
+      "encounter_class" : "outpatient",
       "codes" : [{
           "system": "SNOMED-CT",
           "code": "266707007",
@@ -440,7 +440,7 @@
 
     "Directed_Use_Overdose_Encounter" : { 
       "type" : "Encounter",
-      "class" : "outpatient",
+      "encounter_class" : "outpatient",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "50849002",
@@ -471,7 +471,7 @@
 
     "Misuse_Overdose_Encounter" : {
       "type" : "Encounter",
-      "class" : "outpatient",
+      "encounter_class" : "outpatient",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "50849002",
@@ -502,7 +502,7 @@
 
     "Addiction_Overdose_Encounter" : {
       "type" : "Encounter",
-      "class" : "outpatient",
+      "encounter_class" : "outpatient",
       "codes" : [{
         "system" : "SNOMED-CT",
         "code" : "50849002",

--- a/lib/generic/modules/pregnancy.json
+++ b/lib/generic/modules/pregnancy.json
@@ -51,7 +51,7 @@
     },
     "Week_10_Visit": {
       "type": "Encounter",
-      "class": "inpatient",
+      "encounter_class": "inpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -81,7 +81,7 @@
     },
     "Week_15_Visit": {
       "type": "Encounter",
-      "class": "inpatient",
+      "encounter_class": "inpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -112,7 +112,7 @@
     },
     "Week_26_Visit": {
       "type": "Encounter",
-      "class": "inpatient",
+      "encounter_class": "inpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -158,7 +158,7 @@
     },
     "Week_32_Visit": {
       "type": "Encounter",
-      "class": "inpatient",
+      "encounter_class": "inpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -204,7 +204,7 @@
     },
     "Week_36_Visit": {
       "type": "Encounter",
-      "class": "inpatient",
+      "encounter_class": "inpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -234,7 +234,7 @@
     },
     "Week_38_Visit": {
       "type": "Encounter",
-      "class": "inpatient",
+      "encounter_class": "inpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -264,7 +264,7 @@
     },
     "Week_39_Visit": {
       "type": "Encounter",
-      "class": "inpatient",
+      "encounter_class": "inpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -294,7 +294,7 @@
     },
     "Week_40_Visit": {
       "type": "Encounter",
-      "class": "inpatient",
+      "encounter_class": "inpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -323,7 +323,7 @@
     },
     "Week_41_Visit": {
       "type": "Encounter",
-      "class": "inpatient",
+      "encounter_class": "inpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -353,7 +353,7 @@
     },
     "Week_42_Visit": {
       "type": "Encounter",
-      "class": "inpatient",
+      "encounter_class": "inpatient",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -366,7 +366,7 @@
     },
     "Premature_Birth": {
       "type": "Encounter",
-      "class": "emergency",
+      "encounter_class": "emergency",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -378,7 +378,7 @@
     },
     "Normal_Birth": {
       "type": "Encounter",
-      "class": "emergency",
+      "encounter_class": "emergency",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -390,7 +390,7 @@
     },
     "Induced_Birth": {
       "type": "Encounter",
-      "class": "emergency",
+      "encounter_class": "emergency",
       "codes": [
         {
           "system": "SNOMED-CT",

--- a/lib/generic/modules/sinusitis.json
+++ b/lib/generic/modules/sinusitis.json
@@ -96,7 +96,7 @@
 
     "Doctor_Visit" : {
       "type" : "Encounter",
-      "class" : "ambulatory",
+      "encounter_class" : "ambulatory",
       "codes" : [{
         "system": "SNOMED-CT",
         "code": "185345009",
@@ -230,7 +230,7 @@
 
     "Chronic_Sinusitis_Followup" : {
       "type" : "Encounter",
-      "class" : "ambulatory",
+      "encounter_class" : "ambulatory",
       "codes" : [{
         "system": "SNOMED-CT",
         "code": "185345009",

--- a/lib/generic/modules/sore_throat.json
+++ b/lib/generic/modules/sore_throat.json
@@ -147,7 +147,7 @@
 
     "Doctor_Visit" : {
       "type" : "Encounter",
-      "class" : "ambulatory",
+      "encounter_class" : "ambulatory",
       "codes" : [{
         "system": "SNOMED-CT",
         "code": "185345009",

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -161,7 +161,7 @@ module Synthea
 
         required_field or: [:wellness, and: [:codes, :encounter_class]]
 
-        metadata 'codes', type: 'Components::Code', min: 1, max: 999
+        metadata 'codes', type: 'Components::Code', min: 1, max: Float::INFINITY
 
         def process(time, entity)
           unless @wellness
@@ -266,7 +266,7 @@ module Synthea
       class MedicationEnd < State
         attr_accessor :referenced_by_attribute, :medication_order, :reason, :codes
 
-        metadata 'codes', type: 'Components::Code', min: 0, max: 999
+        metadata 'codes', type: 'Components::Code', min: 0, max: Float::INFINITY
 
         def initialize(context, name)
           super
@@ -349,7 +349,7 @@ module Synthea
       class CarePlanEnd < State
         attr_accessor :careplan, :reason, :codes, :referenced_by_attribute
 
-        metadata 'codes', type: 'Components::Code', min: 0, max: 999
+        metadata 'codes', type: 'Components::Code', min: 0, max: Float::INFINITY
 
         def initialize(context, name)
           super
@@ -411,7 +411,7 @@ module Synthea
         required_field and: [:target_encounter, :codes, :unit]
         required_field or: [:range, :exact]
 
-        metadata 'codes', type: 'Components::Code', min: 1, max: 999
+        metadata 'codes', type: 'Components::Code', min: 1, max: Float::INFINITY
         metadata 'range', type: 'Components::Range', min: 0, max: 1
         metadata 'exact', type: 'Components::Exact', min: 0, max: 1
 
@@ -472,7 +472,7 @@ module Synthea
       class Death < State
         attr_accessor :range, :exact, :referenced_by_attribute, :condition_onset, :codes
 
-        metadata 'codes', type: 'Components::Code', min: 0, max: 999
+        metadata 'codes', type: 'Components::Code', min: 0, max: Float::INFINITY
         metadata 'range', type: 'Components::RangeWithUnit', min: 0, max: 1
         metadata 'exact', type: 'Components::ExactWithUnit', min: 0, max: 1
 

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -104,6 +104,8 @@ module Synthea
       end
 
       class Terminal < State
+        required_fields.delete(:transition)
+
         def process(_time, _entity)
           # never pass through the terminal state
           false

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -144,7 +144,6 @@ module Synthea
         def process(time, entity)
           # only indicate successful processing if the condition evaluates to true
           @allow.test(@context, time, entity)
-          # Synthea::Generic::Logic.test(@allow, @context, time, entity)
         end
       end
 

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -137,7 +137,7 @@ module Synthea
       end
 
       class Encounter < State
-        attr_accessor :wellness, :processed, :time, :codes, :class
+        attr_accessor :wellness, :processed, :time, :codes, :encounter_class
 
         def process(time, entity)
           unless @wellness
@@ -156,7 +156,7 @@ module Synthea
 
           if record_encounter
             value = add_lookup_code(ENCOUNTER_LOOKUP)
-            value[:class] = @class
+            value[:class] = @encounter_class
             entity.record_synthea.encounter(symbol, time)
           end
 
@@ -256,7 +256,7 @@ module Synthea
       end
 
       class CarePlanStart < State
-        attr_accessor :target_encounter, :codes, :activities, :target_encounter, :reason
+        attr_accessor :target_encounter, :codes, :activities, :reason
 
         def process(time, entity)
           start_plan(time, entity) if concurrent_with_target_encounter(time)

--- a/lib/generic/transitions.rb
+++ b/lib/generic/transitions.rb
@@ -48,7 +48,7 @@ module Synthea
       class DistributedTransition < Transition
         attr_accessor :transitions
 
-        metadata 'transitions', type: 'Transitions::DistributedTransitionOption', min: 1, max: 999
+        metadata 'transitions', type: 'Transitions::DistributedTransitionOption', min: 1, max: Float::INFINITY
 
         def initialize(transition)
           super('transitions' => transition)
@@ -87,7 +87,7 @@ module Synthea
       class ConditionalTransition < Transition
         attr_accessor :transitions
 
-        metadata 'transitions', type: 'Transitions::ConditionalTransitionOption', min: 1, max: 999
+        metadata 'transitions', type: 'Transitions::ConditionalTransitionOption', min: 1, max: Float::INFINITY
 
         def initialize(transition)
           super('transitions' => transition)
@@ -113,12 +113,12 @@ module Synthea
         required_field or: [:transition, :distributions]
 
         metadata 'condition', type: 'Logic::Condition', polymorphism: { key: 'condition_type', package: 'Logic' }, min: 0, max: 1
-        metadata 'distributions', type: 'Transitions::DistributedTransitionOption', min: 1, max: 999
+        metadata 'distributions', type: 'Transitions::DistributedTransitionOption', min: 1, max: Float::INFINITY
       end
 
       class ComplexTransition < DistributedTransition
         # inherit from distributed to get access to pick_distributed_transition
-        metadata 'transitions', type: 'Transitions::ComplexTransitionOption', min: 1, max: 999
+        metadata 'transitions', type: 'Transitions::ComplexTransitionOption', min: 1, max: Float::INFINITY
 
         def all_transitions
           ts = @transitions.collect do |ct|

--- a/lib/generic/transitions.rb
+++ b/lib/generic/transitions.rb
@@ -1,0 +1,77 @@
+module Synthea
+  module Generic
+    module Transitions
+      class Transition
+        include Synthea::Generic::Validation
+      end
+
+      class DirectTransition < Transition
+        def initialize(transition)
+          @transition = transition
+        end
+
+        def follow(_context, _entity, _time)
+          @transition
+        end
+      end
+
+      class DistributedTransition < Transition
+        def initialize(transition)
+          @distributions = transition
+        end
+
+        def follow(_context, _entity, _time)
+          pick_distributed_transition(@distributions)
+        end
+
+        def pick_distributed_transition(transitions)
+          # distributed_transition is an array of distributions that should total 1.0.
+          # So... pick a random float from 0.0 to 1.0 and walk up the scale.
+          choice = rand
+          high = 0.0
+          transitions.each do |dt|
+            high += dt['distribution']
+            return dt['transition'] if choice < high
+          end
+          # We only get here if the numbers didn't add to 1.0 or if one of the numbers caused
+          # floating point imprecision (very, very rare).  Just go with the last one.
+          transitions.last['transition']
+        end
+      end
+
+      class ConditionalTransition < Transition
+        def initialize(transition)
+          @transitions = transition
+        end
+
+        def follow(context, entity, time)
+          @transitions.each do |ct|
+            cond = ct['condition']
+            if cond.nil? || Synthea::Generic::Logic.test(cond, context, time, entity)
+              return ct['transition']
+            end
+          end
+          nil # no condition met
+        end
+      end
+
+      class ComplexTransition < DistributedTransition
+        # inherit from distributed to get access to pick_distributed_transition
+        def initialize(transition)
+          @transitions = transition
+        end
+
+        def follow(context, entity, time)
+          @transitions.each do |ct|
+            cond = ct['condition']
+            if cond.nil? || Synthea::Generic::Logic.test(cond, context, time, entity)
+              return ct['transition'] if ct['transition']
+              return pick_distributed_transition(ct['distributions'])
+            end
+          end
+          nil # no condition met
+        end
+      end
+    end
+  end
+end

--- a/lib/generic/transitions.rb
+++ b/lib/generic/transitions.rb
@@ -30,7 +30,7 @@ module Synthea
         include Synthea::Generic::Metadata
         include Synthea::Generic::Hashable
 
-        attr_accessor :transition
+        attr_accessor :transition # not required here because complex transition doesn't require 'transition' property
 
         def initialize(transition)
           from_hash(transition)
@@ -42,8 +42,7 @@ module Synthea
         include Synthea::Generic::Hashable
 
         attr_accessor :distribution
-        required_field :transition
-        required_field :distribution
+        required_field and: [:transition, :distribution]
       end
 
       class DistributedTransition < Transition
@@ -79,7 +78,8 @@ module Synthea
       end
 
       class ConditionalTransitionOption < TransitionOption
-        attr_accessor :condition
+        attr_accessor :condition # not required
+        required_field :transition
 
         metadata 'condition', type: 'Logic::Condition', polymorphism: { key: 'condition_type', package: 'Logic' }, min: 0, max: 1
       end
@@ -110,6 +110,7 @@ module Synthea
 
       class ComplexTransitionOption < TransitionOption
         attr_accessor :condition, :distributions
+        required_field or: [:transition, :distributions]
 
         metadata 'condition', type: 'Logic::Condition', polymorphism: { key: 'condition_type', package: 'Logic' }, min: 0, max: 1
         metadata 'distributions', type: 'Transitions::DistributedTransitionOption', min: 1, max: 999
@@ -117,8 +118,6 @@ module Synthea
 
       class ComplexTransition < DistributedTransition
         # inherit from distributed to get access to pick_distributed_transition
-        attr_accessor :transitions
-
         metadata 'transitions', type: 'Transitions::ComplexTransitionOption', min: 1, max: 999
 
         def all_transitions

--- a/lib/generic/transitions.rb
+++ b/lib/generic/transitions.rb
@@ -32,6 +32,8 @@ module Synthea
 
         attr_accessor :transition # not required here because complex transition doesn't require 'transition' property
 
+        metadata 'transition', reference_to_state_type: 'State', min: 0, max: 1
+
         def initialize(transition)
           from_hash(transition)
         end

--- a/lib/generic/transitions.rb
+++ b/lib/generic/transitions.rb
@@ -2,12 +2,19 @@ module Synthea
   module Generic
     module Transitions
       class Transition
-        include Synthea::Generic::Validation
+        include Synthea::Generic::Metadata
+        include Synthea::Generic::Hashable
+
+        def initialize(transition)
+          from_hash(transition)
+        end
       end
 
       class DirectTransition < Transition
+        attr_accessor :transition
+
         def initialize(transition)
-          @transition = transition
+          super('transition' => transition)
         end
 
         def follow(_context, _entity, _time)
@@ -19,66 +26,107 @@ module Synthea
         end
       end
 
-      class DistributedTransition < Transition
+      class TransitionOption
+        include Synthea::Generic::Metadata
+        include Synthea::Generic::Hashable
+
+        attr_accessor :transition
+
         def initialize(transition)
-          @distributions = transition
+          from_hash(transition)
+        end
+      end
+
+      class DistributedTransitionOption < TransitionOption
+        include Synthea::Generic::Metadata
+        include Synthea::Generic::Hashable
+
+        attr_accessor :distribution
+        required_field :transition
+        required_field :distribution
+      end
+
+      class DistributedTransition < Transition
+        attr_accessor :transitions
+
+        metadata 'transitions', type: 'Transitions::DistributedTransitionOption', min: 1, max: 999
+
+        def initialize(transition)
+          super('transitions' => transition)
         end
 
         def follow(_context, _entity, _time)
-          pick_distributed_transition(@distributions)
+          pick_distributed_transition(@transitions)
         end
 
         def all_transitions
-          @distributions.collect { |dt| dt['transition'] }
+          @transitions.collect(&:transition)
         end
 
-        def pick_distributed_transition(transitions)
+        def pick_distributed_transition(distributions)
           # distributed_transition is an array of distributions that should total 1.0.
           # So... pick a random float from 0.0 to 1.0 and walk up the scale.
           choice = rand
           high = 0.0
-          transitions.each do |dt|
-            high += dt['distribution']
-            return dt['transition'] if choice < high
+          distributions.each do |dt|
+            high += dt.distribution
+            return dt.transition if choice < high
           end
           # We only get here if the numbers didn't add to 1.0 or if one of the numbers caused
           # floating point imprecision (very, very rare).  Just go with the last one.
-          transitions.last['transition']
+          distributions.last.transition
         end
       end
 
+      class ConditionalTransitionOption < TransitionOption
+        attr_accessor :condition
+
+        metadata 'condition', type: 'Logic::Condition', polymorphism: { key: 'condition_type', package: 'Logic' }, min: 0, max: 1
+      end
+
       class ConditionalTransition < Transition
+        attr_accessor :transitions
+
+        metadata 'transitions', type: 'Transitions::ConditionalTransitionOption', min: 1, max: 999
+
         def initialize(transition)
-          @transitions = transition
+          super('transitions' => transition)
         end
 
         def all_transitions
-          @transitions.collect { |ct| ct['transition'] }
+          @transitions.collect(&:transition)
         end
 
         def follow(context, entity, time)
           @transitions.each do |ct|
-            cond = ct['condition']
-            if cond.nil? || Synthea::Generic::Logic.test(cond, context, time, entity)
-              return ct['transition']
+            cond = ct.condition
+            if cond.nil? || cond.test(context, time, entity)
+              return ct.transition
             end
           end
           nil # no condition met
         end
       end
 
+      class ComplexTransitionOption < TransitionOption
+        attr_accessor :condition, :distributions
+
+        metadata 'condition', type: 'Logic::Condition', polymorphism: { key: 'condition_type', package: 'Logic' }, min: 0, max: 1
+        metadata 'distributions', type: 'Transitions::DistributedTransitionOption', min: 1, max: 999
+      end
+
       class ComplexTransition < DistributedTransition
         # inherit from distributed to get access to pick_distributed_transition
-        def initialize(transition)
-          @transitions = transition
-        end
+        attr_accessor :transitions
+
+        metadata 'transitions', type: 'Transitions::ComplexTransitionOption', min: 1, max: 999
 
         def all_transitions
           ts = @transitions.collect do |ct|
-            if ct['transition']
-              ct['transition']
+            if ct.transition
+              ct.transition
             else
-              ct['distributions'].collect { |dt| dt['transition'] }
+              ct.distributions.collect(&:transition)
             end
           end
           ts.flatten.uniq
@@ -86,10 +134,10 @@ module Synthea
 
         def follow(context, entity, time)
           @transitions.each do |ct|
-            cond = ct['condition']
-            if cond.nil? || Synthea::Generic::Logic.test(cond, context, time, entity)
-              return ct['transition'] if ct['transition']
-              return pick_distributed_transition(ct['distributions'])
+            cond = ct.condition
+            if cond.nil? || cond.test(context, time, entity)
+              return ct.transition if ct.transition
+              return pick_distributed_transition(ct.distributions)
             end
           end
           nil # no condition met

--- a/lib/generic/transitions.rb
+++ b/lib/generic/transitions.rb
@@ -13,6 +13,10 @@ module Synthea
         def follow(_context, _entity, _time)
           @transition
         end
+
+        def all_transitions
+          [@transition]
+        end
       end
 
       class DistributedTransition < Transition
@@ -22,6 +26,10 @@ module Synthea
 
         def follow(_context, _entity, _time)
           pick_distributed_transition(@distributions)
+        end
+
+        def all_transitions
+          @distributions.collect { |dt| dt['transition'] }
         end
 
         def pick_distributed_transition(transitions)
@@ -44,6 +52,10 @@ module Synthea
           @transitions = transition
         end
 
+        def all_transitions
+          @transitions.collect { |ct| ct['transition'] }
+        end
+
         def follow(context, entity, time)
           @transitions.each do |ct|
             cond = ct['condition']
@@ -59,6 +71,17 @@ module Synthea
         # inherit from distributed to get access to pick_distributed_transition
         def initialize(transition)
           @transitions = transition
+        end
+
+        def all_transitions
+          ts = @transitions.collect do |ct|
+            if ct['transition']
+              ct['transition']
+            else
+              ct['distributions'].collect { |dt| dt['transition'] }
+            end
+          end
+          ts.flatten.uniq
         end
 
         def follow(context, entity, time)

--- a/lib/generic/validation.rb
+++ b/lib/generic/validation.rb
@@ -29,13 +29,13 @@ module Synthea
         if field[:or]
           valid = field[:or].any? { |f| validate_required_field(f, []) }
           unless valid
-            messages << "At least one of [#{to_string(field[:or])}] is required on #{inspect}"
+            messages << "At least one of #{to_string(field)} is required on #{inspect}"
             return false
           end
         elsif field[:and]
           valid = field[:and].all? { |f| validate_required_field(f, []) }
           unless valid
-            messages << "All of [#{to_string(field[:and])}] are required on #{inspect}"
+            messages << "All of #{to_string(field)} are required on #{inspect}"
             return false
           end
         end
@@ -65,10 +65,10 @@ module Synthea
           key, list = field.first
           # there's only one element, either field[:or] or field[:and]
           operator = " #{key} "
-          list.map! { |f| to_string(f) }
+          list = list.map { |f| to_string(f) }
           "(#{list.join(operator)})"
         else
-          raise "Unexpected Required Field format. Expected Symbol or Hash, got: #{field}"
+          raise "Unexpected Required Field format. Expected Symbol or Hash, got: #{field.inspect}"
         end
       end
     end

--- a/lib/generic/validation.rb
+++ b/lib/generic/validation.rb
@@ -13,6 +13,12 @@ module Synthea
         def required_field(field)
           required_fields << field
         end
+
+        def inherited(klass)
+          super
+          # this is needed because otherwise the children classes don't get the parent required fields
+          klass.required_fields.push(*required_fields)
+        end
       end
 
       def validate
@@ -48,7 +54,7 @@ module Synthea
 
         if field.is_a?(Symbol)
           valid = send(field)
-          messages << "Required field #{field} is missing on #{inspect}" unless valid
+          messages << "Required field #{field} is missing on #{self}" unless valid
         elsif field.is_a?(Hash)
           valid = validate_field_hash(field, messages)
         else

--- a/lib/generic/validation.rb
+++ b/lib/generic/validation.rb
@@ -1,0 +1,76 @@
+module Synthea
+  module Generic
+    module Validation
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def required_fields
+          @required_fields ||= []
+        end
+
+        def required_field(field)
+          required_fields << field
+        end
+      end
+
+      def validate
+        messages = []
+        self.class.required_fields.each do |field|
+          validate_required_field(field, messages)
+        end
+        messages
+      end
+
+      def validate_field_hash(field, messages)
+        raise 'Validation hash must have exactly 1 top-level key' if field.size != 1
+
+        if field[:or]
+          valid = field[:or].any? { |f| validate_required_field(f, []) }
+          unless valid
+            messages << "At least one of [#{to_string(field[:or])}] is required on #{inspect}"
+            return false
+          end
+        elsif field[:and]
+          valid = field[:and].all? { |f| validate_required_field(f, []) }
+          unless valid
+            messages << "All of [#{to_string(field[:and])}] are required on #{inspect}"
+            return false
+          end
+        end
+
+        true
+      end
+
+      def validate_required_field(field, messages)
+        valid = true
+
+        if field.is_a?(Symbol)
+          valid = send(field)
+          messages << "Required field #{field} is missing on #{inspect}" unless valid
+        elsif field.is_a?(Hash)
+          valid = validate_field_hash(field, messages)
+        else
+          raise "Unexpected Required Field format. Expected Symbol or Hash, got: #{field}"
+        end
+
+        valid
+      end
+
+      def to_string(field)
+        if field.is_a?(Symbol)
+          field.to_s
+        elsif field.is_a?(Hash)
+          key, list = field.first
+          # there's only one element, either field[:or] or field[:and]
+          operator = " #{key} "
+          list.map! { |f| to_string(f) }
+          "(#{list.join(operator)})"
+        else
+          raise "Unexpected Required Field format. Expected Symbol or Hash, got: #{field}"
+        end
+      end
+    end
+  end
+end

--- a/lib/synthea.rb
+++ b/lib/synthea.rb
@@ -51,6 +51,7 @@ Dir.glob(File.join(root, 'lib', 'entity', '**', '*.rb')).each do |file|
   require file
 end
 
+require File.join(root, 'lib', 'generic', 'validation.rb')
 Dir.glob(File.join(root, 'lib', 'generic', '**', '*.rb')).each do |file|
   require file
 end

--- a/lib/synthea.rb
+++ b/lib/synthea.rb
@@ -51,7 +51,8 @@ Dir.glob(File.join(root, 'lib', 'entity', '**', '*.rb')).each do |file|
   require file
 end
 
-require File.join(root, 'lib', 'generic', 'validation.rb')
+require File.join(root, 'lib', 'generic', 'metadata.rb')
+require File.join(root, 'lib', 'generic', 'hashable.rb')
 Dir.glob(File.join(root, 'lib', 'generic', '**', '*.rb')).each do |file|
   require file
 end

--- a/test/fixtures/generic/careplan_end.json
+++ b/test/fixtures/generic/careplan_end.json
@@ -4,7 +4,7 @@
 
         "Initial": {
             "type": "Initial",
-            "direct_transition": "Wellness_Encounter"
+            "direct_transition": "The_Condition"
         },
 
         "The_Condition": {

--- a/test/fixtures/generic/condition_onset.json
+++ b/test/fixtures/generic/condition_onset.json
@@ -24,7 +24,7 @@
         },
         "ED_Visit": {
             "type": "Encounter",
-            "class": "emergency",
+            "encounter_class": "emergency",
             "codes": [{
                 "system": "SNOMED-CT",
                 "code": "50849002",

--- a/test/fixtures/generic/condition_onset.json
+++ b/test/fixtures/generic/condition_onset.json
@@ -3,7 +3,7 @@
     "states": {
         "Initial": {
             "type": "Initial",
-            "direct_transition": "Annual_Physical"
+            "direct_transition": "Diabetes"
         },
         "Diabetes": {
             "type": "ConditionOnset",
@@ -12,6 +12,7 @@
                 "code": "73211009",
                 "display": "Diabetes mellitus"
             }],
+            "target_encounter": "ED_Visit",
             "direct_transition": "6_Month_Delay"
         },
         "6_Month_Delay": {
@@ -20,7 +21,7 @@
                 "quantity": 6,
                 "unit": "months"
             },
-            "direct_transition": "Diabetes"
+            "direct_transition": "ED_Visit"
         },
         "ED_Visit": {
             "type": "Encounter",

--- a/test/fixtures/generic/death.json
+++ b/test/fixtures/generic/death.json
@@ -3,7 +3,7 @@
     "states": {
         "Initial": {
             "type": "Initial",
-            "direct_transition": "Gender_Guard"
+            "direct_transition": "Death"
         },
         "Death": {
             "type": "Death",

--- a/test/fixtures/generic/death_reason.json
+++ b/test/fixtures/generic/death_reason.json
@@ -14,7 +14,7 @@
                 "display": "Diabetes mellitus"
             }],
             "assign_to_attribute" : "Cause of Death",
-            "direct_transition": "Terminal"
+            "direct_transition": "Diagnosis"
         },
         "Diagnosis" : {
             "type" : "Encounter",

--- a/test/fixtures/generic/death_reason.json
+++ b/test/fixtures/generic/death_reason.json
@@ -7,6 +7,7 @@
         },
         "OnsetDiabetes": {
             "type": "ConditionOnset",
+            "target_encounter" : "Diagnosis",
             "codes": [{
                 "system": "SNOMED-CT",
                 "code": "73211009",
@@ -14,6 +15,15 @@
             }],
             "assign_to_attribute" : "Cause of Death",
             "direct_transition": "Terminal"
+        },
+        "Diagnosis" : {
+            "type" : "Encounter",
+            "wellness" : true,
+            "distributed_transition" : [
+                { "distribution" : 0.33 , "transition" : "Death_by_Code" },
+                { "distribution" : 0.33 , "transition" : "Death_by_Attribute" },
+                { "distribution" : 0.33 , "transition" : "Death_by_ConditionOnset" }
+            ]
         },
         "Death_by_Code": {
             "type": "Death",

--- a/test/fixtures/generic/delay_time_travel.json
+++ b/test/fixtures/generic/delay_time_travel.json
@@ -15,7 +15,7 @@
         },
         "ED_Visit": {
             "type": "Encounter",
-            "class": "emergency",
+            "encounter_class": "emergency",
             "codes": [{
                 "system": "SNOMED-CT",
                 "code": "50849002",

--- a/test/fixtures/generic/encounter.json
+++ b/test/fixtures/generic/encounter.json
@@ -43,7 +43,7 @@
         },
         "ED_Visit": {
             "type": "Encounter",
-            "class": "emergency",
+            "encounter_class": "emergency",
             "codes": [{
                 "system": "SNOMED-CT",
                 "code": "50849002",

--- a/test/fixtures/generic/encounter.json
+++ b/test/fixtures/generic/encounter.json
@@ -49,7 +49,7 @@
                 "code": "50849002",
                 "display": "Emergency Room Admission"
             }],
-            "direct_transition": "2_Year_Delay"
+            "direct_transition": "Terminal"
         },
         "Terminal": {
             "type": "Terminal"

--- a/test/fixtures/generic/example_module.json
+++ b/test/fixtures/generic/example_module.json
@@ -94,7 +94,7 @@
         },
         "Examplotomy_Encounter": {
             "type": "Encounter",
-            "class": "daytime",
+            "encounter_class": "daytime",
             "codes": [{
                 "system": "SNOMED-CT",
                 "code": "ABC",

--- a/test/fixtures/generic/example_module.json
+++ b/test/fixtures/generic/example_module.json
@@ -132,7 +132,8 @@
             "direct_transition": "Death" 
         },
         "Death": {
-            "type": "Death"
+            "type": "Death",
+            "direct_transition" : "Terminal"
         },
         "Terminal": {
             "type": "Terminal"

--- a/test/fixtures/generic/medication_end.json
+++ b/test/fixtures/generic/medication_end.json
@@ -3,7 +3,7 @@
     "states": {
         "Initial": {
             "type": "Initial",
-            "direct_transition": "Condition"
+            "direct_transition": "Diabetes"
         },
         "Diabetes": {
             "type": "ConditionOnset",

--- a/test/fixtures/generic/medication_order.json
+++ b/test/fixtures/generic/medication_order.json
@@ -3,7 +3,7 @@
     "states": {
         "Initial": {
             "type": "Initial",
-            "direct_transition": "ConditionOnset"
+            "direct_transition": "Diabetes"
         },
         "Diabetes": {
             "type": "ConditionOnset",

--- a/test/fixtures/generic/no_transition.json
+++ b/test/fixtures/generic/no_transition.json
@@ -1,8 +1,0 @@
-{
-    "name": "NoTransition",
-    "states": {
-        "Initial": {
-            "type": "Initial"
-        }
-    }
-}

--- a/test/fixtures/generic/observation.json
+++ b/test/fixtures/generic/observation.json
@@ -8,7 +8,7 @@
 
         "SomeEncounter" : {
             "type" : "Encounter",
-            "class": "inpatient",
+            "encounter_class": "inpatient",
             "codes": [{
                 "system": "SNOMED-CT",
                 "code": "32485007",

--- a/test/fixtures/generic/observation.json
+++ b/test/fixtures/generic/observation.json
@@ -3,7 +3,7 @@
     "states": {
         "Initial": {
             "type": "Initial",
-            "direct_transition": "SomeObservation"
+            "direct_transition": "SomeEncounter"
         },
 
         "SomeEncounter" : {
@@ -28,7 +28,8 @@
             "exact" : { 
                 "quantity" : "120/80"
             },
-            "unit" : "mmHg"
+            "unit" : "mmHg",
+            "direct_transition" : "Terminal"
         },
 
         "Terminal": {

--- a/test/fixtures/generic/procedure.json
+++ b/test/fixtures/generic/procedure.json
@@ -7,7 +7,7 @@
         },
         "Inpatient_Encounter": {
             "type": "Encounter",
-            "class": "inpatient",
+            "encounter_class": "inpatient",
             "codes": [{
                 "system": "SNOMED-CT",
                 "code": "32485007",

--- a/test/fixtures/generic/validation/field_errors.json
+++ b/test/fixtures/generic/validation/field_errors.json
@@ -1,0 +1,106 @@
+{
+  "name": "Field_Errors",
+  "states": {
+
+    "Initial" : {
+      "type" : "Initial",
+      "direct_transition" : "Terminal"
+    },
+
+    "Terminal" : {
+      "type" : "Terminal"
+    },
+
+    "Missing_Transition": {
+      "type": "Simple"
+    },
+
+    "Guard_Missing_Allow" : {
+      "type" : "Guard",
+      "direct_transition" : "Terminal"
+    },
+
+    "Delay_Missing_Amount" : {
+      "type" : "Delay",
+      "direct_transition" : "Terminal"
+    },
+
+    "Encounter_Empty" : {
+      "type" : "Encounter",
+      "direct_transition" : "Terminal"
+    },
+
+    "Encounter_With_Class_Missing_Codes" : {
+      "type" : "Encounter",
+      "encounter_class" : "emergency",
+      "direct_transition" : "Terminal"
+    },
+
+    "Encounter_With_Code_Missing_System" : {
+      "type" : "Encounter",
+      "encounter_class" : "emergency",
+      "codes" : [{
+        "code" : "123456",
+        "display" : "Emergency Room Admission"
+      }],
+      "direct_transition" : "Terminal"
+    },
+
+    "Procedure_Missing_Target_Encounter" : {
+      "type" : "Procedure",
+      "codes" : [{
+        "system" : "aaa",
+        "code" : "bbb",
+        "display" : "ccc"
+      }],
+      "direct_transition" : "Terminal"
+    },
+
+    "Conditional_Transition_Missing_Transition" : {
+      "type" : "Simple",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "True"
+          }
+        },
+        {
+          "transition" : "Terminal"
+        }
+      ]
+    },
+
+    "Distributed_Transition_Missing_Pieces" : {
+      "type" : "Simple",
+      "distributed_transition" : [
+        { "distribution" : 0.5, "transition" : "Initial" },
+        { "transition" : "Terminal" },
+        { "distribution" : 0.5 }
+      ]
+    },
+
+    "Complex_Transition_Missing_Pieces" : {
+      "type" : "Simple",
+      "complex_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "True"
+          }
+        },
+        {
+          "transition" : "Terminal"
+        }
+      ]
+    },
+
+    "Date_Condition_Missing_Operator" : {
+      "type" : "Guard",
+      "allow" : {
+        "condition_type" : "Date",
+        "year" : 2016
+      },
+      "direct_transition" : "Terminal"
+    }
+
+  }
+}

--- a/test/fixtures/generic/validation/reference_errors.json
+++ b/test/fixtures/generic/validation/reference_errors.json
@@ -1,0 +1,41 @@
+{
+  "name": "Reference_Errors",
+  "states": {
+    "Initial" : {
+      "type" : "Initial",
+      "direct_transition" : "ConditionOnset_references_Non_Encounter_State"
+    },
+
+    "Unreachable_State" : {
+      "type" : "Simple",
+      "direct_transition" : "Terminal"
+    },
+
+    "ConditionOnset_references_Non_Encounter_State" : {
+      "type" : "ConditionOnset",
+      "codes" : [{
+        "system" : "blah",
+        "code" : "blah",
+        "display" : "blah"
+      }],
+      "target_encounter" : "Nonexistent_State",
+      "direct_transition" : "Doctor_Visit"
+    },
+
+    "Doctor_Visit" : {
+      "type" : "Encounter",
+      "wellness" : true,
+      "direct_transition" : "ConditionEnd_references_Incorrect_State"
+    },
+
+    "ConditionEnd_references_Incorrect_State" : {
+      "type" : "ConditionEnd",
+      "condition_onset" : "Doctor_Visit",
+      "direct_transition" : "Terminal"
+    },
+
+    "Terminal" : {
+      "type" : "Terminal"
+    }
+  }
+}

--- a/test/unit/generic_context_test.rb
+++ b/test/unit/generic_context_test.rb
@@ -104,14 +104,6 @@ class GenericContextTest < Minitest::Test
 
   end
 
-  def test_no_transition
-    ctx = get_context('no_transition.json')
-    assert_equal("Initial", ctx.current_state.name)
-    ctx.run(@time, @patient)
-    # If there is no transition, it should go to a default Terminal state
-    assert_equal("Terminal", ctx.current_state.name)
-  end
-
   def test_history
     # seed rand so we have deterministic results
     srand 3

--- a/test/unit/generic_logic_test.rb
+++ b/test/unit/generic_logic_test.rb
@@ -23,7 +23,9 @@ class GenericLogicTest < Minitest::Test
   end
 
   def do_test(name)
-    Synthea::Generic::Logic::test(@logic[name], @context, @time, @patient)
+    logic = @logic[name]
+    type = logic['condition_type'].gsub(/\s+/, '_').camelize
+    Object.const_get("Synthea::Generic::Logic::#{type}").new(logic).test(@context, @time, @patient)
   end
 
   def test_true

--- a/test/unit/generic_modules_test.rb
+++ b/test/unit/generic_modules_test.rb
@@ -1,76 +1,49 @@
 require_relative '../test_helper'
 
 class GenericModulesTest < Minitest::Test
-  def setup
-
-  end
-
   def test_all_modules
-    # loop over all the states, verify all logic is semantically valid, and all transitions go to valid states
-    # (not checking for impossible conditions, like AND(gender=M, gender=F) )
+    # loop over all the modules, verify all states and all transitions are valid
+    # future considerations: verify all logic
 
-    Dir.glob('./lib/generic/modules/*.json') do |wf_file|
-      wf = JSON.parse(File.read(wf_file))
-
-      context = Synthea::Generic::Context.new(wf)
-
-      wf['states'].each do |state_name, state|
-        generic_state_test(state_name, context, wf_file)
-        generic_transition_test(state_name, state, wf['states'].keys, wf_file)
-      end
+    Dir.glob('./lib/generic/modules/*.json') do |file|
+      check_file(file)
     end
 
-    Dir.glob('./test/fixtures/generic/*.json') do |wf_file|
-      if wf_file == './test/fixtures/generic/logic.json' # logic.json has only conditions, not real states
-        # logic = JSON.parse(File.read(wf_file))
-        # logic.each do |name, condition|
-        #   generic_logic_test(name, condition)
-        # end
-      else
-        wf = JSON.parse(File.read(wf_file))
-        context = Synthea::Generic::Context.new(wf)
-        wf['states'].each do |state_name, state|
-          generic_state_test(state_name, context, wf_file)
-          generic_transition_test(state_name, state, wf['states'].keys, wf_file)
-        end
-      end
+    Dir.glob('./test/fixtures/generic/*.json') do |file|
+      next if file == './test/fixtures/generic/logic.json' # logic.json has only conditions, not real states
+      check_file(file)
     end
   end
 
+  def check_file(file)
+    wf = JSON.parse(File.read(file))
+    context = Synthea::Generic::Context.new(wf)
 
-  def generic_state_test(state_name, context, file)
-    state = context.create_state(state_name)
-    assert_empty state.validate, "#{file}: State #{state_name} failed to validate"
+    all_states = wf['states'].keys
+    reachable = ['Initial']
+
+    all_states.each do |state_name|
+      state = context.create_state(state_name)
+      assert_empty state.validate, "#{file}: State #{state_name} failed to validate"
+      check_transitions(state_name, state, all_states, file, reachable)
+    end
+
+    unreachable = all_states - reachable
+    assert_empty(unreachable, "#{file}: Unreachable states detected")
   end
 
-  def generic_logic_test(state_name, condition)
-    #Synthea::Generic::Logic.test(condition, @context, @time, @patient)
-    pass # it's good as long as it doesn't raise an exception
-  end
-
-  def generic_transition_test(state_name, state, all_states, file)
-    if state['direct_transition']
-      check_transition_possible(state_name, all_states, state['direct_transition'], file)
-    elsif state['conditional_transition']
-      state['conditional_transition'].each do |ct|
-        check_transition_possible(state_name, all_states, ct['transition'], file)
-      end
-    elsif state['distributed_transition']
-      state['distributed_transition'].each do |dt|
-        check_transition_possible(state_name, all_states, dt['transition'], file)
-      end
-    elsif state['complex_transition']
-      state['complex_transition'].each do |ct|
-        if ct['transition']
-          check_transition_possible(state_name, all_states, ct['transition'], file)
-        elsif ct['distributions']
-          ct['distributions'].each do |dt|
-            check_transition_possible(state_name, all_states, dt['transition'], file)
-          end
-        end
-      end
+  def check_transitions(state_name, state, all_states, file, reachable)
+    if state.is_a?(Synthea::Generic::States::Terminal)
+      assert_equal(nil, state.transition, "#{file}: Terminal state #{state_name} has a transition defined")
     else
-      flunk("#{file}: State #{state_name} has no transitions defined") unless state['type'] == 'Terminal'
+      msg = "#{file}: State #{state_name} has no transitions defined"
+      refute_equal(nil, state.transition, msg)
+      refute_empty(state.transition.all_transitions, msg)
+      all_transitions = state.transition.all_transitions
+      all_transitions.each do |transition|
+        check_transition_possible(state_name, all_states, transition, file)
+        reachable << transition
+      end
     end
   end
 

--- a/test/unit/generic_modules_test.rb
+++ b/test/unit/generic_modules_test.rb
@@ -24,7 +24,8 @@ class GenericModulesTest < Minitest::Test
 
     all_states.each do |state_name|
       state = context.create_state(state_name)
-      assert_empty state.validate, "#{file}: State #{state_name} failed to validate"
+      errors = state.validate
+      assert errors.empty?, "#{file}: State #{state_name} failed to validate.\nErrors:\n#{errors.join('\n')}"
       check_transitions(state_name, state, all_states, file, reachable)
     end
 

--- a/test/unit/generic_modules_test.rb
+++ b/test/unit/generic_modules_test.rb
@@ -1,0 +1,81 @@
+require_relative '../test_helper'
+
+class GenericModulesTest < Minitest::Test
+  def setup
+
+  end
+
+  def test_all_modules
+    # loop over all the states, verify all logic is semantically valid, and all transitions go to valid states
+    # (not checking for impossible conditions, like AND(gender=M, gender=F) )
+
+    Dir.glob('./lib/generic/modules/*.json') do |wf_file|
+      wf = JSON.parse(File.read(wf_file))
+
+      context = Synthea::Generic::Context.new(wf)
+
+      wf['states'].each do |state_name, state|
+        generic_state_test(state_name, context, wf_file)
+        generic_transition_test(state_name, state, wf['states'].keys, wf_file)
+      end
+    end
+
+    Dir.glob('./test/fixtures/generic/*.json') do |wf_file|
+      if wf_file == './test/fixtures/generic/logic.json' # logic.json has only conditions, not real states
+        # logic = JSON.parse(File.read(wf_file))
+        # logic.each do |name, condition|
+        #   generic_logic_test(name, condition)
+        # end
+      else
+        wf = JSON.parse(File.read(wf_file))
+        context = Synthea::Generic::Context.new(wf)
+        wf['states'].each do |state_name, state|
+          generic_state_test(state_name, context, wf_file)
+          generic_transition_test(state_name, state, wf['states'].keys, wf_file)
+        end
+      end
+    end
+  end
+
+
+  def generic_state_test(state_name, context, file)
+    state = context.create_state(state_name)
+    assert_empty state.validate, "#{file}: State #{state_name} failed to validate"
+  end
+
+  def generic_logic_test(state_name, condition)
+    #Synthea::Generic::Logic.test(condition, @context, @time, @patient)
+    pass # it's good as long as it doesn't raise an exception
+  end
+
+  def generic_transition_test(state_name, state, all_states, file)
+    if state['direct_transition']
+      check_transition_possible(state_name, all_states, state['direct_transition'], file)
+    elsif state['conditional_transition']
+      state['conditional_transition'].each do |ct|
+        check_transition_possible(state_name, all_states, ct['transition'], file)
+      end
+    elsif state['distributed_transition']
+      state['distributed_transition'].each do |dt|
+        check_transition_possible(state_name, all_states, dt['transition'], file)
+      end
+    elsif state['complex_transition']
+      state['complex_transition'].each do |ct|
+        if ct['transition']
+          check_transition_possible(state_name, all_states, ct['transition'], file)
+        elsif ct['distributions']
+          ct['distributions'].each do |dt|
+            check_transition_possible(state_name, all_states, dt['transition'], file)
+          end
+        end
+      end
+    else
+      flunk("#{file}: State #{state_name} has no transitions defined") unless state['type'] == 'Terminal'
+    end
+  end
+
+  def check_transition_possible(state_name, all_states, transition, file)
+    assert_includes(all_states, transition,
+                    "#{file}: State '#{state_name}' transitions to '#{transition}' but this state does not exist")
+  end
+end

--- a/test/unit/metadata_test.rb
+++ b/test/unit/metadata_test.rb
@@ -2,7 +2,7 @@ require_relative '../test_helper'
 
 class MetadataTest < Minitest::Test
 
-  def test_validate
+  def test_validate_field_errors
     cfg = JSON.parse(File.read(File.join(File.expand_path("../../fixtures/generic/validation/", __FILE__), 'field_errors.json')))
     context = Synthea::Generic::Context.new(cfg)
 
@@ -50,7 +50,17 @@ class MetadataTest < Minitest::Test
     errors = validation_errors(context, 'Date_Condition_Missing_Operator')
     assert_equal 1, errors.count, "Expected 1 error, got #{errors}"
     assert_starts_with('All of (year and operator) are required on', errors[0])
+  end
 
+  def test_validate_reference_errors
+    cfg = JSON.parse(File.read(File.join(File.expand_path("../../fixtures/generic/validation/", __FILE__), 'reference_errors.json')))
+    context = Synthea::Generic::Context.new(cfg)
+
+    errors = context.validate
+    assert_equal 3, errors.count, "Expected 3 errors, got #{errors}"
+    assert_starts_with('target_encounter references state \'Nonexistent_State\' which does not exist', errors[0])
+    assert_starts_with('condition_onset is expected to refer to a \'ConditionOnset\' but value \'Doctor_Visit\' is actually a \'Encounter\'', errors[1])
+    assert_starts_with('State \'Unreachable_State\' is unreachable', errors[2])
   end
 
   def validation_errors(context, state_name)

--- a/test/unit/metadata_test.rb
+++ b/test/unit/metadata_test.rb
@@ -1,0 +1,81 @@
+require_relative '../test_helper'
+
+class MetadataTest < Minitest::Test
+
+  def test_validate
+    cfg = JSON.parse(File.read(File.join(File.expand_path("../../fixtures/generic/validation/", __FILE__), 'field_errors.json')))
+    context = Synthea::Generic::Context.new(cfg)
+
+    errors = validation_errors(context, 'Missing_Transition')
+    assert_equal 1, errors.count, "Expected 1 error, got #{errors}"
+    assert_starts_with('Required \'transition\' is missing', errors[0])
+
+    errors = validation_errors(context, 'Guard_Missing_Allow')
+    assert_equal 1, errors.count, "Expected 1 error, got #{errors}"
+    assert_starts_with('Required \'allow\' is missing', errors[0])
+
+    errors = validation_errors(context, 'Delay_Missing_Amount')
+    assert_equal 1, errors.count, "Expected 1 error, got #{errors}"
+    assert_starts_with('At least one of (range or exact) is required on', errors[0])
+
+    errors = validation_errors(context, 'Encounter_Empty')
+    assert_equal 1, errors.count, "Expected 1 error, got #{errors}"
+    assert_starts_with('At least one of (wellness or (codes and encounter_class)) is required on', errors[0])
+
+    errors = validation_errors(context, 'Encounter_With_Class_Missing_Codes')
+    assert_equal 1, errors.count, "Expected 1 error, got #{errors}"
+    assert_starts_with('At least one of (wellness or (codes and encounter_class)) is required on', errors[0])
+
+    errors = validation_errors(context, 'Encounter_With_Code_Missing_System')
+    assert_equal 1, errors.count, "Expected 1 error, got #{errors}"
+    assert_starts_with('All of (code and system and display) are required on', errors[0])
+
+    errors = validation_errors(context, 'Procedure_Missing_Target_Encounter')
+    assert_equal 1, errors.count, "Expected 1 error, got #{errors}"
+    assert_starts_with('All of (target_encounter and codes) are required on', errors[0])
+
+    errors = validation_errors(context, 'Conditional_Transition_Missing_Transition')
+    assert_equal 1, errors.count, "Expected 1 error, got #{errors}"
+    assert_starts_with('Required \'transition\' is missing', errors[0])
+
+    errors = validation_errors(context, 'Distributed_Transition_Missing_Pieces')
+    assert_equal 2, errors.count, "Expected 2 errors, got #{errors}"
+    assert_starts_with('All of (transition and distribution) are required on', errors[0])
+    assert_starts_with('All of (transition and distribution) are required on', errors[1])
+
+    errors = validation_errors(context, 'Complex_Transition_Missing_Pieces')
+    assert_equal 1, errors.count, "Expected 1 error, got #{errors}"
+    assert_starts_with('At least one of (transition or distributions) is required on', errors[0])
+
+    errors = validation_errors(context, 'Date_Condition_Missing_Operator')
+    assert_equal 1, errors.count, "Expected 1 error, got #{errors}"
+    assert_starts_with('All of (year and operator) are required on', errors[0])
+
+  end
+
+  def validation_errors(context, state_name)
+    context.create_state(state_name).validate
+  end
+
+  def assert_starts_with(prefix, obj, msg = nil)
+    msg ||= "Expected '#{obj}' to start with '#{prefix}'"
+    assert(obj.start_with?(prefix), msg)
+  end
+
+  def test_to_string
+    obj = Class.new.extend(Synthea::Generic::Metadata)
+
+    assert_equal 'symbol', obj.to_string(:symbol)
+    assert_equal '(this or that)', obj.to_string(or: [:this, :that])
+    assert_equal '(gold and silver)', obj.to_string(and: [:gold, :silver])
+    assert_equal '((salt and pepper) or (sugar and spice))', obj.to_string( or: [{ and: [:salt, :pepper] }, { and: [:sugar, :spice] }])
+
+    assert_raises { obj.to_string([:this, :that]) }
+    assert_raises { obj.to_string('string') }
+    assert_raises { obj.to_string({ or: [:this, :that], and: [:something_else] }) } # note this is 2 entries in 1 hash
+    assert_raises { obj.to_string({}) }
+      
+      
+
+  end
+end

--- a/test/unit/metadata_test.rb
+++ b/test/unit/metadata_test.rb
@@ -54,7 +54,7 @@ class MetadataTest < Minitest::Test
   end
 
   def validation_errors(context, state_name)
-    context.create_state(state_name).validate
+    context.create_state(state_name).validate(context, [])
   end
 
   def assert_starts_with(prefix, obj, msg = nil)


### PR DESCRIPTION
Re-architects some of the internals of the Generic Module Framework such that we can easily validate modules with a unit test, and not have to duplicate logic between using and validating states. 
Includes:
 - new Transition and Component modules, and updates Logic module so that conditions are their own objects. (Component includes Range, Delay, and Code classes)
 - class Metadata, and the ability to build up objects from JSON; heavily inspired by FHIR's "Hashable"
 - objects within the GMF are now true objects instead of just hashes
 - automatic validation based on required fields
 - new "generic_modules_test" to verify that all modules are valid, including all test fixtures
 - renaming "class" within Encounter states to "encounter_class"