### PR TITLE
Updated deceased datetime in FHIR exporter

### DIFF
--- a/lib/records/ccda.rb
+++ b/lib/records/ccda.rb
@@ -59,7 +59,7 @@ module Synthea
         patient.race = { 'name' => entity[:race].to_s.capitalize, 'code' => RACE_ETHNICITY_CODES[entity[:race]] }
         patient.ethnicity = { 'name' => entity[:ethnicity].to_s.capitalize, 'code' => RACE_ETHNICITY_CODES[entity[:ethnicity]] }
 
-        if !entity.alive? && entity.record_synthea.patient_info[:deathdate] <= end_time
+        if !entity.alive?(end_time)
           patient.deathdate = entity.record_synthea.patient_info[:deathdate].to_i
           patient.expired = true
           # TODO: would like to put cause of death on the record, though different IGs seem to provide different templates

--- a/lib/records/ccda.rb
+++ b/lib/records/ccda.rb
@@ -59,7 +59,7 @@ module Synthea
         patient.race = { 'name' => entity[:race].to_s.capitalize, 'code' => RACE_ETHNICITY_CODES[entity[:race]] }
         patient.ethnicity = { 'name' => entity[:ethnicity].to_s.capitalize, 'code' => RACE_ETHNICITY_CODES[entity[:ethnicity]] }
 
-        if !entity.alive?(end_time)
+        unless entity.alive?(end_time)
           patient.deathdate = entity.record_synthea.patient_info[:deathdate].to_i
           patient.expired = true
           # TODO: would like to put cause of death on the record, though different IGs seem to provide different templates

--- a/lib/records/exporter.rb
+++ b/lib/records/exporter.rb
@@ -120,13 +120,8 @@ module Synthea
           # If any entries have an end date in the future but are within the cutoff_date,
           # remove the end date but keep the entry (since it's still active).
           entries.each do |e|
-            if e['stop'] && e['stop'] > end_time
-              e['stop'] = nil
-            end
-
-            if e['end_time'] && e['end_time'] > end_time
-              e['end_time'] = nil
-            end
+            e['stop'] = nil if e['stop'] && e['stop'] > end_time
+            e['end_time'] = nil if e['end_time'] && e['end_time'] > end_time
           end
 
           patient.record_synthea.send("#{attribute}=", entries)

--- a/lib/records/exporter.rb
+++ b/lib/records/exporter.rb
@@ -1,11 +1,11 @@
 module Synthea
   module Output
     module Exporter
-      def self.export(patient)
-        patient = filter_for_export(patient) unless Synthea::Config.exporter.years_of_history <= 0
+      def self.export(patient, end_time = Time.now)
+        patient = filter_for_export(patient, end_time) unless Synthea::Config.exporter.years_of_history <= 0
 
         if Synthea::Config.exporter.ccda.export || Synthea::Config.exporter.ccda.upload || Synthea::Config.exporter.html.export
-          ccda_record = Synthea::Output::CcdaRecord.convert_to_ccda(patient)
+          ccda_record = Synthea::Output::CcdaRecord.convert_to_ccda(patient, end_time)
 
           if Synthea::Config.exporter.ccda.export
             out_dir = get_output_folder('CCDA', patient)
@@ -23,7 +23,7 @@ module Synthea
         end
 
         if Synthea::Config.exporter.fhir.export || Synthea::Config.exporter.fhir.upload
-          fhir_record = Synthea::Output::FhirRecord.convert_to_fhir(patient)
+          fhir_record = Synthea::Output::FhirRecord.convert_to_fhir(patient, end_time)
 
           if Synthea::Config.exporter.fhir.upload
             fhir_upload(fhir_record, Synthea::Config.exporter.fhir.upload)
@@ -100,11 +100,13 @@ module Synthea
         entry
       end
 
-      def self.filter_for_export(patient)
+      def self.filter_for_export(patient, end_time = Time.now)
         # filter the patient's history to only the last __ years
-        # but also include relevant history from before that
+        # but also include relevant history from before that. Exclude
+        # any history that occurs after the specified end_time (typically
+        # this is Time.now).
 
-        cutoff_date = Time.now - Synthea::Config.exporter.years_of_history.years
+        cutoff_date = end_time - Synthea::Config.exporter.years_of_history.years
 
         # dup the patient so that we export only the last _ years but the rest still exists, just in case
         patient = patient.dup
@@ -113,18 +115,18 @@ module Synthea
         [:encounters, :conditions, :observations, :procedures, :immunizations, :careplans, :medications].each do |attribute|
           entries = patient.record_synthea.send(attribute).dup
 
-          entries.keep_if { |e| should_keep_entry(e, attribute, patient.record_synthea, cutoff_date) }
+          entries.keep_if { |e| should_keep_entry(e, attribute, patient.record_synthea, cutoff_date, end_time) }
           patient.record_synthea.send("#{attribute}=", entries)
         end
 
         patient
       end
 
-      def self.should_keep_entry(e, attribute, record, cutoff_date)
-        return true if e['time'] > cutoff_date # trivial case, when we're within the last __ years
+      def self.should_keep_entry(e, attribute, record, cutoff_date, end_time = Time.now)
+        return true if e['time'] > cutoff_date && e['time'] <= end_time # trivial case, when we're within the last __ years
 
         # if the entry has a stop time, check if the effective date range overlapped the last __ years
-        return true if e['stop'] && e['stop'] > cutoff_date
+        return true if e['stop'] && e['stop'] > cutoff_date && e['stop'] <= end_time
 
         # - encounters, observations, immunizations are single dates and have no "reason"
         #    so they can only be filtered by the single date
@@ -137,7 +139,7 @@ module Synthea
         when :careplans
           return record.careplan_active?(e['type'])
         when :conditions
-          return record.present[e['type']] || (e['end_time'] && e['end_time'] > cutoff_date)
+          return record.present[e['type']] || (e['end_time'] && e['end_time'] > cutoff_date && e['end_time'] <= end_time)
         when :encounters
           return e['type'] == :death_certification
         when :observations

--- a/lib/records/fhir.rb
+++ b/lib/records/fhir.rb
@@ -141,7 +141,7 @@ module Synthea
                                                          'data' => Base64.strict_encode64(entity[:fingerprint].to_blob))
         end
         # record death if applicable
-        if !entity.alive?(end_time)
+        unless entity.alive?(end_time)
           patient_resource.deceasedDateTime = convert_fhir_date_time(entity.record_synthea.patient_info[:deathdate], 'time')
         end
 

--- a/lib/records/fhir.rb
+++ b/lib/records/fhir.rb
@@ -141,7 +141,7 @@ module Synthea
                                                          'data' => Base64.strict_encode64(entity[:fingerprint].to_blob))
         end
         # record death if applicable
-        if !entity.alive? && entity.record_synthea.patient_info[:deathdate] <= end_time
+        if !entity.alive?(end_time)
           patient_resource.deceasedDateTime = convert_fhir_date_time(entity.record_synthea.patient_info[:deathdate], 'time')
         end
 

--- a/lib/records/fhir.rb
+++ b/lib/records/fhir.rb
@@ -3,12 +3,12 @@ module Synthea
     module FhirRecord
       SHR_EXT = 'http://standardhealthrecord.org/fhir/extensions/'.freeze
 
-      def self.convert_to_fhir(entity)
+      def self.convert_to_fhir(entity, end_time = Time.now)
         synthea_record = entity.record_synthea
         indices = { observations: 0, conditions: 0, procedures: 0, immunizations: 0, careplans: 0, medications: 0 }
         fhir_record = FHIR::Bundle.new
         fhir_record.type = 'collection'
-        patient = basic_info(entity, fhir_record)
+        patient = basic_info(entity, fhir_record, end_time)
         synthea_record.encounters.each do |encounter|
           curr_encounter = encounter(encounter, fhir_record, patient)
           [:conditions, :observations, :procedures, :immunizations, :careplans, :medications].each do |attribute|
@@ -25,7 +25,7 @@ module Synthea
         fhir_record
       end
 
-      def self.basic_info(entity, fhir_record)
+      def self.basic_info(entity, fhir_record, end_time = Time.now)
         if entity[:race] == :hispanic
           race_fhir = :other
           ethnicity_fhir = entity[:ethnicity]
@@ -141,11 +141,8 @@ module Synthea
                                                          'data' => Base64.strict_encode64(entity[:fingerprint].to_blob))
         end
         # record death if applicable
-        if !entity.alive?(Time.now)
+        if !entity.alive? && entity.record_synthea.patient_info[:deathdate] <= end_time
           patient_resource.deceasedDateTime = convert_fhir_date_time(entity.record_synthea.patient_info[:deathdate], 'time')
-          patient_resource.deceasedBoolean = true
-        else
-          patient_resource.deceasedBoolean = false
         end
 
         entry = FHIR::Bundle::Entry.new

--- a/lib/records/fhir.rb
+++ b/lib/records/fhir.rb
@@ -141,8 +141,11 @@ module Synthea
                                                          'data' => Base64.strict_encode64(entity[:fingerprint].to_blob))
         end
         # record death if applicable
-        unless entity.alive?
+        if !entity.alive?(Time.now)
           patient_resource.deceasedDateTime = convert_fhir_date_time(entity.record_synthea.patient_info[:deathdate], 'time')
+          patient_resource.deceasedBoolean = true
+        else
+          patient_resource.deceasedBoolean = false
         end
 
         entry = FHIR::Bundle::Entry.new


### PR DESCRIPTION
Updated FHIR exporter to handle the rare case when a patient's death date exists as an event but still occurs in the future (the patient hasn't actually died yet). This is typically seen for patients with lung cancer and is a rare occurence (1-3 in 10k records). Also added the deceasedBoolean field to the FHIR records that are exported to make it easier to query FHIR for living or deceased patients using the Patient?deceased=true/false query.