### PR TITLE
Encounter reason

### DIFF
--- a/lib/generic/modules/allergic_rhinitis.json
+++ b/lib/generic/modules/allergic_rhinitis.json
@@ -126,6 +126,7 @@
           "display": "Encounter for symptom"
         }
       ],
+      "reason" : "has_allergic_rhinitis",
       "remarks": [
         "I select one of several over-the-counter (OTC) medications to be prescribed",
         "to the patient. These are uniformly distributed since they are all equally",
@@ -227,6 +228,7 @@
           "display": "Allergic disorder initial assessment"
         }
       ],
+      "reason" : "has_allergic_rhinitis",
       "distributed_transition": [
         {
           "distribution": 0.75,

--- a/lib/generic/modules/appendicitis.json
+++ b/lib/generic/modules/appendicitis.json
@@ -163,6 +163,7 @@
         "code" : "50849002",
         "display" : "Emergency Room Admission"
       }],
+      "reason" : "Appendicitis",
       "remarks" : "Currently the GMF does not include Vital Signs, if we decide to add that then there are some lab tests we could add at this Encounter."
     },
 
@@ -185,6 +186,7 @@
         "code": "183452005",
         "display": "Encounter Inpatient"
       }],
+      "reason" : "Appendicitis",
       "direct_transition": "Appendectomy"
     },
 

--- a/lib/generic/modules/asthma.json
+++ b/lib/generic/modules/asthma.json
@@ -71,6 +71,7 @@
           "display": "Childhood asthma"
         }
       ],
+      "assign_to_attribute" : "asthma_condition",
       "direct_transition": "Cough"
     },
 
@@ -84,6 +85,7 @@
           "display": "Asthma"
         }
       ],
+      "assign_to_attribute" : "asthma_condition",
       "direct_transition": "Cough"
     },
 
@@ -111,6 +113,7 @@
           "display": "Encounter for symptom"
         }
       ],
+      "reason" : "asthma_condition",
       "direct_transition": "Asthma_Screening"
     },
 

--- a/lib/generic/modules/bronchitis.json
+++ b/lib/generic/modules/bronchitis.json
@@ -107,6 +107,7 @@
         "code": "185345009",
         "display": "Encounter for symptom"
       }],
+      "reason" : "Bronchitis_Infection",
       "distributed_transition" : [
         { "distribution" : 0.05, "transition" : "Chest_Xray" },
         { "distribution" : 0.20, "transition" : "Sputum_Test" },

--- a/lib/generic/modules/copd.json
+++ b/lib/generic/modules/copd.json
@@ -646,9 +646,10 @@
       "encounter_class" : "inpatient",
       "codes" : [{
         "system" : "SNOMED-CT",
-        "code" : "",
-        "display" : ""
+        "code" : "305411003",
+        "display" : "Admission to thoracic surgery department"
       }],
+      "reason" : "copd_variant",
       "conditional_transition" : [
         {
           "condition" : {

--- a/lib/generic/modules/dementia.json
+++ b/lib/generic/modules/dementia.json
@@ -361,6 +361,7 @@
           "display": "Office Visit"
         }
       ],
+      "reason" : "Type of Alzheimer's",
       "direct_transition": "ModeratelySevere_MMSE_Score"
     },
 
@@ -492,6 +493,7 @@
           "display": "Office Visit"
         }
       ],
+      "reason" : "Type of Alzheimer's",
       "direct_transition": "Severe_MMSE_Score"
     },
 
@@ -535,6 +537,7 @@
           "display": "Office Visit"
         }
       ],
+      "reason" : "Type of Alzheimer's",
       "direct_transition": "VerySevere_MMSE_Score"
     },
 
@@ -603,6 +606,7 @@
         "code" : "34285007",
         "display" : "Hospital admission"
       }],
+      "reason" : "Pneumonia",
       "direct_transition" : "PneumoniaDeath"
     },
 

--- a/lib/generic/modules/ear_infections.json
+++ b/lib/generic/modules/ear_infections.json
@@ -122,6 +122,7 @@
           "display": "Encounter for symptom"
         }
       ],
+      "reason" : "Gets_Ear_Infection",
       "distributed_transition": [
         {
           "distribution": 0.859,

--- a/lib/generic/modules/lung_cancer.json
+++ b/lib/generic/modules/lung_cancer.json
@@ -130,6 +130,7 @@
         "code": "50849002",
         "display": "Emergency Room Admission"
       }],
+      "reason" : "Suspected Lung Cancer",
       "direct_transition": "Chest X-Ray"
     },
 
@@ -162,6 +163,7 @@
         "code": "185347001",
         "display": "Encounter for problem"
       }],
+      "reason" : "Suspected Lung Cancer",
       "direct_transition": "Chest CT Scan"
     },
 
@@ -241,6 +243,7 @@
         "code": "185347001",
         "display": "Encounter for problem"
       }],
+      "reason" : "Lung Cancer",
       "distributed_transition": [
         { "distribution": 0.25, "transition": "Sputum Cytology (Phelgm)"},
         { "distribution": 0.25, "transition": "Thoracentesis (Fluid)"},

--- a/lib/generic/modules/opioid_addiction.json
+++ b/lib/generic/modules/opioid_addiction.json
@@ -185,6 +185,7 @@
           "display": "Encounter Inpatient"
         }
       ],
+      "reason" : "Enter_Directed_Use_Condition1",
       "direct_transition": "Enter_Directed_Use_Procedure1"
     },
 
@@ -238,6 +239,7 @@
           "display": "Encounter Inpatient"
         }
       ],
+      "reason" : "Enter_Directed_Use_Condition2",
       "direct_transition": "Directed_Use_Prescription2"
     },
 
@@ -539,6 +541,7 @@
           "display": "Emergency Room Admission"
         }
       ],
+      "reason" : "Directed_Use_Overdose",
       "distributed_transition": [
         {
           "distribution": 0.98747,
@@ -574,6 +577,7 @@
           "display": "Emergency Room Admission"
         }
       ],
+      "reason" : "Misuse_Overdose",
       "distributed_transition": [
         {
           "distribution": 0.98747,
@@ -609,6 +613,7 @@
           "display": "Emergency Room Admission"
         }
       ],
+      "reason" : "Addiction_Overdose",
       "distributed_transition": [
         {
           "distribution": 0.98747,

--- a/lib/generic/modules/pregnancy.json
+++ b/lib/generic/modules/pregnancy.json
@@ -1157,6 +1157,7 @@
           "display": "Admission to surgical department"
         }
       ],
+      "reason" : "Ectopic_Pregnancy",
       "direct_transition": "Ectopic_Pregnancy_Surgery_Procedure"
     },
 
@@ -1242,6 +1243,7 @@
           "display": "Prenatal visit"
         }
       ],
+      "reason" : "fatal_pregnancy_complication",
       "direct_transition": "Miscarriage_End"
     },
 

--- a/lib/generic/modules/sinusitis.json
+++ b/lib/generic/modules/sinusitis.json
@@ -102,6 +102,7 @@
         "code": "185345009",
         "display": "Encounter for symptom"
       }],
+      "reason" : "Sinusitis Condition",
       "distributed_transition" : [
         { "distribution" : 0.80, "transition" : "Wait_for_condition_to_resolve" },
         { "distribution" : 0.20, "transition" : "Prescribe_Antibiotic" }
@@ -236,6 +237,7 @@
         "code": "185345009",
         "display": "Encounter for symptom"
       }],
+      "reason" : "Inflammation_Starts",
       "complex_transition" : [
         {
           "condition" : {

--- a/lib/generic/modules/sore_throat.json
+++ b/lib/generic/modules/sore_throat.json
@@ -153,6 +153,7 @@
         "code": "185345009",
         "display": "Encounter for symptom"
       }],
+      "reason" : "Sore Throat Condition",
       "conditional_transition" : [
         {
           "condition": {

--- a/lib/generic/modules/urinary_tract_infections.json
+++ b/lib/generic/modules/urinary_tract_infections.json
@@ -188,6 +188,7 @@
           "display": "Encounter for symptom"
         }
       ],
+      "reason" : "uti",
       "direct_transition": "Prescribe_UTI_Antibiotic"
     },
 
@@ -282,6 +283,7 @@
           "display": "Encounter for symptom"
         }
       ],
+      "reason" : "uti",
       "direct_transition": "Prescribe_Second_Round_Of_Antibiotics"
     },
 

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -169,7 +169,7 @@ module Synthea
       end
 
       class Encounter < State
-        attr_accessor :wellness, :processed, :time, :codes, :encounter_class
+        attr_accessor :wellness, :processed, :time, :codes, :encounter_class, :reason
 
         required_field or: [:wellness, and: [:codes, :encounter_class]]
 
@@ -190,10 +190,16 @@ module Synthea
           @processed = true
           @time = time
 
+          if @reason
+            cond = @context.most_recent_by_name(@reason)
+            cond = cond.symbol if cond
+            cond = entity[@reason].to_sym if cond.nil? && entity[@reason]
+          end
+
           if record_encounter
             value = add_lookup_code(Synthea::ENCOUNTER_LOOKUP)
             value[:class] = @encounter_class
-            entity.record_synthea.encounter(symbol, time)
+            entity.record_synthea.encounter(symbol, time, cond)
           end
 
           # Look through the history for conditions to diagnose

--- a/lib/modules/encounters.rb
+++ b/lib/modules/encounters.rb
@@ -110,7 +110,7 @@ module Synthea
 
       #------------------------------------------------------------------------------------------#
 
-      def self.encounter(entity, time)
+      def self.encounter(entity, time, reason = nil)
         age = entity[:age]
         type = if age <= 1
                  :age_lt_1
@@ -127,11 +127,11 @@ module Synthea
                else
                  :age_senior
                end
-        entity.record_synthea.encounter(type, time)
+        entity.record_synthea.encounter(type, time, reason)
       end
 
-      def self.emergency_encounter(entity, time)
-        entity.record_synthea.encounter(:emergency, time)
+      def self.emergency_encounter(entity, time, reason = nil)
+        entity.record_synthea.encounter(:emergency, time, reason)
       end
     end
   end

--- a/lib/records/ccda.rb
+++ b/lib/records/ccda.rb
@@ -100,11 +100,17 @@ module Synthea
       def self.encounter(encounter, ccda_record)
         type = encounter['type']
         time = encounter['time']
+        reason_data = COND_LOOKUP[encounter['reason']] if encounter['reason']
+        # find the ccda condition based on the code
+        # encounter.reason is an entry
+        reason = ccda_record.conditions.find { |c| c.codes == reason_data[:codes] } if reason_data
+
         ccda_record.encounters << Encounter.new(
           'codes' => ENCOUNTER_LOOKUP[type][:codes],
           'description' => ENCOUNTER_LOOKUP[type][:description],
           'start_time' => time.to_i,
-          'end_time' => time.to_i + 15.minutes
+          'end_time' => time.to_i + 15.minutes,
+          'reason' => reason
           # "oid" => "2.16.840.1.113883.3.560.1.79"
         )
       end

--- a/lib/records/record.rb
+++ b/lib/records/record.rb
@@ -69,10 +69,11 @@ module Synthea
         }
       end
 
-      def encounter(type, time)
+      def encounter(type, time, reason = nil)
         @encounters << {
           'type' => type,
-          'time' => time
+          'time' => time,
+          'reason' => reason
         }
       end
 

--- a/test/fixtures/generic/encounter.json
+++ b/test/fixtures/generic/encounter.json
@@ -26,6 +26,7 @@
                 "code": "73211009",
                 "display": "Diabetes Mellitus"
             }],
+            "assign_to_attribute" : "some_active_condition",
             "direct_transition": "Annual_Physical_2"
         },
         "Annual_Physical_2": {
@@ -49,8 +50,22 @@
                 "code": "50849002",
                 "display": "Emergency Room Admission"
             }],
+            "reason" : "Diabetes",
+            "direct_transition": "ED_Visit_AttributeReason"
+        },
+
+        "ED_Visit_AttributeReason": {
+            "type": "Encounter",
+            "encounter_class": "emergency",
+            "codes": [{
+                "system": "SNOMED-CT",
+                "code": "50849002",
+                "display": "Emergency Room Admission"
+            }],
+            "reason" : "some_active_condition",
             "direct_transition": "Terminal"
         },
+
         "Terminal": {
             "type": "Terminal"
         }

--- a/test/unit/generic/appendicitis_test.rb
+++ b/test/unit/generic/appendicitis_test.rb
@@ -36,8 +36,8 @@ class AppendicitisTest < Minitest::Test
     @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, :appendicitis])
     @patient.record_synthea.expect(:condition, nil, [:history_of_appendectomy, @time])
 
-    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time])
-    @patient.record_synthea.expect(:encounter, nil, [:encounter_inpatient, @time])
+    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, :appendicitis])
+    @patient.record_synthea.expect(:encounter, nil, [:encounter_inpatient, @time, :appendicitis])
 
     @context.run(@time, @patient)
 
@@ -57,8 +57,8 @@ class AppendicitisTest < Minitest::Test
     @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, :appendicitis])
     @patient.record_synthea.expect(:condition, nil, [:history_of_appendectomy, @time])
 
-    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time])
-    @patient.record_synthea.expect(:encounter, nil, [:encounter_inpatient, @time])
+    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, :appendicitis])
+    @patient.record_synthea.expect(:encounter, nil, [:encounter_inpatient, @time, :appendicitis])
     @context.run(@time, @patient)
 
     assert @patient.record_synthea.verify

--- a/test/unit/generic_context_test.rb
+++ b/test/unit/generic_context_test.rb
@@ -139,7 +139,7 @@ class GenericContextTest < Minitest::Test
 
     # Run number two should go all the way to Terminal, but should process Encounter and Death along the way
     # Ensure that the encounter really happens 2 days after the initial run
-    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time.advance(:days => 2)])
+    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time.advance(:days => 2), nil])
     # Ensure that death really happens 2 + 3 days after the initial run
     @patient.record_synthea.expect(:death, nil, [@time.advance(:days => 5)])
     # Run number 2: 7 days after run number 1


### PR DESCRIPTION
Adds a "reason" to the encounter state in GMF, and updates existing modules with that reason.
Reason may be either a previous ConditionOnset state name or an attribute set by a ConditionOnset.