### PR TITLE
counter state

### DIFF
--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -168,6 +168,24 @@ module Synthea
         end
       end
 
+      class Counter < State
+        attr_accessor :action, :attribute
+
+        required_field and: [:action, :attribute]
+
+        def process(_time, entity)
+          entity[@attribute] ||= 0
+
+          if @action == 'increment'
+            entity[@attribute] += 1
+          elsif @action == 'decrement'
+            entity[@attribute] -= 1
+          end
+
+          true
+        end
+      end
+
       class Encounter < State
         attr_accessor :wellness, :processed, :time, :codes, :encounter_class, :reason
 

--- a/lib/tasks/graphviz.rb
+++ b/lib/tasks/graphviz.rb
@@ -233,6 +233,8 @@ module Synthea
             e = state['exact']
             details = "#{e['quantity']} #{unit}\\l"
           end
+        when 'Counter'
+          details = "#{state['action']} value of attribute '#{state['attribute']}' by 1"
         end
 
         # Things common to many states

--- a/test/fixtures/generic/counter.json
+++ b/test/fixtures/generic/counter.json
@@ -1,0 +1,46 @@
+{
+  "name": "Counter",
+  "states": {
+
+    "Initial" : {
+      "type" : "Initial",
+      "direct_transition" : "Counter"
+    },
+
+    "Counter" : {
+      "type" : "Counter",
+      "action" : "increment",
+      "attribute" : "loop_index",
+      "direct_transition" : "Check_Counter"
+    },
+
+    "Check_Counter" : {
+      "type" : "Simple",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Attribute",
+            "attribute" : "loop_index",
+            "operator" : ">",
+            "value" : 10
+          },
+          "transition" : "Counter_Decrement"
+        },
+        { "transition" : "Counter" }
+      ]
+    },
+
+    "Counter_Decrement" : {
+      "type" : "Counter",
+      "action" : "decrement",
+      "attribute" : "loop_index",
+      "direct_transition" : "Terminal"
+    },
+
+    "Terminal" : {
+      "type" : "Terminal"
+    }
+
+  }
+
+}

--- a/test/unit/generic_states_test.rb
+++ b/test/unit/generic_states_test.rb
@@ -883,6 +883,29 @@ class GenericStatesTest < Minitest::Test
     @patient.record_synthea.verify
   end
 
+  def test_counter
+    ctx = get_context('counter.json')
+
+    assert @patient['loop_index'].nil?
+
+    counter = Synthea::Generic::States::Counter.new(ctx, "Counter")
+    assert(counter.process(@time, @patient))
+    assert_equal 1, @patient['loop_index']
+
+    assert(counter.process(@time, @patient))
+    assert_equal 2, @patient['loop_index']
+
+    assert(counter.process(@time, @patient))
+    assert_equal 3, @patient['loop_index']
+
+    decrement = Synthea::Generic::States::Counter.new(ctx, "Counter_Decrement")
+    assert(decrement.process(@time, @patient))
+    assert_equal 2, @patient['loop_index']
+
+    assert(decrement.process(@time, @patient))
+    assert_equal 1, @patient['loop_index']
+  end
+
   def get_context(file_name)
     cfg = JSON.parse(File.read(File.join(File.expand_path("../../fixtures/generic", __FILE__), file_name)))
     Synthea::Generic::Context.new(cfg)


### PR DESCRIPTION
New Counter state for GMF, allows for incrementing or decrementing an attribute. The attribute value is initialized to 0 if not previously set.

for the wiki:

## Counter

The `Counter` state type indicates a point in the module that increments or decrements a specified value on the patient entity. In essence, this state counts the number of times it is processed. Note: The attribute is initialized with a default value of 0 if not previously set.

**Supported Properties**

* **type**: must be "Counter" _(required)_
* **action**: whether this counter will _increment_ or _decrement_ the attribute's value _(required)_
* **attribute**: the name of the Attribute for which the value will be incremented or decremented. _(required)_

**Example**

The following is an example of a Counter that decreases the value in attribute 'loop_index' by 1 every time it is hit:

```json
{
  "type": "Counter",
  "attribute": "loop_index",
  "action": "decrement"
}
```

The following is an example of a Counter that increases the value of Attribute 'bronchitis_occurrences' by 1 every time it is hit:

```json
{
  "type": "Counter",
  "attribute": "bronchitis_occurrences",
  "action": "increment"
}
```
