### PR TITLE
Use the New Counter State

### DIFF
--- a/lib/generic/modules/allergic_rhinitis.json
+++ b/lib/generic/modules/allergic_rhinitis.json
@@ -223,6 +223,21 @@
           }
         ]
       },
+      "direct_transition": "Delay_For_Consultation"
+    },
+
+    "Delay_For_Consultation": {
+      "type": "Delay",
+      "remarks": [
+        "This state is used to stagger the age that patient's consider/begin ",
+        "immunotherapy treatment. Patients can now begin receiving treatment ",
+        "between age 12 and age 17."
+      ],
+      "range": {
+        "low": 0,
+        "high": 5,
+        "unit": "years"
+      },
       "direct_transition": "Immunotherapy_Consultation"
     },
 
@@ -301,17 +316,42 @@
           "display": "Allergy screening test"
         }
       ],
+      "direct_transition": "Initialize_Immunotherapy_Counter"
+    },
+
+    "Initialize_Immunotherapy_Counter": {
+      "type": "SetAttribute",
+      "attribute": "immunotherapy_counter",
+      "value": 0,
       "direct_transition": "Undergoing_Immunotherapy_Treatment"
     },
 
     "Undergoing_Immunotherapy_Treatment": {
       "type": "Delay",
+      "remarks": [
+        "Patients get immunotherapy treatments for an average of 5 years.",
+        "Given monthly appointments we count a total of 60 appointments before ",
+        "ending the immunotherapy."
+      ],
       "range": {
         "low": 3,
         "high": 4,
         "unit": "weeks"
       },
-      "direct_transition": "Immunotherapy_Treatment"
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "immunotherapy_counter",
+            "operator": "<",
+            "value": 60
+          },
+          "transition": "Immunotherapy_Treatment"
+        },
+        {
+          "transition": "Immunotherapy_Treatment_Complete"
+        }
+      ]
     },
 
     "Immunotherapy_Treatment": {
@@ -339,20 +379,14 @@
           "display": "Subcutaneous immunotherapy"
         }
       ],
-      "conditional_transition": [
-        {
-          "condition": {
-            "condition_type": "Age",
-            "operator": ">",
-            "quantity": 15,
-            "unit": "years"
-          },
-          "transition": "Immunotherapy_Treatment_Complete"
-        },
-        {
-          "transition": "Undergoing_Immunotherapy_Treatment"
-        }
-      ]
+      "direct_transition": "Count_A_Treatment"
+    },
+
+    "Count_A_Treatment": {
+      "type": "Counter",
+      "action": "increment",
+      "attribute": "immunotherapy_counter",
+      "direct_transition": "Undergoing_Immunotherapy_Treatment"
     },
 
     "Immunotherapy_Treatment_Complete": {
@@ -391,7 +425,7 @@
       "careplan": "Immunotherapy_CarePlan",
       "direct_transition": "Terminal"
     },
-    
+
     "Terminal": {
       "type": "Terminal"
     }

--- a/lib/generic/modules/pregnancy.json
+++ b/lib/generic/modules/pregnancy.json
@@ -108,10 +108,10 @@
     "Will_Have_One_Child": {
       "type": "SetAttribute",
       "attribute": "pregnancy_iterator",
-      "value": "4",
+      "value": 4,
       "remarks": [
-        "This leaves the mother with 2 remaining passes through the pregnancy module (out of 6 total). ",
-        "The second pass accounts for the potential for a miscarriage or abortion."
+        "This leaves the mother with 3 remaining passes through the pregnancy module (out of 7 total). ",
+        "Additional passes account for potential miscarriages or abortions."
       ],
       "direct_transition": "Wait_For_First_Conception"
     },
@@ -119,9 +119,9 @@
     "Will_Have_Two_Children": {
       "type": "SetAttribute",
       "attribute": "pregnancy_iterator",
-      "value": "2",
+      "value": 2,
       "remarks": [
-        "This leaves the mother with 4 remaining passes through the pregnancy module (out of 6 total). ",
+        "This leaves the mother with 5 remaining passes through the pregnancy module (out of 7 total). ",
         "Additional passes account for potential miscarriages or abortions."
       ],
       "direct_transition": "Wait_For_First_Conception"
@@ -130,9 +130,9 @@
     "Will_Have_Three_Or_More_Children": {
       "type": "SetAttribute",
       "attribute": "pregnancy_iterator",
-      "value": "0",
+      "value": 0,
       "remarks": [
-        "This leaves the mother with 6 remaining passes through the pregnancy module (out of 6 total). ",
+        "This leaves the mother with 7 remaining passes through the pregnancy module (out of 7 total). ",
         "Additional passes account for potential miscarriages or abortions."
       ],
       "direct_transition": "Wait_For_First_Conception"
@@ -149,113 +149,6 @@
         "high": 20,
         "unit": "years"
       },
-      "direct_transition": "Increment_Pregnancy_Count"
-    },
-
-    "Increment_Pregnancy_Count": {
-      "type": "Simple",
-      "remarks": [
-        "======================================================================",
-        " PREGNANCY COUNTER                                                    ",
-        "======================================================================"
-      ],
-      "conditional_transition": [
-        {
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "pregnancy_iterator",
-            "operator": "==",
-            "value": "0"
-          },
-          "transition": "Pregnancy_Iterator_1"
-        },
-        {
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "pregnancy_iterator",
-            "operator": "==",
-            "value": "1"
-          },
-          "transition": "Pregnancy_Iterator_2"
-        },
-        {
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "pregnancy_iterator",
-            "operator": "==",
-            "value": "2"
-          },
-          "transition": "Pregnancy_Iterator_3"
-        },
-        {
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "pregnancy_iterator",
-            "operator": "==",
-            "value": "3"
-          },
-          "transition": "Pregnancy_Iterator_4"
-        },
-        {
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "pregnancy_iterator",
-            "operator": "==",
-            "value": "4"
-          },
-          "transition": "Pregnancy_Iterator_5"
-        },
-        {
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "pregnancy_iterator",
-            "operator": "==",
-            "value": "5"
-          },
-          "transition": "Pregnancy_Iterator_6"
-        }
-      ]
-    },
-
-    "Pregnancy_Iterator_1": {
-      "type": "SetAttribute",
-      "attribute": "pregnancy_iterator",
-      "value": "1",
-      "direct_transition": "Become_Pregnant"
-    },
-
-    "Pregnancy_Iterator_2": {
-      "type": "SetAttribute",
-      "attribute": "pregnancy_iterator",
-      "value": "2",
-      "direct_transition": "Become_Pregnant"
-    },
-
-    "Pregnancy_Iterator_3": {
-      "type": "SetAttribute",
-      "attribute": "pregnancy_iterator",
-      "value": "3",
-      "direct_transition": "Become_Pregnant"
-    },
-
-    "Pregnancy_Iterator_4": {
-      "type": "SetAttribute",
-      "attribute": "pregnancy_iterator",
-      "value": "4",
-      "direct_transition": "Become_Pregnant"
-    },
-
-    "Pregnancy_Iterator_5": {
-      "type": "SetAttribute",
-      "attribute": "pregnancy_iterator",
-      "value": "5",
-      "direct_transition": "Become_Pregnant"
-    },
-
-    "Pregnancy_Iterator_6": {
-      "type": "SetAttribute",
-      "attribute": "pregnancy_iterator",
-      "value": "6",
       "direct_transition": "Become_Pregnant"
     },
 
@@ -1361,11 +1254,11 @@
               {
                 "condition_type": "Attribute",
                 "attribute": "pregnancy_iterator",
-                "operator": "!=",
-                "value": "6",
+                "operator": "<",
+                "value": 7,
                 "remarks": [
-                  "We use 6 as a hard limit. Given the probabilities of miscarriage and abortion ",
-                  "if a woman goes through the module all 6 times we expect 3-4 pregnancies."
+                  "We use 7 as a hard limit. Given the probabilities of miscarriage and abortion ",
+                  "if a woman goes through the module all 7 times we expect 3-4 pregnancies."
                 ]
               },
               {
@@ -1396,7 +1289,14 @@
       },
       "direct_transition": "Increment_Pregnancy_Count"
     },
-    
+
+    "Increment_Pregnancy_Count": {
+      "type": "Counter",
+      "action": "increment",
+      "attribute": "pregnancy_iterator",
+      "direct_transition": "Become_Pregnant"
+    },
+
     "Terminal": {
       "type": "Terminal"
     }


### PR DESCRIPTION
Added `Counter` states to `allergic_rhinitis` and `pregnancy` modules to improve and simplify these modules. Ran a test of 100 patients and checked the log to confirm that things still behaved as expected. Also added 1 extra pass through the pregnancy module to give a slightly higher incidence of pregnancy/birth.

## In the Allergic Rhinitis Module:

![ar_counter](https://cloud.githubusercontent.com/assets/5651138/20900213/73b9bd44-bafb-11e6-9ce8-01493605c3d7.png)

## In the Pregnancy Module:

![pg_counter](https://cloud.githubusercontent.com/assets/5651138/20900285/a3a2c9d8-bafb-11e6-9992-4480bcb406e3.png)
