### PR TITLE
Adds missing target_encounter + metadata, fixes #103

### DIFF
--- a/lib/generic/modules/injuries.json
+++ b/lib/generic/modules/injuries.json
@@ -971,6 +971,7 @@
 
     "Whiplash_CarePlan": {
       "type": "CarePlanStart",
+      "target_encounter" : "ED_Visit_For_Whiplash",
       "assign_to_attribute": "injury_careplan",
       "reason": "Whiplash",
       "codes": [

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -335,6 +335,8 @@ module Synthea
       class CarePlanStart < State
         attr_accessor :target_encounter, :codes, :activities, :reason
 
+        required_field and: [:target_encounter, :codes]
+
         metadata 'codes', type: 'Components::Code', min: 1, max: Float::INFINITY
         metadata 'target_encounter', reference_to_state_type: 'Encounter', min: 1, max: 1
 


### PR DESCRIPTION
Adds the missing `target_encounter` from the injuries model, and adds the metadata that should have caught the missing field in the first place.