### PR TITLE
Dockerized Synthea

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Synthea .dockerignore
+# The MITRE Corporation
+
+# Ignores all files that are not needed to run Synthea.
+# This minimizes the number of files that are copied to
+# build a new Synthea image.
+.git
+.gitignore
+
+# Project directories
+test
+resources
+!resources/fingerprint.png
+output
+coverage
+
+# Project files
+*.md
+deploy.sh
+.palate
+.rubocop.yml
+.travis.yml
+.DS_Store
+
+# Log files
+*.log

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,0 +1,6 @@
+ccda:
+  sessions:
+    default:
+      database: synthea
+      hosts:
+        - localhost:27017

--- a/config/synthea.yml
+++ b/config/synthea.yml
@@ -153,3 +153,8 @@ synthea:
   version_identifier: <%= `git rev-parse HEAD` %> # get the current git commit hash
   graphviz:
     output: './output/graphviz/'
+  docker:
+    dockerized: false
+    # If dockerized, write Synthea's output to this location, which should match
+    # a volume mounted to a persistent data volume container.
+    location: '/mnt/synthea'

--- a/docker/mongoid.yml
+++ b/docker/mongoid.yml
@@ -1,0 +1,6 @@
+ccda:
+  sessions:
+    default:
+      database: synthea
+      hosts:
+        - mongo:27017

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -1,0 +1,22 @@
+FROM ruby:2.3
+MAINTAINER Carlton Duffett (duffett@mitre.org)
+
+# Copy Synthea into /usr/src/synthea/. Only copies the essential files
+# not ignored by .dockerignore.
+RUN mkdir -p /usr/src/synthea
+COPY . /usr/src/synthea/
+WORKDIR /usr/src/synthea/
+
+# Mount shared storage volume for Synthea's output. Unless the output directory
+# in synthea.yml is set to this location and a data volume is mounted at runtime
+# using volumes_from data written to this mount will not persist.
+VOLUME ["/mnt/synthea"]
+
+# Install Synthea's dependencies. The base ruby image comes pre-installed with
+# gem, bundler, rake, etc. The .dockerignore file doesn't copy over the .git
+# directory, so we need to initialize git again to keep bundler from complaining.
+RUN git init && bundle install
+
+# Invoke a single command using bash when the container is run. Command line
+# args to the container will be passed to bash.
+CMD ["/bin/bash", "-c"]

--- a/docker/ruby/docker-compose.yml
+++ b/docker/ruby/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "2"
+services:
+  # mongodb container used only to support CCDA/HTML export
+  # via the health-data-standards gem. Synthea will connect
+  # to this container using the following connection string:
+  # mongodb://mongo:27017. Docker automagically adds "mongo"
+  # to /etc/hosts in the Synthea container.
+  mongo:
+    container_name: mongo
+    image: "mongo:3.2"
+    expose:
+      - "27017"
+  # Synthea will expect the usual commands at runtime.
+  synthea:
+    container_name: synthea
+    image: synthetichealth/synthea:latest
+    build:
+      # The build context is relative to docker-compose.yml.
+      context: ../..
+      # But the Dockerfile is relative to the build context.
+      dockerfile: ./docker/ruby/Dockerfile
+      args:
+        # If defined, this will pick up the proxy from the
+        # host's environment.
+        http_proxy: "${http_proxy}"
+        https_proxy: "${https_proxy}"
+    volumes_from:
+      # This data volume is created separately from the
+      # docker-compose script. See: docker create -v
+      - container:synthea_output:rw
+    links:
+      - mongo
+    expose:
+      - "27017"
+    depends_on:
+      - mongo

--- a/lib/records/exporter.rb
+++ b/lib/records/exporter.rb
@@ -54,8 +54,11 @@ module Synthea
       end
 
       def self.get_output_folder(folder_name, patient = nil)
-        base = Synthea::Config.exporter.location
-
+        base = if Synthea::Config.docker.dockerized
+                 Synthea::Config.docker.location
+               else
+                 Synthea::Config.exporter.location
+               end
         dirs = [base, folder_name]
 
         if patient

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -38,7 +38,11 @@ namespace :synthea do
       datafile = File.read(datafile)
     end
     # we need to configure mongo to export for some reason... not ideal
-    Mongoid.configure { |config| config.connect_to('synthea_test') }
+    if Synthea::Config.docker.dockerized
+      Mongoid.load!("docker/mongoid.yml", :ccda)
+    else
+      Mongoid.load!("config/mongoid.yml", :ccda)
+    end
 
     if Synthea::Config.sequential.clean_output_each_run
       %w(html fhir CCDA text).each do |type|


### PR DESCRIPTION
Dockerized Synthea using Matz's standard C Ruby. jRuby to follow in a separate PR. See the "Docker" page of the Synthea Wiki for more information and instructions on how to run Synthea in Docker.