### PR TITLE
Fix for exception in Colorectal Cancer module

### DIFF
--- a/lib/generic/modules/colorectal_cancer.json
+++ b/lib/generic/modules/colorectal_cancer.json
@@ -488,8 +488,14 @@
       "complex_transition": [
         {
           "condition": {
-            "condition_type": "PriorState",
-            "name": "Recurrent_Colorectal_Adenoma",
+            "condition_type": "Active Condition",
+            "codes": [
+              {
+                "system": "SNOMED-CT",
+                "code": "713197008",
+                "display": "Recurrent rectal polyp"
+              }
+            ],
             "remarks": [
               "For variety, if the patient was referred to a followup and not ",
               "immediately diagnosed with colorectal cancer that means his/her ",


### PR DESCRIPTION
Fixes a potential exception that could be thrown in the Colorectal Cancer module, when trying to end a condition that wasn't active. In this case, the `Followup_Colonoscopy_Procedure` state checks whether the `Recurrent_Colorectal_Adenoma` state was previously hit, and if so ends the condition that was onset in `Recurrent_Colorectal_Adenoma`. There is a possible sequence where the `Recurrent_Colorectal_Adenoma` state was previously hit but its condition was later ended, so trying to end the condition again will fail.

This PR changes the condition from a PriorState to an Active Condition with the codes from the referenced state, which prevents this double-end of a condition and better represents the intent of the check anyway.