### PR TITLE
Homelessness Module

### DIFF
--- a/config/synthea.yml
+++ b/config/synthea.yml
@@ -20,6 +20,7 @@ synthea:
     birth_variance: 0.01
     daily_births_per_square_mile: <%= (ma_births_per_year = 73000.0)/(ma_square_miles=10554.0)/365.0 %>
     append_hash_to_person_names: true # If true, person names have a numeric hash appended to them to make them more obviously fake
+    generate_fingerprints: true
   sequential: # sequential population generation... one at a time...
     # population is scaled to accurately represent MA (using a "true" population of 6,794,422)
     population: 100

--- a/lib/generic/modules/homelessness.json
+++ b/lib/generic/modules/homelessness.json
@@ -194,9 +194,21 @@
                    "National Alliance to End Homelessness estimates that 3.4% of homeless people are HIV+",
                    "compared to 0.4% in the general population. (2006 data)",
                    "http://www.nationalhomeless.org/factsheets/hiv.html"],
-      "distributed_transition" : [
-        { "distribution" : 0.966, "transition" : "Question_2_Negative" },
-        { "distribution" : 0.034, "transition" : "Question_2_Positive" }
+      "complex_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "PriorState",
+            "name" : "Question_2_Positive"
+          },
+          "transition" : "Question_2_Positive",
+          "remarks" : ["If they previously said they are HIV+ then stick with it"]
+        },
+        {
+          "distributions" : [
+            { "distribution" : 0.966, "transition" : "Question_2_Negative" },
+            { "distribution" : 0.034, "transition" : "Question_2_Positive" }
+          ]
+        }
       ]
     },
 

--- a/lib/generic/modules/homelessness.json
+++ b/lib/generic/modules/homelessness.json
@@ -1,0 +1,337 @@
+{
+  "name": "Homelessness",
+  "remarks" : ["Primary source of info is the 2016 U.S. Department of Housing and Urban Development (HUD) ",
+               "2016 Annual Homeless Assessment Report (AHAR) to Congress (AHAR)",
+               "https://www.hudexchange.info/resources/documents/2016-AHAR-Part-1.pdf"],
+  "states": {
+
+    "Initial" : {
+      "type" : "Initial",
+      "direct_transition" : "Potential_Homelessness"
+    },
+
+    "Potential_Homelessness" : {
+      "type" : "Delay",
+      "exact": {
+        "quantity": 1,
+        "unit": "years"
+      },
+      "remarks" : ["On a single night in 2016, 549,928 people were experiencing homelessness in the United States.",
+                   "Assuming a US population of 300M, 550k/300M == ~0.18%",
+                   "we assume that these are more likely to be of low SES, but not guaranteed. ",
+                   "these transition %s result higher than .18% because people do not stay homeless forever.",
+                   "from http://www.endhomelessness.org/library/entry/the-state-of-homelessness-in-america-2012 : ",
+                   "  'The odds for a person in the general U.S. population of experiencing homelessness in the course of a year are 1 in 194.",
+                   "For an individual living doubled up the odds are 1 in 12.",
+                   "For a released prisoner they are 1 in 13.",
+                   "For a young adult who has aged out of foster care they are 1 in 11.'  ",
+                   "synthea doesn't model these factors so we'll give a higher risk to people of low SES",
+                   "'doubled up population' is ~ 6 million == ~ 2%, prison population is ~ 1%"],
+      "complex_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "PriorState",
+            "name" : "Begin_Homelessness"
+          },
+          "remarks" : "people who have ever been homeless have the highest risk of becoming homeless again",
+          "distributions" : [
+            { "distribution" : 0.99, "transition" : "Potential_Homelessness" },
+            { "distribution" : 0.01, "transition" : "Begin_Homelessness" } 
+          ]
+        },
+        {
+          "condition" : {
+            "condition_type" : "Socioeconomic Status",
+            "category" : "Low"
+          },
+          "distributions" : [
+            { "distribution" : 0.009975, "transition" : "Potential_Homelessness" },
+            { "distribution" : 0.990025, "transition" : "Begin_Homelessness" } 
+          ]
+        },
+        {
+          "distributions" : [
+            { "distribution" : 0.999, "transition" : "Potential_Homelessness" },
+            { "distribution" : 0.001, "transition" : "Begin_Homelessness" } 
+          ]
+        }
+      ]
+    },
+
+
+    "Begin_Homelessness" : {
+      "type" : "SetAttribute",
+      "attribute": "homeless",
+      "value": true,
+      "direct_transition" : "Homelessness_Counter"
+    },
+
+    "Homelessness_Counter" : {
+      "type" : "Counter",
+      "attribute" : "instances_of_homelessness",
+      "action" : "increment",
+      "conditional_transition" : [
+        {
+          "condition": {
+            "condition_type" : "Attribute",
+            "attribute" : "instances_of_homelessness",
+            "operator" : ">=",
+            "value" : 4
+          },
+          "remarks" : ["Chronic homelessness is defined as either 12 consecutive months of homelessness",
+                       "OR 4+ occasions of homelessness over 3 years. For simplicity in this model assume",
+                       "4 total occasions --> chronic",
+                       "January 2016 - ~1 in 5 individuals experiencing homelessness had chronic patterns of homelessness."],
+          "transition" : "Chronic_Homelessness"
+        },
+        {
+          "transition" : "Temporary_Homelessness"
+        }
+      ]
+    },
+
+    "Chronic_Homelessness" : {
+      "type" : "SetAttribute",
+      "attribute": "homelessness_category",
+      "value": "chronic",
+      "direct_transition" : "Living_Homeless"
+    },
+
+    "Temporary_Homelessness" : {
+      "type" : "SetAttribute",
+      "attribute": "homelessness_category",
+      "value": "temporary",
+      "direct_transition" : "Living_Homeless"
+    },
+
+    "Living_Homeless" : {
+      "type" : "Delay",
+      "exact": {
+        "quantity": 1,
+        "unit": "months"
+      },
+      "complex_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Attribute",
+            "attribute" : "homelessness_category",
+            "operator" : "==",
+            "value" : "temporary"
+          },
+          "remarks" : ["About 44% of homeless people are sheltered. ",
+                       "The average length of stay in emergency shelter was 69 days for single men, 51 days for single women, and 70 days for families.",
+                       "For those staying in transitional housing, the avg stay for single men was 175 days, 196 days for single women, and 223 days for families.",
+                       "Permanent supportive housing had the longest stay, with 556 days for single men, 571 days for single women",
+                       "http://www.nationalhomeless.org/factsheets/How_Many.html",
+                       "we assume the expected length of homelessness to be ~6 months"],
+          "distributions" : [
+            { "distribution" : 0.44, "transition" : "Visit_Homeless_Shelter" },
+            { "distribution" : 0.16, "transition" : "End_Homelessness" },
+            { "distribution" : 0.40, "transition" : "Living_Homeless" }
+          ]
+        },
+        {
+          "condition" : {
+            "condition_type" : "Attribute",
+            "attribute" : "homelessness_category",
+            "operator" : "==",
+            "value" : "chronic"
+          },
+          "remarks" : ["Of chronically homeless individuals, more than two thirds (68% or 52,890 people) were staying",
+                       "in unsheltered locations such as under bridges, in cars, or in abandoned buildings. ",
+                       "This is much greater than the unsheltered rate for all people ",
+                       "experiencing homelessness as individuals in the United States, which was 44 percent.",
+                       "--We assume that chronically homeless individuals are less likely to visit a homeless shelter"],
+          "distributions" : [
+            { "distribution" : 0.32, "transition" : "Visit_Homeless_Shelter" },
+            { "distribution" : 0.08, "transition" : "End_Homelessness" },
+            { "distribution" : 0.60, "transition" : "Living_Homeless" }
+          ]
+        }
+      ]
+    },
+
+    "Visit_Homeless_Shelter" : {
+      "type" : "Encounter",
+      "encounter_class" : "ambulatory",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "210098006",
+        "display" : "Domiciliary or rest home patient evaluation and management"
+      }],
+      "direct_transition" : "Information_Gathering"
+    },
+
+    "Information_Gathering" : {
+      "type" : "Procedure",
+      "target_encounter" : "Visit_Homeless_Shelter",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "311791003",
+        "display" : "Information gathering (procedure)"
+      }],
+      "direct_transition" : "Question_1",
+      "remarks" : ["the following questions are temporary. going forward we would like these risk factors to be modeled directly",
+                   "the LOINC codes selected & responses are a best guess at modeling the information here"]
+    },
+
+    "Question_1" : {
+      "type" : "Observation",
+      "target_encounter" : "Visit_Homeless_Shelter",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "76690-7",
+        "display" : "Sexual orientation"
+      }],
+      "attribute" : "sexual_orientation",
+      "unit" : "{nominal}",
+      "direct_transition" : "Question_2"
+    },
+
+    "Question_2" : {
+      "type" : "Simple",
+      "remarks" : ["simple random statistics here until we have a real HIV model",
+                   "National Alliance to End Homelessness estimates that 3.4% of homeless people are HIV+",
+                   "compared to 0.4% in the general population. (2006 data)",
+                   "http://www.nationalhomeless.org/factsheets/hiv.html"],
+      "distributed_transition" : [
+        { "distribution" : 0.966, "transition" : "Question_2_Negative" },
+        { "distribution" : 0.034, "transition" : "Question_2_Positive" }
+      ]
+    },
+
+    "Question_2_Positive" : {
+      "type" : "Observation",
+      "target_encounter" : "Visit_Homeless_Shelter",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "55277-8",
+        "display" : "HIV status"
+      }],
+      "exact" : { "quantity" : "HIV positive" },
+      "unit" : "{nominal}",
+      "direct_transition" : "Question_3"
+    },
+
+    "Question_2_Negative" : {
+      "type" : "Observation",
+      "target_encounter" : "Visit_Homeless_Shelter",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "55277-8",
+        "display" : "HIV status"
+      }],
+      "exact" : { "quantity" : "not HIV positive" },
+      "unit" : "{nominal}",
+      "direct_transition" : "Question_3"
+    },
+
+    "Question_3" : {
+      "type" : "Simple",
+      "remarks" : ["see http://www.nationalhomeless.org/factsheets/addiction.pdf "],
+      "distributed_transition" : [
+        { "distribution" : 0.26, "transition" : "Question_3_Abuser" },
+        { "distribution" : 0.74, "transition" : "Question_3_Nonabuser" }
+      ]    
+    },
+
+    "Question_3_Abuser" : {
+      "type" : "Observation",
+      "remarks" : ["here we leverage our existing opioids model, for simplicity.",
+                   "in the real world homelessness has a stronger asssociation with drug abuse",
+                   "see http://www.nationalhomeless.org/factsheets/addiction.pdf "],
+      "target_encounter" : "Visit_Homeless_Shelter",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "28245-9",
+        "display" : "Abuse Status [OMAHA]"
+      }],
+      "exact" : { "quantity" : "Severe signs/symptoms" },
+      "unit" : "{nominal}",
+      "direct_transition" : "Question_4"
+    },
+
+    "Question_3_Nonabuser" : {
+      "type" : "Observation",
+      "target_encounter" : "Visit_Homeless_Shelter",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "28245-9",
+        "display" : "Abuse Status [OMAHA]"
+      }],
+      "exact" : { "quantity" : "No signs/symptoms" },
+      "unit" : "{nominal}",
+      "direct_transition" : "Question_4"
+    },
+
+    "Question_4" : {
+      "type" : "Observation",
+      "target_encounter" : "Visit_Homeless_Shelter",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "71802-3",
+        "display" : "Housing status"
+      }],
+      "exact" : { "quantity" : "Patient is homeless" },
+      "unit" : "{nominal}",
+      "direct_transition" : "Question_5"
+    },
+
+    "Question_5" : {
+      "type" : "Simple",
+      "remarks" : ["estimated >70% of homeless do not have health insurance http://www.nationalhomeless.org/factsheets/health.html"],
+      "distributed_transition" : [
+        { "distribution" : 0.25, "transition" : "Question_5_Yes" },
+        { "distribution" : 0.75, "transition" : "Question_5_No" }
+      ]      
+    },
+
+    "Question_5_Yes" : {
+      "type" : "Observation",
+      "target_encounter" : "Visit_Homeless_Shelter",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "63513-6",
+        "display" : "Are you covered by health insurance or some other kind of health care plan [PhenX]"
+      }],
+      "exact" : { "quantity" : "Yes" },
+      "unit" : "{nominal}",
+      "direct_transition" : "Question_6"
+    },
+
+    "Question_5_No" : {
+      "type" : "Observation",
+      "target_encounter" : "Visit_Homeless_Shelter",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "63513-6",
+        "display" : "Are you covered by health insurance or some other kind of health care plan [PhenX]"
+      }],
+      "exact" : { "quantity" : "No" },
+      "unit" : "{nominal}",
+      "direct_transition" : "Question_6"
+    },
+
+    "Question_6" : {
+      "type" : "Observation",
+      "target_encounter" : "Visit_Homeless_Shelter",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "46240-8",
+        "display" : "History of Hospitalizations+​Outpatient visits"
+      }],
+      "range" : { "low" : 0, "high" : 10 },
+      "unit" : "{count}",
+      "direct_transition" : "Living_Homeless"
+    },
+
+
+    "End_Homelessness" : {
+      "type" : "SetAttribute",
+      "attribute": "homeless",
+      "value": false,
+      "direct_transition" : "Potential_Homelessness"
+    }
+
+  }
+}

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -448,10 +448,10 @@ module Synthea
       end
 
       class Observation < State
-        attr_accessor :codes, :range, :exact, :unit, :target_encounter
+        attr_accessor :codes, :range, :exact, :unit, :target_encounter, :attribute
 
         required_field and: [:target_encounter, :codes, :unit]
-        required_field or: [:range, :exact]
+        required_field or: [:range, :exact, :attribute]
 
         metadata 'codes', type: 'Components::Code', min: 1, max: Float::INFINITY
         metadata 'range', type: 'Components::Range', min: 0, max: 1
@@ -476,10 +476,10 @@ module Synthea
 
           if @range
             @value = @range.value
-          elsif exact
+          elsif @exact
             @value = @exact.value
-          else
-            raise 'Observation state must specify value using either "range" or "exact"'
+          elsif @attribute
+            @value = entity[@attribute] || entity[@attribute.to_sym]
           end
 
           if concurrent_with_target_encounter(time)

--- a/lib/modules/lifecycle.rb
+++ b/lib/modules/lifecycle.rb
@@ -26,7 +26,8 @@ module Synthea
           entity[:race] ||= Synthea::World::Demographics::RACES.pick
           entity[:ethnicity] ||= Synthea::World::Demographics::ETHNICITY[entity[:race]].pick
           entity[:blood_type] = Synthea::World::Demographics::BLOOD_TYPES[entity[:race]].pick
-          entity[:fingerprint] = Synthea::Fingerprint.generate
+          entity[:sexual_orientation] = Synthea::World::Demographics::SEXUAL_ORIENTATION.pick.to_s
+          entity[:fingerprint] = Synthea::Fingerprint.generate if Synthea::Config.population.generate_fingerprints
           # new babies are average weight and length for American newborns
           entity[:height] = 51 # centimeters
           entity[:weight] = 3.5 # kilograms

--- a/lib/tasks/graphviz.rb
+++ b/lib/tasks/graphviz.rb
@@ -273,13 +273,15 @@ module Synthea
             details = "#{s}: #{e['quantity']}"
           end
         when 'Observation'
-          unit = state['unit']
+          unit = state['unit'].gsub('{','(').gsub('}',')') # replace curly braces with parens, braces can cause issues
           if state.has_key? 'range'
             r = state['range']
             details = "#{r['low']} - #{r['high']} #{unit}\\l"
           elsif state.has_key? 'exact'
             e = state['exact']
             details = "#{e['quantity']} #{unit}\\l"
+          elsif state.has_key? 'attribute'
+            details = "Value from Attribute: '#{state['attribute']}', Unit: #{unit}\\l"
           end
         when 'Counter'
           details = "#{state['action']} value of attribute '#{state['attribute']}' by 1"

--- a/lib/world/demographics.rb
+++ b/lib/world/demographics.rb
@@ -36,6 +36,13 @@ module Synthea
         other: Pickup.new(arab: 1)
       }.freeze
 
+      # http://www.cdc.gov/nchs/data/nhsr/nhsr077.pdf
+      # Among all U.S. adults aged 18 and over, 96.6% identified as straight, 1.6% identified as gay or lesbian, and 0.7% identified as bisexual.
+      # The remaining 1.1% of adults identified as 'something else' (0.2%), selected 'I dont know the answer' (0.4%), or refused to provide an answer (0.6%).
+      SEXUAL_ORIENTATION = Pickup.new(heterosexual: 96.6,
+                                      homosexual: 1.6,
+                                      bisexual: 0.7)
+
       # blood type data from http://www.redcrossblood.org/learn-about-blood/blood-types
       # data for :native and :other from https://en.wikipedia.org/wiki/Blood_type_distribution_by_country
       BLOOD_TYPES = {


### PR DESCRIPTION
Adds a module that represents people experiencing homelessness. Targets around 0.18% of the population being homeless at any one time. People cycle in and out of homelessness at roughly accurate rates. Currently the fact that a person is homeless is only recorded as an attribute, the person's residential address is unchanged. People that are homeless may visit shelters, at which point they are given a form and observations are taken regarding certain risk factors. These observations are intentionally simplified - eventually these risk factors should be modeled and represented directly within the patient record itself.

Also includes a couple minor tweaks: 1 - adds the ability to record an observation with the value of an attribute, and 2 - adds a config setting to disable generating fingerprints (which can speed up generation)

![homelessness](https://cloud.githubusercontent.com/assets/13512036/21196168/af53ce70-c204-11e6-9523-3e85d6142cf6.png)
