### PR TITLE
Medication order details

### DIFF
--- a/lib/generic/components.rb
+++ b/lib/generic/components.rb
@@ -83,6 +83,21 @@ module Synthea
             (duration.value / dosage.period_value) * dosage.amount * dosage.frequency
           end
         end
+
+        def patient_instructions
+          # Returns a single string representing any and all instructions.
+          # Format: "<instr_1>; <instr_2>; <instr_3>" etc.
+          # Used primarilly for CCDA export.
+          fi = ''
+          unless @instructions.length.zero?
+            fi += @instructions[0].display
+            additional_instrs = @instructions.drop(1)
+            additional_instrs.each do |instr|
+              fi += '; ' + instr.display
+            end
+          end
+          fi
+        end
       end
     end
   end

--- a/lib/generic/components.rb
+++ b/lib/generic/components.rb
@@ -50,6 +50,39 @@ module Synthea
       class Code < Component
         attr_accessor :code, :system, :display
         required_field and: [:code, :system, :display]
+
+        def to_sym
+          raise 'Code must have a display value to convert to a symbol' if display.nil?
+          display.gsub(/\s+/, '_').downcase.to_sym
+        end
+      end
+
+      class Dosage < Component
+        attr_accessor :amount, :frequency, :period, :unit
+        required_field and: [:amount, :frequency, :period, :unit]
+
+        def period_value
+          period.send(unit)
+        end
+      end
+
+      class Prescription < Component
+        attr_accessor :as_needed, :dosage, :duration, :instructions, :refills
+        required_field or: [:as_needed, and: [:dosage, :duration]]
+
+        metadata 'dosage', type: 'Components::Dosage', min: 1, max: 1
+        metadata 'duration', type: 'Components::ExactWithUnit', min: 1, max: 1
+        metadata 'instructions', type: 'Components::Code', min: 0, max: Float::INFINITY
+
+        def doses
+          # Returns the total number of doses based on the dosage and duration.
+          # This is used to infer the total number of doses in a prescription.
+          if @as_needed
+            0
+          else
+            (duration.value / dosage.period_value) * dosage.amount * dosage.frequency
+          end
+        end
       end
     end
   end

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -368,6 +368,7 @@ module Synthea
               rx_info['dosage'] = @prescription.dosage
               rx_info['duration'] = @prescription.duration
               rx_info['instructions'] = add_lookup_codes(@prescription.instructions, Synthea::INSTRUCTION_LOOKUP)
+              rx_info['patient_instructions'] = @prescription.patient_instructions # for CCDA export
             end
           end
           entity.record_synthea.medication_start(symbol, time, reasons, rx_info)

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -373,24 +373,6 @@ module Synthea
           entity.record_synthea.medication_start(symbol, time, reasons, rx_info)
           @prescribed = true
         end
-
-        def add_instruction_lookup_codes(lookup_hash)
-          symbols = []
-          unless @prescription.nil? || @prescription.instructions.nil? || @prescription.instructions.empty?
-            @prescription.instructions.each do |instr|
-              sym = instruction_symbol(instr)
-              symbols << sym
-              value = {
-                description: instr['display'],
-                codes: {}
-              }
-              value[:codes][instr['system']] ||= []
-              value[:codes][instr['system']] << a['code']
-              lookup_hash[sym] = value
-            end
-          end
-          symbols
-        end
       end
 
       class MedicationEnd < State

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -88,6 +88,23 @@ module Synthea
           lookup_hash[sym] = value
         end
 
+        def add_lookup_codes(codes, lookup_hash)
+          return if codes.nil? || codes.empty?
+          symbols = []
+          codes.each do |code|
+            sym = code.to_sym
+            symbols << sym
+            value = {
+              description: code.display,
+              codes: {}
+            }
+            value[:codes][code.system] ||= []
+            value[:codes][code.system] << code.code
+            lookup_hash[sym] = value
+          end
+          symbols
+        end
+
         def to_s
           "#<#{self.class}::#{object_id}> #{@name}"
         end
@@ -309,12 +326,13 @@ module Synthea
       end
 
       class MedicationOrder < State
-        attr_accessor :prescribed, :target_encounter, :codes, :reason
+        attr_accessor :prescribed, :target_encounter, :codes, :reason, :prescription
 
         required_field and: [:target_encounter, :codes]
 
         metadata 'codes', type: 'Components::Code', min: 1, max: Float::INFINITY
         metadata 'target_encounter', reference_to_state_type: 'Encounter', min: 1, max: 1
+        metadata 'prescription', type: 'Components::Prescription', min: 0, max: 1
 
         def process(time, entity)
           if concurrent_with_target_encounter(time)
@@ -332,12 +350,46 @@ module Synthea
             cond = cond.symbol if cond
             cond = entity[@reason].to_sym if cond.nil? && entity[@reason]
           end
-          if cond.nil?
-            entity.record_synthea.medication_start(symbol, time, [])
-          else
-            entity.record_synthea.medication_start(symbol, time, [cond])
+          reasons = if cond.nil?
+                      []
+                    else
+                      [cond]
+                    end
+
+          # Handle the prescription object
+          rx_info = {}
+          unless @prescription.nil?
+            rx_info['as_needed'] = @prescription.as_needed || false
+            unless @prescription.as_needed
+              raise 'Prescription information must include dosage' if @prescription.dosage.nil?
+              raise 'Prescription information must include duration' if @prescription.duration.nil?
+              rx_info['total_doses'] = @prescription.doses
+              rx_info['refills'] = @prescription.refills || 0
+              rx_info['dosage'] = @prescription.dosage
+              rx_info['duration'] = @prescription.duration
+              rx_info['instructions'] = add_lookup_codes(@prescription.instructions, Synthea::INSTRUCTION_LOOKUP)
+            end
           end
+          entity.record_synthea.medication_start(symbol, time, reasons, rx_info)
           @prescribed = true
+        end
+
+        def add_instruction_lookup_codes(lookup_hash)
+          symbols = []
+          unless @prescription.nil? || @prescription.instructions.nil? || @prescription.instructions.empty?
+            @prescription.instructions.each do |instr|
+              sym = instruction_symbol(instr)
+              symbols << sym
+              value = {
+                description: instr['display'],
+                codes: {}
+              }
+              value[:codes][instr['system']] ||= []
+              value[:codes][instr['system']] << a['code']
+              lookup_hash[sym] = value
+            end
+          end
+          symbols
         end
       end
 
@@ -378,6 +430,7 @@ module Synthea
 
         metadata 'codes', type: 'Components::Code', min: 1, max: Float::INFINITY
         metadata 'target_encounter', reference_to_state_type: 'Encounter', min: 1, max: 1
+        metadata 'activities', type: 'Components::Code', min: 0, max: Float::INFINITY
 
         def process(time, entity)
           if concurrent_with_target_encounter(time)
@@ -390,7 +443,7 @@ module Synthea
 
         def start_plan(time, entity)
           add_lookup_code(Synthea::CAREPLAN_LOOKUP)
-          activities = add_activity_lookup_codes(Synthea::CAREPLAN_LOOKUP)
+          activities = add_lookup_codes(@activities, Synthea::CAREPLAN_LOOKUP)
 
           unless @reason.nil?
             rsn = @context.most_recent_by_name(@reason)
@@ -402,31 +455,6 @@ module Synthea
             entity.record_synthea.careplan_start(symbol, activities, time, [rsn])
           else
             entity.record_synthea.careplan_start(symbol, activities, time, [])
-          end
-        end
-
-        def add_activity_lookup_codes(lookup_hash)
-          return if @activities.nil? || @activities.empty?
-          symbols = []
-          @activities.each do |a|
-            sym = activity_symbol(a)
-            symbols << sym
-            value = {
-              description: a['display'],
-              codes: {}
-            }
-            value[:codes][a['system']] ||= []
-            value[:codes][a['system']] << a['code']
-            lookup_hash[sym] = value
-          end
-          symbols
-        end
-
-        def activity_symbol(activity)
-          if activity.key?('display')
-            activity['display'].gsub(/\s+/, '_').downcase.to_sym
-          else
-            raise 'Activity must have a display name to hash'
           end
         end
       end

--- a/lib/records/lookup.rb
+++ b/lib/records/lookup.rb
@@ -127,7 +127,10 @@ module Synthea
   }
 
   # http://hl7.org/fhir/2017Jan/valueset-additional-instructions-codes.html
-  INSTRUCTION_LOOKUP = {}
+  # The only instruction here is used just for testing
+  INSTRUCTION_LOOKUP = {
+    half_to_one_hour_before_food: { description: 'Half to one hour before food', codes: {'SNOMED-CT'=>['311501008']}}
+  }
 
   RACE_ETHNICITY_CODES = {
     :white => '2106-3',

--- a/lib/records/lookup.rb
+++ b/lib/records/lookup.rb
@@ -126,6 +126,9 @@ module Synthea
     alteplase: { description: 'Alteplase 1 MG/ML Injectable Solution', codes: {'RxNorm'=>['308056']}}
   }
 
+  # http://hl7.org/fhir/2017Jan/valueset-additional-instructions-codes.html
+  INSTRUCTION_LOOKUP = {}
+
   RACE_ETHNICITY_CODES = {
     :white => '2106-3',
     :hispanic => '2131-1',

--- a/lib/records/record.rb
+++ b/lib/records/record.rb
@@ -86,13 +86,15 @@ module Synthea
         }
       end
 
-      def medication_start(type, time, reasons)
-        @medications << {
+      def medication_start(type, time, reasons, rx_info = {})
+        med = {
           'type' => type,
           'time' => time,
           'start_time' => time,
           'reasons' => reasons # an array of reasons
         }
+        med['rx_info'] = rx_info
+        @medications << med
       end
 
       def medication_active?(type)

--- a/test/fixtures/generic/medication_order.json
+++ b/test/fixtures/generic/medication_order.json
@@ -30,7 +30,56 @@
             }],
             "assign_to_attribute" : "Diabetes Medication",
             "reason": "Diabetes",
-            "direct_transition": "Terminal"
+            "direct_transition": "Metformin_With_Dosage"
+        },
+        "Metformin_With_Dosage": {
+            "type": "MedicationOrder",
+            "target_encounter": "Wellness_Encounter",
+            "reason": "Diabetes",
+            "codes": [
+              {
+                "system": "RxNorm",
+                "code": "860975",
+                "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
+              }
+            ],
+            "prescription": {
+              "refills": 1,
+              "dosage": {
+                "amount": 1,
+                "frequency": 1,
+                "period": 1,
+                "unit": "days"
+              },
+              "duration": {
+                "quantity": 1,
+                "unit": "months"
+              },
+              "instructions": [
+                {
+                  "system": "SNOMED-CT",
+                  "code": "311501008",
+                  "display": "Half to one hour before food"
+                }
+              ]
+            },
+            "direct_transition": "Tylenol_As_Needed"
+        },
+        "Tylenol_As_Needed": {
+          "type": "MedicationOrder",
+          "target_encounter": "Wellness_Encounter",
+          "reason": "Diabetes",
+          "codes": [
+            {
+              "system": "RxNorm",
+              "code": "123456",
+              "display": "Acetaminophen 325mg [Tylenol]"
+            }
+          ],
+          "prescription": {
+            "as_needed": true
+          },
+          "direct_transition": "Terminal"
         },
         "Terminal": {
             "type": "Terminal"

--- a/test/unit/generic_states_test.rb
+++ b/test/unit/generic_states_test.rb
@@ -407,7 +407,8 @@ class GenericStatesTest < Minitest::Test
         'refills' => 1,
         'dosage' => med.prescription.dosage,
         'duration' => med.prescription.duration,
-        'instructions' => [:half_to_one_hour_before_food]
+        'instructions' => [:half_to_one_hour_before_food],
+        'patient_instructions' => 'Half to one hour before food'
       }
     ])
     assert(med.process(@time, @patient))


### PR DESCRIPTION
I added additional, optional properties to the `MedicationOrder` state that capture dosage information. I updated the FHIR exporter but did not touch the CCDA export (yet). Where can I find documentation on the fields/values accepted by the HDS resources like `Medication`? I updated the tests for the `MedicationOrder` state and added an additional FHIR validation test in the event that prescription information is included.

For the wiki:
***

## MedicationOrder

The `MedicationOrder` state type indicates a point in the module where a medication should be prescribed.  The MedicationOrder state must come after the `target_encounter` Encounter state in the module, but must have the same start time as that Encounter; otherwise it will not be recorded in the patient's record.  See the Encounter section above for more details.

The `MedicationOrder` also supports identifying a previous `ConditionOnset` or the name of an `attribute` as the `reason` for the prescription.

### Supported Properties

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `type` | `string` | Must be `"MedicationOrder"`. |
| `target_encounter` | `string` | Either an `"attribute"` or a `"State_Name"` referencing a<br/>_previous_ but concurrent `Encounter` state. |
| `assign_to_attribute` | `string` | **(optional)** The name of the `"attribute"` to assign this state to. |
| `reason` | `string` | **(optional)** Either an `"attribute"` or a `"State_Name"`<br/>referencing a _previous_ `ConditionOnset` state. |
| `codes` | `[]` | One or more codes that describe the Medication.<br/>Must be valid [RxNorm codes](https://github.com/synthetichealth/synthea/wiki/Generic-Module-Framework%3A-Basics#rxnorm-codes). |
|`prescription` | `{}` | **(optional)** Detailed information about the prescription, including dosage information (see below). |

##### `prescription`:

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `refills` | `numeric` | **(optional)** The number of refills to allow. If not specified, defaults to `0`. |
| `as_needed` | `boolean` | If `true`, the medication may be taken as needed instead of on a specific schedule. **(optional)** if `false`. |
| `dosage` | `{}` | The amount and frequency that the medication should be taken. |
| `duration` | `{}` | The total length of time that the medication should be taken for. |
| `instructions` | `[]` | **(optional)** Specific instructions for taking the medication. Must be valid [SNOMED codes](https://github.com/synthetichealth/synthea/wiki/Generic-Module-Framework%3A-Basics#snomed-codes) from the [Instruction Valueset](http://hl7.org/fhir/2017Jan/valueset-additional-instructions-codes.html).  |

##### `dosage`:

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `amount` | `numeric` | The number of doses to take each time. |
| `frequency` | `numeric` | The number of times the medication should be taken per period. |
| `period` | `numeric` | The number of `units` that represents a period. |
| `unit` | `string` | The unit of time describing the period. |

##### `duration`:

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `quantity` | `numeric` | The number of `units` that the medication should be taken for. |
| `unit` | `string` | The unit of time describing the duration. |


### Examples

The following is an example of a `MedicationOrder` that should be prescribed at the `"Annual_Checkup"` Encounter and cite the `"Diabetes"` condition as the reason:

```json
"Prescribe_Metformin": {
  "type": "MedicationOrder",
  "target_encounter": "Annual_Checkup",
  "assign_to_attribute": "diabetes_medication",
  "reason": "Diabetes",
  "codes": [
    {
      "system": "RxNorm",
      "code": "860975",
      "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
    }
  ]
}
```

The following is an example of a `MedicationOrder` that also specifies dosage information. In this example, the patient should take "1 dose, twice per day for 2 weeks, before food":

```json
"Examplitol": {
  "type": "MedicationOrder",
  "target_encounter": "Encounter",
  "reason": "Examplitis",
  "codes": [
    {
      "system": "RxNorm",
      "code": "123456",
      "display": "Examplitol 100mg [Examplitol]"
    }
  ],
  "prescription": {
    "refills": 2,
    "dosage": {
      "amount": 1,
      "frequency": 2,
      "period": 1,
      "unit": "days"
    },
    "duration": {
      "quantity": 2,
      "unit": "weeks"
    },
    "instructions": [
      {
        "system": "SNOMED-CT",
        "code": "311501008",
        "display": "Half to one hour before food"
      }
    ]
  }
}
```

If `as_needed` is true then dosage information does not need to be specified:

```json
"Examplitol": {
  "type": "MedicationOrder",
  "target_encounter": "Encounter",
  "reason": "Examplitis",
  "codes": [
    {
      "system": "RxNorm",
      "code": "123456",
      "display": "Examplitol 100mg [Examplitol]"
    }
  ],
  "prescription": {
    "as_needed": true
  }
}
```