### PR TITLE
GMF Vital Signs

### DIFF
--- a/lib/entity/entity.rb
+++ b/lib/entity/entity.rb
@@ -4,7 +4,7 @@ module Synthea
     attr_accessor :events
 
     def initialize
-      @attributes = {}
+      @attributes = { vital_signs: {} }
       @events = Synthea::EventList.new
 
       # We represent symptoms as a hash of hashes; the first level key is the symptom name (ie :fatigue), the
@@ -35,6 +35,20 @@ module Synthea
 
     def alive?(time = nil)
       event(:birth) && !had_event?(:death, time)
+    end
+
+    def vital_sign(vital_sign_name)
+      vital_sign_name = vital_sign_name.to_s.gsub(/\s+/, '_').downcase.to_sym
+      @attributes[:vital_signs][vital_sign_name]
+    end
+
+    def get_vital_sign_value(vital_sign_name)
+      vital_sign(vital_sign_name)[:value]
+    end
+
+    def set_vital_sign(vital_sign_name, value, unit)
+      vital_sign_name = vital_sign_name.to_s.gsub(/\s+/, '_').downcase.to_sym
+      @attributes[:vital_signs][vital_sign_name] = { value: value, unit: unit }
     end
 
     #-----------------------------------------------------------------------

--- a/lib/generic/modules/wellness_encounters.json
+++ b/lib/generic/modules/wellness_encounters.json
@@ -1,0 +1,462 @@
+{
+  "name": "Wellness Encounters",
+  "remarks": [
+    "migrated observations from Lifecycle and Metabolic Syndrome ruby modules"
+  ],
+  "states": {
+
+    "Initial" : {
+      "type" : "Initial",
+      "direct_transition" : "Wellness_Encounter"
+    },
+
+    "Wellness_Encounter" : {
+      "type" : "Encounter",
+      "wellness" : true,
+      "direct_transition" : "Record_Height"
+    },
+
+    "Record_Height" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Height",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "8302-2",
+        "display" : "Body Height"
+      }],
+      "unit" : "cm",
+      "direct_transition" : "Record_Weight"
+    },
+
+    "Record_Weight" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Weight",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "29463-7",
+        "display" : "Body Weight"
+      }],
+      "unit" : "kg",
+      "conditional_transition" : [
+        {
+          "condition" :{
+            "condition_type": "Age",
+            "operator": "<",
+            "quantity": 2,
+            "unit": "years"
+          },
+          "remarks" : ["BMI is not particularly meaningful for children under 2"],
+          "transition" : "Record_Systolic_BP"
+        },
+        {
+          "transition" : "Record_BMI"
+        }
+      ]
+    },
+
+    "Record_BMI" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "BMI",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "39156-5",
+        "display" : "Body Mass Index"
+      }],
+      "unit" : "kg/m2",
+      "direct_transition" : "Record_Systolic_BP"
+    },
+
+    "Record_Systolic_BP" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Systolic Blood Pressure",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "8480-6",
+        "display" : "Systolic Blood Pressure"
+      }],
+      "unit" : "mmHg",
+      "direct_transition" : "Record_Diastolic_BP"
+    },
+
+    "Record_Diastolic_BP" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Diastolic Blood Pressure",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "8462-4",
+        "display" : "Diastolic Blood Pressure"
+      }],
+      "unit" : "mmHg",
+      "direct_transition" : "Record_BP"
+    },
+
+    "Record_BP" : {
+      "type" : "MultiObservation",
+      "number_of_observations" : 2,
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "55284-4",
+        "display" : "Blood Pressure"
+      }],
+      "target_encounter" : "Wellness_Encounter",
+      "direct_transition" : "Lab_1_HA1C"
+    },
+
+    "Lab_1_HA1C" : {
+      "type" : "Simple",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Or",
+            "conditions" : [
+              {
+                "condition_type": "Attribute",
+                "attribute": "diabetes",
+                "operator": "is not nil"
+              },
+              {
+                "condition_type": "Attribute",
+                "attribute": "prediabetes",
+                "operator": "is not nil"
+              }
+            ]
+          },
+          "transition" : "Record_HA1C"
+        },
+        {
+          "transition" : "Lab_2_MetabolicPanel"
+        }
+      ]
+    },
+
+    "Record_HA1C" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Blood Glucose",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "4548-4",
+        "display" : "Hemoglobin A1c/Hemoglobin.total in Blood"
+      }],
+      "unit" : "%",
+      "direct_transition" : "Lab_2_MetabolicPanel"
+    },
+
+    "Lab_2_MetabolicPanel" : {
+      "type" : "Simple",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Or",
+            "conditions" : [
+              {
+                "condition_type": "Attribute",
+                "attribute": "diabetes",
+                "operator": "is not nil"
+              },
+              {
+                "condition_type": "Attribute",
+                "attribute": "prediabetes",
+                "operator": "is not nil"
+              }
+            ]
+          },
+          "transition" : "Record_Glucose"
+        },
+        {
+          "transition" : "Lab_3_LipidPanel"
+        }
+      ]
+    },
+
+    "Record_Glucose" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Glucose",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "2339-0",
+        "display" : "Glucose"
+      }],
+      "unit" : "mg/dL",
+      "direct_transition" : "Record_UreaNitrogen"
+    },
+    "Record_UreaNitrogen" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Urea Nitrogen",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "6299-2",
+        "display" : "Urea Nitrogen"
+      }],
+      "unit" : "mg/dL",
+      "direct_transition" : "Record_Creatinine"
+    },
+    "Record_Creatinine" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Creatinine",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "38483-4",
+        "display" : "Creatinine"
+      }],
+      "unit" : "mg/dL",
+      "direct_transition" : "Record_Calcium"
+    },
+    "Record_Calcium" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Calcium",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "49765-1",
+        "display" : "Calcium"
+      }],
+      "unit" : "mg/dL",
+      "direct_transition" : "Record_Sodium"
+    },
+    "Record_Sodium" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Sodium",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "2947-0",
+        "display" : "Sodium"
+      }],
+      "unit" : "mmol/L",
+      "direct_transition" : "Record_Potassium"
+    },
+    "Record_Potassium" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Potassium",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "6298-4",
+        "display" : "Potassium"
+      }],
+      "unit" : "mmol/L",
+      "direct_transition" : "Record_Chloride"
+    },
+    "Record_Chloride" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Chloride",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "2069-3",
+        "display" : "Chloride"
+      }],
+      "unit" : "mmol/L",
+      "direct_transition" : "Record_CO2"
+    },
+    "Record_CO2" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Carbon Dioxide",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "20565-8",
+        "display" : "Carbon Dioxide"
+      }],
+      "unit" : "mmol/L",
+      "direct_transition" : "Record_MetabolicPanel"
+    },
+
+    "Record_MetabolicPanel" : {
+      "type" : "DiagnosticReport",
+      "number_of_observations" : 8,
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "51990-0",
+        "display" : "Basic Metabolic Panel"
+      }],
+      "target_encounter" : "Wellness_Encounter",
+      "direct_transition" : "Lab_3_LipidPanel"
+    },
+
+
+    "Lab_3_LipidPanel" : {
+      "type" : "Simple",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Or",
+            "conditions" : [
+              {
+                "condition_type": "Attribute",
+                "attribute": "diabetes",
+                "operator": "is not nil"
+              },
+              {
+                "condition_type": "And",
+                "conditions" : [
+                  {
+                    "condition_type" : "Not",
+                    "condition" : {
+                      "condition_type": "PriorState",
+                      "name" : "Record_Cholesterol",
+                      "within" : { "quantity" : 3, "unit" : "years" }
+                    }
+                  },
+                  {
+                    "condition_type": "Age",
+                    "operator": ">=",
+                    "quantity": 30,
+                    "unit": "years"
+                  }
+                ]
+              }
+            ]
+          },
+          "transition" : "Record_Cholesterol"
+        },
+        {
+          "transition" : "Lab_4_ACR"
+        }
+      ]
+    },
+
+    "Record_Cholesterol" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Total Cholesterol",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "2093-3",
+        "display" : "Total Cholesterol"
+      }],
+      "unit" : "mg/dL",
+      "direct_transition" : "Record_Triglycerides"
+    },
+
+    "Record_Triglycerides" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Triglycerides",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "2571-8",
+        "display" : "Triglycerides"
+      }],
+      "unit" : "mg/dL",
+      "direct_transition" : "Record_LDL"
+    },
+
+    "Record_LDL" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "LDL",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "18262-6",
+        "display" : "Low Density Lipoprotein Cholesterol"
+      }],
+      "unit" : "mg/dL",
+      "direct_transition" : "Record_HDL"
+    },
+
+    "Record_HDL" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "HDL",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "2085-9",
+        "display" : "High Density Lipoprotein Cholesterol"
+      }],
+      "unit" : "mg/dL",
+      "direct_transition" : "Record_LipidPanel"
+    },
+
+    "Record_LipidPanel" : {
+      "type" : "DiagnosticReport",
+      "number_of_observations" : 4,
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "57698-3",
+        "display" : "Lipid Panel"
+      }],
+      "target_encounter" : "Wellness_Encounter",
+      "direct_transition" : "Lab_4_ACR"
+    },
+
+    "Lab_4_ACR" : {
+      "type" : "Simple",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type": "Attribute",
+            "attribute": "diabetes",
+            "operator": "is not nil"
+          },
+          "transition" : "Record_ACR"
+        },
+        {
+          "transition" : "Lab_5_EGFR"
+        }
+      ]
+    },
+
+    "Record_ACR" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "Microalbumin Creatine Ratio",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "14959-1",
+        "display" : "Microalbumin Creatine Ratio"
+      }],
+      "unit" : "mg/g",
+      "direct_transition" : "Lab_5_EGFR"
+    },
+
+    "Lab_5_EGFR" : {
+      "type" : "Simple",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Or",
+            "conditions" : [
+              {
+                "condition_type": "Attribute",
+                "attribute": "diabetes",
+                "operator": "is not nil"
+              },
+              {
+                "condition_type": "Attribute",
+                "attribute": "hypertension",
+                "operator": "is not nil"
+              }
+            ]
+          },
+          "transition" : "Record_EGFR"
+        },
+        {
+          "transition" : "Wellness_Encounter"
+        }
+      ]
+    },
+
+    "Record_EGFR" : {
+      "type" : "Observation",
+      "target_encounter" : "Wellness_Encounter",
+      "vital_sign" : "EGFR",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "33914-3",
+        "display" : "Estimated Glomerular Filtration Rate"
+      }],
+      "unit" : "mL/min/{1.73_m2}",
+      "direct_transition" : "Wellness_Encounter"
+    }
+  }
+}

--- a/lib/generic/modules/wellness_encounters.json
+++ b/lib/generic/modules/wellness_encounters.json
@@ -115,14 +115,20 @@
             "condition_type" : "Or",
             "conditions" : [
               {
-                "condition_type": "Attribute",
-                "attribute": "diabetes",
-                "operator": "is not nil"
+                "condition_type": "Active Condition",
+                "codes" : [{
+                  "system" : "SNOMED-CT",
+                  "code" : "44054006",
+                  "display" : "Diabetes"
+                }]
               },
               {
-                "condition_type": "Attribute",
-                "attribute": "prediabetes",
-                "operator": "is not nil"
+                "condition_type": "Active Condition",
+                "codes" : [{
+                  "system" : "SNOMED-CT",
+                  "code" : "15777000",
+                  "display" : "Prediabetes"
+                }]
               }
             ]
           },
@@ -155,14 +161,20 @@
             "condition_type" : "Or",
             "conditions" : [
               {
-                "condition_type": "Attribute",
-                "attribute": "diabetes",
-                "operator": "is not nil"
+                "condition_type": "Active Condition",
+                "codes" : [{
+                  "system" : "SNOMED-CT",
+                  "code" : "44054006",
+                  "display" : "Diabetes"
+                }]
               },
               {
-                "condition_type": "Attribute",
-                "attribute": "prediabetes",
-                "operator": "is not nil"
+                "condition_type": "Active Condition",
+                "codes" : [{
+                  "system" : "SNOMED-CT",
+                  "code" : "15777000",
+                  "display" : "Prediabetes"
+                }]
               }
             ]
           },
@@ -292,9 +304,12 @@
             "condition_type" : "Or",
             "conditions" : [
               {
-                "condition_type": "Attribute",
-                "attribute": "diabetes",
-                "operator": "is not nil"
+                "condition_type": "Active Condition",
+                "codes" : [{
+                  "system" : "SNOMED-CT",
+                  "code" : "44054006",
+                  "display" : "Diabetes"
+                }]
               },
               {
                 "condition_type": "And",
@@ -394,9 +409,12 @@
       "conditional_transition" : [
         {
           "condition" : {
-            "condition_type": "Attribute",
-            "attribute": "diabetes",
-            "operator": "is not nil"
+            "condition_type": "Active Condition",
+            "codes" : [{
+              "system" : "SNOMED-CT",
+              "code" : "44054006",
+              "display" : "Diabetes"
+            }]
           },
           "transition" : "Record_ACR"
         },
@@ -427,14 +445,20 @@
             "condition_type" : "Or",
             "conditions" : [
               {
-                "condition_type": "Attribute",
-                "attribute": "diabetes",
-                "operator": "is not nil"
+                "condition_type": "Active Condition",
+                "codes" : [{
+                  "system" : "SNOMED-CT",
+                  "code" : "44054006",
+                  "display" : "Diabetes"
+                }]
               },
               {
-                "condition_type": "Attribute",
-                "attribute": "hypertension",
-                "operator": "is not nil"
+                "condition_type": "Active Condition",
+                "codes" : [{
+                  "system" : "SNOMED-CT",
+                  "code" : "38341003",
+                  "display" : "Hypertension"
+                }]
               }
             ]
           },

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -571,7 +571,7 @@ module Synthea
       end
 
       class VitalSign < State
-        attr_accessor :vital_sign, :range, :exact, :unit
+        attr_accessor :vital_sign, :range, :exact, :unit, :target_encounter
 
         required_field or: [:range, :exact]
         required_field and: [:vital_sign, :unit]

--- a/lib/modules/cardiovascular_disease.rb
+++ b/lib/modules/cardiovascular_disease.rb
@@ -152,7 +152,7 @@ module Synthea
       end
 
       rule :calculate_cardio_risk, [:cholesterol, :HDL, :age, :gender, :blood_pressure, :smoker], [:coronary_heart_disease?] do |_time, entity|
-        return if entity[:age].nil? || entity[:blood_pressure].nil? || entity[:gender].nil? || entity[:cholesterol].nil?
+        return if entity[:age].nil? || entity.vital_sign(:systolic_blood_pressure).nil? || entity[:gender].nil? || entity[:cholesterol].nil?
         age = entity[:age]
         gender = entity[:gender]
         bp_treated = entity[:bp_treated?] || false
@@ -249,15 +249,15 @@ module Synthea
       }
 
       rule :calculate_atrial_fibrillation_risk, [:age, :bmi, :blood_pressure, :gender], [:atrial_fibrillation_risk] do |_time, entity|
-        if entity[:atrial_fibrillation] || entity[:age].nil? || entity[:blood_pressure].nil? || entity[:gender].nil? || entity[:bmi].nil? || entity[:age] < 45
+        if entity[:atrial_fibrillation] || entity[:age].nil? || entity.vital_sign(:systolic_blood_pressure).nil? || entity[:gender].nil? || entity[:bmi].nil? || entity[:age] < 45
           return
         end
         age = entity[:age]
         af_score = 0
         age_range = [(age - 45) / 5, 8].min
         af_score += age_af[entity[:gender]][age_range]
-        af_score += 1 if entity[:bmi] >= 30
-        af_score += 1 if entity[:blood_pressure][0] >= 160
+        af_score += 1 if entity.get_vital_sign_value(:bmi) >= 30
+        af_score += 1 if entity.get_vital_sign_value(:systolic_blood_pressure) >= 160
         af_score += 1 if entity[:bp_treated?]
         af_score = [[af_score, 0].max, 10].min
 
@@ -323,10 +323,10 @@ module Synthea
       atrial_fibrillation_stroke_points = { 'M' => 4, 'F' => 6 }
 
       rule :calculate_stroke_risk, [:age, :diabetes, :coronary_heart_disease, :blood_pressure, :stroke_history, :smoker], [:stroke_risk] do |_time, entity|
-        return if entity[:age].nil? || entity[:blood_pressure].nil? || entity[:gender].nil?
+        return if entity[:age].nil? || entity.vital_sign(:systolic_blood_pressure).nil? || entity[:gender].nil?
         age = entity[:age]
         gender = entity[:gender]
-        blood_pressure = entity[:blood_pressure][0]
+        blood_pressure = entity.get_vital_sign_value(:systolic_blood_pressure)
         # https://www.heart.org/idc/groups/heart-public/@wcm/@sop/@smd/documents/downloadable/ucm_449858.pdf
         # calculate stroke risk based off of prevalence of stroke in age group for people younger than 54. Framingham score system does not cover these.
 

--- a/lib/modules/encounters.rb
+++ b/lib/modules/encounters.rb
@@ -47,7 +47,6 @@ module Synthea
           unprocessed_events.each do |event|
             entity.events.process(event)
             self.class.encounter(entity, event.time)
-            Synthea::Modules::Lifecycle.record_height_weight(entity, event.time)
             Synthea::Modules::Immunizations.perform_encounter(entity, event.time)
             Synthea::Modules::MetabolicSyndrome.perform_encounter(entity, event.time)
             Synthea::Modules::CardiovascularDisease.perform_encounter(entity, event.time)

--- a/lib/modules/metabolic_syndrome.rb
+++ b/lib/modules/metabolic_syndrome.rb
@@ -75,14 +75,6 @@ module Synthea
         ldl = entity.get_vital_sign_value(:total_cholesterol) - entity.get_vital_sign_value(:hdl) - (0.2 * entity.get_vital_sign_value(:triglycerides))
         entity.set_vital_sign(:ldl, ldl.to_i, 'mg/dL')
 
-        # entity[:cholesterol] = {
-        #   total: rand(cholesterol[index]..cholesterol[index + 1]),
-        #   triglycerides: rand(triglycerides[index]..triglycerides[index + 1]),
-        #   hdl: rand(hdl[index + 1]..hdl[index])
-        # }
-        # entity[:cholesterol][:ldl] = entity[:cholesterol][:total] - entity[:cholesterol][:hdl] - (0.2 * entity[:cholesterol][:triglycerides])
-        # entity[:cholesterol][:ldl] = entity[:cholesterol][:ldl].to_i
-
         # calculate the components of a metabolic panel and associated observations
         normal = Synthea::Config.metabolic.basic_panel.normal
         metabolic_panel = {

--- a/lib/tasks/graphviz.rb
+++ b/lib/tasks/graphviz.rb
@@ -287,20 +287,32 @@ module Synthea
             details = "#{s}: #{e['quantity']}"
           end
         when 'Observation'
-          unit = state['unit'].gsub('{','(').gsub('}',')') # replace curly braces with parens, braces can cause issues
-          if state.has_key? 'range'
-            r = state['range']
-            details = "#{r['low']} - #{r['high']} #{unit}\\l"
-          elsif state.has_key? 'exact'
-            e = state['exact']
-            details = "#{e['quantity']} #{unit}\\l"
+          unit = state['unit']
+          if unit
+            unit = 'in ' + unit.gsub('{','(').gsub('}',')') # replace curly braces with parens, braces can cause issues
+          end
+          
+          if state.has_key? 'vital_sign'
+            details = "Record value from Vital Sign '#{state['vital_sign']}' #{unit}\\l"
           elsif state.has_key? 'attribute'
-            details = "Value from Attribute: '#{state['attribute']}', Unit: #{unit}\\l"
+            details = "Record value from Attribute '#{state['attribute']}' #{unit}\\l"
           end
         when 'Counter'
           details = "#{state['action']} value of attribute '#{state['attribute']}' by 1"
+        when 'VitalSign'
+          vs = state['vital_sign']
+          unit = state['unit']
+          if state.has_key? 'range'
+            r = state['range']
+            details = "Set #{vs}: #{r['low']} - #{r['high']} #{unit}"
+          elsif state.has_key? 'exact'
+            e = state['exact']
+            details = "Set #{vs}: #{e['quantity']} #{unit}"
+          end
         when 'CallSubmodule'
           details = "Call submodule '#{state['submodule']}'"
+        when 'MultiObservation', 'DiagnosticReport'
+          details = "Group the last #{state['number_of_observations']} Observations\\l"
         end
 
         # Things common to many states
@@ -401,6 +413,8 @@ module Synthea
         when 'Observation'
           obs = find_referenced_type(logic)
           "Observation #{obs} \\#{logic['operator']} #{logic['value']}\\l"
+        when 'Vital Sign'
+          "Vital Sign #{logic['vital_sign']} \\#{logic['operator']} #{logic['value']}\\l"
         when 'Active Condition'
           cond = find_referenced_type(logic)
           "Condition #{cond} is active\\l"

--- a/lib/world/sequential.rb
+++ b/lib/world/sequential.rb
@@ -212,7 +212,7 @@ module Synthea
         str << "#{person[:name_last]}, #{person[:name_first]}. #{person[:race].to_s.capitalize} #{person[:ethnicity].to_s.tr('_', ' ').capitalize}. #{person[:age]} y/o #{person[:gender]}"
 
         conditions = track_conditions(person)
-        weight = (person[:weight] * 2.20462).to_i
+        weight = (person.get_vital_sign_value(:weight) * 2.20462).to_i
         str << " #{weight} lbs. -- #{conditions.join(', ')}"
 
         puts str

--- a/test/fixtures/generic/logic.json
+++ b/test/fixtures/generic/logic.json
@@ -114,6 +114,12 @@
     "referenced_by_attribute" : "Diabetes Test Performed",
     "operator" : "is not nil"
   },
+  "SystolicBloodPressureGt120" : {
+    "condition_type" : "Vital Sign",
+    "vital_sign" : "Systolic Blood Pressure",
+    "operator" : ">",
+    "value" : 120
+  },
   "diabetesConditionTest" : {
     "condition_type" : "Active Condition",
     "codes": [{
@@ -151,6 +157,22 @@
   "priorStateDoctorVisitTest" : {
     "condition_type": "PriorState",
     "name" : "DoctorVisit"
+  },
+  "priorStateCarePlanSinceDoctorVisitTest" : {
+    "condition_type": "PriorState",
+    "name" : "CarePlan",
+    "since" : "DoctorVisit"
+  },
+  "priorStateDoctorVisitWithin3YearsTest" : {
+    "condition_type": "PriorState",
+    "name" : "DoctorVisit",
+    "within" : { "quantity" : 3, "unit" : "years" }
+  },
+  "priorStateCarePlanSinceDoctorVisitWithin3YearsTest" : {
+    "condition_type": "PriorState",
+    "name" : "CarePlan",
+    "since" : "DoctorVisit",
+    "within" : { "quantity" : 3, "unit" : "years" }
   },
   "andAllTrueTest": {
     "condition_type": "And",

--- a/test/fixtures/generic/vitalsign_observation.json
+++ b/test/fixtures/generic/vitalsign_observation.json
@@ -1,9 +1,17 @@
 {
-    "name": "Observation",
+    "name": "VitalSign_Observation",
     "states": {
         "Initial": {
             "type": "Initial",
-            "direct_transition": "SomeEncounter"
+            "direct_transition": "VitalSign"
+        },
+
+        "VitalSign" : {
+            "type" : "VitalSign",
+            "vital_sign" : "Systolic Blood Pressure",
+            "exact" : { "quantity" : "120" },
+            "unit" : "mmHg",
+            "direct_transition" : "SomeEncounter"
         },
 
         "SomeEncounter" : {
@@ -19,15 +27,13 @@
 
         "SomeObservation" : {
             "type" : "Observation",
+            "vital_sign" : "Systolic Blood Pressure",
             "codes" : [{
               "system" : "LOINC",
-              "code" : "55284-4",
-              "display" : "Blood Pressure"
+              "code" : "8480-6",
+              "display" : "Systolic Blood Pressure"
             }],
             "target_encounter" : "SomeEncounter",
-            "exact" : {
-                "quantity" : "120/80"
-            },
             "unit" : "mmHg",
             "direct_transition" : "Terminal"
         },

--- a/test/unit/generic_modules_test.rb
+++ b/test/unit/generic_modules_test.rb
@@ -43,7 +43,8 @@ class GenericModulesTest < Minitest::Test
       "name" => "Logic",
       "states" => {
         "Initial" => { "type" => "Initial" },
-        "DoctorVisit" => { "type" => "Simple" } # needed for the PriorState test
+        "DoctorVisit" => { "type" => "Simple" }, # needed for the PriorState tests
+        "CarePlan" => { "type" => "Simple" } # needed for the PriorState tests
       }
     }
     context = Synthea::Generic::Context.new('logic')


### PR DESCRIPTION
Adds Vital Signs to the Generic Module Framework. Vital Sign states can be used to store information which can then be captured by Observations or drive conditional logic. Vital Signs represent the physical state of the patient, in contrast to Observations which are the recording of that physical state. For instance, height and weight are physical properties of a person which can be observed. Note that not all observations are direct recording of physical properties, so Observations can still specify a range or exact value. For instance, MMSE (Mini–Mental State Examination, a diagnostic evaluation used for tracking dementia, ex Alzheimer's) is not a physical quantity but a score representing an evaluation. There may not be a clear distinction between the Vital Sign and Observation in all cases, so I leave it to the author to decide which is more appropriate. In general, the Vital Sign should be used if the value directly affects the patient's physical condition. For example, high blood pressure directly increases the risk of heart attack so any conditional logic that would trigger a heart attack should consider the Vital Sign instead of the Observation. On the other hand, if the value affects the patient's care, the Observation would be more appropriate. For example, it is the Observation of high blood pressure that leads a doctor to prescribe medication, not the high blood pressure itself.

Also added DiagnosticReport and MultiObservation states to group observations.

Also upgraded the PriorState logic to allow checking within a certain timeframe or since a previous state. For example, you may want to check whether a patient has had a certain test within the past 5 years.

Adds a "Wellness Encounters" generic module that records various observations at each wellness encounter. This replaces the recording of observations from the ruby modules. See graphviz below

For the Wiki:
# States
## VitalSign
The `VitalSign` state type indicates a point in the module where a patient's vital sign is set. Vital Signs represent the physical state of the patient, in contrast to Observations which are the recording of that physical state.

### Notes
There may not be a clear distinction between the Vital Sign and Observation in all cases, so it is left to the module author to decide which is more appropriate. In general, the Vital Sign should be used if the value directly affects the patient's physical condition. For example, high blood pressure directly increases the risk of heart attack so any conditional logic that would trigger a heart attack should reference a Vital Sign instead of an Observation. On the other hand, if the value affects the patient's care, the Observation would be more appropriate. For example, it is the Observation of high blood pressure that leads a doctor to prescribe medication, not the high blood pressure itself.

### Supported Properties
| Attribute | Type | Description |
|:----------|:-----|:------------|
| `type` | `string` | Must be `"VitalSign"`. |
| `vital_sign`| `string` | The name of the Vital Sign, which may be referenced later
| `unit` | `string` | The unit of measure in which the vital sign is measured (e.g. `"cm"`). |

And one of: 

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `exact` | `{}` | The exact value to be recorded for this Observation |
| `range` | `{}` | A range of values from which one value will be recorded |


##### `exact`:

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `quantity` | `numeric` | The exact value of `unit` observed. |

##### `range`:

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `low` | `numeric` | The lowest (inclusive) numeric value of `unit` observed. |
| `high` | `numeric` | The greatest (inclusive) numeric value of `unit` observed. |

### Example
The following is an example of a VitalSign state that sets the patient's Systolic Blood Pressure to 120 mmHg:

```
"SetBP" : {
   "type" : "VitalSign",
   "vital_sign" : "Systolic Blood Pressure",
   "exact" : { "quantity" : "120" },
   "unit" : "mmHg"
},
```

## Observation
The `Observation` state type indicates a point in the module where an observation is recorded. Observations include clinical findings, vital signs, lab tests, etc.

If the Observation state's `target_encounter` is set to the name of a future encounter, then the observation will be recorded when that future encounter occurs.  If the `target_encounter` is set to the name of a previous encounter, then the observation will only be recorded if the Observation start time is the _same_ as the encounter's start time.  See the Encounter section above for more details.

### Supported Properties

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `type` | `string` | Must be `"Observation"`. |
| `target_encounter` | `string` | Either an `"attribute"` or a `"State_Name"` referencing a concurrent or future `Encounter` state. |
| `unit` | `string` | The unit of measure in which the observation is recorded (e.g. `"cm"`). |
| `codes` | `[]` | One or more codes that describe the Observation. Must be valid [LOINC codes](https://github.com/synthetichealth/synthea/wiki/Generic-Module-Framework%3A-Basics#loinc-codes). |

And one of: 

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `exact` | `{}` | The exact value to be recorded for this Observation |
| `range` | `{}` | A range of values from which one value will be recorded |
| `attribute` | `string` | The name of an attribute that contains the value of some Observation |
| `vital_sign`| `string` | The name of a Vital Sign that contains a value

##### `exact`:

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `quantity` | `numeric` | The exact value of `unit` observed. |

##### `range`:

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `low` | `numeric` | The lowest (inclusive) numeric value of `unit` observed. |
| `high` | `numeric` | The greatest (inclusive) numeric value of `unit` observed. |

The actual value for the observation will be chosen randomly from this range.

### Example

The following is an example of an Observation that should be taken at the `"Checkup"` Encounter, that will result in an observation of body height between 40 and 60 cm:

```json
"Height_Measurement": {
  "type": "Observation",
  "target_encounter": "Checkup",
  "unit": "cm",
  "range": {
    "low": 40,
    "high": 60
  },
  "codes": [
    {
      "system": "LOINC",
      "code": "8302-2",
      "display": "Body Height"
    }
  ]
}
```


## MultiObservation
The `MultiObservation` state indicates that some number of prior Observation states should be grouped together as a single observation. This can be necessary when one observation records multiple values, for example in the case of Blood Pressure, which is really 2 values, Systolic and Diastolic Blood Pressure. This state must occur directly after the relevant Observation states, otherwise unexpected behavior can occur.

### Supported Properties

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `type` | `string` | Must be `"MultiObservation"`. |
| `target_encounter` | `string` | Either an `"attribute"` or a `"State_Name"` referencing a concurrent or future `Encounter` state. |
| `number_of_observations` | `integer` | The number of observations to group within this `MultiObservation`
| `codes` | `[]` | One or more codes that describe the Observation. Must be valid [LOINC codes](https://github.com/synthetichealth/synthea/wiki/Generic-Module-Framework%3A-Basics#loinc-codes). |

### Example
The following example shows a `MultiObservation` which groups the 2 previous observations into 1 observation for Blood Pressure:

```
"Record_BP" : {
   "type" : "MultiObservation",
   "number_of_observations" : 2,
   "codes" : [{
     "system" : "LOINC",
     "code" : "55284-4",
     "display" : "Blood Pressure"
   }],
   "target_encounter" : "Wellness_Encounter"
 }
```

## DiagnosticReport
The `DiagnosticReport` state indicates that some number of prior Observation states should be grouped together within a single Diagnostic Report. This can be used when multiple observations are part of a single panel.

### Supported Properties

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `type` | `string` | Must be `"DiagnosticReport"`. |
| `target_encounter` | `string` | Either an `"attribute"` or a `"State_Name"` referencing a concurrent or future `Encounter` state. |
| `number_of_observations` | `integer` | The number of observations to group within this `DiagnosticReport`
| `codes` | `[]` | One or more codes that describe the DiagnosticReport. Must be valid [LOINC codes](https://github.com/synthetichealth/synthea/wiki/Generic-Module-Framework%3A-Basics#loinc-codes). |

### Example
The following example shows a `DiagnosticReport` which groups the 8 previous observations into a Metabolic Panel Diagnostic Report:

```
"Record_MetabolicPanel" : {
   "type" : "DiagnosticReport",
   "number_of_observations" : 8,
   "codes" : [{
     "system" : "LOINC",
     "code" : "51990-0",
     "display" : "Basic Metabolic Panel"
   }],
   "target_encounter" : "Wellness_Encounter"
 }
```

# Logic
## Vital Sign
The `Vital Sign` condition type tests a patient's current vital signs. Synthea tracks vital signs in order to drive a patient's physical condition, and are recorded in observations. See also the [[Symptom|Generic Module Framework: States#VitalSign]] state.

### Supported Properties

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `condition_type` | `string` | Must be `"Vital Sign"`. |
| `vital_sign` | `string` | The name of the vital sign to test against. |
| `operator` | `string` | One of [`"=="`, `"!="`, `"<"`, `">"`, `"<="`, `">="`]. |
| `value` | `numeric` | The value to test the vital sign against. |

### Example

The following `Vital Sign` condition will return `true` if the patient's Systolic Blood Pressure vital sign is greater than 120:

```json
{
    "condition_type" : "Vital Sign",
    "vital_sign" : "Systolic Blood Pressure",
    "operator" : ">",
    "value" : 120
  },
```

## PriorState

The `PriorState` condition type tests the progression of the patient through the module, and checks if a specific state has already been processed (in other words, the state is in the module's state history). The search for the state may be limited by time or the name of another state.

### Supported Properties

| Attribute | Type | Description |
|:----------|:-----|:------------|
| `condition_type` | `string` | Must be `"PriorState"`. |
| `name` | `string` | The name of the state to check for in the module's history. |
| `since` | `string` | The name of a state at which this logic will stop checking for the target state.
| `within` | `{}` | An exact timespan to use to limit the search for the target state

### Example

The following `PriorState` condition will return `true` if the patient has already passed through a state called `"Emergency_Encounter"`, `false` otherwise:

```json
{
  "condition_type": "PriorState",
  "name": "Emergency_Encounter"
}
```

The following `PriorState` condition will return `true` if the patient has passed through a state called `"Emergency_Encounter"` within the last 3 years, or `false` if the patient has never passed through the state, or last passed through the state more than 3 years ago:

```json
{
  "condition_type": "PriorState",
  "name": "Emergency_Encounter",
  "within": { "quantity": 3, "unit" : "years"}
}
```

The following `PriorState` condition will return `true` if the patient has already passed through a state called `"Emergency_Encounter"` since last passing through a state called "Followup", `false` otherwise. (In other words, if the patient hit state "Emergency_Encounter" more recently than state "Followup". Note that it is not necessary for the state "Followup" to have been hit for this to return true.)

```json
{
  "condition_type": "PriorState",
  "name": "Emergency_Encounter",
  "since" : "Followup"
}
```


![wellness encounters](https://cloud.githubusercontent.com/assets/13512036/21642337/875d58d6-d24f-11e6-9ecb-d78a2bc3dae4.png)
