### PR TITLE
Target_encounter Sequence fixes

### DIFF
--- a/lib/generic/modules/gout.json
+++ b/lib/generic/modules/gout.json
@@ -84,6 +84,20 @@
           "display": "Gout"
         }
       ],
+      "direct_transition": "Gout_Diagnosis"
+    },
+
+    "Gout_Diagnosis": {
+      "type": "Encounter",
+      "encounter_class": "ambulatory",
+      "reason": "Gout",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "185347001",
+          "display": "Encounter for problem"
+        }
+      ],
       "direct_transition": "Gout_CarePlan"
     },
 
@@ -114,20 +128,6 @@
           "system": "SNOMED-CT",
           "code": "226234005",
           "display": "Healthy diet"
-        }
-      ],
-      "direct_transition": "Gout_Diagnosis"
-    },
-
-    "Gout_Diagnosis": {
-      "type": "Encounter",
-      "encounter_class": "ambulatory",
-      "reason": "Gout",
-      "codes": [
-        {
-          "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem"
         }
       ],
       "direct_transition": "Gout_Nonopioid_Pain_Medication"

--- a/lib/generic/modules/lupus.json
+++ b/lib/generic/modules/lupus.json
@@ -145,6 +145,7 @@
     "Corticosteroid": {
       "type": "MedicationOrder",
       "target_encounter": "Lupus_Diagnosis",
+      "assign_to_attribute": "lupus_corticosteroid",
       "reason": "Lupus",
       "remarks": [
         "When introduced in higher levels than those produced by the body, corticosteroids ",
@@ -173,7 +174,7 @@
 
     "End_Corticosteroid": {
       "type": "MedicationEnd",
-      "medication_order": "Corticosteroid",
+      "referenced_by_attribute": "lupus_corticosteroid",
       "conditional_transition": [
         {
           "condition": {
@@ -238,7 +239,27 @@
           "display": "cycloSPORINE, modified 100 MG [Neoral]"
         }
       ],
-      "direct_transition": "Corticosteroid"
+      "direct_transition": "Flareup_Corticosteroid"
+    },
+
+    "Flareup_Corticosteroid": {
+      "type": "MedicationOrder",
+      "target_encounter": "Lupus_Flareup",
+      "assign_to_attribute": "lupus_corticosteroid",
+      "reason": "Lupus",
+      "remarks": [
+        "When introduced in higher levels than those produced by the body, corticosteroids ",
+        "inhibit inflammation. However, doctors prefer to use these for as short a time period ",
+        "as possible to avoid dangerous side effects."
+      ],
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "567645",
+          "display": "predniSONE 2.5 MG [Deltasone]"
+        }
+      ],
+      "direct_transition": "Corticosteroid_Treatment"
     },
 
     "End_Immune_Suppressant": {


### PR DESCRIPTION
Fixes #123 & #124 .  A previous change added exceptions when a procedure, careplan, medication, etc was not concurrent with the target encounter. This fixes 2 instances where an exception could be thrown.
In Gout - just changed the order of the Encounter and CarePlanStart states. In Lupus - added a second MedicationOrder state instead of looping back to the original MedicationOrder state. The MedicationEnd now looks at an attribute instead of the MedicationOrder state name.


New Gout Module:
![gout](https://cloud.githubusercontent.com/assets/13512036/21687328/db068d62-d336-11e6-8d87-c2dd2b5bdcd8.png)


New Lupus Module:
![lupus](https://cloud.githubusercontent.com/assets/13512036/21687333/deb79ea6-d336-11e6-8530-2111500ef927.png)
