### PR TITLE
Realism fixes

### DIFF
--- a/lib/generic/modules/asthma.json
+++ b/lib/generic/modules/asthma.json
@@ -417,9 +417,19 @@
       "conditional_transition": [
         {
           "condition": {
-            "condition_type": "Attribute",
-            "attribute": "prescribed_emergency_inhaler",
-            "operator": "is nil"
+            "condition_type" : "And",
+            "conditions" : [
+              {
+                "condition_type": "Attribute",
+                "attribute": "prescribed_emergency_inhaler",
+                "operator": "is nil"
+              },
+              {
+                "condition_type" : "Date",
+                "operator" : ">=",
+                "year" : 1982
+              }
+            ]
           },
           "transition": "Needs_Emergency_Inhaler"
         },
@@ -446,8 +456,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "361796",
-          "display": "Albuterol 2.5MG"
+          "code": "801093",
+          "display": "Albuterol 0.09MG/ACTUAT [Ventolin]"
         }
       ],
       "direct_transition": "Loopback_Maintaining_Asthma"

--- a/lib/generic/modules/ear_infections.json
+++ b/lib/generic/modules/ear_infections.json
@@ -151,15 +151,57 @@
       ]
     },
 
-    "Ear_Infection_Prescribed_Antibiotic": {
+    "Ear_Infection_Prescribed_Antibiotic" : {
+      "type" : "Simple",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Date",
+            "operator" : ">=",
+            "year" : 1972
+          },
+          "transition" : "Ear_Infection_Prescribed_Amoxicillin"
+        },
+        {
+          "condition" : {
+            "condition_type" : "Date",
+            "operator" : ">=",
+            "year" : 1956
+          },
+          "transition" : "Ear_Infection_Prescribed_Penicillin"
+        },
+        {
+          "transition" : "Ear_Infection_Prescribed_OTC_Painkiller",
+          "remarks" : ["Antibiotics not available yet, just go to the painkillers"]
+        }
+      ]
+    },
+
+    "Ear_Infection_Prescribed_Amoxicillin": {
       "type": "MedicationOrder",
       "target_encounter": "Ear_Infection_Encounter",
+      "assign_to_attribute" : "ear_infection_antibiotic",
       "reason": "Gets_Ear_Infection",
       "codes": [
         {
           "system": "RxNorm",
           "code": "317616",
           "display": "Amoxicillin 500MG"
+        }
+      ],
+      "direct_transition": "Ear_Infection_Antibiotic_Taken"
+    },
+
+    "Ear_Infection_Prescribed_Penicillin": {
+      "type": "MedicationOrder",
+      "target_encounter": "Ear_Infection_Encounter",
+      "assign_to_attribute" : "ear_infection_antibiotic",
+      "reason": "Gets_Ear_Infection",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "834060",
+          "display": "Penicillin V Potassium 250 MG"
         }
       ],
       "direct_transition": "Ear_Infection_Antibiotic_Taken"
@@ -176,7 +218,7 @@
     },
     "Ear_Infection_Antibiotic_End": {
       "type": "MedicationEnd",
-      "medication_order": "Ear_Infection_Prescribed_Antibiotic",
+      "referenced_by_attribute" : "ear_infection_antibiotic",
       "direct_transition": "Next_Wellness_Encounter"
     },
 

--- a/lib/modules/metabolic_syndrome.rb
+++ b/lib/modules/metabolic_syndrome.rb
@@ -518,7 +518,9 @@ module Synthea
 
       def self.record_egfr(entity, time)
         patient = entity.record_synthea
-        patient.observation(:egfr, time, entity[:metabolic][:creatinine_clearance])
+        egfr = entity[:metabolic][:creatinine_clearance]
+        egfr = '>60' if egfr > 60
+        patient.observation(:egfr, time, egfr)
       end
 
       def self.process_amputations(amputations, entity, time)

--- a/lib/modules/metabolic_syndrome.rb
+++ b/lib/modules/metabolic_syndrome.rb
@@ -493,7 +493,7 @@ module Synthea
 
       def self.record_ha1c(entity, time)
         patient = entity.record_synthea
-        patient.observation(:ha1c, time, entity[:blood_glucose], :observation, :vital_sign)
+        patient.observation(:ha1c, time, entity[:blood_glucose].round(1), :observation, :vital_sign)
       end
 
       def self.record_metabolic_panel(entity, time)

--- a/lib/records/lookup.rb
+++ b/lib/records/lookup.rb
@@ -114,7 +114,7 @@ module Synthea
     clopidogrel: { description: 'Clopidogrel 75 MG Oral Tablet', codes: {'RxNorm'=>['309362']}},
     simvastatin: { description: 'Simvastatin 20 MG Oral Tablet', codes: {'RxNorm'=>['312961']}},
     amlodipine: { description: 'Amlodipine 5 MG Oral Tablet', codes: {'RxNorm'=>['197361']}},
-    nitroglycerin: { description: 'Nitroglycerin 0.4 MG/ML Injectible Solution', codes: {'RxNorm'=>['312006']}},
+    nitroglycerin: { description: 'Nitroglycerin 0.4 MG/ACTUAT [Nitrolingual]', codes: {'RxNorm'=>['564666']}},
     atorvastatin: { description: 'Atorvastatin 80 MG Oral Tablet', codes: {'RxNorm'=>['259255']}},
     captopril: { description: 'Captopril 25 MG Oral Tablet', codes: {'RxNorm'=>['833036']}},
     warfarin: { description: 'Warfarin Sodium 5 MG Oral Tablet', codes: {'RxNorm'=>['855332']}},


### PR DESCRIPTION
Some fixes for realism based on physician feedback. Includes:

- Prescribe sublingual nitroglycerin instead of injected
- Certain medications are filtered by year first available (still a work in progress to do this across all modules though)
- Asthma emergency inhaler should be an actual inhaler, limited by date first available
- HB1AC recorded with only 1 decimal place
- High values of EGFR are recorded as >60