### PR TITLE
Encounter and procedure duration

### DIFF
--- a/lib/generic/context.rb
+++ b/lib/generic/context.rb
@@ -39,9 +39,6 @@ module Synthea
             end
           end
         end
-        # Each time a run expires, the current_encounter should be set to nil since
-        # any concurrent clinical states should have already been processed.
-        @current_encounter = nil
 
         if Synthea::Config.generic.log && !active? && @logged.nil?
           log_history

--- a/lib/generic/modules/allergic_rhinitis.json
+++ b/lib/generic/modules/allergic_rhinitis.json
@@ -199,7 +199,7 @@
     },
 
     "Living_With_Allergic_Rhinitis": {
-      "type": "Simple",
+      "type": "EncounterEnd",
       "direct_transition": "Immunotherapy_Guard"
     },
     "Immunotherapy_Guard": {
@@ -278,9 +278,7 @@
     },
 
     "Immunotherapy_Not_Given": {
-      "type": "SetAttribute",
-      "attribute": "immunotherapy_status",
-      "value": "not-given",
+      "type": "EncounterEnd",
       "direct_transition": "Terminal"
     },
 
@@ -316,7 +314,12 @@
           "display": "Allergy screening test"
         }
       ],
-      "direct_transition": "Initialize_Immunotherapy_Counter"
+      "direct_transition": "End_Consultation"
+    },
+
+    "End_Consultation" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Initialize_Immunotherapy_Counter"
     },
 
     "Initialize_Immunotherapy_Counter": {
@@ -379,6 +382,11 @@
           "display": "Subcutaneous immunotherapy"
         }
       ],
+      "direct_transition": "End_Treatment_Session"
+    },
+
+    "End_Treatment_Session" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Count_A_Treatment"
     },
 
@@ -423,6 +431,11 @@
     "Immunotherapy_CarePlan_Ends": {
       "type": "CarePlanEnd",
       "careplan": "Immunotherapy_CarePlan",
+      "direct_transition": "Followup_End"
+    },
+
+    "Followup_End" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Terminal"
     },
 

--- a/lib/generic/modules/allergic_rhinitis.json
+++ b/lib/generic/modules/allergic_rhinitis.json
@@ -314,6 +314,9 @@
           "display": "Allergy screening test"
         }
       ],
+      "duration" : { "low" : 30, "high" : 60, "unit" : "minutes" },
+      "remarks" : ["Skin testing is fast. For both types of skin tests, positive reactions usually appear within 20 minutes.",
+                   "http://acaai.org/allergies/treatment/allergy-testing"],
       "direct_transition": "End_Consultation"
     },
 
@@ -382,6 +385,7 @@
           "display": "Subcutaneous immunotherapy"
         }
       ],
+      "duration" : { "low" : 15, "high" : 60, "unit" : "minutes" },
       "direct_transition": "End_Treatment_Session"
     },
 

--- a/lib/generic/modules/appendicitis.json
+++ b/lib/generic/modules/appendicitis.json
@@ -222,7 +222,27 @@
           "display": "Appendectomy"
         }
       ],
-      "direct_transition": "Terminal"
+      "direct_transition": "Recovery"
+    },
+
+    "Recovery" : {
+      "type" : "Delay",
+      "range" : { "low" : 1, "high" : 5, "unit" : "days" },
+      "remarks" : ["Traditionally, patients are hospitalized for 24 hours after laparoscopic appendectomy. ",
+                   "A retrospective review of 119 patients [...] ",
+                   "Forty-two patients were dismissed on the day of surgery and 77 were admitted for 1 to 5 days postoperatively.",
+                   "https://www.ncbi.nlm.nih.gov/pubmed/22369831"],
+      "direct_transition" : "End_Appendectomy_Encounter"
+    },
+
+    "End_Appendectomy_Encounter" : {
+      "type" : "EncounterEnd",
+      "discharge_disposition" : {
+        "system" : "NUBC",
+        "code" : "01",
+        "display" : "Discharged to home care or self care (routine discharge)"
+      },
+      "direct_transition" : "Terminal"
     },
     
     "Terminal": {

--- a/lib/generic/modules/appendicitis.json
+++ b/lib/generic/modules/appendicitis.json
@@ -222,6 +222,9 @@
           "display": "Appendectomy"
         }
       ],
+      "duration" : { "low" : 40, "high" : 70, "unit" : "minutes" },
+      "remarks" : ["Avg operative time is ~55 minutes",
+                   "https://www.ncbi.nlm.nih.gov/pubmed/17658102"],
       "direct_transition": "Recovery"
     },
 

--- a/lib/generic/modules/asthma.json
+++ b/lib/generic/modules/asthma.json
@@ -218,7 +218,7 @@
           "display": "Home nebulizer therapy"
         }
       ],
-      "direct_transition": "Maintaining_Asthma"
+      "direct_transition": "End_Diagnosis_Encounter"
     },
     "Nonsmoker_CarePlan": {
       "type": "CarePlanStart",
@@ -249,7 +249,12 @@
           "display": "Breathing control"
         }
       ],
-      "direct_transition": "Maintaining_Asthma"
+      "direct_transition": "End_Diagnosis_Encounter"
+    },
+
+    "End_Diagnosis_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Maintaining_Asthma"
     },
 
     "Maintaining_Asthma": {
@@ -488,7 +493,7 @@
     },
 
     "Loopback_Maintaining_Asthma": {
-      "type": "Simple",
+      "type": "EncounterEnd",
       "direct_transition": "Maintaining_Asthma"
     },
     

--- a/lib/generic/modules/attention_deficit_disorder.json
+++ b/lib/generic/modules/attention_deficit_disorder.json
@@ -115,14 +115,14 @@
       "distributed_transition": [
         {
           "distribution": 0.15,
-          "transition": "Age_Guard",
+          "transition": "End_Diagnosis_Encounter_without_BT",
           "remarks": [
             "This will just wait until adulthood before ending the ADHD and terminating the module."
           ]
         },
         {
           "distribution": 0.35,
-          "transition": "Behavior_Therapy",
+          "transition": "End_Diagnosis_Encounter_with_BT",
           "remarks": [
             "Additionally 50% of those treated with medication will also receive behavioral ",
             "therapy, for about 55% in total."
@@ -174,6 +174,11 @@
           "display": "Cognitive and behavioral therapy"
         }
       ],
+      "direct_transition" : "End_Behavior_Treatment_Encounter"
+    },
+
+    "End_Behavior_Treatment_Encounter" : {
+      "type" : "EncounterEnd",
       "complex_transition": [
         {
           "condition": {
@@ -225,7 +230,7 @@
           "distributions": [
             {
               "distribution": 0.4,
-              "transition": "Behavior_Therapy",
+              "transition": "End_Diagnosis_Encounter_with_BT",
               "remarks": [
                 "If no medication is available we defer additional patients to behavioral therapy. ",
                 "The rest get no form of treatment at all."
@@ -233,7 +238,7 @@
             },
             {
               "distribution": 0.6,
-              "transition": "Age_Guard"
+              "transition": "End_Diagnosis_Encounter_without_BT"
             }
           ]
         },
@@ -255,11 +260,11 @@
             },
             {
               "distribution": 0.15,
-              "transition": "Behavior_Therapy"
+              "transition": "End_Diagnosis_Encounter_with_BT"
             },
             {
               "distribution": 0.25,
-              "transition": "Age_Guard"
+              "transition": "End_Diagnosis_Encounter_without_BT"
             }
           ]
         },
@@ -298,11 +303,11 @@
       "distributed_transition": [
         {
           "distribution": 0.5,
-          "transition": "Behavior_Therapy"
+          "transition": "End_Diagnosis_Encounter_with_BT"
         },
         {
           "distribution": 0.5,
-          "transition": "Age_Guard"
+          "transition": "End_Diagnosis_Encounter_without_BT"
         }
       ]
     },
@@ -322,13 +327,24 @@
       "distributed_transition": [
         {
           "distribution": 0.5,
-          "transition": "Behavior_Therapy"
+          "transition": "End_Diagnosis_Encounter_with_BT"
         },
         {
           "distribution": 0.5,
-          "transition": "Age_Guard"
+          "transition": "End_Diagnosis_Encounter_without_BT"
         }
       ]
+    },
+
+    "End_Diagnosis_Encounter_without_BT" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Age_Guard"
+    },
+
+    "End_Diagnosis_Encounter_with_BT" : 
+    {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Behavior_Therapy"
     },
 
     "Age_Guard": {

--- a/lib/generic/modules/attention_deficit_disorder.json
+++ b/lib/generic/modules/attention_deficit_disorder.json
@@ -174,6 +174,7 @@
           "display": "Cognitive and behavioral therapy"
         }
       ],
+      "duration" : { "low" : 1, "high" : 1, "unit" : "hours" },
       "direct_transition" : "End_Behavior_Treatment_Encounter"
     },
 

--- a/lib/generic/modules/bronchitis.json
+++ b/lib/generic/modules/bronchitis.json
@@ -334,7 +334,7 @@
           "display": "Dextromethorphan Hydrobromide 1 MG/ML"
         }
       ],
-      "direct_transition": "Wait_for_condition_to_resolve"
+      "direct_transition": "End_Doctor_Visit"
     },
 
     "Acetaminophen": {
@@ -348,6 +348,11 @@
           "display": "Acetaminophen 160 MG"
         }
       ],
+      "direct_transition": "End_Doctor_Visit"
+    },
+
+    "End_Doctor_Visit" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Wait_for_condition_to_resolve"
     },
 

--- a/lib/generic/modules/bronchitis.json
+++ b/lib/generic/modules/bronchitis.json
@@ -161,6 +161,7 @@
           "display": "Plain chest X-ray (procedure)"
         }
       ],
+      "duration" : { "low" : 10, "high" : 25, "unit" : "minutes" },
       "direct_transition": "Bronchitis_CarePlan_Selector"
     },
 
@@ -175,6 +176,7 @@
           "display": "Sputum examination (procedure)"
         }
       ],
+      "duration" : { "low" : 3, "high" : 15, "unit" : "minutes" },
       "direct_transition": "Bronchitis_CarePlan_Selector"
     },
 
@@ -189,6 +191,7 @@
           "display": "Measurement of respiratory function (procedure)"
         }
       ],
+      "duration" : { "low" : 10, "high" : 25, "unit" : "minutes" },
       "direct_transition": "Bronchitis_CarePlan_Selector"
     },
 

--- a/lib/generic/modules/colorectal_cancer.json
+++ b/lib/generic/modules/colorectal_cancer.json
@@ -141,7 +141,7 @@
           "distributions": [
             {
               "distribution": 0.9,
-              "transition": "Wait_For_Next_Routine_Colonoscopy"
+              "transition": "End_Routine_Colonoscopy_Encounter"
             },
             {
               "distribution": 0.1,
@@ -159,7 +159,7 @@
           "distributions": [
             {
               "distribution": 0.85,
-              "transition": "Wait_For_Next_Routine_Colonoscopy"
+              "transition": "End_Routine_Colonoscopy_Encounter"
             },
             {
               "distribution": 0.15,
@@ -177,7 +177,7 @@
           "distributions": [
             {
               "distribution": 0.8,
-              "transition": "Wait_For_Next_Routine_Colonoscopy"
+              "transition": "End_Routine_Colonoscopy_Encounter"
             },
             {
               "distribution": 0.2,
@@ -186,6 +186,11 @@
           ]
         }
       ]
+    },
+
+    "End_Routine_Colonoscopy_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Wait_For_Next_Routine_Colonoscopy"
     },
 
     "Wait_For_Next_Routine_Colonoscopy": {
@@ -384,9 +389,14 @@
           "transition": "Adenoma_Biopsy"
         },
         {
-          "transition": "Wait_For_Followup_Colonoscopy"
+          "transition": "End_Routine_Colonoscopy_with_Benign_Adenoma"
         }
       ]
+    },
+
+    "End_Routine_Colonoscopy_with_Benign_Adenoma" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Wait_For_Followup_Colonoscopy"
     },
 
     "Adenoma_Biopsy": {
@@ -400,7 +410,12 @@
           "display": "Biopsy of colon"
         }
       ],
-      "direct_transition": "Wait_For_Biopsy_Followup"
+      "direct_transition": "End_Routine_Colonoscopy_with_Malignant_Adenoma"
+    },
+
+    "End_Routine_Colonoscopy_with_Malignant_Adenoma" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Wait_For_Biopsy_Followup"
     },
 
     "Wait_For_Biopsy_Followup": {
@@ -424,6 +439,11 @@
           "display": "Encounter for problem"
         }
       ],
+      "direct_transition" : "End_Biopsy_Followup"
+    },
+
+    "End_Biopsy_Followup" : {
+      "type" : "EncounterEnd",
       "distributed_transition": [
         {
           "distribution": 0.4,
@@ -533,6 +553,11 @@
         "still have the option for their adenoma to recur later in the future."
       ],
       "referenced_by_attribute": "colorectal_adenoma",
+      "direct_transition": "End_Followup_Encounter_Clean"
+    },
+
+    "End_Followup_Encounter_Clean" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Wait_For_Next_Routine_Colonoscopy"
     },
 
@@ -570,6 +595,11 @@
           "display": "Rectal polypectomy"
         }
       ],
+      "direct_transition" : "End_Followup_Encounter_After_Adenoma_Removal"
+    },
+
+    "End_Followup_Encounter_After_Adenoma_Removal" : {
+      "type" : "EncounterEnd",
       "distributed_transition": [
         {
           "distribution": 0.3,
@@ -636,7 +666,12 @@
           "display": "Encounter for symptom"
         }
       ],
-      "direct_transition": "Wait_For_Diagnostic_Colonoscopy"
+      "direct_transition": "End_Symptom_Encounter"
+    },
+
+    "End_Symptom_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Wait_For_Diagnostic_Colonoscopy"
     },
 
     "Wait_For_Diagnostic_Colonoscopy": {
@@ -680,6 +715,11 @@
           "display": "Colonoscopy"
         }
       ],
+      "direct_transition" : "End_Diagnostic_Colonoscopy_Encounter"
+    },
+
+    "End_Diagnostic_Colonoscopy_Encounter" : {
+      "type" : "EncounterEnd",
       "distributed_transition": [
         {
           "distribution": 0.5,
@@ -945,7 +985,12 @@
           "display": "Cancer education"
         }
       ],
-      "complex_transition": [
+      "direct_transition" : "End_Oncologist_Encounter"
+    },
+
+    "End_Oncologist_Encounter" : {
+      "type" : "EncounterEnd",
+       "complex_transition": [
         {
           "condition": {
             "condition_type": "Attribute",
@@ -1030,7 +1075,7 @@
             }
           ]
         }
-      ]
+      ]     
     },
 
     "Wait_For_Partial_Colectomy": {
@@ -1100,6 +1145,11 @@
           "display": "Administration of intravenous fluids"
         }
       ],
+      "direct_transition": "End_Partial_Colectomy_Encounter"
+    },
+
+    "End_Partial_Colectomy_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Delay_For_Partial_Colectomy_Recovery"
     },
 
@@ -1229,6 +1279,11 @@
           "display": "Administration of intravenous fluids"
         }
       ],
+      "direct_transition": "End_Diverting_Colostomy_Encounter"
+    },
+
+    "End_Diverting_Colostomy_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Delay_For_Diverting_Colostomy_Recovery"
     },
 
@@ -1351,6 +1406,11 @@
           "display": "Combined chemotherapy and radiation therapy (procedure)"
         }
       ],
+      "direct_transition": "End_Chemotherapy_Encounter"
+    },
+
+    "End_Chemotherapy_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Count_A_Chemo_Treatment"
     },
 
@@ -1420,6 +1480,11 @@
     "End_Colorectal_Cancer": {
       "type": "ConditionEnd",
       "referenced_by_attribute": "colorectal_cancer",
+      "direct_transition": "End_Remission_Encounter"
+    },
+
+    "End_Remission_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Terminal"
     },
 

--- a/lib/generic/modules/colorectal_cancer.json
+++ b/lib/generic/modules/colorectal_cancer.json
@@ -130,6 +130,7 @@
           "display": "Colonoscopy"
         }
       ],
+      "duration" : { "low" : 25, "high" : 45, "unit" : "minutes" },
       "complex_transition": [
         {
           "condition": {
@@ -505,6 +506,7 @@
           "display": "Colonoscopy"
         }
       ],
+      "duration" : { "low" : 25, "high" : 45, "unit" : "minutes" },
       "complex_transition": [
         {
           "condition": {
@@ -532,6 +534,7 @@
         },
         {
           "distributions": [
+
             {
               "distribution": 0.75,
               "transition": "End_Colorectal_Adenoma"
@@ -715,6 +718,7 @@
           "display": "Colonoscopy"
         }
       ],
+      "duration" : { "low" : 25, "high" : 45, "unit" : "minutes" },
       "direct_transition" : "End_Diagnostic_Colonoscopy_Encounter"
     },
 

--- a/lib/generic/modules/copd.json
+++ b/lib/generic/modules/copd.json
@@ -329,7 +329,7 @@
           "display": "Pulmonary rehabilitation (regime/therapy)"
         }
       ],
-      "direct_transition": "Living_with_COPD"
+      "direct_transition": "End_Diagnosis_Encounter"
     },
 
     "Smoker_CarePlan": {
@@ -355,7 +355,12 @@
           "display": "Home oxygen therapy (procedure)"
         }
       ],
-      "direct_transition": "Living_with_COPD"
+      "direct_transition": "End_Diagnosis_Encounter"
+    },
+
+    "End_Diagnosis_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Living_with_COPD"
     },
 
     "Living_with_COPD": {
@@ -919,7 +924,7 @@
           "display": "Transplant of lung (procedure)"
         }
       ],
-      "direct_transition": "Loop_back_to_Living_with_COPD"
+      "direct_transition": "End_Surgery_Encounter"
     },
 
     "Lung_Volume_Reduction": {
@@ -933,6 +938,11 @@
           "display": "Lung volume reduction surgery (procedure)"
         }
       ],
+      "direct_transition": "End_Surgery_Encounter"
+    },
+
+    "End_Surgery_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Loop_back_to_Living_with_COPD"
     },
 

--- a/lib/generic/modules/copd.json
+++ b/lib/generic/modules/copd.json
@@ -924,6 +924,7 @@
           "display": "Transplant of lung (procedure)"
         }
       ],
+      "duration" : { "low" : 5, "high" : 7, "unit" : "hours" },
       "direct_transition": "End_Surgery_Encounter"
     },
 

--- a/lib/generic/modules/dementia.json
+++ b/lib/generic/modules/dementia.json
@@ -490,7 +490,7 @@
           ]
         },
         {
-          "transition": "ModeratelySevereDecline"
+          "transition": "End_ModeratelySevere_Encounter"
         }
       ]
     },
@@ -506,7 +506,7 @@
           "display": "Donepezil hydrochloride 10 MG / Memantine hydrochloride 28 MG [Namzaric]"
         }
       ],
-      "direct_transition": "ModeratelySevereDecline"
+      "direct_transition": "End_ModeratelySevere_Encounter"
     },
 
     "SecondPrescription2": {
@@ -520,7 +520,7 @@
           "display": "Memantine hydrochloride 2 MG/ML [Namenda]"
         }
       ],
-      "direct_transition": "ModeratelySevereDecline"
+      "direct_transition": "End_ModeratelySevere_Encounter"
     },
 
     "SecondPrescription3": {
@@ -534,7 +534,12 @@
           "display": "Donepezil hydrochloride 23 MG [Aricept]"
         }
       ],
-      "direct_transition": "ModeratelySevereDecline"
+      "direct_transition": "End_ModeratelySevere_Encounter"
+    },
+
+    "End_ModeratelySevere_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "ModeratelySevereDecline"
     },
 
     "ModeratelySevereDecline": {
@@ -585,6 +590,11 @@
         "http://www.alz.org/alzheimers_disease_steps_to_diagnosis.asp"
       ],
       "unit": "(score)",
+      "direct_transition": "End_Severe_Encounter"
+    },
+
+    "End_Severe_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "SevereDecline"
     },
     
@@ -635,8 +645,14 @@
         "http://www.alz.org/alzheimers_disease_steps_to_diagnosis.asp"
       ],
       "unit": "(score)",
+      "direct_transition": "End_VerySevere_Encounter"
+    },
+
+    "End_VerySevere_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "VerySevereDecline"
     },
+    
 
     "VerySevereDecline": {
       "type": "Delay",

--- a/lib/generic/modules/ear_infections.json
+++ b/lib/generic/modules/ear_infections.json
@@ -180,7 +180,7 @@
     "Ear_Infection_Prescribed_Amoxicillin": {
       "type": "MedicationOrder",
       "target_encounter": "Ear_Infection_Encounter",
-      "assign_to_attribute" : "ear_infection_antibiotic",
+      "assign_to_attribute" : "ear_infection_prescription",
       "reason": "Gets_Ear_Infection",
       "codes": [
         {
@@ -189,13 +189,13 @@
           "display": "Amoxicillin 500MG"
         }
       ],
-      "direct_transition": "Ear_Infection_Antibiotic_Taken"
+      "direct_transition": "End_Encounter"
     },
 
     "Ear_Infection_Prescribed_Penicillin": {
       "type": "MedicationOrder",
       "target_encounter": "Ear_Infection_Encounter",
-      "assign_to_attribute" : "ear_infection_antibiotic",
+      "assign_to_attribute" : "ear_infection_prescription",
       "reason": "Gets_Ear_Infection",
       "codes": [
         {
@@ -204,27 +204,13 @@
           "display": "Penicillin V Potassium 250 MG"
         }
       ],
-      "direct_transition": "Ear_Infection_Antibiotic_Taken"
-    },
-
-    "Ear_Infection_Antibiotic_Taken": {
-      "type": "Delay",
-      "range": {
-        "low": 7,
-        "high": 14,
-        "unit": "days"
-      },
-      "direct_transition": "Ear_Infection_Antibiotic_End"
-    },
-    "Ear_Infection_Antibiotic_End": {
-      "type": "MedicationEnd",
-      "referenced_by_attribute" : "ear_infection_antibiotic",
-      "direct_transition": "Next_Wellness_Encounter"
+      "direct_transition": "End_Encounter"
     },
 
     "Ear_Infection_Prescribed_OTC_Painkiller": {
       "type": "MedicationOrder",
       "target_encounter": "Ear_Infection_Encounter",
+      "assign_to_attribute" : "ear_infection_prescription",
       "reason": "Gets_Ear_Infection",
       "codes": [
         {
@@ -236,24 +222,29 @@
           ]
         }
       ],
-      "direct_transition": "Ear_Infection_OTC_Painkiller_Taken"
+      "direct_transition": "End_Encounter"
     },
 
-    "Ear_Infection_OTC_Painkiller_Taken": {
+    "End_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Ear_Infection_Prescription_Taken"
+    },
+
+    "Ear_Infection_Prescription_Taken": {
       "type": "Delay",
       "range": {
         "low": 7,
         "high": 14,
         "unit": "days"
       },
-      "direct_transition": "Ear_Infection_OTC_Painkiller_End"
+      "direct_transition": "Ear_Infection_Prescription_End"
     },
-
-    "Ear_Infection_OTC_Painkiller_End": {
+    "Ear_Infection_Prescription_End": {
       "type": "MedicationEnd",
-      "medication_order": "Ear_Infection_Prescribed_OTC_Painkiller",
+      "referenced_by_attribute" : "ear_infection_prescription",
       "direct_transition": "Next_Wellness_Encounter"
     },
+
 
     "Next_Wellness_Encounter": {
       "type": "Encounter",

--- a/lib/generic/modules/fibromyalgia.json
+++ b/lib/generic/modules/fibromyalgia.json
@@ -160,7 +160,12 @@
           "display": "Naproxen sodium 550 MG [Anaprox]"
         }
       ],
-      "direct_transition": "Delay_Until_Fibromyalgia_Episode"
+      "direct_transition": "End_Diagnosis_Encounter"
+    },
+
+    "End_Diagnosis_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Delay_Until_Fibromyalgia_Episode"
     },
 
     "Delay_Until_Fibromyalgia_Episode": {
@@ -233,7 +238,7 @@
             },
             {
               "distribution": 0.8,
-              "transition": "Delay_Until_Fibromyalgia_Episode"
+              "transition": "End_Episode_Encounter"
             }
           ]
         },
@@ -241,7 +246,7 @@
           "distributions": [
             {
               "distribution": 1,
-              "transition": "Delay_Until_Fibromyalgia_Episode"
+              "transition": "End_Episode_Encounter"
             }
           ]
         }
@@ -260,7 +265,7 @@
           "display": "pregabalin 100 MG [Lyrica]"
         }
       ],
-      "direct_transition": "Take_Prescription"
+      "direct_transition": "End_Episode_Encounter"
     },
 
     "Prescribe_Cymbalta": {
@@ -275,7 +280,7 @@
           "display": "DULoxetine 20 MG [Cymbalta]"
         }
       ],
-      "direct_transition": "Take_Prescription"
+      "direct_transition": "End_Episode_Encounter"
     },
 
     "Prescribe_Savella": {
@@ -290,7 +295,7 @@
           "display": "Milnacipran hydrochloride 100 MG [Savella]"
         }
       ],
-      "direct_transition": "Take_Prescription"
+      "direct_transition": "End_Episode_Encounter"
     },
 
     "Prescribe_Opioid": {
@@ -308,7 +313,24 @@
           "display": "Acetaminophen 325 MG / oxyCODONE Hydrochloride 2.5 MG [Percocet]"
         }
       ],
-      "direct_transition": "Delay_Until_Fibromyalgia_Episode"
+      "direct_transition": "End_Episode_Encounter"
+    },
+
+    "End_Episode_Encounter" : {
+      "type" : "EncounterEnd",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type": "Attribute",
+            "attribute": "fibromyalgia_prescription",
+            "operator": "is not nil"
+          },
+          "transition" : "Take_Prescription"
+        },
+        {
+          "transition" : "Delay_Until_Fibromyalgia_Episode"
+        }
+      ]
     },
 
     "Take_Prescription": {

--- a/lib/generic/modules/gout.json
+++ b/lib/generic/modules/gout.json
@@ -197,7 +197,12 @@
           "display": "Allopurinol 100 MG [Zyloprim]"
         }
       ],
-      "direct_transition": "Gout_Treatment_Period"
+      "direct_transition": "End_Diagnosis_Encounter"
+    },
+
+    "End_Diagnosis_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Gout_Treatment_Period"
     },
 
     "Gout_Treatment_Period": {

--- a/lib/generic/modules/homelessness.json
+++ b/lib/generic/modules/homelessness.json
@@ -334,6 +334,11 @@
       }],
       "range" : { "low" : 0, "high" : 10 },
       "unit" : "{count}",
+      "direct_transition" : "End_Shelter_Visit"
+    },
+
+    "End_Shelter_Visit" : {
+      "type" : "EncounterEnd",
       "direct_transition" : "Living_Homeless"
     },
 

--- a/lib/generic/modules/injuries.json
+++ b/lib/generic/modules/injuries.json
@@ -480,6 +480,11 @@
           "display": "Acetaminophen 325 MG / oxyCODONE Hydrochloride 10 MG [Percocet]"
         }
       ],
+      "direct_transition": "End_Spinal_Injury_Encounter"
+    },
+
+    "End_Spinal_Injury_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Spinal_Treatment_Period"
     },
 
@@ -514,6 +519,11 @@
         "cord damage and survived, his/her chronic paralysis will persist for life."
       ],
       "referenced_by_attribute": "spinal_injury",
+      "direct_transition": "End_Spinal_Injury_Followup"
+    },
+
+    "End_Spinal_Injury_Followup" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Conclude_Injury"
     },
 
@@ -706,6 +716,11 @@
           "display": "Behavior to prevent infection"
         }
       ],
+      "direct_transition": "End_Gunshot_Encounter"
+    },
+
+    "End_Gunshot_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Gunshot_Wound_Healing_Period"
     },
 
@@ -736,6 +751,11 @@
     "Gunshot_Wound_Ends": {
       "type": "ConditionEnd",
       "condition_onset": "Gunshot_Wound",
+      "direct_transition": "End_Gunshot_Followup"
+    },
+
+    "End_Gunshot_Followup" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Conclude_Injury"
     },
 
@@ -878,6 +898,11 @@
           "display": "Alcohol-free diet"
         }
       ],
+      "direct_transition": "End_Concussion_Encounter"
+    },
+
+    "End_Concussion_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Concussion_Recovery_Period"
     },
 
@@ -908,6 +933,11 @@
     "End_Concussion_Injury": {
       "type": "ConditionEnd",
       "referenced_by_attribute": "concussion_injury",
+      "direct_transition": "End_Concussion_Followup"
+    },
+
+    "End_Concussion_Followup" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Conclude_Injury"
     },
 
@@ -993,6 +1023,11 @@
           "display": "Recommendation to rest"
         }
       ],
+      "direct_transition": "End_Whiplash_Encounter"
+    },
+
+    "End_Whiplash_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Whiplash_Recovery_Period"
     },
 
@@ -1280,6 +1315,11 @@
           ]
         }
       ],
+      "direct_transition": "End_Broken_Bone_Encounter"
+    },
+
+    "End_Broken_Bone_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Broken_Bone_Recovery_Period"
     },
 
@@ -1310,6 +1350,11 @@
     "End_Broken_Bone_Injury": {
       "type": "ConditionEnd",
       "referenced_by_attribute": "broken_bone",
+      "direct_transition": "End_Broken_Bone_Followup"
+    },
+
+    "End_Broken_Bone_Followup" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Conclude_Injury"
     },
 
@@ -1573,7 +1618,7 @@
           "display": "Acetaminophen 650 MG [Tylenol]"
         }
       ],
-      "direct_transition": "Burn_Recovery_Period"
+      "direct_transition": "End_Burn_Encounter"
     },
 
     "Burn_Injury_Prescribe_Opioid": {
@@ -1588,6 +1633,11 @@
           "display": "Acetaminophen 325 MG / oxyCODONE Hydrochloride 10 MG [Percocet]"
         }
       ],
+      "direct_transition": "End_Burn_Encounter"
+    },
+
+    "End_Burn_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Burn_Recovery_Period"
     },
 
@@ -1618,6 +1668,11 @@
     "End_Burn_Injury": {
       "type": "ConditionEnd",
       "referenced_by_attribute": "burn_injury",
+      "direct_transition": "End_Burn_Followup"
+    },
+
+    "End_Burn_Followup" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Conclude_Injury"
     },
 
@@ -1826,6 +1881,11 @@
           "display": "Acetaminophen 325 MG [Tylenol]"
         }
       ],
+      "direct_transition": "End_Laceration_Encounter"
+    },
+
+    "End_Laceration_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Laceration_Recovery_Period"
     },
 
@@ -1945,6 +2005,11 @@
           "display": "Acetaminophen 325 MG [Tylenol]"
         }
       ],
+      "direct_transition": "End_Sprain_Encounter"
+    },
+
+    "End_Sprain_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Sprain_Recovery_Period"
     },
 
@@ -2052,7 +2117,7 @@
           "display": "Injury of anterior cruciate ligament"
         }
       ],
-      "direct_transition": "Wait_For_Knee_Surgery"
+      "direct_transition": "End_Knee_Injury_Encounter_I"
     },
 
     "Torn_MCL": {
@@ -2066,7 +2131,7 @@
           "display": "Injury of medial collateral ligament of knee"
         }
       ],
-      "direct_transition": "Wait_For_Knee_Surgery"
+      "direct_transition": "End_Knee_Injury_Encounter_I"
     },
 
     "Torn_Meniscus": {
@@ -2083,7 +2148,7 @@
           "display": "Tear of meniscus of knee"
         }
       ],
-      "direct_transition": "Knee_Injury_Recovery_Period"
+      "direct_transition": "End_Knee_Injury_Encounter_II"
     },
 
     "Torn_Patellar_Tendon": {
@@ -2097,7 +2162,12 @@
           "display": "Rupture of patellar tendon"
         }
       ],
-      "direct_transition": "Wait_For_Knee_Surgery"
+      "direct_transition": "End_Knee_Injury_Encounter_I"
+    },
+
+    "End_Knee_Injury_Encounter_I" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Wait_For_Knee_Surgery"
     },
 
     "Wait_For_Knee_Surgery": {
@@ -2182,7 +2252,7 @@
           "display": "Acetaminophen 650 MG [Tylenol]"
         }
       ],
-      "direct_transition": "Knee_Injury_Recovery_Period"
+      "direct_transition": "End_Knee_Injury_Encounter_II"
     },
 
     "Knee_Injury_Prescribe_Opioid": {
@@ -2197,6 +2267,12 @@
           "display": "Acetaminophen 300 MG / HYDROcodone Bitartrate 5 MG [Vicodin]"
         }
       ],
+      "direct_transition": "End_Knee_Injury_Encounter_II"
+    },
+
+    "End_Knee_Injury_Encounter_II" : 
+    {
+      "type" : "EncounterEnd",
       "direct_transition": "Knee_Injury_Recovery_Period"
     },
 
@@ -2282,6 +2358,11 @@
           "display": "Stretching exercises"
         }
       ],
+      "direct_transition" : "End_Shoulder_Injury_Encounter"
+    },
+
+    "End_Shoulder_Injury_Encounter" : {
+      "type" : "EncounterEnd",
       "distributed_transition": [
         {
           "distribution": 0.9,
@@ -2376,7 +2457,7 @@
           "display": "Acetaminophen 650 MG [Tylenol]"
         }
       ],
-      "direct_transition": "Shoulder_Injury_Recovery_Period"
+      "direct_transition": "End_Shoulder_Surgery_Encounter"
     },
 
     "Shoulder_Surgery_Prescribe_Opioid": {
@@ -2391,6 +2472,11 @@
           "display": "Acetaminophen 300 MG / HYDROcodone Bitartrate 5 MG [Vicodin]"
         }
       ],
+      "direct_transition": "End_Shoulder_Surgery_Encounter"
+    },
+
+    "End_Shoulder_Surgery_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Shoulder_Injury_Recovery_Period"
     },
 
@@ -2421,6 +2507,11 @@
     "End_Shoulder_Injury": {
       "type": "ConditionEnd",
       "condition_onset": "Torn_Rotator_Cuff",
+      "direct_transition": "End_Shoulder_Followup"
+    },
+
+    "End_Shoulder_Followup" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Conclude_Injury"
     },
 

--- a/lib/generic/modules/lung_cancer.json
+++ b/lib/generic/modules/lung_cancer.json
@@ -211,6 +211,11 @@
           "display": "Plain chest X-ray (procedure)"
         }
       ],
+      "direct_transition": "End_Diagnosis_Encounter_I"
+    },
+
+    "End_Diagnosis_Encounter_I" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Schedule Follow Up I"
     },
 
@@ -249,6 +254,11 @@
           "display": "Computed tomography of chest and abdomen"
         }
       ],
+      "direct_transition": "End_Diagnosis_Encounter_II"
+    },
+
+    "End_Diagnosis_Encounter_II" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Schedule Follow Up II"
     },
 
@@ -360,7 +370,7 @@
           "display": "Sputum microscopy (procedure)"
         }
       ],
-      "direct_transition": "Schedule Follow Up III"
+      "direct_transition": "End_Diagnosis_Encounter_III"
     },
 
     "Thoracentesis (Fluid)": {
@@ -374,7 +384,7 @@
           "display": "Thoracentesis (procedure)"
         }
       ],
-      "direct_transition": "Schedule Follow Up III"
+      "direct_transition": "End_Diagnosis_Encounter_III"
     },
 
     "Needle Biopsy (Cells)": {
@@ -388,7 +398,7 @@
           "display": "Fine needle aspiration biopsy of lung (procedure)"
         }
       ],
-      "direct_transition": "Schedule Follow Up III"
+      "direct_transition": "End_Diagnosis_Encounter_III"
     },
 
     "Bronchoscopy (Tube)": {
@@ -402,6 +412,11 @@
           "display": "Diagnostic fiberoptic bronchoscopy (procedure)"
         }
       ],
+      "direct_transition": "End_Diagnosis_Encounter_III"
+    },
+
+    "End_Diagnosis_Encounter_III" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Schedule Follow Up III"
     },
 
@@ -763,6 +778,11 @@
           "display": "Magnetic resonance imaging for measurement of brain volume (procedure)"
         }
       ],
+      "direct_transition" : "End_Diagnosis_Encounter_IV"
+    },
+
+    "End_Diagnosis_Encounter_IV" : {
+      "type" : "EncounterEnd",
       "conditional_transition": [
         {
           "condition": {
@@ -872,6 +892,11 @@
           "display": "Combined chemotherapy and radiation therapy (procedure)"
         }
       ],
+      "direct_transition": "End_SCLC_Treatment_Encounter"
+    },
+
+    "End_SCLC_Treatment_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "SCLC Treatment Delay"
     },
 
@@ -978,6 +1003,11 @@
           "display": "Combined chemotherapy and radiation therapy (procedure)"
         }
       ],
+      "direct_transition": "End_NSCLC_Treatment_Encounter"
+    },
+
+    "End_NSCLC_Treatment_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "NSCLC Treatment Delay"
     },
 

--- a/lib/generic/modules/lung_cancer.json
+++ b/lib/generic/modules/lung_cancer.json
@@ -211,6 +211,7 @@
           "display": "Plain chest X-ray (procedure)"
         }
       ],
+      "duration" : { "low" : 10, "high" : 25, "unit" : "minutes" },
       "direct_transition": "End_Diagnosis_Encounter_I"
     },
 
@@ -254,6 +255,7 @@
           "display": "Computed tomography of chest and abdomen"
         }
       ],
+      "duration" : { "low" : 20, "high" : 60, "unit" : "minutes" },
       "direct_transition": "End_Diagnosis_Encounter_II"
     },
 
@@ -778,6 +780,7 @@
           "display": "Magnetic resonance imaging for measurement of brain volume (procedure)"
         }
       ],
+      "duration" : { "low" : 30, "high" : 120, "unit" : "minutes" },
       "direct_transition" : "End_Diagnosis_Encounter_IV"
     },
 
@@ -892,6 +895,7 @@
           "display": "Combined chemotherapy and radiation therapy (procedure)"
         }
       ],
+      "duration" : { "low" : 0.5, "high" : 4.0, "unit" : "hours" },
       "direct_transition": "End_SCLC_Treatment_Encounter"
     },
 
@@ -1003,6 +1007,7 @@
           "display": "Combined chemotherapy and radiation therapy (procedure)"
         }
       ],
+      "duration" : { "low" : 0.5, "high" : 4.0, "unit" : "hours" },
       "direct_transition": "End_NSCLC_Treatment_Encounter"
     },
 

--- a/lib/generic/modules/lupus.json
+++ b/lib/generic/modules/lupus.json
@@ -159,7 +159,12 @@
           "display": "predniSONE 2.5 MG [Deltasone]"
         }
       ],
-      "direct_transition": "Corticosteroid_Treatment"
+      "direct_transition": "End_Diagnosis_Encounter"
+    },
+
+    "End_Diagnosis_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Corticosteroid_Treatment"
     },
 
     "Corticosteroid_Treatment": {
@@ -259,7 +264,12 @@
           "display": "predniSONE 2.5 MG [Deltasone]"
         }
       ],
-      "direct_transition": "Corticosteroid_Treatment"
+      "direct_transition": "End_Flareup_Encounter"
+    },
+
+    "End_Flareup_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Corticosteroid_Treatment"
     },
 
     "End_Immune_Suppressant": {

--- a/lib/generic/modules/opioid_addiction.json
+++ b/lib/generic/modules/opioid_addiction.json
@@ -211,7 +211,7 @@
           "display": "Acetaminophen 300 MG / HYDROcodone Bitartrate 5 MG [Vicodin]"
         }
       ],
-      "direct_transition": "Directed_Use"
+      "direct_transition": "End_Directed_Use_Encounter"
     },
 
     "Enter_Directed_Use_Condition2": {
@@ -252,7 +252,7 @@
           "display": "oxyCODONE Hydrochloride 15 MG [OxyCONTIN]"
         }
       ],
-      "direct_transition": "Directed_Use"
+      "direct_transition": "End_Directed_Use_Encounter"
     },
 
     "Enter_Directed_Use_Condition3": {
@@ -285,7 +285,12 @@
           "display": "Acetaminophen 325 MG / oxyCODONE Hydrochloride 5 MG [Percocet]"
         }
       ],
-      "direct_transition": "Directed_Use"
+      "direct_transition": "End_Directed_Use_Encounter"
+    },
+
+    "End_Directed_Use_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Directed_Use"
     },
 
     "Directed_Use": {
@@ -463,6 +468,11 @@
           "display": "Drug rehabilitation and detoxification"
         }
       ],
+      "direct_transition": "End_Addiction_Treatment_Encounter"
+    },
+
+    "End_Addiction_Treatment_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Addiction_Treatment"
     },
 
@@ -498,6 +508,11 @@
           "display": "Drug addiction therapy"
         }
       ],
+      "direct_transition": "End_Recovery_Management_Encounter"
+    },
+
+    "End_Recovery_Management_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Recovery_Management_Delay"
     },
 
@@ -549,13 +564,18 @@
       "distributed_transition": [
         {
           "distribution": 0.98747,
-          "transition": "Directed_Use"
+          "transition": "End_Directed_Use_Overdose_Encounter"
         },
         {
           "distribution": 0.01253,
           "transition": "Death"
         }
       ]
+    },
+
+    "End_Directed_Use_Overdose_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Directed_Use"
     },
 
     "Misuse_Overdose": {
@@ -585,13 +605,18 @@
       "distributed_transition": [
         {
           "distribution": 0.98747,
-          "transition": "Misuse"
+          "transition": "End_Misuse_Overdose_Encounter"
         },
         {
           "distribution": 0.01253,
           "transition": "Death"
         }
       ]
+    },
+
+    "End_Misuse_Overdose_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Misuse"
     },
 
     "Addiction_Overdose": {
@@ -642,7 +667,7 @@
           "transition": "Opioid_Addiction_CarePlan"
         },
         {
-          "transition": "Detoxification"
+          "transition": "End_Addiction_Overdose_Encounter"
         }
       ]
     },
@@ -671,7 +696,12 @@
           "display": "Drug detoxification"
         }
       ],
-      "direct_transition": "Detoxification"
+      "direct_transition": "End_Addiction_Overdose_Encounter"
+    },
+
+    "End_Addiction_Overdose_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Detoxification"
     },
     
     "Death": {

--- a/lib/generic/modules/osteoarthritis.json
+++ b/lib/generic/modules/osteoarthritis.json
@@ -213,7 +213,7 @@
             },
             {
               "distribution": 0.9879,
-              "transition": "Terminal"
+              "transition": "End_Encounter"
             }
           ]
         },
@@ -229,7 +229,7 @@
             },
             {
               "distribution": 0.9811,
-              "transition": "Terminal"
+              "transition": "End_Encounter"
             }
           ]
         },
@@ -237,7 +237,7 @@
           "distributions": [
             {
               "distribution": 1,
-              "transition": "Terminal"
+              "transition": "End_Encounter"
             }
           ]
         }
@@ -248,14 +248,19 @@
       "type": "SetAttribute",
       "attribute": "joint_replacement",
       "value": "knee",
-      "direct_transition": "Terminal"
+      "direct_transition": "End_Encounter"
     },
 
     "Setup_Hip_Replacement": {
       "type": "SetAttribute",
       "attribute": "joint_replacement",
       "value": "hip",
-      "direct_transition": "Terminal"
+      "direct_transition": "End_Encounter"
+    },
+
+    "End_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Terminal"
     },
     
     "Terminal": {

--- a/lib/generic/modules/pregnancy.json
+++ b/lib/generic/modules/pregnancy.json
@@ -201,7 +201,7 @@
       "distributed_transition": [
         {
           "distribution": 0.179,
-          "transition": "Wait_For_Induced_Abortion",
+          "transition": "End_Initial_Visit_Towards_Abortion",
           "remarks": [
             "See bottom of this module for abortion and miscarriage handling"
           ]
@@ -211,6 +211,11 @@
           "transition": "Pregnancy_Test"
         }
       ]
+    },
+
+    "End_Initial_Visit_Towards_Abortion" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Wait_For_Induced_Abortion"
     },
 
     "Pregnancy_Test": {
@@ -275,7 +280,12 @@
         }
       ],
       "assign_to_attribute": "pregnancy_careplan",
-      "direct_transition": "Week_15"
+      "direct_transition": "End_Prenatal_Initial_Visit"
+    },
+
+    "End_Prenatal_Initial_Visit" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Week_15"
     },
 
     "Week_15": {
@@ -311,9 +321,14 @@
         },
         {
           "distribution": 0.962,
-          "transition": "Week_26"
+          "transition": "End_Week_15_Visit"
         }
       ]
+    },
+
+    "End_Week_15_Visit" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Week_26"
     },
 
     "Week_26": {
@@ -336,7 +351,12 @@
           "display": "Prenatal visit"
         }
       ],
-      "direct_transition": "Week_32"
+      "direct_transition": "End_Week_26_Visit"
+    },
+
+    "End_Week_26_Visit" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Week_32"
     },
 
     "Week_32": {
@@ -382,7 +402,12 @@
           "display": "Prenatal visit"
         }
       ],
-      "direct_transition": "Week_36"
+      "direct_transition": "End_Week_32_Visit"
+    },
+
+    "End_Week_32_Visit" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Week_36"
     },
 
     "Week_36": {
@@ -454,7 +479,12 @@
           "display": "Prenatal visit"
         }
       ],
-      "direct_transition": "Week_38"
+      "direct_transition": "End_Week_36_Visit"
+    },
+
+    "End_Week_36_Visit" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Week_38"
     },
 
     "Week_38": {
@@ -493,7 +523,12 @@
           "display": "Prenatal visit"
         }
       ],
-      "direct_transition": "Week_39"
+      "direct_transition": "End_Week_38_Visit"
+    },
+
+    "End_Week_38_Visit" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Week_39"
     },
 
     "Week_39": {
@@ -525,7 +560,12 @@
           "display": "Prenatal visit"
         }
       ],
-      "direct_transition": "Week_40"
+      "direct_transition": "End_Week_39_Visit"
+    },
+
+    "End_Week_39_Visit" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Week_40"
     },
 
     "Week_40": {
@@ -564,7 +604,12 @@
           "display": "Prenatal visit"
         }
       ],
-      "direct_transition": "Week_41"
+      "direct_transition": "End_Week_40_Visit"
+    },
+
+    "End_Week_40_Visit" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Week_41"
     },
 
     "Week_41": {
@@ -596,7 +641,12 @@
           "display": "Prenatal visit"
         }
       ],
-      "direct_transition": "Week_42"
+      "direct_transition": "End_Week_41_Visit"
+    },
+
+    "End_Week_41_Visit" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Week_42"
     },
 
     "Week_42": {
@@ -628,7 +678,17 @@
           "display": "Prenatal visit"
         }
       ],
-      "direct_transition": "Induced_Birth"
+      "direct_transition": "End_Week_42_Visit"
+    },
+
+    "End_Week_42_Visit" : {
+      "type" : "EncounterEnd",
+      "discharge_disposition" : {
+        "system" : "NUBC",
+        "code" : "02",
+        "display" : "Transferred to a short term general hospital for inpatient care"
+      },
+      "direct_transition" : "Induced_Birth"
     },
 
     "Induced_Birth": {
@@ -960,9 +1020,14 @@
         },
         {
           "distribution": 0.115,
-          "transition": "Ectopic_Pregnancy"
+          "transition": "End_Initial_Visit_Towards_Ectopic_Pregnancy"
         }
       ]
+    },
+
+    "End_Initial_Visit_Towards_Ectopic_Pregnancy" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Ectopic_Pregnancy"
     },
 
     "Miscarriage_In_Second_Trimester": {
@@ -1003,7 +1068,7 @@
         }
       ],
       "assign_to_attribute": "fatal_pregnancy_complication",
-      "direct_transition": "Wait_For_Miscarriage_Followup_Encounter"
+      "direct_transition": "End_Miscarriage_Encounter"
     },
 
     "Blighted_Ovum": {
@@ -1017,7 +1082,7 @@
         }
       ],
       "assign_to_attribute": "fatal_pregnancy_complication",
-      "direct_transition": "Wait_For_Miscarriage_Followup_Encounter"
+      "direct_transition": "End_Miscarriage_Encounter"
     },
 
     "Ectopic_Pregnancy": {
@@ -1069,7 +1134,7 @@
           "display": "Excision of fallopian tube and surgical removal of ectopic pregnancy"
         }
       ],
-      "direct_transition": "Wait_For_Miscarriage_Followup_Encounter"
+      "direct_transition": "End_Miscarriage_Encounter"
     },
 
     "Late_Fetal_Chromosomal_Anomaly": {
@@ -1088,7 +1153,7 @@
           "display": "Fetus with chromosomal abnormality"
         }
       ],
-      "direct_transition": "Wait_For_Miscarriage_Followup_Encounter"
+      "direct_transition": "End_Miscarriage_Encounter"
     },
 
     "Uterine_Anomaly": {
@@ -1102,7 +1167,7 @@
           "display": "Congenital uterine anomaly"
         }
       ],
-      "direct_transition": "Wait_For_Miscarriage_Followup_Encounter"
+      "direct_transition": "End_Miscarriage_Encounter"
     },
 
     "Unknown_Complication": {
@@ -1116,7 +1181,12 @@
           "display": "Complication occuring during pregnancy"
         }
       ],
-      "direct_transition": "Wait_For_Miscarriage_Followup_Encounter"
+      "direct_transition": "End_Miscarriage_Encounter"
+    },
+
+    "End_Miscarriage_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Wait_For_Miscarriage_Followup_Encounter"
     },
 
     "Wait_For_Miscarriage_Followup_Encounter": {
@@ -1152,7 +1222,12 @@
     "Fatal_Pregnancy_Complication_Ends": {
       "type": "ConditionEnd",
       "referenced_by_attribute": "fatal_pregnancy_complication",
-      "direct_transition": "Pregnancy_Ends"
+      "direct_transition": "End_Miscarriage_Followup_Encounter"
+    },
+
+    "End_Miscarriage_Followup_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Pregnancy_Ends"
     },
 
     "Wait_For_Induced_Abortion": {
@@ -1195,7 +1270,12 @@
           "display": "Induced termination of pregnancy"
         }
       ],
-      "direct_transition": "Pregnancy_Ends"
+      "direct_transition": "End_Induced_Abortion_Encounter"
+    },
+
+    "End_Induced_Abortion_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Pregnancy_Ends"
     },
 
     "Normal_Pregnancy_Completion": {
@@ -1235,6 +1315,11 @@
     "Pregnancy_CarePlan_Ends": {
       "type": "CarePlanEnd",
       "referenced_by_attribute": "pregnancy_careplan",
+      "direct_transition": "End_Birth_Encounter"
+    },
+
+    "End_Birth_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Pregnancy_Ends"
     },
 

--- a/lib/generic/modules/rheumatoid_arthritis.json
+++ b/lib/generic/modules/rheumatoid_arthritis.json
@@ -158,6 +158,11 @@
           "display": "Methotrexate 10 MG [Trexall]"
         }
       ],
+      "direct_transition": "Encounter_Ends_After_DMARD"
+    },
+
+    "Encounter_Ends_After_DMARD" : {
+      "type" : "EncounterEnd",
       "direct_transition": "DMARD_Treatment_Period"
     },
 
@@ -205,6 +210,11 @@
           "display": "predniSONE 2.5 MG [Deltasone]"
         }
       ],
+      "direct_transition": "Encounter_Ends_After_Corticosteroids"
+    },
+
+    "Encounter_Ends_After_Corticosteroids" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Corticosteroid_Treatment"
     },
 

--- a/lib/generic/modules/self_harm.json
+++ b/lib/generic/modules/self_harm.json
@@ -430,15 +430,12 @@
           "display": "Hospital admission, short-term, 24 hours"
         }
       ],
-      "direct_transition": "Attempted_Suicide_Observation_Period"
+      "duration" : { "low" : 24, "high" : 72, "unit": "hours" },
+      "direct_transition": "End_Attempted_Suicide_Observation_Period"
     },
 
-    "Attempted_Suicide_Observation_Period": {
-      "type": "Delay",
-      "exact": {
-        "quantity": 24,
-        "unit": "hours"
-      },
+    "End_Attempted_Suicide_Observation_Period": {
+      "type": "EncounterEnd",
       "direct_transition": "End_Suicide_Attempt"
     },
 
@@ -532,6 +529,11 @@
           "display": "Psychiatric follow-up"
         }
       ],
+      "direct_transition" : "End_Followup_Encounter"
+    },
+
+    "End_Followup_Encounter" : {
+      "type" : "EncounterEnd",
       "remarks": [
         "From the Harvard University study on suicide attempts: ",
         " 7% are fatal ",

--- a/lib/generic/modules/sinusitis.json
+++ b/lib/generic/modules/sinusitis.json
@@ -140,7 +140,7 @@
       "distributed_transition": [
         {
           "distribution": 0.8,
-          "transition": "Wait_for_condition_to_resolve"
+          "transition": "End_Encounter"
         },
         {
           "distribution": 0.2,
@@ -163,6 +163,11 @@
           "display": " Amoxicillin 250 MG / Clavulanate 125 MG [Augmentin]"
         }
       ],
+      "direct_transition": "End_Encounter"
+    },
+
+    "End_Encounter" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Wait_for_condition_to_resolve"
     },
 
@@ -359,6 +364,11 @@
           "display": "Chronic sinusitis (disorder)"
         }
       ],
+      "direct_transition": "End_Chronic_Followup"
+    },
+
+    "End_Chronic_Followup" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Chronic_Sinusitis_Continues"
     },
 
@@ -372,6 +382,11 @@
           "display": "Nasal sinus endoscopy (procedure)"
         }
       ],
+      "direct_transition" : "End_Surgery_Encounter"
+    },
+
+    "End_Surgery_Encounter" : {
+      "type" : "EncounterEnd",
       "conditional_transition": [
         {
           "condition": {

--- a/lib/generic/modules/sore_throat.json
+++ b/lib/generic/modules/sore_throat.json
@@ -366,7 +366,7 @@
           "transition": "Throat_Culture"
         },
         {
-          "transition": "Time_Passes"
+          "transition": "End_Encounter"
         }
       ]
     },
@@ -404,7 +404,7 @@
           "display": "Penicillin V Potassium 250 MG"
         }
       ],
-      "direct_transition": "Time_Passes"
+      "direct_transition": "End_Encounter"
     },
 
     "Prescribe_Antibiotics_Adult": {
@@ -419,7 +419,7 @@
           "display": "Penicillin V Potassium 500 MG"
         }
       ],
-      "direct_transition": "Time_Passes"
+      "direct_transition": "End_Encounter"
     },
 
     "Throat_Culture": {
@@ -451,9 +451,14 @@
           ]
         },
         {
-          "transition": "Time_Passes"
+          "transition": "End_Encounter"
         }
       ]
+    },
+
+    "End_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Time_Passes"
     },
 
     "Time_Passes": {

--- a/lib/generic/modules/total_joint_replacement.json
+++ b/lib/generic/modules/total_joint_replacement.json
@@ -135,7 +135,18 @@
           "display": "Stretching exercises"
         }
       ],
-      "direct_transition": "Delay_For_Recovery"
+      "direct_transition": "In_Hospital_Post_Surgery_Recovery"
+    },
+
+    "In_Hospital_Post_Surgery_Recovery" : {
+      "type" : "Delay",
+      "range" : { "low" : 3, "high" : 5, "unit" : "days" },
+      "direct_transition" : "End_Encounter"
+    },
+
+    "End_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Delay_For_Recovery"
     },
 
     "Delay_For_Recovery": {

--- a/lib/generic/modules/urinary_tract_infections.json
+++ b/lib/generic/modules/urinary_tract_infections.json
@@ -242,8 +242,14 @@
           "display": "Urine screening"
         }
       ],
-      "direct_transition": "Take_Antibiotics"
+      "direct_transition": "End_Diagnosis_Encounter"
     },
+
+    "End_Diagnosis_Encounter" : {
+      "type" : "EncounterEnd",
+      "direct_transition" : "Take_Antibiotics"
+    },
+
     "Take_Antibiotics": {
       "type": "Delay",
       "exact": {
@@ -296,6 +302,11 @@
           "display": "NITROFURANTOIN, MACROCRYSTALS 50 MG [Macrodantin]"
         }
       ],
+      "direct_transition": "End_Followup"
+    },
+
+    "End_Followup" : {
+      "type" : "EncounterEnd",
       "direct_transition": "Take_More_Antibiotics"
     },
 

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -59,7 +59,7 @@ module Synthea
           end
         end
 
-        def concurrent_with_target_encounter(time)
+        def concurrent_with_target_encounter(_time)
           current_encounter = @context.current_encounter
           if is_a?(OnsetState)
             # ConditionOnset and AllergyOnset are allowed to be processed before any Encounter state.
@@ -83,7 +83,7 @@ module Synthea
               raise "No encounter state was processed before state '#{@name}'"
             end
           end
-          !past.nil? && past.time == time
+          !past.nil?
         end
 
         # the record methods require the use of lookup tables.  Other (non-generic) modules statically define
@@ -269,7 +269,6 @@ module Synthea
           if @context.current_encounter
             # if there is a current non-wellness encounter, end it with no discharge type
             enc = @context.most_recent_by_name(@context.current_encounter)
-            puts "it broke at #{@context.current_encounter} / #{@context.name}" if enc.nil?
             entity.record_synthea.encounter_end(enc.symbol, time) unless enc.wellness
           end
           @context.current_encounter = @name

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -82,12 +82,6 @@ module Synthea
             if past.nil?
               raise "No encounter state was processed before state '#{@name}'"
             end
-
-            unless past.time == time
-              puts "past: #{past.time}"
-              puts "now: #{time}"
-              raise "State '#{@name}' is not concurrent with the most recent encounter '#{current_encounter}'"
-            end
           end
           !past.nil? && past.time == time
         end

--- a/lib/modules/cardiovascular_disease.rb
+++ b/lib/modules/cardiovascular_disease.rb
@@ -472,7 +472,7 @@ module Synthea
             procedures.each do |proc|
               unless entity.record_synthea.present[proc]
                 # TODO: assumes a procedure will only be performed once, might need to be revisited
-                entity.record_synthea.procedure(proc, time, reason, :procedure, :procedure)
+                entity.record_synthea.procedure(proc, time, reason: reason)
               end
             end
           end
@@ -507,7 +507,7 @@ module Synthea
           end
 
           emergency_procedures[diagnosis].each do |proc|
-            entity.record_synthea.procedure(proc, time, diagnosis, :procedure, :procedure)
+            entity.record_synthea.procedure(proc, time, reason: diagnosis)
           end
 
           history_conditions[diagnosis].each do |cond|

--- a/lib/modules/encounters.rb
+++ b/lib/modules/encounters.rb
@@ -126,11 +126,18 @@ module Synthea
                else
                  :age_senior
                end
-        entity.record_synthea.encounter(type, time, reason)
+        entity.record_synthea.encounter(type, time, reason: reason)
+        # TODO: wellness encounters need their duration defined by the activities performed
+        # the trouble is those activities are split among many modules
+        entity.record_synthea.encounter_end(type, time + 1.hour)
       end
 
       def self.emergency_encounter(entity, time, reason = nil)
-        entity.record_synthea.encounter(:emergency, time, reason)
+        entity.record_synthea.encounter(:emergency, time, reason: reason)
+        # TODO: emergency encounters need their duration to be defined by the activities performed
+        # based on the emergencies given here (heart attack, stroke)
+        # assume people will be in the hospital for observation for a few days
+        entity.record_synthea.encounter_end(:emergency, time + 4.days)
       end
     end
   end

--- a/lib/modules/generic.rb
+++ b/lib/modules/generic.rb
@@ -74,7 +74,6 @@ module Synthea
 
           st = context.current_state
           next unless st.is_a?(Synthea::Generic::States::Encounter) && st.wellness && !st.processed
-          context.current_encounter = st.name
           st.perform_encounter(time, entity, false)
           # The encounter got unjammed -- progress through the subsequent states
           context.run(time, entity)

--- a/lib/modules/metabolic_syndrome.rb
+++ b/lib/modules/metabolic_syndrome.rb
@@ -528,7 +528,7 @@ module Synthea
           amp_str = amputation.to_s
           key = "amputation_#{amp_str}".to_sym
           unless entity.record_synthea.present[key]
-            entity.record_synthea.procedure(key, time, :neuropathy, :procedure, :procedure)
+            entity.record_synthea.procedure(key, time, reason: :neuropathy)
           end
 
           body_part = amp_str.split('_')[1]

--- a/lib/records/ccda.rb
+++ b/lib/records/ccda.rb
@@ -105,12 +105,20 @@ module Synthea
         # encounter.reason is an entry
         reason = ccda_record.conditions.find { |c| c.codes == reason_data[:codes] } if reason_data
 
+        end_time = encounter['end_time'] || encounter['time'] + 15.minutes
+
+        if encounter['discharge']
+          discharge = { 'code' => encounter['discharge'].code,
+                        'code_system' => '2.16.840.1.113883.6.96' }
+        end
+
         ccda_record.encounters << Encounter.new(
           'codes' => ENCOUNTER_LOOKUP[type][:codes],
           'description' => ENCOUNTER_LOOKUP[type][:description],
           'start_time' => time.to_i,
-          'end_time' => time.to_i + 15.minutes,
-          'reason' => reason
+          'end_time' => end_time.to_i,
+          'reason' => reason,
+          'discharge_disposition' => discharge
           # "oid" => "2.16.840.1.113883.3.560.1.79"
         )
       end
@@ -126,10 +134,11 @@ module Synthea
       def self.procedure(procedure, ccda_record)
         type = procedure['type']
         time = procedure['time']
+        duration = procedure['duration'] || 15.minutes
         ccda_record.procedures << Procedure.new('codes' => PROCEDURE_LOOKUP[type][:codes],
                                                 'description' => PROCEDURE_LOOKUP[type][:description],
                                                 'start_time' => time.to_i,
-                                                'end_time' => time.to_i + 15.minutes)
+                                                'end_time' => time.to_i + duration)
       end
 
       def self.careplans(plan, ccda_record)

--- a/lib/records/fhir.rb
+++ b/lib/records/fhir.rb
@@ -201,13 +201,13 @@ module Synthea
         end
 
         if encounter['discharge']
-          fhir_encounter.hospitalization = FHIR::Hospitalization.new('dischargeDisposition' => {
-                                                                       'coding' => [{
-                                                                         'code' => encounter['discharge'].code,
-                                                                         'display' => encounter['discharge'].display,
-                                                                         'system' => 'http://www.nubc.org/patient-discharge'
-                                                                       }]
-                                                                     })
+          fhir_encounter.hospitalization = FHIR::Encounter::Hospitalization.new('dischargeDisposition' => {
+                                                                                  'coding' => [{
+                                                                                    'code' => encounter['discharge'].code,
+                                                                                    'display' => encounter['discharge'].display,
+                                                                                    'system' => 'http://www.nubc.org/patient-discharge'
+                                                                                  }]
+                                                                                })
         end
 
         entry = FHIR::Bundle::Entry.new

--- a/lib/records/record.rb
+++ b/lib/records/record.rb
@@ -48,14 +48,13 @@ module Synthea
         @present[type] = nil
       end
 
-      def procedure(type, time, reason, fhir_method = :procedure, ccda_method = :procedure)
+      def procedure(type, time, options = {})
         @present[type] = {
           'type' => type,
           'time' => time,
-          'reason' => reason,
-          'fhir' => fhir_method,
-          'ccda' => ccda_method
-        }
+          'fhir' => :procedure,
+          'ccda' => :procedure
+        }.merge(options)
         @procedures << @present[type]
       end
 
@@ -69,12 +68,19 @@ module Synthea
         }
       end
 
-      def encounter(type, time, reason = nil)
+      def encounter(type, time, options = {})
         @encounters << {
           'type' => type,
-          'time' => time,
-          'reason' => reason
-        }
+          'time' => time
+        }.merge(options)
+      end
+
+      def encounter_end(type, time, options = {})
+        enc = @encounters.find { |x| x['type'] == type && x['end_time'].nil? }
+        if enc
+          enc.merge(options)
+          enc['end_time'] = time
+        end
       end
 
       def immunization(imm, time, fhir_method = :immunization, ccda_method = :immunization)

--- a/lib/tasks/graphviz.rb
+++ b/lib/tasks/graphviz.rb
@@ -268,6 +268,12 @@ module Synthea
           if state['wellness']
             details = 'Wait for regularly scheduled wellness encounter'
           end
+        when 'EncounterEnd'
+          details = 'End the current encounter'
+          if state['discharge_disposition']
+            code = state['discharge_disposition']
+            details = details + "\\lDischarge Disposition: [#{code['code']}] #{code['display']}"
+          end
         when 'SetAttribute'
           v = state['value']
           details = "Set '#{state['attribute']}' = #{v ? "'#{v}'" : 'nil'}"
@@ -339,6 +345,10 @@ module Synthea
           state['activities'].each do |activity|
             details = details + activity['system'] + "[" + activity['code'] + "]: " + activity['display'] + "\\l"
           end
+        end
+        if state.has_key? 'duration'
+          d = state['duration']
+          details = details + "\\lDuration: #{d['low']} - #{d['high']} #{d['unit']}\\l"
         end
 
         details

--- a/test/fixtures/generic/procedure.json
+++ b/test/fixtures/generic/procedure.json
@@ -23,6 +23,7 @@
                 "code": "6025007",
                 "display": "Laparoscopic appendectomy"
             }],
+            "duration" : { "low": 45, "high" : 45, "unit": "minutes" },
             "assign_to_attribute" : "Most Recent Surgery",
             "direct_transition": "Terminal"
         },

--- a/test/unit/exporter_test.rb
+++ b/test/unit/exporter_test.rb
@@ -127,7 +127,7 @@ class ExporterTest < Minitest::Test
   end
 
   def test_export_filter_should_not_keep_old_stuff
-    @record.procedure(:appendectomy, @time - 20.years, :appendicitis)
+    @record.procedure(:appendectomy, @time - 20.years, reason: :appendicitis)
     @record.encounter(:er_visit, @time - 18.years)
     @record.immunization(:flu_shot, @time - 12.years)
     @record.observation(:weight, @time - 10.years, 123)

--- a/test/unit/fhir_test.rb
+++ b/test/unit/fhir_test.rb
@@ -141,6 +141,19 @@ class FhirTest < Minitest::Test
     assert_empty @fhir_record.validate
   end
 
+  def test_encounter_discharge
+    discharge = Synthea::Generic::Components::Code.new('system' => 'NUBC', 'code' => '01', 'display' => 'discharge to home')
+    encounter = { 'type' => :age_lt_11, 'time' => @time, 'discharge' => discharge }
+
+    fhir_encounter = Synthea::Output::FhirRecord.encounter(encounter, @fhir_record, @patient_entry)
+
+    fhir_discharge = fhir_encounter.resource.hospitalization.dischargeDisposition
+    assert_equal('01', fhir_discharge.coding[0].code)
+    assert_equal('discharge to home', fhir_discharge.coding[0].display)
+
+    assert_empty @fhir_record.validate
+  end
+
   def test_allergy
     condition = {'type' => :food_allergy_peanuts, 'time' => @time}
     Synthea::Output::FhirRecord.allergy(condition, @fhir_record, @patient_entry, @encounter_entry)

--- a/test/unit/generic/appendicitis_test.rb
+++ b/test/unit/generic/appendicitis_test.rb
@@ -37,11 +37,12 @@ class AppendicitisTest < Minitest::Test
 
     @patient.record_synthea.expect(:condition, nil, [:appendicitis, @time])
 
-    @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, :appendicitis])
+    @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, { 'reason' => :appendicitis }])
     @patient.record_synthea.expect(:condition, nil, [:history_of_appendectomy, @time])
 
-    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, :appendicitis])
-    @patient.record_synthea.expect(:encounter, nil, [:encounter_inpatient, @time, :appendicitis])
+    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, { 'reason' => :appendicitis }])
+    @patient.record_synthea.expect(:encounter_end, nil, [:emergency_room_admission, @time])
+    @patient.record_synthea.expect(:encounter, nil, [:encounter_inpatient, @time, { 'reason' => :appendicitis }])
 
     @context.run(@time, @patient)
 
@@ -58,11 +59,13 @@ class AppendicitisTest < Minitest::Test
     @patient.record_synthea.expect(:condition, nil, [:appendicitis, @time])
     @patient.record_synthea.expect(:condition, nil, [:rupture_of_appendix, @time])
 
-    @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, :appendicitis])
+    @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, { 'reason' => :appendicitis }])
     @patient.record_synthea.expect(:condition, nil, [:history_of_appendectomy, @time])
 
-    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, :appendicitis])
-    @patient.record_synthea.expect(:encounter, nil, [:encounter_inpatient, @time, :appendicitis])
+    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, { 'reason' => :appendicitis }])
+    @patient.record_synthea.expect(:encounter_end, nil, [:emergency_room_admission, @time])
+    @patient.record_synthea.expect(:encounter, nil, [:encounter_inpatient, @time, { 'reason' => :appendicitis }])
+
     @context.run(@time, @patient)
 
     assert @patient.record_synthea.verify

--- a/test/unit/generic/appendicitis_test.rb
+++ b/test/unit/generic/appendicitis_test.rb
@@ -37,7 +37,7 @@ class AppendicitisTest < Minitest::Test
 
     @patient.record_synthea.expect(:condition, nil, [:appendicitis, @time])
 
-    @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, { 'reason' => :appendicitis }])
+    @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, { 'reason' => :appendicitis, 'duration' => 3549.0 }])
     @patient.record_synthea.expect(:condition, nil, [:history_of_appendectomy, @time])
 
     @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, { 'reason' => :appendicitis }])
@@ -59,7 +59,7 @@ class AppendicitisTest < Minitest::Test
     @patient.record_synthea.expect(:condition, nil, [:appendicitis, @time])
     @patient.record_synthea.expect(:condition, nil, [:rupture_of_appendix, @time])
 
-    @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, { 'reason' => :appendicitis }])
+    @patient.record_synthea.expect(:procedure, nil, [:appendectomy, @time, { 'reason' => :appendicitis, 'duration' => 3594.0 }])
     @patient.record_synthea.expect(:condition, nil, [:history_of_appendectomy, @time])
 
     @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, { 'reason' => :appendicitis }])

--- a/test/unit/generic_context_test.rb
+++ b/test/unit/generic_context_test.rb
@@ -146,7 +146,7 @@ class GenericContextTest < Minitest::Test
 
     # Run number two should go all the way to Terminal, but should process Encounter and Death along the way
     # Ensure that the encounter really happens 2 days after the initial run
-    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time.advance(:days => 2), nil])
+    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time.advance(:days => 2), {}])
     # Ensure that death really happens 2 + 3 days after the initial run
     @patient.record_synthea.expect(:death, nil, [@time.advance(:days => 5)])
     # Run number 2: 7 days after run number 1
@@ -191,7 +191,7 @@ class GenericContextTest < Minitest::Test
     ctx.run(@time, @patient)
     assert(ctx.active?)
     assert(ctx.active_submodule?)
-    assert_equal(nil, ctx.current_encounter)
+    assert_equal('Encounter', ctx.current_encounter)
     assert_equal(6, ctx.history.length)
     assert_equal("MedicationOrder", ctx.history.last.name)
     # The wellness state hasn't been processed yet
@@ -228,7 +228,7 @@ class GenericContextTest < Minitest::Test
     med_stop_time = @time + 2.weeks
     ctx.run(@time, @patient)
     assert(ctx.active_submodule?)
-    assert_equal(nil, ctx.current_encounter)
+    assert_equal("Encounter_In_Submodule", ctx.current_encounter)
     assert_equal("Delay_Yet_Again", ctx.current_state.name)
     assert_equal("Examplitis_Medication", ctx.history.last.name)
 

--- a/test/unit/generic_states_test.rb
+++ b/test/unit/generic_states_test.rb
@@ -238,7 +238,7 @@ class GenericStatesTest < Minitest::Test
     ctx.history << diabetes
 
     encounter = Synthea::Generic::States::Encounter.new(ctx, "ED_Visit")
-    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, :diabetes_mellitus])
+    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, { 'reason' => :diabetes_mellitus }])
     assert(encounter.process(@time, @patient))
     # Verify that the Encounter was added to the record
     @patient.record_synthea.verify
@@ -257,7 +257,7 @@ class GenericStatesTest < Minitest::Test
 
     # Non-wellness encounters happen immediately
     encounter = Synthea::Generic::States::Encounter.new(ctx, "ED_Visit_AttributeReason")
-    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, :diabetes_mellitus])
+    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, { 'reason' => :diabetes_mellitus }])
     assert(encounter.process(@time, @patient))
     # Verify that the Encounter was added to the record
     @patient.record_synthea.verify
@@ -290,7 +290,7 @@ class GenericStatesTest < Minitest::Test
     ctx = get_context('condition_onset.json')
     # The encounter comes first (and add it to history)
     encounter = Synthea::Generic::States::Encounter.new(ctx, "ED_Visit")
-    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, nil])
+    @patient.record_synthea.expect(:encounter, nil, [:emergency_room_admission, @time, {}])
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
 
@@ -325,7 +325,7 @@ class GenericStatesTest < Minitest::Test
     ctx.history << allergy
 
     encounter = Synthea::Generic::States::Encounter.new(ctx, "Dr_Visit")
-    @patient.record_synthea.expect(:encounter, nil, [:encounter_for_symptom, @time, nil])
+    @patient.record_synthea.expect(:encounter, nil, [:encounter_for_symptom, @time, {}])
     @patient.record_synthea.expect(:condition, nil, [:allergy_to_eggs, @time, :allergy, :condition])
     assert(encounter.process(@time, @patient))
 
@@ -344,7 +344,7 @@ class GenericStatesTest < Minitest::Test
     ctx.history << allergy
 
     encounter = Synthea::Generic::States::Encounter.new(ctx, "Dr_Visit")
-    @patient.record_synthea.expect(:encounter, nil, [:encounter_for_symptom, @time, nil])
+    @patient.record_synthea.expect(:encounter, nil, [:encounter_for_symptom, @time, {}])
     @patient.record_synthea.expect(:condition, nil, [:allergy_to_eggs, @time, :allergy, :condition])
     assert(encounter.process(@time, @patient))
 
@@ -376,7 +376,6 @@ class GenericStatesTest < Minitest::Test
     encounter.perform_encounter(@time, @patient, false)
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
-    ctx.current_encounter = encounter.name
 
     # Now process the prescription
     med = Synthea::Generic::States::MedicationOrder.new(ctx, "Metformin")
@@ -412,7 +411,6 @@ class GenericStatesTest < Minitest::Test
     encounter.perform_encounter(@time, @patient, false)
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
-    ctx.current_encounter = encounter.name
 
     # Now process the prescription
     med = Synthea::Generic::States::MedicationOrder.new(ctx, "Metformin_With_Dosage")
@@ -456,7 +454,6 @@ class GenericStatesTest < Minitest::Test
     encounter.perform_encounter(@time, @patient, false)
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
-    ctx.current_encounter = encounter.name
 
     # Now process the prescription
     med = Synthea::Generic::States::MedicationOrder.new(ctx, "Tylenol_As_Needed")
@@ -480,7 +477,6 @@ class GenericStatesTest < Minitest::Test
     encounter = Synthea::Generic::States::Encounter.new(ctx, "Wellness_Encounter")
     assert(encounter.perform_encounter(@time, @patient, false))
     ctx.history << encounter
-    ctx.current_encounter = encounter.name
 
     med = Synthea::Generic::States::MedicationOrder.new(ctx, "Metformin")
     med.run(@time, @patient)
@@ -508,7 +504,6 @@ class GenericStatesTest < Minitest::Test
     encounter.perform_encounter(@time, @patient, false)
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
-    ctx.current_encounter = encounter.name
 
     medication_id = "insulin,_aspart,_human_100_unt/ml_[novolog]".to_sym
 
@@ -547,7 +542,6 @@ class GenericStatesTest < Minitest::Test
     encounter.perform_encounter(@time, @patient, false)
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
-    ctx.current_encounter = encounter.name
 
     medication_id = "bromocriptine_5_mg_[parlodel]".to_sym
 
@@ -586,7 +580,6 @@ class GenericStatesTest < Minitest::Test
     encounter.perform_encounter(@time, @patient, false)
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
-    ctx.current_encounter = encounter.name
 
     medication_id = "24_hr_metformin_hydrochloride_500_mg_extended_release_oral_tablet".to_sym
 
@@ -722,7 +715,6 @@ class GenericStatesTest < Minitest::Test
     encounter.perform_encounter(@time, @patient, false)
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
-    ctx.current_encounter = encounter.name
 
     # Now process the careplan
     plan = Synthea::Generic::States::CarePlanStart.new(ctx, "Diabetes_Self_Management")
@@ -738,7 +730,6 @@ class GenericStatesTest < Minitest::Test
       @patient['Diabetes_CarePlan'] = nil
       ctx = get_context('careplan_start.json')
       encounter = Synthea::Generic::States::Encounter.new(ctx, "Wellness_Encounter")
-      ctx.current_encounter = encounter.name
       encounter.perform_encounter(@time, @patient, false)
       ctx.history << encounter
 
@@ -770,7 +761,6 @@ class GenericStatesTest < Minitest::Test
     encounter.perform_encounter(@time, @patient, false)
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
-    ctx.current_encounter = encounter.name
 
     # Now process the careplan
     plan_id = 'diabetes_self_management_plan'.to_sym
@@ -812,7 +802,6 @@ class GenericStatesTest < Minitest::Test
     encounter.perform_encounter(@time, @patient, false)
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
-    ctx.current_encounter = encounter.name
 
     # Now process the careplan
     plan_id = 'angina_self_management_plan'.to_sym
@@ -852,7 +841,6 @@ class GenericStatesTest < Minitest::Test
     encounter.perform_encounter(@time, @patient, false)
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
-    ctx.current_encounter = encounter.name
 
     # Now process the careplan
     plan_id = 'immunological_care_management'.to_sym
@@ -911,14 +899,16 @@ class GenericStatesTest < Minitest::Test
 
     # The encounter comes first (and add it to history)
     encounter = Synthea::Generic::States::Encounter.new(ctx, "Inpatient_Encounter")
-    @patient.record_synthea.expect(:encounter, nil, [:hospital_admission, @time, nil])
+    @patient.record_synthea.expect(:encounter, nil, [:hospital_admission, @time, {}])
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
 
     # Then have the appendectomy
     appendectomy = Synthea::Generic::States::Procedure.new(ctx, "Appendectomy")
-    @patient.record_synthea.expect(:procedure, nil, [:laparoscopic_appendectomy, @time, nil])
-    assert(appendectomy.process(@time, @patient))
+    appendectomy.start_time = @time
+    @patient.record_synthea.expect(:procedure, nil, [:laparoscopic_appendectomy, @time, { 'duration' => 45.minutes }])
+    refute(appendectomy.process(@time, @patient))
+    assert(appendectomy.process(@time + 45.minutes, @patient))
 
     # Verify that the procedure was added to the record
     @patient.record_synthea.verify
@@ -932,7 +922,7 @@ class GenericStatesTest < Minitest::Test
 
     # The encounter comes first (and add it to history)
     encounter = Synthea::Generic::States::Encounter.new(ctx, "SomeEncounter")
-    @patient.record_synthea.expect(:encounter, nil, [:hospital_admission, @time, nil])
+    @patient.record_synthea.expect(:encounter, nil, [:hospital_admission, @time, {}])
     assert(encounter.process(@time, @patient))
     ctx.history << encounter
 


### PR DESCRIPTION
Adds the ability for Encounters and Procedures to have realistic durations. Currently all encounters and procedures are recorded to take 15 minutes, which is obviously not true in reality. This PR adds:
#### 1.
 a "duration" field on Procedure which takes a range of time that the procedure may take, and
#### 2. 
 an "EncounterEnd" state which signifies the end of the current Encounter and accepts an optional discharge disposition. The time between Encounter and EncounterEnd states is recorded in the final output (CCDA and FHIR).  The switch to having a start + end allows us to use Delays in the middle to represent the amount of time taken. Note that Encounters and EncounterEnds do not have to exist in a 1-1 relationship; multiple Encounters could proceed into a single EncounterEnd, or a single Encounter could branch out and end in various different EncounterEnds.

Because an Encounter can now span a time range from minutes to months, Procedures, MedicationOrders, etc, do not necessarily have to be concurrent with the Encounter in which they occur.


Also updated the modules such that every module now has EncounterEnds, and added durations for various procedures as well.