### PR TITLE
Diagnosed vs. Active Condition

### DIFF
--- a/lib/entity/person.rb
+++ b/lib/entity/person.rb
@@ -1,10 +1,35 @@
 module Synthea
   class Person < Synthea::Entity
-    attr_accessor :record_synthea
+    attr_accessor :record_synthea, :active_conditions
 
     def initialize
       super
       @record_synthea = Synthea::Output::Record.new
+      # Conditions that the patient currently has, but may not be diagnosed yet.
+      # For a patient to have a 'diagnosed' condition, it must be both active and
+      # already recorded in the patient's record.
+      @active_conditions = {}
+    end
+
+    def onset_condition(type, time)
+      # Sets a new active condition for the patient.
+      @active_conditions[type] = {
+        'type' => type,
+        'time' => time
+      }
+    end
+
+    def end_condition(type, time)
+      @active_conditions[type] = nil
+      @record_synthea.end_condition(type, time)
+    end
+
+    def active_condition?(type)
+      !@active_conditions[type].nil?
+    end
+
+    def diagnosed_condition?(type)
+      active_condition?(type) && @record_synthea.diagnosed_condition?(type)
     end
   end
 end

--- a/lib/generic/modules/colorectal_cancer.json
+++ b/lib/generic/modules/colorectal_cancer.json
@@ -510,7 +510,7 @@
       "complex_transition": [
         {
           "condition": {
-            "condition_type": "Active Condition",
+            "condition_type": "Diagnosed Condition",
             "codes": [
               {
                 "system": "SNOMED-CT",
@@ -1079,7 +1079,7 @@
             }
           ]
         }
-      ]     
+      ]
     },
 
     "Wait_For_Partial_Colectomy": {

--- a/lib/generic/modules/injuries.json
+++ b/lib/generic/modules/injuries.json
@@ -1490,7 +1490,7 @@
       "conditional_transition": [
         {
           "condition": {
-            "condition_type": "Active Condition",
+            "condition_type": "Diagnosed Condition",
             "codes": [
               {
                 "system": "SNOMED-CT",
@@ -1503,7 +1503,7 @@
         },
         {
           "condition": {
-            "condition_type": "Active Condition",
+            "condition_type": "Diagnosed Condition",
             "codes": [
               {
                 "system": "SNOMED-CT",
@@ -1516,7 +1516,7 @@
         },
         {
           "condition": {
-            "condition_type": "Active Condition",
+            "condition_type": "Diagnosed Condition",
             "codes": [
               {
                 "system": "SNOMED-CT",
@@ -2270,7 +2270,7 @@
       "direct_transition": "End_Knee_Injury_Encounter_II"
     },
 
-    "End_Knee_Injury_Encounter_II" : 
+    "End_Knee_Injury_Encounter_II" :
     {
       "type" : "EncounterEnd",
       "direct_transition": "Knee_Injury_Recovery_Period"

--- a/lib/generic/modules/sinusitis.json
+++ b/lib/generic/modules/sinusitis.json
@@ -194,7 +194,7 @@
                 ]
               },
               {
-                "condition_type": "Active Condition",
+                "condition_type": "Diagnosed Condition",
                 "codes": [
                   {
                     "system": "SNOMED-CT",
@@ -209,7 +209,7 @@
         },
         {
           "condition": {
-            "condition_type": "Active Condition",
+            "condition_type": "Diagnosed Condition",
             "codes": [
               {
                 "system": "SNOMED-CT",
@@ -319,7 +319,7 @@
       "complex_transition": [
         {
           "condition": {
-            "condition_type": "Active Condition",
+            "condition_type": "Diagnosed Condition",
             "codes": [
               {
                 "system": "SNOMED-CT",
@@ -390,7 +390,7 @@
       "conditional_transition": [
         {
           "condition": {
-            "condition_type": "Active Condition",
+            "condition_type": "Diagnosed Condition",
             "codes": [
               {
                 "system": "SNOMED-CT",
@@ -406,7 +406,7 @@
         }
       ]
     },
-    
+
     "Chronic_Sinusisitis_Ends": {
       "type": "ConditionEnd",
       "condition_onset": "Diagnose_Chronic_Sinusitis",

--- a/lib/generic/modules/sore_throat.json
+++ b/lib/generic/modules/sore_throat.json
@@ -436,7 +436,7 @@
       "conditional_transition": [
         {
           "condition": {
-            "condition_type": "Active Condition",
+            "condition_type": "Diagnosed Condition",
             "codes": [
               {
                 "system": "SNOMED-CT",
@@ -514,7 +514,7 @@
         }
       ]
     },
-    
+
     "End_Antibiotics": {
       "type": "MedicationEnd",
       "referenced_by_attribute": "Sore Throat Antibiotic",

--- a/lib/modules/cardiovascular_disease.rb
+++ b/lib/modules/cardiovascular_disease.rb
@@ -470,7 +470,7 @@ module Synthea
         if entity[:cardiovascular_procedures]
           entity[:cardiovascular_procedures].each do |reason, procedures|
             procedures.each do |proc|
-              unless entity.record_synthea.procedure_perfomed?(proc)
+              unless entity.record_synthea.procedure_performed?(proc)
                 # TODO: assumes a procedure will only be performed once, might need to be revisited
                 entity.record_synthea.procedure(proc, time, reason: reason)
               end

--- a/lib/modules/cardiovascular_disease.rb
+++ b/lib/modules/cardiovascular_disease.rb
@@ -435,18 +435,18 @@ module Synthea
       def self.perform_encounter(entity, time)
         patient = entity.record_synthea
         [:coronary_heart_disease, :atrial_fibrillation].each do |diagnosis|
-          if entity[diagnosis] && !entity.record_synthea.present[diagnosis]
+          if entity[diagnosis] && !entity.record_synthea.diagnosed_condition?(diagnosis)
             patient.condition(diagnosis, time, :condition, :condition)
           end
         end
 
         if entity[:careplan] && entity[:careplan][:cardiovascular_disease]
-          if !entity.record_synthea.careplan_active?(:cardiovascular_disease)
+          if !entity.record_synthea.active_careplan?(:cardiovascular_disease)
             entity.record_synthea.careplan_start(:cardiovascular_disease, entity[:careplan][:cardiovascular_disease]['activities'], time, entity[:careplan][:cardiovascular_disease]['reasons'])
           else
             entity.record_synthea.update_careplan_reasons(:cardiovascular_disease, entity[:careplan][:cardiovascular_disease]['reasons'], time)
           end
-        elsif entity.record_synthea.careplan_active?(:cardiovascular_disease)
+        elsif entity.record_synthea.active_careplan?(:cardiovascular_disease)
           entity.record_synthea.careplan_stop(:cardiovascular_disease, time)
         end
 
@@ -454,12 +454,12 @@ module Synthea
           entity[:med_changes][:cardiovascular_disease].each do |med|
             if entity[:medications][med]
               # Add a prescription to the record if it hasn't been recorded yet
-              if !entity.record_synthea.medication_active?(med)
+              if !entity.record_synthea.active_medication?(med)
                 entity.record_synthea.medication_start(med, time, entity[:medications][med]['reasons'])
               else
                 entity.record_synthea.update_med_reasons(med, entity[:medications][med]['reasons'], time)
               end
-            elsif entity.record_synthea.medication_active?(med)
+            elsif entity.record_synthea.active_medication?(med)
               # This prescription can be stopped...
               entity.record_synthea.medication_stop(med, time, :cardiovascular_improved)
             end
@@ -470,7 +470,7 @@ module Synthea
         if entity[:cardiovascular_procedures]
           entity[:cardiovascular_procedures].each do |reason, procedures|
             procedures.each do |proc|
-              unless entity.record_synthea.present[proc]
+              unless entity.record_synthea.procedure_perfomed?(proc)
                 # TODO: assumes a procedure will only be performed once, might need to be revisited
                 entity.record_synthea.procedure(proc, time, reason: reason)
               end

--- a/lib/records/exporter.rb
+++ b/lib/records/exporter.rb
@@ -161,11 +161,11 @@ module Synthea
         #    should also add a condition code such as "history of ___" (ex 429280009)
         case attribute
         when :medications
-          return record.medication_active?(e['type'])
+          return record.active_medication?(e['type'])
         when :careplans
-          return record.careplan_active?(e['type'])
+          return record.active_careplan?(e['type'])
         when :conditions
-          return record.present[e['type']] || (e['end_time'] && e['end_time'] > cutoff_date)
+          return record.diagnosed_condition?(e['type']) || (e['end_time'] && e['end_time'] > cutoff_date)
         when :encounters
           return e['type'] == :death_certification
         when :observations

--- a/lib/tasks/graphviz.rb
+++ b/lib/tasks/graphviz.rb
@@ -404,6 +404,9 @@ module Synthea
         when 'Active Condition'
           cond = find_referenced_type(logic)
           "Condition #{cond} is active\\l"
+        when 'Diagnosed Condition'
+          cond = find_referenced_type(logic)
+          "Condition #{cond} is diagnosed\\l"
         when 'Active CarePlan'
           plan = find_referenced_type(logic)
           "CarePlan #{plan} is active\\l"
@@ -416,7 +419,7 @@ module Synthea
         when 'True', 'False'
           logic['condition_type']
         else
-          raise "Unsupported Conditon: #{logic['condition_type']}"
+          raise "Unsupported Condition: #{logic['condition_type']}"
         end
       end
 

--- a/test/fixtures/generic/logic.json
+++ b/test/fixtures/generic/logic.json
@@ -114,7 +114,7 @@
     "referenced_by_attribute" : "Diabetes Test Performed",
     "operator" : "is not nil"
   },
-  "diabetesConditionTest" : {
+  "diabetesActiveConditionTest" : {
     "condition_type" : "Active Condition",
     "codes": [{
         "system": "SNOMED-CT",
@@ -122,9 +122,21 @@
         "display": "Diabetes mellitus"
     }]
   },
-  "alzheimersConditionTest" : {
+  "diabetesDiagnosedConditionTest": {
+    "condition_type": "Diagnosed Condition",
+    "codes": [{
+        "system": "SNOMED-CT",
+        "code": "73211009",
+        "display": "Diabetes mellitus"
+    }]
+  },
+  "alzheimersActiveConditionTest" : {
     "condition_type" : "Active Condition",
     "referenced_by_attribute" : "Alzheimer's Variant"
+  },
+  "alzheimersDiagnosedConditionTest": {
+    "condition_type": "Diagnosed Condition",
+    "referenced_by_attribute": "Alzheimer's Variant"
   },
   "diabetesCarePlanTest": {
     "condition_type": "Active CarePlan",

--- a/test/unit/record_test.rb
+++ b/test/unit/record_test.rb
@@ -22,9 +22,9 @@ class RecordTest < Minitest::Test
   end
 
   def test_medication_active?
-    assert(@record.medication_active?(:sglt2i))
+    assert(@record.active_medication?(:sglt2i))
     @record.medication_stop(:sglt2i, @time + 15.minutes, :diabetes_well_controlled)
-    assert(!@record.medication_active?(:sglt2i))
+    assert(!@record.active_medication?(:sglt2i))
   end
 
   def test_update_med_reasons
@@ -49,9 +49,9 @@ class RecordTest < Minitest::Test
   end
 
   def test_careplan_active
-    assert(@record.careplan_active?(:cardiovascular_disease))
+    assert(@record.active_careplan?(:cardiovascular_disease))
     @record.careplan_stop(:cardiovascular_disease,  @time + 15.minutes)
-    assert(!@record.careplan_active?(:cardiovascular_disease))
+    assert(!@record.active_careplan?(:cardiovascular_disease))
   end
 
   def test_update_careplan_reasons


### PR DESCRIPTION
## Conceptual Changes

I created a new `Diagnosed Condition` condition and revised the meaning of `Active Condition`.

"Active" conditions are now conditions that the patient currently has, but _may not_ be in the patient's record yet if the patient hasn't had that condition's `target_encounter`. This new condition is useful for controlling program flow _before_ the diagnosis. For example, consider the following scenario:

A patient has a peanut allergy. They go to an allergist. The allergist runs a series of tests. If the patient has an _active_ peanut allergy, the test will return positive for a peanut allergy (even though the patient's record does not yet list a peanut allergy) and the allergist can then _diagnose_ that allergy.

This could also be useful for separating disease progression and treatment. An `Active Condition` could influence a disease to progress even though the condition is not yet diagnosed.

"Diagnosed" conditions must be both _active_ (the patient is currently affected by the condition) and recorded in the patient's record.

There is one caveat: If a patient has a condition that is no longer active, it will remain in the patient's record as a previously diagnosed condition, but the `Diagnosed Condition` condition will now return `false` since that condition is no longer active.

If the need arises to check if a patient _ever_ had a condition, perhaps we would need a new logical condition to test for that. However, in practice none of our modules need that sort of logic.

## Code Changes

I was able to remove the `present` attribute from the `Record` class. I expanded the `Person` entity to include the `onset_condition`, `end_condition`, `active_condition?`, and  `diagnosed_condition?` methods. These need to be evaluated for the _entity_ rather than just the record since the notion of a condition now spans both the entity (active conditions) and the record (diagnosed conditions).

I also refactored the record API with more consistent method names and some convenience methods that make manipulating the record a little more intuitive. All of the new `find_*` methods (e.g. `find_medication` or `find_condition`) now do a reverse scan of the patient's record and find the _most recent_ item.