### PR TITLE
Add rake task for concept inventory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ output
 coverage
 resources
 *.log*
+concepts.csv

--- a/lib/tasks/concepts.rb
+++ b/lib/tasks/concepts.rb
@@ -91,6 +91,12 @@ module Synthea
             concepts[code['system']][code['code']] = code['display']
           end
         end
+
+        if state.has_key? 'discharge_disposition'
+          code = state['discharge_disposition']
+          concepts[code['system']] = Hash.new unless concepts[code['system']]
+          concepts[code['system']][code['code']] = code['display']
+        end
       end
 
     end

--- a/lib/tasks/concepts.rb
+++ b/lib/tasks/concepts.rb
@@ -84,6 +84,13 @@ module Synthea
             concepts[code['system']][code['code']] = code['display']
           end
         end
+
+        if state.has_key?('prescription') && state['prescription'].has_key?('instructions')
+          state['prescription']['instructions'].each do |code|
+            concepts[code['system']] = Hash.new unless concepts[code['system']]
+            concepts[code['system']][code['code']] = code['display']
+          end
+        end
       end
 
     end

--- a/lib/tasks/concepts.rb
+++ b/lib/tasks/concepts.rb
@@ -1,0 +1,91 @@
+module Synthea
+  module Tasks
+    class Concepts
+
+      def self.inventory
+        puts "Performing an inventory of concepts into `concepts.csv`..."
+        count = 0
+
+        concepts = {}
+
+        inventory_obs(concepts)
+        inventory_lookup(concepts, Synthea::COND_LOOKUP)
+        inventory_lookup(concepts, Synthea::CAREPLAN_LOOKUP)
+        inventory_lookup(concepts, Synthea::REASON_LOOKUP)
+        inventory_lookup(concepts, Synthea::MEDICATION_LOOKUP)
+        inventory_lookup(concepts, Synthea::INSTRUCTION_LOOKUP)
+        inventory_lookup(concepts, Synthea::PROCEDURE_LOOKUP)
+        inventory_lookup(concepts, Synthea::ENCOUNTER_LOOKUP)
+        inventory_generic_modules(concepts)
+
+        concept_file = File.open('concepts.csv','w:UTF-8')
+        concepts.each do |system,codes|
+          codes.each do |code,display|
+            count += 1
+            concept_file.write("#{system},#{code},#{display.gsub(',',' ')}\n")
+          end
+        end
+        concept_file.close
+
+        puts "Cataloged #{count} concepts."
+        puts 'Done.'
+      end
+
+      def self.inventory_obs(concepts)
+        concepts['LOINC'] = Hash.new unless concepts['LOINC']
+        Synthea::OBS_LOOKUP.each do |key,value|
+          concepts['LOINC'][value[:code]] = value[:description]
+        end
+
+        concepts['CVX'] = Hash.new unless concepts['CVX']
+        Synthea::IMM_SCHEDULE.each do |key,value|
+          concepts['CVX'][value[:code]['code']] = value[:code]['display']
+        end
+      end
+
+      def self.inventory_lookup(concepts,lookup)
+        lookup.each do |key,value|
+          value[:codes].each do |system,codes|
+            concepts[system] = Hash.new unless concepts[system]
+            codes.each do |code|
+              concepts[system][code] = value[:description]
+            end
+          end
+        end
+      end
+
+      def self.inventory_generic_modules(concepts)
+        module_dir = File.expand_path('../../generic/modules', __FILE__)
+
+        # all modules and submodules
+        Dir.glob(File.join(module_dir, '**', '*.json')) do |module_file|
+          inventory_module(concepts, module_file)
+        end
+      end
+
+      def self.inventory_module(concepts, module_file)
+        wf = JSON.parse(File.read(module_file))
+        wf['states'].each do |name, state|
+          inventory_state(concepts, state)
+        end
+      end
+
+      def self.inventory_state(concepts, state)
+        if state.has_key? 'codes'
+          state['codes'].each do |code|
+            concepts[code['system']] = Hash.new unless concepts[code['system']]
+            concepts[code['system']][code['code']] = code['display']
+          end
+        end
+
+        if state.has_key? 'activities'
+          state['activities'].each do |code|
+            concepts[code['system']] = Hash.new unless concepts[code['system']]
+            concepts[code['system']][code['code']] = code['display']
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -14,6 +14,11 @@ namespace :synthea do
     Synthea::Tasks::Graphviz.generate_graphs
   end
 
+  desc 'create a list of simulated concepts'
+  task :concepts, [] do |_t, _args|
+    Synthea::Tasks::Concepts.inventory
+  end
+
   desc 'generate'
   task :generate, [] do |_t, _args|
     start = Time.now


### PR DESCRIPTION
This adds a rake task to inventory all the terminology codes and concepts used within Synthea and output them to a comma-separated values (csv) file.

The task inventories all the built-in lookup tables as well as all the codes used within generic module states.

The concept file is used solely for reporting and analysis purposes and does not alter the simulation whatsoever.