### PR TITLE
Medication Submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/.DS_Store
+**/.keep
 .vscode
 .palate
 output

--- a/lib/generic/modules/allergic_rhinitis.json
+++ b/lib/generic/modules/allergic_rhinitis.json
@@ -138,18 +138,9 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "429195002",
-          "display": "Allergic rhinitis caused by animal dander"
-        },
-        {
-          "system": "SNOMED-CT",
-          "code": "449729000",
-          "display": "Allergic rhinitis caused by house dust mite"
+          "code": "446096008",
+          "display": "Perennial allergic rhinitis"
         }
-      ],
-      "remarks": [
-        "These people do not have seasonal hay fever like the other cases.",
-        "These allergies are mainly to pet dander and dust."
       ],
       "direct_transition": "Allergic_Rhinitis_Diagnosis"
     },
@@ -179,86 +170,16 @@
           "display": "Encounter for symptom"
         }
       ],
+      "direct_transition": "Prescribe_OTC_Antihistamine"
+    },
+
+    "Prescribe_OTC_Antihistamine": {
+      "type": "CallSubmodule",
       "remarks": [
-        "I select one of several over-the-counter (OTC) medications to be prescribed",
-        "to the patient. These are uniformly distributed since they are all equally",
-        "common and equally likely to be prescribed for the treatment of seasonal",
-        "nasal allergies."
+        "This submodule will only prescribe an antihistamine if one is ",
+        "not already prescribed."
       ],
-      "complex_transition": [
-        {
-          "condition": {
-            "condition_type": "Active Medication",
-            "referenced_by_attribute": "otc_antihistamine"
-          },
-          "distributions": [
-            {
-              "distribution": 1,
-              "transition": "Advise_To_Visit_Allergist"
-            }
-          ]
-        },
-        {
-          "distributions": [
-            {
-              "distribution": 0.33,
-              "transition": "Prescribe_OTC_Medication_Option_1"
-            },
-            {
-              "distribution": 0.34,
-              "transition": "Prescribe_OTC_Medication_Option_2"
-            },
-            {
-              "distribution": 0.33,
-              "transition": "Prescribe_OTC_Medication_Option_3"
-            }
-          ]
-        }
-      ]
-    },
-
-    "Prescribe_OTC_Medication_Option_1": {
-      "type": "MedicationOrder",
-      "target_encounter": "Allergic_Rhinitis_Diagnosis",
-      "assign_to_attribute": "otc_antihistamine",
-      "reason": "allergic_rhinitis",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "567613",
-          "display": "Loratadine 10 MG [Claritin]"
-        }
-      ],
-      "direct_transition": "Advise_To_Visit_Allergist"
-    },
-
-    "Prescribe_OTC_Medication_Option_2": {
-      "type": "MedicationOrder",
-      "target_encounter": "Allergic_Rhinitis_Diagnosis",
-      "assign_to_attribute": "otc_antihistamine",
-      "reason": "allergic_rhinitis",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "1011483",
-          "display": "Cetirizine hydrochloride 10 MG [ZyrTEC]"
-        }
-      ],
-      "direct_transition": "Advise_To_Visit_Allergist"
-    },
-
-    "Prescribe_OTC_Medication_Option_3": {
-      "type": "MedicationOrder",
-      "target_encounter": "Allergic_Rhinitis_Diagnosis",
-      "assign_to_attribute": "otc_antihistamine",
-      "reason": "allergic_rhinitis",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "896322",
-          "display": "Fluticasone propionate 0.05 MG [Flonase]"
-        }
-      ],
+      "submodule": "medications/otc_antihistamine",
       "direct_transition": "Advise_To_Visit_Allergist"
     },
 

--- a/lib/generic/modules/allergies.json
+++ b/lib/generic/modules/allergies.json
@@ -131,6 +131,16 @@
     "Allergy_Panel": {
       "type": "CallSubmodule",
       "submodule": "allergies/allergy_panel",
+      "direct_transition": "Prescribe_OTC_Antihistamine"
+    },
+
+    "Prescribe_OTC_Antihistamine": {
+      "type": "CallSubmodule",
+      "remarks": [
+        "This submodule will only prescribe an antihistamine if one is ",
+        "not already prescribed."
+      ],
+      "submodule": "medications/otc_antihistamine",
       "direct_transition": "General_Allergy_CarePlan"
     },
 

--- a/lib/generic/modules/bronchitis.json
+++ b/lib/generic/modules/bronchitis.json
@@ -152,7 +152,6 @@
 
     "Chest_Xray": {
       "type": "Procedure",
-      "target_encounter": "Doctor_Visit",
       "reason": "Bronchitis_Infection",
       "codes": [
         {
@@ -167,7 +166,6 @@
 
     "Sputum_Test": {
       "type": "Procedure",
-      "target_encounter": "Doctor_Visit",
       "reason": "Bronchitis_Infection",
       "codes": [
         {
@@ -182,7 +180,6 @@
 
     "Lung_Function_Test": {
       "type": "Procedure",
-      "target_encounter": "Doctor_Visit",
       "reason": "Bronchitis_Infection",
       "codes": [
         {
@@ -226,7 +223,6 @@
 
     "Smoker_CarePlan": {
       "type": "CarePlanStart",
-      "target_encounter": "Doctor_Visit",
       "assign_to_attribute": "bronchitis_careplan",
       "reason": "Bronchitis_Infection",
       "codes": [
@@ -258,7 +254,6 @@
 
     "Nonsmoker_CarePlan": {
       "type": "CarePlanStart",
-      "target_encounter": "Doctor_Visit",
       "assign_to_attribute": "bronchitis_careplan",
       "reason": "Bronchitis_Infection",
       "codes": [
@@ -328,7 +323,7 @@
 
     "Cough_suppressant": {
       "type": "MedicationOrder",
-      "target_encounter": "Doctor_Visit",
+      "assign_to_attribute": "OTC_Bronchitis_Med",
       "reason": "Bronchitis_Infection",
       "codes": [
         {
@@ -342,7 +337,7 @@
 
     "Acetaminophen": {
       "type": "MedicationOrder",
-      "target_encounter": "Doctor_Visit",
+      "assign_to_attribute": "OTC_Bronchitis_Med",
       "reason": "Bronchitis_Infection",
       "codes": [
         {
@@ -424,7 +419,7 @@
       "wellness": true,
       "direct_transition": "End_Bronchitis_CarePlan"
     },
-    
+
     "End_Bronchitis_CarePlan": {
       "type": "CarePlanEnd",
       "referenced_by_attribute": "bronchitis_careplan",

--- a/lib/generic/modules/dermatitis.json
+++ b/lib/generic/modules/dermatitis.json
@@ -548,10 +548,20 @@
       "conditional_transition": [
         {
           "condition": {
-            "condition_type": "Age",
-            "operator": ">",
-            "quantity": 16,
-            "unit": "years"
+            "condition_type": "And",
+            "conditions": [
+              {
+                "condition_type": "Age",
+                "operator": ">",
+                "quantity": 16,
+                "unit": "years"
+              },
+              {
+                "condition_type": "Date",
+                "operator": ">=",
+                "year": 1983
+              }
+            ]
           },
           "transition": "Prescribe_Immunosuppressant"
         },
@@ -564,6 +574,11 @@
     "Prescribe_Immunosuppressant": {
       "type": "MedicationOrder",
       "reason": "dermatitis",
+      "remarks": [
+        "Immunosuppressants like cyclosporine were invented in the late 1970's ",
+        "and came to market in the early 1980s. Cyclosporine was available starting ",
+        "in 1983."
+      ],
       "codes": [
         {
           "system": "SNOMED-CT",

--- a/lib/generic/modules/ear_infections.json
+++ b/lib/generic/modules/ear_infections.json
@@ -151,77 +151,15 @@
       ]
     },
 
-    "Ear_Infection_Prescribed_Antibiotic" : {
-      "type" : "Simple",
-      "conditional_transition" : [
-        {
-          "condition" : {
-            "condition_type" : "Date",
-            "operator" : ">=",
-            "year" : 1972
-          },
-          "transition" : "Ear_Infection_Prescribed_Amoxicillin"
-        },
-        {
-          "condition" : {
-            "condition_type" : "Date",
-            "operator" : ">=",
-            "year" : 1956
-          },
-          "transition" : "Ear_Infection_Prescribed_Penicillin"
-        },
-        {
-          "transition" : "Ear_Infection_Prescribed_OTC_Painkiller",
-          "remarks" : ["Antibiotics not available yet, just go to the painkillers"]
-        }
-      ]
-    },
-
-    "Ear_Infection_Prescribed_Amoxicillin": {
-      "type": "MedicationOrder",
-      "target_encounter": "Ear_Infection_Encounter",
-      "assign_to_attribute" : "ear_infection_prescription",
-      "reason": "Gets_Ear_Infection",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "317616",
-          "display": "Amoxicillin 500MG"
-        }
-      ],
-      "direct_transition": "End_Encounter"
-    },
-
-    "Ear_Infection_Prescribed_Penicillin": {
-      "type": "MedicationOrder",
-      "target_encounter": "Ear_Infection_Encounter",
-      "assign_to_attribute" : "ear_infection_prescription",
-      "reason": "Gets_Ear_Infection",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "834060",
-          "display": "Penicillin V Potassium 250 MG"
-        }
-      ],
-      "direct_transition": "End_Encounter"
+    "Ear_Infection_Prescribed_Antibiotic": {
+      "type": "CallSubmodule",
+      "submodule": "medications/ear_infection_antibiotic",
+      "direct_transition": "Ear_Infection_Prescribed_OTC_Painkiller"
     },
 
     "Ear_Infection_Prescribed_OTC_Painkiller": {
-      "type": "MedicationOrder",
-      "target_encounter": "Ear_Infection_Encounter",
-      "assign_to_attribute" : "ear_infection_prescription",
-      "reason": "Gets_Ear_Infection",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "315263",
-          "display": "Acetaminophen 325MG [Tylenol]",
-          "remarks": [
-            "Dosage based on a single, standard Acetaminophen tablet of 325MG"
-          ]
-        }
-      ],
+      "type": "CallSubmodule",
+      "submodule": "medications/otc_pain_reliever",
       "direct_transition": "End_Encounter"
     },
 
@@ -232,19 +170,48 @@
 
     "Ear_Infection_Prescription_Taken": {
       "type": "Delay",
-      "range": {
-        "low": 7,
-        "high": 14,
+      "exact": {
+        "quantity": 14,
         "unit": "days"
       },
-      "direct_transition": "Ear_Infection_Prescription_End"
-    },
-    "Ear_Infection_Prescription_End": {
-      "type": "MedicationEnd",
-      "referenced_by_attribute" : "ear_infection_prescription",
-      "direct_transition": "Next_Wellness_Encounter"
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "ear_infection_antibiotic",
+            "operator": "is not nil"
+          },
+          "transition": "Ear_Infection_Antibiotic_End"
+        },
+        {
+          "transition": "Ear_Infection_OTC_Painkiller_End"
+        }
+      ]
     },
 
+    "Ear_Infection_Antibiotic_End": {
+      "type": "MedicationEnd",
+      "referenced_by_attribute" : "ear_infection_antibiotic",
+      "direct_transition": "Unset_Antibiotic_Attribute"
+    },
+
+    "Unset_Antibiotic_Attribute": {
+      "type": "SetAttribute",
+      "attribute": "ear_infection_antibiotic",
+      "direct_transition": "Ear_Infection_OTC_Painkiller_End"
+    },
+
+    "Ear_Infection_OTC_Painkiller_End": {
+      "type": "MedicationEnd",
+      "referenced_by_attribute": "otc_pain_reliever",
+      "direct_transition": "Unset_Pain_Reliever_Attribute"
+    },
+
+    "Unset_Pain_Reliever_Attribute": {
+      "type": "SetAttribute",
+      "attribute": "otc_pain_reliever",
+      "direct_transition": "Next_Wellness_Encounter"
+    },
 
     "Next_Wellness_Encounter": {
       "type": "Encounter",
@@ -257,7 +224,7 @@
       "condition_onset": "Gets_Ear_Infection",
       "direct_transition": "Loopback_No_Infection"
     },
-    
+
     "Loopback_No_Infection": {
       "type": "Simple",
       "direct_transition": "No_Infection",

--- a/lib/generic/modules/ear_infections.json
+++ b/lib/generic/modules/ear_infections.json
@@ -191,13 +191,13 @@
 
     "Ear_Infection_Antibiotic_End": {
       "type": "MedicationEnd",
-      "referenced_by_attribute" : "ear_infection_antibiotic",
+      "referenced_by_attribute" : "antibiotic_prescription",
       "direct_transition": "Unset_Antibiotic_Attribute"
     },
 
     "Unset_Antibiotic_Attribute": {
       "type": "SetAttribute",
-      "attribute": "ear_infection_antibiotic",
+      "attribute": "antibiotic_prescription",
       "direct_transition": "Ear_Infection_OTC_Painkiller_End"
     },
 

--- a/lib/generic/modules/injuries.json
+++ b/lib/generic/modules/injuries.json
@@ -29,9 +29,9 @@
     "plan is referenced by the 'injury_careplan' attribute and is ended at the conclusion ",
     "of the injury.",
 
-    "Inury pathways may also prescribe a medication and assign it to one of these attributes: ",
+    "Injury pathways may also prescribe a medication and assign it to one of these attributes: ",
     "1. 'opioid_prescription' ",
-    "2. 'nonopioid_prescription' ",
+    "2. 'otc_pain_reliever' ",
     "3. 'antibiotic_prescription' ",
 
     "Any medication order with one of these attributes will be automatically ended at the ",
@@ -337,7 +337,6 @@
 
     "Spinal_Injury_CarePlan": {
       "type": "CarePlanStart",
-      "target_encounter": "ED_Visit_For_Spinal_Injury",
       "assign_to_attribute": "injury_careplan",
       "reason": "spinal_injury",
       "codes": [
@@ -427,7 +426,6 @@
 
     "Spinal_Surgery": {
       "type": "Procedure",
-      "target_encounter": "ED_Visit_For_Spinal_Injury",
       "reason": "spinal_injury",
       "codes": [
         {
@@ -464,22 +462,8 @@
     },
 
     "Spinal_Injury_Prescribe_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "Spinal_Injury_Treatment_Encounter",
-      "assign_to_attribute": "opioid_prescription",
-      "reason": "spinal_injury",
-      "remarks": [
-        "Since spinal injuries are so close to the central nervous system they ",
-        "are typically very, very painful. Regardless of the age, year, etc. we ",
-        "prescribe an opioid."
-      ],
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "1049624",
-          "display": "Acetaminophen 325 MG / oxyCODONE Hydrochloride 10 MG [Percocet]"
-        }
-      ],
+      "type": "CallSubmodule",
+      "submodule": "medications/moderate_opioid_pain_reliever",
       "direct_transition": "End_Spinal_Injury_Encounter"
     },
 
@@ -598,8 +582,12 @@
 
     "Gunshot_Wound_Surgery": {
       "type": "Procedure",
-      "target_encounter": "ED_Visit_For_Gunshot_Injury",
       "reason": "Gunshot_Wound",
+      "duration": {
+        "low": 1,
+        "high": 4,
+        "unit": "hours"
+      },
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -607,95 +595,38 @@
           "display": "Admission to trauma surgery department"
         }
       ],
-      "direct_transition": "Gunshot_Wound_Prescribe_Antibiotic"
-    },
-
-    "Gunshot_Wound_Prescribe_Antibiotic": {
-      "remarks": [
-        "If the wound was bad enough to require surgery antibiotics will ",
-        "most likely be prescribed to prevent any sort of infection."
-      ],
-      "type": "MedicationOrder",
-      "target_encounter": "ED_Visit_For_Gunshot_Injury",
-      "assign_to_attribute": "antibiotic_prescription",
-      "reason": "Gunshot_Wound",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "1359008",
-          "display": "Amoxicillin 200 MG [Amoxi-tabs]"
-        }
-      ],
       "direct_transition": "Gunshot_Wound_Prescribe_Pain_Medication"
     },
 
     "Gunshot_Wound_Prescribe_Pain_Medication": {
       "type": "Simple",
-      "conditional_transition": [
+      "distributed_transition": [
         {
-          "condition": {
-            "condition_type": "Or",
-            "conditions": [
-              {
-                "condition_type": "Age",
-                "operator": "<",
-                "quantity": 14,
-                "unit": "years"
-              },
-              {
-                "condition_type": "Date",
-                "operator": "<",
-                "year": 1990
-              },
-              {
-                "condition_type": "Attribute",
-                "attribute": "opioid_prescription",
-                "operator": "is not nil"
-              }
-            ]
-          },
-          "transition": "Gunshot_Wound_Prescribe_Non_Opioid"
+          "distribution": 0.7,
+          "transition": "Gunshot_Wound_Prescribe_Opioid"
         },
         {
-          "transition": "Gunshot_Wound_Prescribe_Opioid"
+          "distribution": 0.3,
+          "transition": "Gunshot_Wound_Prescribe_Non_Opioid"
         }
       ]
     },
 
-    "Gunshot_Wound_Prescribe_Non_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "ED_Visit_For_Gunshot_Injury",
-      "assign_to_attribute": "nonopioid_prescription",
-      "reason": "Gunshot_Wound",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "646457",
-          "display": "Acetaminophen 650 MG [Tylenol]"
-        }
-      ],
-      "direct_transition": "Gunshot_Wound_CarePlan"
+    "Gunshot_Wound_Prescribe_Opioid": {
+      "type": "CallSubmodule",
+      "submodule": "medications/moderate_opioid_pain_reliever",
+      "direct_transition": "Gunshot_Wound_Prescribe_Non_Opioid"
     },
 
-    "Gunshot_Wound_Prescribe_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "ED_Visit_For_Gunshot_Injury",
-      "assign_to_attribute": "opioid_prescription",
-      "reason": "Gunshot_Wound",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "1310197",
-          "display": "Acetaminophen 300 MG / HYDROcodone Bitartrate 5 MG [Vicodin]"
-        }
-      ],
+    "Gunshot_Wound_Prescribe_Non_Opioid": {
+      "type": "CallSubmodule",
+      "submodule": "medications/otc_pain_reliever",
       "direct_transition": "Gunshot_Wound_CarePlan"
     },
 
     "Gunshot_Wound_CarePlan": {
       "type": "CarePlanStart",
       "assign_to_attribute": "injury_careplan",
-      "target_encounter": "ED_Visit_For_Gunshot_Injury",
       "reason": "Gunshot_Wound",
       "codes": [
         {
@@ -876,7 +807,6 @@
 
     "Concussion_CarePlan": {
       "type": "CarePlanStart",
-      "target_encounter": "ED_Visit_For_Concussion",
       "assign_to_attribute": "injury_careplan",
       "reason": "concussion_injury",
       "codes": [
@@ -985,23 +915,13 @@
     },
 
     "Whiplash_Injury_Prescribe_Non_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "ED_Visit_For_Whiplash",
-      "assign_to_attribute": "nonopioid_prescription",
-      "reason": "Whiplash",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "849727",
-          "display": "Naproxen sodium 220 MG [Aleve]"
-        }
-      ],
+      "type": "CallSubmodule",
+      "submodule": "medications/otc_pain_reliever",
       "direct_transition": "Whiplash_CarePlan"
     },
 
     "Whiplash_CarePlan": {
       "type": "CarePlanStart",
-      "target_encounter" : "ED_Visit_For_Whiplash",
       "assign_to_attribute": "injury_careplan",
       "reason": "Whiplash",
       "codes": [
@@ -1196,8 +1116,12 @@
 
     "Broken_Bone_Immobilization": {
       "type": "Procedure",
-      "target_encounter": "ED_Visit_For_Broken_Bone",
       "reason": "broken_bone",
+      "duration": {
+        "low": 20,
+        "high": 45,
+        "unit": "minutes"
+      },
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -1210,8 +1134,12 @@
 
     "Broken_Bone_Surgery": {
       "type": "Procedure",
-      "target_encounter": "ED_Visit_For_Broken_Bone",
       "reason": "broken_bone",
+      "duration": {
+        "low": 1,
+        "high": 2,
+        "unit": "hours"
+      },
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -1224,70 +1152,52 @@
 
     "Broken_Bone_Injury_Prescribe_Pain_Medication": {
       "type": "Simple",
-      "conditional_transition": [
+      "complex_transition": [
         {
           "condition": {
-            "condition_type": "Or",
-            "conditions": [
-              {
-                "condition_type": "Age",
-                "operator": "<",
-                "quantity": 14,
-                "unit": "years"
-              },
-              {
-                "condition_type": "Date",
-                "operator": "<",
-                "year": 1990
-              },
-              {
-                "condition_type": "Attribute",
-                "attribute": "opioid_prescription",
-                "operator": "is not nil"
-              }
-            ]
+            "condition_type": "PriorState",
+            "name": "Broken_Bone_Surgery"
           },
-          "transition": "Broken_Bone_Injury_Prescribe_Non_Opioid"
+          "distributions": [
+            {
+              "distribution": 0.8,
+              "transition": "Broken_Bone_Injury_Prescribe_Opioid"
+            },
+            {
+              "distribution": 0.2,
+              "transition": "Broken_Bone_Injury_Prescribe_Non_Opioid"
+            }
+          ]
         },
         {
-          "transition": "Broken_Bone_Injury_Prescribe_Opioid"
+          "distributions": [
+            {
+              "distribution": 0.3,
+              "transition": "Broken_Bone_Injury_Prescribe_Opioid"
+            },
+            {
+              "distribution": 0.7,
+              "transition": "Broken_Bone_Injury_Prescribe_Non_Opioid"
+            }
+          ]
         }
       ]
     },
 
-    "Broken_Bone_Injury_Prescribe_Non_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "ED_Visit_For_Broken_Bone",
-      "assign_to_attribute": "nonopioid_prescription",
-      "reason": "broken_bone",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "646457",
-          "display": "Acetaminophen 650 MG [Tylenol]"
-        }
-      ],
-      "direct_transition": "Broken_Bone_CarePlan"
+    "Broken_Bone_Injury_Prescribe_Opioid": {
+      "type": "CallSubmodule",
+      "submodule": "medications/moderate_opioid_pain_reliever",
+      "direct_transition": "Broken_Bone_Injury_Prescribe_Non_Opioid"
     },
 
-    "Broken_Bone_Injury_Prescribe_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "ED_Visit_For_Broken_Bone",
-      "assign_to_attribute": "opioid_prescription",
-      "reason": "broken_bone",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "1049503",
-          "display": "oxyCODONE Hydrochloride 10 MG [OxyCONTIN]"
-        }
-      ],
+    "Broken_Bone_Injury_Prescribe_Non_Opioid": {
+      "type": "CallSubmodule",
+      "submodule": "medications/otc_pain_reliever",
       "direct_transition": "Broken_Bone_CarePlan"
     },
 
     "Broken_Bone_CarePlan": {
       "type": "CarePlanStart",
-      "target_encounter": "ED_Visit_For_Broken_Bone",
       "assign_to_attribute": "injury_careplan",
       "reason": "broken_bone",
       "codes": [
@@ -1460,7 +1370,6 @@
 
     "Burn_CarePlan": {
       "type": "CarePlanStart",
-      "target_encounter": "ED_Visit_For_Burn",
       "assign_to_attribute": "injury_careplan",
       "reason": "burn_injury",
       "codes": [
@@ -1532,7 +1441,6 @@
 
     "Severe_Burn_Care": {
       "type": "Procedure",
-      "target_encounter": "ED_Visit_For_Burn",
       "reason": "burn_injury",
       "codes": [
         {
@@ -1546,8 +1454,12 @@
 
     "Severe_Burn_Hospitalization": {
       "type": "Procedure",
-      "target_encounter": "ED_Visit_For_Burn",
       "reason": "burn_injury",
+      "duration": {
+        "low": 1,
+        "high": 3,
+        "unit": "weeks"
+      },
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -1559,80 +1471,24 @@
     },
 
     "Burn_Injury_Prescribe_Antibiotic": {
-      "type": "MedicationOrder",
-      "target_encounter": "ED_Visit_For_Burn",
-      "assign_to_attribute": "antibiotic_prescription",
-      "reason": "burn_injury",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "563983",
-          "display": "Minocycline 100 MG [Minocin]"
-        }
+      "type": "CallSubmodule",
+      "remarks": [
+        "Antibiotics that can be used to treat ear infections are equally ",
+        "suitable for treating bacterial tissue infections."
       ],
-      "direct_transition": "Burn_Injury_Prescribe_Pain_Medication"
-    },
-
-    "Burn_Injury_Prescribe_Pain_Medication": {
-      "type": "Simple",
-      "conditional_transition": [
-        {
-          "condition": {
-            "condition_type": "Or",
-            "conditions": [
-              {
-                "condition_type": "Age",
-                "operator": "<",
-                "quantity": 14,
-                "unit": "years"
-              },
-              {
-                "condition_type": "Date",
-                "operator": "<",
-                "year": 1990
-              },
-              {
-                "condition_type": "Attribute",
-                "attribute": "opioid_prescription",
-                "operator": "is not nil"
-              }
-            ]
-          },
-          "transition": "Burn_Injury_Prescribe_Non_Opioid"
-        },
-        {
-          "transition": "Burn_Injury_Prescribe_Opioid"
-        }
-      ]
-    },
-
-    "Burn_Injury_Prescribe_Non_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "ED_Visit_For_Burn",
-      "assign_to_attribute": "nonopioid_prescription",
-      "reason": "burn_injury",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "646457",
-          "display": "Acetaminophen 650 MG [Tylenol]"
-        }
-      ],
-      "direct_transition": "End_Burn_Encounter"
+      "submodule": "medications/ear_infection_antibiotic",
+      "direct_transition": "Burn_Injury_Prescribe_Opioid"
     },
 
     "Burn_Injury_Prescribe_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "ED_Visit_For_Burn",
-      "assign_to_attribute": "opioid_prescription",
-      "reason": "burn_injury",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "1049624",
-          "display": "Acetaminophen 325 MG / oxyCODONE Hydrochloride 10 MG [Percocet]"
-        }
-      ],
+      "type": "CallSubmodule",
+      "submodule": "medications/moderate_opioid_pain_reliever",
+      "direct_transition": "Burn_Injury_Prescribe_Non_Opioid"
+    },
+
+    "Burn_Injury_Prescribe_Non_Opioid": {
+      "type": "CallSubmodule",
+      "submodule": "medications/otc_pain_reliever",
       "direct_transition": "End_Burn_Encounter"
     },
 
@@ -1801,7 +1657,6 @@
 
     "Laceration_CarePlan": {
       "type": "CarePlanStart",
-      "target_encounter": "ED_Visit_For_Laceration",
       "assign_to_attribute": "injury_careplan",
       "reason": "laceration_injury",
       "codes": [
@@ -1828,8 +1683,12 @@
 
     "Suture_Laceration": {
       "type": "Procedure",
-      "target_encounter": "ED_Visit_For_Laceration",
       "reason": "laceration_injury",
+      "duration": {
+        "low": 10,
+        "high": 30,
+        "unit": "minutes"
+      },
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -1857,8 +1716,12 @@
 
     "Laceration_Tetanus_Shot": {
       "type": "Procedure",
-      "target_encounter": "ED_Visit_For_Laceration",
       "reason": "laceration_injury",
+      "duration": {
+        "low": 10,
+        "high": 20,
+        "unit": "minutes"
+      },
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -1870,17 +1733,8 @@
     },
 
     "Laceration_Injury_Prescribe_Non_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "ED_Visit_For_Laceration",
-      "assign_to_attribute": "nonopioid_prescription",
-      "reason": "laceration_injury",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "569998",
-          "display": "Acetaminophen 325 MG [Tylenol]"
-        }
-      ],
+      "type": "CallSubmodule",
+      "submodule": "medications/otc_pain_reliever",
       "direct_transition": "End_Laceration_Encounter"
     },
 
@@ -1968,7 +1822,6 @@
 
     "Sprain_CarePlan": {
       "type": "CarePlanStart",
-      "target_encounter": "ED_Visit_For_Sprain",
       "assign_to_attribute": "injury_careplan",
       "reason": "sprain_injury",
       "codes": [
@@ -1994,17 +1847,8 @@
     },
 
     "Sprain_Prescribe_Non_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "ED_Visit_For_Sprain",
-      "assign_to_attribute": "nonopioid_prescription",
-      "reason": "sprain_injury",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "569998",
-          "display": "Acetaminophen 325 MG [Tylenol]"
-        }
-      ],
+      "type": "CallSubmodule",
+      "submodule": "medications/otc_pain_reliever",
       "direct_transition": "End_Sprain_Encounter"
     },
 
@@ -2064,7 +1908,6 @@
 
     "Knee_Injury_CarePlan": {
       "type": "CarePlanStart",
-      "target_encounter": "ED_Visit_For_Knee_Injury",
       "assign_to_attribute": "injury_careplan",
       "reason": "knee_injury",
       "codes": [
@@ -2148,7 +1991,7 @@
           "display": "Tear of meniscus of knee"
         }
       ],
-      "direct_transition": "End_Knee_Injury_Encounter_II"
+      "direct_transition": "Knee_Injury_Prescribe_Non_Opioid"
     },
 
     "Torn_Patellar_Tendon": {
@@ -2195,8 +2038,12 @@
 
     "Knee_Surgery_Procedure": {
       "type": "Procedure",
-      "target_encounter": "Knee_Surgery_Encounter",
       "reason": "knee_injury",
+      "duration": {
+        "low": 2,
+        "high": 4,
+        "unit": "hours"
+      },
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -2204,73 +2051,22 @@
           "display": "Surgical manipulation of joint of knee"
         }
       ],
-      "direct_transition": "Knee_Injury_Prescribe_Pain_Medication"
-    },
-
-    "Knee_Injury_Prescribe_Pain_Medication": {
-      "type": "Simple",
-      "conditional_transition": [
-        {
-          "condition": {
-            "condition_type": "Or",
-            "conditions": [
-              {
-                "condition_type": "Age",
-                "operator": "<",
-                "quantity": 14,
-                "unit": "years"
-              },
-              {
-                "condition_type": "Date",
-                "operator": "<",
-                "year": 1990
-              },
-              {
-                "condition_type": "Attribute",
-                "attribute": "opioid_prescription",
-                "operator": "is not nil"
-              }
-            ]
-          },
-          "transition": "Knee_Injury_Prescribe_Non_Opioid"
-        },
-        {
-          "transition": "Knee_Injury_Prescribe_Opioid"
-        }
-      ]
-    },
-
-    "Knee_Injury_Prescribe_Non_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "Knee_Surgery_Encounter",
-      "assign_to_attribute": "nonopioid_prescription",
-      "reason": "knee_injury",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "646457",
-          "display": "Acetaminophen 650 MG [Tylenol]"
-        }
-      ],
-      "direct_transition": "End_Knee_Injury_Encounter_II"
+      "direct_transition": "Knee_Injury_Prescribe_Opioid"
     },
 
     "Knee_Injury_Prescribe_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "Knee_Surgery_Encounter",
-      "assign_to_attribute": "opioid_prescription",
-      "reason": "knee_injury",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "1310197",
-          "display": "Acetaminophen 300 MG / HYDROcodone Bitartrate 5 MG [Vicodin]"
-        }
-      ],
+      "type": "CallSubmodule",
+      "submodule": "medications/moderate_opioid_pain_reliever",
+      "direct_transition": "Knee_Injury_Prescribe_Non_Opioid"
+    },
+
+    "Knee_Injury_Prescribe_Non_Opioid": {
+      "type": "CallSubmodule",
+      "submodule": "medications/otc_pain_reliever",
       "direct_transition": "End_Knee_Injury_Encounter_II"
     },
 
-    "End_Knee_Injury_Encounter_II" : 
+    "End_Knee_Injury_Encounter_II" :
     {
       "type" : "EncounterEnd",
       "direct_transition": "Knee_Injury_Recovery_Period"
@@ -2336,7 +2132,6 @@
 
     "Shoulder_Injury_CarePlan": {
       "type": "CarePlanStart",
-      "target_encounter": "Encounter_For_Shoulder_Injury",
       "assign_to_attribute": "injury_careplan",
       "reason": "Torn_Rotator_Cuff",
       "codes": [
@@ -2400,8 +2195,12 @@
 
     "Shoulder_Surgery_Procedure": {
       "type": "Procedure",
-      "target_encounter": "Shoulder_Surgery_Encounter",
       "reason": "Torn_Rotator_Cuff",
+      "duration": {
+        "low": 2,
+        "high": 4,
+        "unit": "hours"
+      },
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -2409,69 +2208,18 @@
           "display": "Surgical manipulation of shoulder joint"
         }
       ],
-      "direct_transition": "Shoulder_Surgery_Prescribe_Pain_Medication"
-    },
-
-    "Shoulder_Surgery_Prescribe_Pain_Medication": {
-      "type": "Simple",
-      "conditional_transition": [
-        {
-          "condition": {
-            "condition_type": "Or",
-            "conditions": [
-              {
-                "condition_type": "Age",
-                "operator": "<",
-                "quantity": 14,
-                "unit": "years"
-              },
-              {
-                "condition_type": "Date",
-                "operator": "<",
-                "year": 1990
-              },
-              {
-                "condition_type": "Attribute",
-                "attribute": "opioid_prescription",
-                "operator": "is not nil"
-              }
-            ]
-          },
-          "transition": "Shoulder_Surgery_Prescribe_Non_Opioid"
-        },
-        {
-          "transition": "Shoulder_Surgery_Prescribe_Opioid"
-        }
-      ]
-    },
-
-    "Shoulder_Surgery_Prescribe_Non_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "Shoulder_Surgery_Encounter",
-      "assign_to_attribute": "nonopioid_prescription",
-      "reason": "Torn_Rotator_Cuff",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "646457",
-          "display": "Acetaminophen 650 MG [Tylenol]"
-        }
-      ],
-      "direct_transition": "End_Shoulder_Surgery_Encounter"
+      "direct_transition": "Shoulder_Surgery_Prescribe_Opioid"
     },
 
     "Shoulder_Surgery_Prescribe_Opioid": {
-      "type": "MedicationOrder",
-      "target_encounter": "Shoulder_Surgery_Encounter",
-      "assign_to_attribute": "opioid_prescription",
-      "reason": "Torn_Rotator_Cuff",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": "1310197",
-          "display": "Acetaminophen 300 MG / HYDROcodone Bitartrate 5 MG [Vicodin]"
-        }
-      ],
+      "type": "CallSubmodule",
+      "submodule": "medications/moderate_opioid_pain_reliever",
+      "direct_transition": "Shoulder_Surgery_Prescribe_Non_Opioid"
+    },
+
+    "Shoulder_Surgery_Prescribe_Non_Opioid": {
+      "type": "CallSubmodule",
+      "submodule": "medications/otc_pain_reliever",
       "direct_transition": "End_Shoulder_Surgery_Encounter"
     },
 
@@ -2543,7 +2291,7 @@
         "more prescriptions are remaining.",
 
         "The attributes that this state looks for are: ",
-        "1. nonopioid_prescription ",
+        "1. otc_pain_reliever ",
         "2. antibiotic_prescription ",
 
         "Any other medications prescribed in this module and not assigned to one of those ",
@@ -2562,7 +2310,7 @@
         {
           "condition": {
             "condition_type": "Attribute",
-            "attribute": "nonopioid_prescription",
+            "attribute": "otc_pain_reliever",
             "operator": "is not nil"
           },
           "transition": "End_Non_Opioid_Prescription"
@@ -2590,13 +2338,13 @@
 
     "End_Non_Opioid_Prescription": {
       "type": "MedicationEnd",
-      "referenced_by_attribute": "nonopioid_prescription",
+      "referenced_by_attribute": "otc_pain_reliever",
       "direct_transition": "Unset_Non_Opioid_Prescription_Attribute"
     },
 
     "Unset_Non_Opioid_Prescription_Attribute": {
       "type": "SetAttribute",
-      "attribute": "nonopioid_prescription",
+      "attribute": "otc_pain_reliever",
       "direct_transition": "End_Injury_Medications"
     },
 

--- a/lib/generic/modules/medications/ear_infection_antibiotic.json
+++ b/lib/generic/modules/medications/ear_infection_antibiotic.json
@@ -9,19 +9,22 @@
     "All antibiotics prescribed in this module are assigned to the attribute ",
     "'ear_infection_antibiotic'.",
 
+    "Source for common antibiotics used to treat otitis media: ",
+    "http://www.nps.org.au/conditions/ear-nose-mouth-and-throat-disorders/ear-nose-and-throat-infections/ear-infection-middle/for-individuals/medicines-and-treatments",
+
+    "Availability dates for different drugs came from the FDA: ",
+    "http://www.accessdata.fda.gov/scripts/cder/daf/",
+
+    "Dosage information came from FDA reference sheets available at: ",
+    "https://www.drugs.com/dosage/",
+
     "Medications prescribed in this module:     ",
     "1. Penicillin        available after 1945  ",
     "2. Ampicillin        available after 1961  ",
     "3. Doxycycline       available after 1967  ",
     "4. Amoxicillin       available after 1979  ",
     "5. Cefaclor          available 1979 - 2004 ",
-    "6. Cefuroxime        available after 1983  ",
-
-    "Source for common antibiotics used to treat otitis media: ",
-    "http://www.nps.org.au/conditions/ear-nose-mouth-and-throat-disorders/ear-nose-and-throat-infections/ear-infection-middle/for-individuals/medicines-and-treatments",
-
-    "Availability dates for different drugs came from the FDA: ",
-    "http://www.accessdata.fda.gov/scripts/cder/daf/"
+    "6. Cefuroxime        available after 1983  "
   ],
   "states": {
 

--- a/lib/generic/modules/medications/ear_infection_antibiotic.json
+++ b/lib/generic/modules/medications/ear_infection_antibiotic.json
@@ -1,0 +1,542 @@
+{
+  "name": "Ear Infection Antibiotic",
+  "remarks": [
+    "This submodule prescribes an antibiotic used to treat ear infections ",
+    "(otitis media). If no medication is available in the current year of ",
+    "the simulation then none is prescribed.",
+
+    "IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
+    "All antibiotics prescribed in this module are assigned to the attribute ",
+    "'ear_infection_antibiotic'.",
+
+    "Medications prescribed in this module:     ",
+    "1. Penicillin        available after 1945  ",
+    "2. Ampicillin        available after 1961  ",
+    "3. Doxycycline       available after 1967  ",
+    "4. Amoxicillin       available after 1979  ",
+    "5. Cefaclor          available 1979 - 2004 ",
+    "6. Cefuroxime        available after 1983  ",
+
+    "Source for common antibiotics used to treat otitis media: ",
+    "http://www.nps.org.au/conditions/ear-nose-mouth-and-throat-disorders/ear-nose-and-throat-infections/ear-infection-middle/for-individuals/medicines-and-treatments",
+
+    "Availability dates for different drugs came from the FDA: ",
+    "http://www.accessdata.fda.gov/scripts/cder/daf/"
+  ],
+  "states": {
+
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "ear_infection_antibiotic",
+            "operator": "is nil"
+          },
+          "transition": "Prescribe_Ear_Infection_Antibiotic"
+        },
+        {
+          "transition": "Ear_Infection_Antibiotic_Terminal"
+        }
+      ]
+    },
+
+    "Prescribe_Ear_Infection_Antibiotic": {
+      "type": "Simple",
+      "complex_transition": [
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1945
+          },
+          "distributions": [
+            {
+              "distribution": 1,
+              "transition": "Ear_Infection_Antibiotic_Terminal"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1961
+          },
+          "distributions": [
+            {
+              "distribution": 1,
+              "transition": "Prescribe_Penicillin"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1967
+          },
+          "distributions": [
+            {
+              "distribution": 0.4,
+              "transition": "Prescribe_Penicillin"
+            },
+            {
+              "distribution": 0.4,
+              "transition": "Prescribe_Ampicillin"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1979
+          },
+          "distributions": [
+            {
+              "distribution": 0.2,
+              "transition": "Prescribe_Penicillin"
+            },
+            {
+              "distribution": 0.2,
+              "transition": "Prescribe_Ampicillin"
+            },
+            {
+              "distribution": 0.6,
+              "transition": "Prescribe_Doxycycline"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1983
+          },
+          "distributions": [
+            {
+              "distribution": 0.6,
+              "transition": "Prescribe_Amoxicillin"
+            },
+            {
+              "distribution": 0.3,
+              "transition": "Prescribe_Cefaclor"
+            },
+            {
+              "distribution": 0.1,
+              "transition": "Prescribe_Doxycycline"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 2004
+          },
+          "distributions": [
+            {
+              "distribution": 0.6,
+              "transition": "Prescribe_Amoxicillin"
+            },
+            {
+              "distribution": 0.2,
+              "transition": "Prescribe_Cefaclor"
+            },
+            {
+              "distribution": 0.2,
+              "transition": "Prescribe_Cefuroxime"
+            }
+          ]
+        },
+        {
+          "distributions": [
+            {
+              "distribution": 0.8,
+              "transition": "Prescribe_Amoxicillin"
+            },
+            {
+              "distribution": 0.2,
+              "transition": "Prescribe_Cefuroxime"
+            }
+          ]
+        }
+      ]
+    },
+
+    "Prescribe_Penicillin": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ear_infection_antibiotic",
+      "remarks": [
+        "Historically this was injected, not ingested. There are still modern ",
+        "variant of penicillin that come as oral or injectable solutions. There ",
+        "is no distinction between a pediatric and adult dose."
+      ],
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "105078",
+          "display": "Penicillin G 375 MG/ML Injectable Solution"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 4,
+          "period": 1,
+          "unit": "days"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        },
+        "instructions": [
+          {
+            "system": "SNOMED-CT",
+            "code": "418577003",
+            "display": "Take at regular intervals. Complete the prescribed course unless otherwise directed."
+          }
+        ]
+      },
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
+    },
+
+    "Prescribe_Ampicillin": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ear_infection_antibiotic",
+      "remarks": [
+        "Historically this was injected, not ingested. There are still modern ",
+        "variant of ampicillin that come as oral or injectable solutions. There ",
+        "is no distinction between a pediatric and adult dose."
+      ],
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "789980",
+          "display": "Ampicillin 100 MG/ML Injectable Solution"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 2,
+          "period": 1,
+          "unit": "days"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        },
+        "instructions": [
+          {
+            "system": "SNOMED-CT",
+            "code": "418577003",
+            "display": "Take at regular intervals. Complete the prescribed course unless otherwise directed."
+          }
+        ]
+      },
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
+    },
+
+    "Prescribe_Doxycycline": {
+      "type": "Simple",
+      "remarks": [
+        "Not recommended for children < 8 years old. For children the dose is ",
+        "100 - 200mg/day. For adults, the dose is 200mg/day."
+      ],
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Age",
+            "operator": "<",
+            "quantity": 12,
+            "unit": "years"
+          },
+          "transition": "Pediatric_Doxycycline"
+        },
+        {
+          "transition": "Adult_Doxycycline"
+        }
+      ]
+    },
+
+    "Pediatric_Doxycycline": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ear_infection_antibiotic",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1652673",
+          "display": "Doxycycline Monohydrate 50 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 2,
+          "period": 1,
+          "unit": "days"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        },
+        "instructions": [
+          {
+            "system": "SNOMED-CT",
+            "code": "418577003",
+            "display": "Take at regular intervals. Complete the prescribed course unless otherwise directed."
+          },
+          {
+            "system": "SNOMED-CT",
+            "code": "419115000",
+            "display": "Do not take milk, indigestion remedies, or medicines containing iron or zinc at the same time of day as this medicine"
+          }
+        ]
+      },
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
+    },
+
+    "Adult_Doxycycline": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ear_infection_antibiotic",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1650142",
+          "display": "Doxycycline Monohydrate 100 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 2,
+          "period": 1,
+          "unit": "days"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        },
+        "instructions": [
+          {
+            "system": "SNOMED-CT",
+            "code": "418577003",
+            "display": "Take at regular intervals. Complete the prescribed course unless otherwise directed."
+          },
+          {
+            "system": "SNOMED-CT",
+            "code": "419115000",
+            "display": "Do not take milk, indigestion remedies, or medicines containing iron or zinc at the same time of day as this medicine"
+          }
+        ]
+      },
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
+    },
+
+    "Prescribe_Amoxicillin": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Age",
+            "operator": "<",
+            "quantity": 12,
+            "unit": "years"
+          },
+          "transition": "Pediatric_Amoxicillin"
+        },
+        {
+          "transition": "Adult_Amoxicillin"
+        }
+      ]
+    },
+
+    "Pediatric_Amoxicillin": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ear_infection_antibiotic",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "392151",
+          "display": "Amoxicillin 200 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 2,
+          "period": 1,
+          "unit": "days"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        },
+        "instructions": [
+          {
+            "system": "SNOMED-CT",
+            "code": "418577003",
+            "display": "Take at regular intervals. Complete the prescribed course unless otherwise directed."
+          }
+        ]
+      },
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
+    },
+
+    "Adult_Amoxicillin": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ear_infection_antibiotic",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "308192",
+          "display": "Amoxicillin 500 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 3,
+          "period": 1,
+          "unit": "days"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        },
+        "instructions": [
+          {
+            "system": "SNOMED-CT",
+            "code": "418577003",
+            "display": "Take at regular intervals. Complete the prescribed course unless otherwise directed."
+          }
+        ]
+      },
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
+    },
+
+    "Prescribe_Cefaclor": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Age",
+            "operator": "<",
+            "quantity": 12,
+            "unit": "years"
+          },
+          "transition": "Pediatric_Cefaclor"
+        },
+        {
+          "transition": "Adult_Cefaclor"
+        }
+      ]
+    },
+
+    "Pediatric_Cefaclor": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ear_infection_antibiotic",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "309045",
+          "display": "Cefaclor 250 MG Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 2,
+          "period": 1,
+          "unit": "days"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        },
+        "instructions": [
+          {
+            "system": "SNOMED-CT",
+            "code": "418577003",
+            "display": "Take at regular intervals. Complete the prescribed course unless otherwise directed."
+          }
+        ]
+      },
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
+    },
+
+    "Adult_Cefaclor": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ear_infection_antibiotic",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "309043",
+          "display": "12 HR Cefaclor 500 MG Extended Release Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 2,
+          "period": 1,
+          "unit": "days"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        },
+        "instructions": [
+          {
+            "system": "SNOMED-CT",
+            "code": "418577003",
+            "display": "Take at regular intervals. Complete the prescribed course unless otherwise directed."
+          }
+        ]
+      },
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
+    },
+
+    "Prescribe_Cefuroxime": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ear_infection_antibiotic",
+      "remarks": [
+        "The pediatric and adult doses of Cefuroxime are the same."
+      ],
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "309097",
+          "display": "Cefuroxime 250 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 2,
+          "period": 1,
+          "unit": "days"
+        },
+        "duration": {
+          "quantity": 10,
+          "unit": "days"
+        },
+        "instructions": [
+          {
+            "system": "SNOMED-CT",
+            "code": "418577003",
+            "display": "Take at regular intervals. Complete the prescribed course unless otherwise directed."
+          }
+        ]
+      },
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
+    },
+
+    "Ear_Infection_Antibiotic_Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/lib/generic/modules/medications/ear_infection_antibiotic.json
+++ b/lib/generic/modules/medications/ear_infection_antibiotic.json
@@ -7,7 +7,7 @@
 
     "IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
     "All antibiotics prescribed in this module are assigned to the attribute ",
-    "'ear_infection_antibiotic'.",
+    "'antibiotic_prescription'.",
 
     "Source for common antibiotics used to treat otitis media: ",
     "http://www.nps.org.au/conditions/ear-nose-mouth-and-throat-disorders/ear-nose-and-throat-infections/ear-infection-middle/for-individuals/medicines-and-treatments",
@@ -34,7 +34,7 @@
         {
           "condition": {
             "condition_type": "Attribute",
-            "attribute": "ear_infection_antibiotic",
+            "attribute": "antibiotic_prescription",
             "operator": "is nil"
           },
           "transition": "Prescribe_Ear_Infection_Antibiotic"
@@ -171,7 +171,7 @@
 
     "Prescribe_Penicillin": {
       "type": "MedicationOrder",
-      "assign_to_attribute": "ear_infection_antibiotic",
+      "assign_to_attribute": "antibiotic_prescription",
       "remarks": [
         "Historically this was injected, not ingested. There are still modern ",
         "variant of penicillin that come as oral or injectable solutions. There ",
@@ -208,7 +208,7 @@
 
     "Prescribe_Ampicillin": {
       "type": "MedicationOrder",
-      "assign_to_attribute": "ear_infection_antibiotic",
+      "assign_to_attribute": "antibiotic_prescription",
       "remarks": [
         "Historically this was injected, not ingested. There are still modern ",
         "variant of ampicillin that come as oral or injectable solutions. There ",
@@ -267,7 +267,7 @@
 
     "Pediatric_Doxycycline": {
       "type": "MedicationOrder",
-      "assign_to_attribute": "ear_infection_antibiotic",
+      "assign_to_attribute": "antibiotic_prescription",
       "codes": [
         {
           "system": "RxNorm",
@@ -304,7 +304,7 @@
 
     "Adult_Doxycycline": {
       "type": "MedicationOrder",
-      "assign_to_attribute": "ear_infection_antibiotic",
+      "assign_to_attribute": "antibiotic_prescription",
       "codes": [
         {
           "system": "RxNorm",
@@ -359,7 +359,7 @@
 
     "Pediatric_Amoxicillin": {
       "type": "MedicationOrder",
-      "assign_to_attribute": "ear_infection_antibiotic",
+      "assign_to_attribute": "antibiotic_prescription",
       "codes": [
         {
           "system": "RxNorm",
@@ -391,7 +391,7 @@
 
     "Adult_Amoxicillin": {
       "type": "MedicationOrder",
-      "assign_to_attribute": "ear_infection_antibiotic",
+      "assign_to_attribute": "antibiotic_prescription",
       "codes": [
         {
           "system": "RxNorm",
@@ -441,7 +441,7 @@
 
     "Pediatric_Cefaclor": {
       "type": "MedicationOrder",
-      "assign_to_attribute": "ear_infection_antibiotic",
+      "assign_to_attribute": "antibiotic_prescription",
       "codes": [
         {
           "system": "RxNorm",
@@ -473,7 +473,7 @@
 
     "Adult_Cefaclor": {
       "type": "MedicationOrder",
-      "assign_to_attribute": "ear_infection_antibiotic",
+      "assign_to_attribute": "antibiotic_prescription",
       "codes": [
         {
           "system": "RxNorm",
@@ -505,7 +505,7 @@
 
     "Prescribe_Cefuroxime": {
       "type": "MedicationOrder",
-      "assign_to_attribute": "ear_infection_antibiotic",
+      "assign_to_attribute": "antibiotic_prescription",
       "remarks": [
         "The pediatric and adult doses of Cefuroxime are the same."
       ],

--- a/lib/generic/modules/medications/moderate_opioid_pain_reliever.json
+++ b/lib/generic/modules/medications/moderate_opioid_pain_reliever.json
@@ -1,0 +1,183 @@
+{
+  "name": "Moderate Opioid Pain Reliever",
+  "remarks": [
+    "This submodule prescribes a moderate opioid pain reliever for acute pain. ",
+    "For example, after a major surgery or injury. Medications prescribed ",
+    "in this module are accurate for the current year of the simulation. ",
+    "If a patient is not eligible for an opioid pain reliever (for example, ",
+    "if they are already taking one, or if they are a young child), none is prescribed.",
+
+    "All medications prescribed in this module are assigned to the attribute ",
+    "'opioid_prescription'. It is the responsibility of the Opioid Addiction module ",
+    "to end this medication.",
+
+    "Availability dates for different drugs came from the FDA: ",
+    "http://www.accessdata.fda.gov/scripts/cder/daf/",
+
+    "Dosage information came from FDA reference sheets available at: ",
+    "https://www.drugs.com/dosage/",
+
+    "The following medications are prescribed in this module. Most opioids were invented ",
+    "during or prior to WWII, but did not become widely available until after the war:",
+    "1. Meperidine (Demerol)                      available after 1945      ",
+    "2. Hydrocodone/Acetaminophen (Vicondin)      available after 1943      ",
+    "3. Oxycodone/Acetaminophen (Percocet)        available after 1920 (est)"
+  ],
+  "states": {
+
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "And",
+            "conditions": [
+              {
+                "condition_type": "Attribute",
+                "attribute": "opioid_prescription",
+                "operator": "is nil"
+              },
+              {
+                "condition_type": "Age",
+                "operator": ">=",
+                "quantity": 12,
+                "unit": "years"
+              }
+            ]
+          },
+          "transition": "Prescribe_Moderate_Opioid"
+        },
+        {
+          "transition": "Moderate_Opioid_Terminal"
+        }
+      ]
+    },
+
+    "Prescribe_Moderate_Opioid": {
+      "type": "Simple",
+      "complex_transition": [
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1920
+          },
+          "distributions": [
+            {
+              "distribution": 1,
+              "transition": "Moderate_Opioid_Terminal"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1945
+          },
+          "distributions": [
+            {
+              "distribution": 1,
+              "transition": "Prescribe_Oxycodone_Acetaminophen"
+            }
+          ]
+        },
+        {
+          "distributions": [
+            {
+              "distribution": 0.4,
+              "transition": "Prescribe_Meperidine"
+            },
+            {
+              "distribution": 0.3,
+              "transition": "Prescribe_Oxycodone_Acetaminophen"
+            },
+            {
+              "distribution": 0.3,
+              "transition": "Prescribe_Hydrocodone_Acetaminophen"
+            }
+          ]
+        }
+      ]
+    },
+
+    "Prescribe_Meperidine": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "opioid_prescription",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "861467",
+          "display": "Meperidine Hydrochloride 50 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 1,
+          "period": 4,
+          "unit": "hours"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        }
+      },
+      "direct_transition": "Moderate_Opioid_Terminal"
+    },
+
+    "Prescribe_Oxycodone_Acetaminophen": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "opioid_prescription",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1049221",
+          "display": "Acetaminophen 325 MG / oxyCODONE Hydrochloride 5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 1,
+          "period": 6,
+          "unit": "hours"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        }
+      },
+      "direct_transition": "Moderate_Opioid_Terminal"
+    },
+
+    "Prescribe_Hydrocodone_Acetaminophen": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "opioid_prescription",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "857005",
+          "display": "Acetaminophen 325 MG / HYDROcodone Bitartrate 7.5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 1,
+          "period": 6,
+          "unit": "hours"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        }
+      },
+      "direct_transition": "Moderate_Opioid_Terminal"
+    },
+
+    "Moderate_Opioid_Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/lib/generic/modules/medications/otc_antihistamine.json
+++ b/lib/generic/modules/medications/otc_antihistamine.json
@@ -7,8 +7,15 @@
     "were invented, and older medications (e.g. benadryl) are prescribed less ",
     "frequently as alternatives (e.g. claritin) become available.",
 
+    "IT IS THE RESPONSIBILITY OF THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
+    "All medications prescribed in this module are assigned to the attribute ",
+    "'otc_antihistamine'.",
+
     "Availability dates for different drugs came from the FDA: ",
     "http://www.accessdata.fda.gov/scripts/cder/daf/",
+
+    "Dosage information came from FDA reference sheets available at: ",
+    "https://www.drugs.com/dosage/",
 
     "Although there are now liquid forms of some medications (especially for ",
     "children), it's unclear when those became available and the dosing is too ",

--- a/lib/generic/modules/medications/otc_antihistamine.json
+++ b/lib/generic/modules/medications/otc_antihistamine.json
@@ -7,11 +7,13 @@
     "were invented, and older medications (e.g. benadryl) are prescribed less ",
     "frequently as alternatives (e.g. claritin) become available.",
 
-    "Dosage and availability information was primarilly obtained from FDA reports ",
-    "available at https://www.drugs.com. Although there are now liquid forms of ",
-    "some medications (especially for children), it's unclear when those became ",
-    "available and the dosing is too complicated. For simplicity, all OTC ",
-    "antihistamines prescribed in this module are of the oral tablet type.",
+    "Availability dates for different drugs came from the FDA: ",
+    "http://www.accessdata.fda.gov/scripts/cder/daf/",
+
+    "Although there are now liquid forms of some medications (especially for ",
+    "children), it's unclear when those became available and the dosing is too ",
+    "complicated to model easily. For simplicity, all OTC antihistamines prescribed ",
+    "in this module are of the oral tablet type.",
 
     "Historically there has been 3 'generations' of antihistamines: ",
 
@@ -33,6 +35,23 @@
 
     "Initial": {
       "type": "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "otc_antihistamine",
+            "operator": "is nil"
+          },
+          "transition": "Prescribe_OTC_Antihistamine"
+        },
+        {
+          "transition": "OTC_Anthistamine_Terminal"
+        }
+      ]
+    },
+
+    "Prescribe_OTC_Antihistamine": {
+      "type": "Simple",
       "complex_transition": [
         {
           "condition": {
@@ -182,6 +201,7 @@
 
     "Prescribe_Diphenhydramine": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_antihistamine",
       "remarks": [
         "There is no distinction between pediatric and adult forms of this ",
         "medication. Adults just take more doses of the standard 25mg pill."
@@ -219,6 +239,7 @@
 
     "Pediatric_Chlorphenamine": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_antihistamine",
       "codes": [
         {
           "system": "RxNorm",
@@ -234,6 +255,7 @@
 
     "Adult_Chlorphenamine": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_antihistamine",
       "codes": [
         {
           "system": "RxNorm",
@@ -249,6 +271,7 @@
 
     "Prescribe_Astemizole": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_antihistamine",
       "remarks": [
         "There is only one RxNorm code available for this medication.",
         "Since it was withdrawn from the market in the 1990's there is ",
@@ -269,6 +292,7 @@
 
     "Prescribe_Terfenadine": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_antihistamine",
       "remarks": [
         "There are few RxNorm codes available for this medication.",
         "Since it was withdrawn from the market in the 1990's there is ",
@@ -307,6 +331,7 @@
 
     "Pediatric_Loratadine": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_antihistamine",
       "codes": [
         {
           "system": "RxNorm",
@@ -322,6 +347,7 @@
 
     "Adult_Loratadine": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_antihistamine",
       "codes": [
         {
           "system": "RxNorm",
@@ -355,6 +381,7 @@
 
     "Pediatric_Fexofenadine": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_antihistamine",
       "codes": [
         {
           "system": "RxNorm",
@@ -370,6 +397,7 @@
 
     "Adult_Fexofenadine": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_antihistamine",
       "codes": [
         {
           "system": "RxNorm",
@@ -403,6 +431,7 @@
 
     "Pediatric_Cetirizine": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_antihistamine",
       "codes": [
         {
           "system": "RxNorm",
@@ -418,6 +447,7 @@
 
     "Adult_Cetirizine": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_antihistamine",
       "codes": [
         {
           "system": "RxNorm",

--- a/lib/generic/modules/medications/otc_antihistamine.json
+++ b/lib/generic/modules/medications/otc_antihistamine.json
@@ -1,0 +1,438 @@
+{
+  "name": "Over-The-Counter Antihistamine",
+  "remarks": [
+    "This submodule correctly prescribes an over-the-counter antihistamine ",
+    "that has accurate dosage for adults and children and is accurate for the ",
+    "current year of the simulation. Medications are not prescribed before they ",
+    "were invented, and older medications (e.g. benadryl) are prescribed less ",
+    "frequently as alternatives (e.g. claritin) become available.",
+
+    "Dosage and availability information was primarilly obtained from FDA reports ",
+    "available at https://www.drugs.com. Although there are now liquid forms of ",
+    "some medications (especially for children), it's unclear when those became ",
+    "available and the dosing is too complicated. For simplicity, all OTC ",
+    "antihistamines prescribed in this module are of the oral tablet type.",
+
+    "Historically there has been 3 'generations' of antihistamines: ",
+
+    "Generaton 1 H1 antihistamines: ",
+    "1. Diphenhydramine (Benadryl)           available after 1946 ",
+    "2. Chlorphenamine (Chlor-Timeton)       available after 1951 ",
+
+    "Generation 2 H1 antihistamines. Some were discontinued in the 1990's due ",
+    "to rare but serious risk of cardiac arrest: ",
+    "3. Astemizole (Hismanal)                available 1977 - 1990 ",
+    "4. Terfenadine (Seldane)                available 1985 - 1992 ",
+    "5. Loratadine (Claritin)                available after 1993 ",
+    "6. Cetirizine (Zyrtec)                  available after 2007 ",
+
+    "Generation 3 H1 antihistamines: ",
+    "7. Fexofenadine (Allegra)               available after 1996 "
+  ],
+  "states": {
+
+    "Initial": {
+      "type": "Initial",
+      "complex_transition": [
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1946
+          },
+          "distributions": [
+            {
+              "distribution": 1,
+              "transition": "OTC_Anthistamine_Terminal"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1951
+          },
+          "distributions": [
+            {
+              "distribution": 1,
+              "transition": "Prescribe_Diphenhydramine"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1977
+          },
+          "distributions": [
+            {
+              "distribution": 0.6,
+              "transition": "Prescribe_Diphenhydramine"
+            },
+            {
+              "distribution": 0.6,
+              "transition": "Prescribe_Chlorphenamine"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1985
+          },
+          "distributions": [
+            {
+              "distribution": 0.34,
+              "transition": "Prescribe_Diphenhydramine"
+            },
+            {
+              "distribution": 0.33,
+              "transition": "Prescribe_Chlorphenamine"
+            },
+            {
+              "distribution": 0.33,
+              "transition": "Prescribe_Astemizole"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1992
+          },
+          "distributions": [
+            {
+              "distribution": 0.2,
+              "transition": "Prescribe_Diphenhydramine"
+            },
+            {
+              "distribution": 0.2,
+              "transition": "Prescribe_Chlorphenamine"
+            },
+            {
+              "distribution": 0.3,
+              "transition": "Prescribe_Astemizole"
+            },
+            {
+              "distribution": 0.3,
+              "transition": "Prescribe_Terfenadine"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1996
+          },
+          "distributions": [
+            {
+              "distribution": 0.2,
+              "transition": "Prescribe_Diphenhydramine"
+            },
+            {
+              "distribution": 0.8,
+              "transition": "Prescribe_Loratadine"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 2007
+          },
+          "distributions": [
+            {
+              "distribution": 0.5,
+              "transition": "Prescribe_Loratadine"
+            },
+            {
+              "distribution": 0.5,
+              "transition": "Prescribe_Fexofenadine"
+            }
+          ]
+        },
+        {
+          "remarks": [
+            "After 2007, only the latest generation and most common antihistamines ",
+            "are still prescribed."
+          ],
+          "distributions": [
+            {
+              "distribution": 0.34,
+              "transition": "Prescribe_Loratadine"
+            },
+            {
+              "distribution": 0.33,
+              "transition": "Prescribe_Fexofenadine"
+            },
+            {
+              "distribution": 0.33,
+              "transition": "Prescribe_Cetirizine"
+            }
+          ]
+        }
+      ]
+    },
+
+    "Prescribe_Diphenhydramine": {
+      "type": "MedicationOrder",
+      "remarks": [
+        "There is no distinction between pediatric and adult forms of this ",
+        "medication. Adults just take more doses of the standard 25mg pill."
+      ],
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1049630",
+          "display": "diphenhydrAMINE Hydrochloride 25 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Anthistamine_Terminal"
+    },
+
+    "Prescribe_Chlorphenamine": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Age",
+            "operator": "<",
+            "quantity": 12,
+            "unit": "years"
+          },
+          "transition": "Pediatric_Chlorphenamine"
+        },
+        {
+          "transition": "Adult_Chlorphenamine"
+        }
+      ]
+    },
+
+    "Pediatric_Chlorphenamine": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "239981",
+          "display": "Chlorpheniramine 2 MG Chewable Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Anthistamine_Terminal"
+    },
+
+    "Adult_Chlorphenamine": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "389128",
+          "display": "Chlorpheniramine 8 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Anthistamine_Terminal"
+    },
+
+    "Prescribe_Astemizole": {
+      "type": "MedicationOrder",
+      "remarks": [
+        "There is only one RxNorm code available for this medication.",
+        "Since it was withdrawn from the market in the 1990's there is ",
+        "only limited information available."
+      ],
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "197378",
+          "display": "Astemizole 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Anthistamine_Terminal"
+    },
+
+    "Prescribe_Terfenadine": {
+      "type": "MedicationOrder",
+      "remarks": [
+        "There are few RxNorm codes available for this medication.",
+        "Since it was withdrawn from the market in the 1990's there is ",
+        "only limited information available."
+      ],
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "141918",
+          "display": "Terfenadine 60 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Anthistamine_Terminal"
+    },
+
+    "Prescribe_Loratadine": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Age",
+            "operator": "<",
+            "quantity": 12,
+            "unit": "years"
+          },
+          "transition": "Pediatric_Loratadine"
+        },
+        {
+          "transition": "Adult_Loratadine"
+        }
+      ]
+    },
+
+    "Pediatric_Loratadine": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "665078",
+          "display": "Loratadine 5 MG Chewable Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Anthistamine_Terminal"
+    },
+
+    "Adult_Loratadine": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "311372",
+          "display": "Loratadine 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Anthistamine_Terminal"
+    },
+
+    "Prescribe_Fexofenadine": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Age",
+            "operator": "<",
+            "quantity": 12,
+            "unit": "years"
+          },
+          "transition": "Pediatric_Fexofenadine"
+        },
+        {
+          "transition": "Adult_Fexofenadine"
+        }
+      ]
+    },
+
+    "Pediatric_Fexofenadine": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "997488",
+          "display": "Fexofenadine hydrochloride 30 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Anthistamine_Terminal"
+    },
+
+    "Adult_Fexofenadine": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "997501",
+          "display": "Fexofenadine hydrochloride 60 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Anthistamine_Terminal"
+    },
+
+    "Prescribe_Cetirizine": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Age",
+            "operator": "<",
+            "quantity": 12,
+            "unit": "years"
+          },
+          "transition": "Pediatric_Cetirizine"
+        },
+        {
+          "transition": "Adult_Cetirizine"
+        }
+      ]
+    },
+
+    "Pediatric_Cetirizine": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1014676",
+          "display": "cetirizine hydrochloride 5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Anthistamine_Terminal"
+    },
+
+    "Adult_Cetirizine": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1014678",
+          "display": "cetirizine hydrochloride 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Anthistamine_Terminal"
+    },
+
+    "OTC_Anthistamine_Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/lib/generic/modules/medications/otc_pain_reliever.json
+++ b/lib/generic/modules/medications/otc_pain_reliever.json
@@ -7,8 +7,15 @@
     "were invented, and older medications (e.g. aspirin) are prescribed less ",
     "frequently as alternatives (e.g. acetaminophen) become available.",
 
+    "IT IS THE RESPONSIBILITY OF THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
+    "All medications prescribed in this module are assigned to the attribute ",
+    "'otc_pain_reliever'.",
+
     "Availability dates for different drugs came from the FDA: ",
     "http://www.accessdata.fda.gov/scripts/cder/daf/",
+
+    "Dosage information came from FDA reference sheets available at: ",
+    "https://www.drugs.com/dosage/",
 
     "Although there are now liquid forms of some medications (especially for ",
     "children), it's unclear when those became available and the dosing is too ",

--- a/lib/generic/modules/medications/otc_pain_reliever.json
+++ b/lib/generic/modules/medications/otc_pain_reliever.json
@@ -7,6 +7,12 @@
     "were invented, and older medications (e.g. aspirin) are prescribed less ",
     "frequently as alternatives (e.g. acetaminophen) become available.",
 
+    "Dosage and availability information was primarilly obtained from FDA reports ",
+    "available at https://www.drugs.com. Although there are now liquid forms of ",
+    "some medications (especially for children), it's unclear when those became ",
+    "available and the dosing is too complicated. For simplicity, all OTC pain ",
+    "relievers prescribed in this module are of the oral tablet type.",
+
     "The following medications may be prescribed by this module:  ",
     "1. Aspirin                              available after 1899 ",
     "2. Acetaminophen (Tylenol)              available after 1950 ",
@@ -126,11 +132,6 @@
 
     "Prescribe_Acetaminophen": {
       "type": "Simple",
-      "remarks": [
-        "Although liquid acetaminophen is now available it's unclear when it first ",
-        "became available. For simplicity, all acetaminophen prescribed in this module ",
-        "is of the oral tablet type."
-      ],
       "conditional_transition": [
         {
           "condition": {

--- a/lib/generic/modules/medications/otc_pain_reliever.json
+++ b/lib/generic/modules/medications/otc_pain_reliever.json
@@ -1,0 +1,283 @@
+{
+  "name": "Over-The-Counter Pain Reliever",
+  "remarks": [
+    "This submodule correctly prescribes an over-the-counter pain reliever ",
+    "that has accurate dosage for adults and children and is accurate for the ",
+    "current year of the simulation. Medications are not prescribed before they ",
+    "were invented, and older medications (e.g. aspirin) are prescribed less ",
+    "frequently as alternatives (e.g. acetaminophen) become available.",
+
+    "The following medications may be prescribed by this module:  ",
+    "1. Aspirin                              available after 1899 ",
+    "2. Acetaminophen (Tylenol)              available after 1950 ",
+    "3. Ibuprofen (Motrin, Advil)            available after 1974 ",
+    "4. Naproxen Sodium (Aleve)              available after 1994 "
+  ],
+  "states": {
+
+    "Initial": {
+      "type": "Initial",
+      "complex_transition": [
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1899
+          },
+          "distributions": [
+            {
+              "distribution": 1,
+              "transition": "OTC_Pain_Reliever_Terminal"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1950
+          },
+          "distributions": [
+            {
+              "distribution": 1,
+              "transition": "Prescribe_Aspirin"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1974
+          },
+          "distributions": [
+            {
+              "distribution": 0.6,
+              "transition": "Prescribe_Aspirin"
+            },
+            {
+              "distribution": 0.4,
+              "transition": "Prescribe_Acetaminophen"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1994
+          },
+          "distributions": [
+            {
+              "distribution": 0.15,
+              "transition": "Prescribe_Aspirin"
+            },
+            {
+              "distribution": 0.6,
+              "transition": "Prescribe_Acetaminophen"
+            },
+            {
+              "distribution": 0.25,
+              "transition": "Prescribe_Ibuprofen"
+            }
+          ]
+        },
+        {
+          "remarks": [
+            "After 1994, all medications are available. At this point ",
+            "aspirin is phased out in favor of newer alternatives."
+          ],
+          "distributions": [
+            {
+              "distribution": 0.34,
+              "transition": "Prescribe_Acetaminophen"
+            },
+            {
+              "distribution": 0.33,
+              "transition": "Prescribe_Ibuprofen"
+            },
+            {
+              "distribution": 0.33,
+              "transition": "Prescribe_Naproxen_Sodium"
+            }
+          ]
+        }
+      ]
+    },
+
+    "Prescribe_Aspirin": {
+      "type": "MedicationOrder",
+      "remarks": [
+        "There is no children's dose of aspirin. Anyone prescribed aspirin ",
+        "gets the same 81mg dose."
+      ],
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "243670",
+          "display": "Aspirin 81 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Pain_Reliever_Terminal"
+    },
+
+    "Prescribe_Acetaminophen": {
+      "type": "Simple",
+      "remarks": [
+        "Although liquid acetaminophen is now available it's unclear when it first ",
+        "became available. For simplicity, all acetaminophen prescribed in this module ",
+        "is of the oral tablet type."
+      ],
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Age",
+            "operator": "<",
+            "quantity": 12,
+            "unit": "years"
+          },
+          "transition": "Pediatric_Acetaminophen"
+        },
+        {
+          "transition": "Adult_Acetaminophen"
+        }
+      ]
+    },
+
+    "Pediatric_Acetaminophen": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "282464",
+          "display": "Acetaminophen 160 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Pain_Reliever_Terminal"
+    },
+
+    "Adult_Acetaminophen": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "313782",
+          "display": "Acetaminophen 325 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Pain_Reliever_Terminal"
+    },
+
+    "Prescribe_Ibuprofen": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Age",
+            "operator": "<",
+            "quantity": 12,
+            "unit": "years"
+          },
+          "transition": "Pediatric_Ibuprofen"
+        },
+        {
+          "transition": "Adult_Ibuprofen"
+        }
+      ]
+    },
+
+    "Pediatric_Ibuprofen": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "198405",
+          "display": "Ibuprofen 100 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Pain_Reliever_Terminal"
+    },
+
+    "Adult_Ibuprofen": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "310965",
+          "display": "Ibuprofen 200 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Pain_Reliever_Terminal"
+    },
+
+    "Prescribe_Naproxen_Sodium": {
+      "type": "Simple",
+      "remarks": [
+        "Naproxen Sodium is not prescribed for children. Patients < age 12 that ",
+        "reach this state are redirected to Acetaminophen or Ibuprofen."
+      ],
+      "complex_transition": [
+        {
+          "condition": {
+            "condition_type": "Age",
+            "operator": "<",
+            "quantity": 12,
+            "unit": "years"
+          },
+          "distributions": [
+            {
+              "distribution": 0.5,
+              "transition": "Prescribe_Acetaminophen"
+            },
+            {
+              "distribution": 0.5,
+              "transition": "Prescribe_Ibuprofen"
+            }
+          ]
+        },
+        {
+          "distributions": [
+            {
+              "distribution": 1,
+              "transition": "Naproxen_Sodium"
+            }
+          ]
+        }
+      ]
+    },
+
+    "Naproxen_Sodium": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "849574",
+          "display": "Naproxen sodium 220 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "as_needed": true
+      },
+      "direct_transition": "OTC_Pain_Reliever_Terminal"
+    },
+
+    "OTC_Pain_Reliever_Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/lib/generic/modules/medications/otc_pain_reliever.json
+++ b/lib/generic/modules/medications/otc_pain_reliever.json
@@ -7,11 +7,13 @@
     "were invented, and older medications (e.g. aspirin) are prescribed less ",
     "frequently as alternatives (e.g. acetaminophen) become available.",
 
-    "Dosage and availability information was primarilly obtained from FDA reports ",
-    "available at https://www.drugs.com. Although there are now liquid forms of ",
-    "some medications (especially for children), it's unclear when those became ",
-    "available and the dosing is too complicated. For simplicity, all OTC pain ",
-    "relievers prescribed in this module are of the oral tablet type.",
+    "Availability dates for different drugs came from the FDA: ",
+    "http://www.accessdata.fda.gov/scripts/cder/daf/",
+
+    "Although there are now liquid forms of some medications (especially for ",
+    "children), it's unclear when those became available and the dosing is too ",
+    "complicated to model easily. For simplicity, all OTC pain relievers prescribed ",
+    "in this module are of the oral tablet type.",
 
     "The following medications may be prescribed by this module:  ",
     "1. Aspirin                              available after 1899 ",
@@ -23,6 +25,23 @@
 
     "Initial": {
       "type": "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "otc_pain_reliever",
+            "operator": "is nil"
+          },
+          "transition": "Prescribe_OTC_Pain_Reliever"
+        },
+        {
+          "transition": "OTC_Pain_Reliever_Terminal"
+        }
+      ]
+    },
+
+    "Prescribe_OTC_Pain_Reliever": {
+      "type": "Simple",
       "complex_transition": [
         {
           "condition": {
@@ -113,6 +132,7 @@
 
     "Prescribe_Aspirin": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_pain_reliever",
       "remarks": [
         "There is no children's dose of aspirin. Anyone prescribed aspirin ",
         "gets the same 81mg dose."
@@ -150,6 +170,7 @@
 
     "Pediatric_Acetaminophen": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_pain_reliever",
       "codes": [
         {
           "system": "RxNorm",
@@ -165,6 +186,7 @@
 
     "Adult_Acetaminophen": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_pain_reliever",
       "codes": [
         {
           "system": "RxNorm",
@@ -198,6 +220,7 @@
 
     "Pediatric_Ibuprofen": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_pain_reliever",
       "codes": [
         {
           "system": "RxNorm",
@@ -213,6 +236,7 @@
 
     "Adult_Ibuprofen": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_pain_reliever",
       "codes": [
         {
           "system": "RxNorm",
@@ -264,6 +288,7 @@
 
     "Naproxen_Sodium": {
       "type": "MedicationOrder",
+      "assign_to_attribute": "otc_pain_reliever",
       "codes": [
         {
           "system": "RxNorm",

--- a/lib/generic/modules/medications/strong_opioid_pain_reliever.json
+++ b/lib/generic/modules/medications/strong_opioid_pain_reliever.json
@@ -1,0 +1,153 @@
+{
+  "name": "Strong Opioid Pain Reliever",
+  "remarks": [
+    "This submodule prescribes a strong opioid pain reliever for chronic or ",
+    "terminal pain. For example, the late stages of cancer. Medications prescribed ",
+    "in this module are accurate for the current year of the simulation. ",
+    "If a patient is not eligible for an opioid pain reliever (for example, ",
+    "if they are already taking one, or if they are a young child), none is prescribed.",
+
+    "All medications prescribed in this module are assigned to the attribute ",
+    "'opioid_prescription'. It is the responsibility of the Opioid Addiction module ",
+    "to end this medication.",
+
+    "Availability dates for different drugs came from the FDA: ",
+    "http://www.accessdata.fda.gov/scripts/cder/daf/",
+
+    "Dosage information came from FDA reference sheets available at: ",
+    "https://www.drugs.com/dosage/",
+
+    "The following medications are prescribed in this module. Most opioids were invented ",
+    "during or prior to WWII, but did not become widely available until after the war:",
+    "1. Methadone (Dolophine)             available after 1947      ",
+    "2. Oxycodone (OxyContin)             available after 1920 (est)"
+  ],
+  "states": {
+
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "And",
+            "conditions": [
+              {
+                "condition_type": "Attribute",
+                "attribute": "opioid_prescription",
+                "operator": "is nil"
+              },
+              {
+                "condition_type": "Age",
+                "operator": ">=",
+                "quantity": 12,
+                "unit": "years"
+              }
+            ]
+          },
+          "transition": "Prescribe_Strong_Opioid"
+        },
+        {
+          "transition": "Strong_Opioid_Terminal"
+        }
+      ]
+    },
+
+    "Prescribe_Strong_Opioid": {
+      "type": "Simple",
+      "complex_transition": [
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1920
+          },
+          "distributions": [
+            {
+              "distribution": 1,
+              "transition": "Strong_Opioid_Terminal"
+            }
+          ]
+        },
+        {
+          "condition": {
+            "condition_type": "Date",
+            "operator": "<",
+            "year": 1947
+          },
+          "distributions": [
+            {
+              "distribution": 1,
+              "transition": "Prescribe_Oxycodone"
+            }
+          ]
+        },
+        {
+          "distributions": [
+            {
+              "distribution": 0.6,
+              "transition": "Prescribe_Oxycodone"
+            },
+            {
+              "distribution": 0.4,
+              "transition": "Prescribe_Methadone"
+            }
+          ]
+        }
+      ]
+    },
+
+    "Prescribe_Oxycodone": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "opioid_prescription",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1049683",
+          "display": "oxyCODONE Hydrochloride 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 1,
+          "period": 6,
+          "unit": "hours"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        }
+      },
+      "direct_transition": "Strong_Opioid_Terminal"
+    },
+
+    "Prescribe_Methadone": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "opioid_prescription",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "864718",
+          "display": "Methadone Hydrochloride 5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "dosage": {
+          "amount": 1,
+          "frequency": 1,
+          "period": 12,
+          "unit": "hours"
+        },
+        "duration": {
+          "quantity": 2,
+          "unit": "weeks"
+        }
+      },
+      "direct_transition": "Strong_Opioid_Terminal"
+    },
+
+    "Strong_Opioid_Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/lib/generic/modules/total_joint_replacement.json
+++ b/lib/generic/modules/total_joint_replacement.json
@@ -135,6 +135,12 @@
           "display": "Stretching exercises"
         }
       ],
+      "direct_transition": "Post_Op_Prescribe_Pain_Reliever"
+    },
+
+    "Post_Op_Prescribe_Pain_Reliever": {
+      "type": "CallSubmodule",
+      "submodule": "medications/moderate_opioid_pain_reliever",
       "direct_transition": "In_Hospital_Post_Surgery_Recovery"
     },
 
@@ -186,7 +192,7 @@
         }
       ]
     },
-    
+
     "Terminal": {
       "type": "Terminal"
     }

--- a/lib/tasks/graphviz.rb
+++ b/lib/tasks/graphviz.rb
@@ -291,7 +291,7 @@ module Synthea
           if unit
             unit = 'in ' + unit.gsub('{','(').gsub('}',')') # replace curly braces with parens, braces can cause issues
           end
-          
+
           if state.has_key? 'vital_sign'
             details = "Record value from Vital Sign '#{state['vital_sign']}' #{unit}\\l"
           elsif state.has_key? 'attribute'
@@ -430,7 +430,7 @@ module Synthea
         when 'True', 'False'
           logic['condition_type']
         else
-          raise "Unsupported Conditon: #{logic['condition_type']}"
+          raise "Unsupported Condition: #{logic['condition_type']}"
         end
       end
 


### PR DESCRIPTION
These were the O.G. submodules that I finally got around to compiling and integrating with our existing modules. I created several different submodules that prescribe commonly used medications across several main modules:

* OTC Pain Relievers
* OTC Antihistamines
* Moderate Opioid Pain Relievers (post surgery, or for injuries)
* Strong Opioid Pain Reliever (for chronic pain, e.g. cancer)
* Ear Infection Antibiotic (also used for bacterial infections due to burns/open wounds)

The Strong Opioid Pain Reliever module isn't actually used yet - I expected the cancer modules to prescribe a strong opioid for chronic pain but neither one does. I will go back in and add a strong pain reliever for the late stages of cancer if my approach so far tickles your fancy.

I made updates to some of our modules to use these submodules, namely:

* Allergies/Allergic Rhinitis (otc_antihistamine)
* Ear Infections/Injuries (ear_infection_antibiotic)
* Injuries, surgery (moderate opioid)
* Numerous modules for otc pain reliever

I made a couple of fixes to existing modules as I encountered them, including a partial refactoring where I removed `target_encounter` states, added `duration` fields to procedures, and added `prescription` information to MedicationOrder states. There are still **many** states to refactor this way but I figure it will be a passive effort as we periodically go back in and edit existing modules.

Would love to hear you feedback to see what you like, or what you think may need improvement/expansion.