### PR TITLE
Add Care Goals to CarePlans

### DIFF
--- a/lib/generic/components.rb
+++ b/lib/generic/components.rb
@@ -57,6 +57,14 @@ module Synthea
         end
       end
 
+      class CareGoal < Component
+        attr_accessor :observation, :text, :addresses, :codes
+        required_field or: [:observation, :text, :codes]
+
+        metadata 'observation', type: 'Logic::Observation', min: 0, max: 1
+        metadata 'codes', type: 'Components::Code', min: 0, max: Float::INFINITY
+      end
+
       class Dosage < Component
         attr_accessor :amount, :frequency, :period, :unit
         required_field and: [:amount, :frequency, :period, :unit]

--- a/lib/generic/modules/metabolic_syndrome_care.json
+++ b/lib/generic/modules/metabolic_syndrome_care.json
@@ -282,6 +282,45 @@
           "display" : "Exercise therapy"
         }
       ],
+      "goals" : [
+        {
+          "observation" : {
+            "codes" : [{
+              "system" : "LOINC",
+              "code" : "4548-4",
+              "display" : "Hemoglobin A1c total in Blood"
+            }],
+            "operator" : "<",
+            "value" : "7.0"
+          },
+          "addresses" : ["diabetes_stage"]
+        },
+        {
+          "observation" : {
+            "codes" : [{
+              "system" : "LOINC",
+              "code" : "2339-0",
+              "display" : "Glucose [Mass/volume] in Blood"
+            }],
+            "operator" : "<",
+            "value" : "108"
+          },
+          "addresses" : ["diabetes_stage"]
+        },
+        {
+          "text" : "Maintain blood pressure below 140/90 mmHg",
+          "addresses" : ["diabetes_stage"]
+        },
+        {
+          "text" : "Improve and maintenance of optimal foot health: aim at early detection of peripheral vascular problems and neuropathy presumed due to diabetes; and prevention of diabetic foot ulcer, gangrene",
+          "addresses" : ["diabetes_stage"]
+        },
+        {
+          "text" : "Address patient knowledge deficit on diabetic self-care",
+          "addresses" : ["diabetes_stage"]
+        }
+      ],
+      "remarks" : ["based on https://github.com/clinical-cloud/sample-careplans"],
       "reason" : "diabetes_stage",
       "direct_transition" : "Prescribe_Medications"
     },

--- a/lib/modules/cardiovascular_disease.rb
+++ b/lib/modules/cardiovascular_disease.rb
@@ -442,7 +442,7 @@ module Synthea
 
         if entity[:careplan] && entity[:careplan][:cardiovascular_disease]
           if !entity.record_synthea.careplan_active?(:cardiovascular_disease)
-            entity.record_synthea.careplan_start(:cardiovascular_disease, entity[:careplan][:cardiovascular_disease]['activities'], time, entity[:careplan][:cardiovascular_disease]['reasons'])
+            entity.record_synthea.careplan_start(:cardiovascular_disease, entity[:careplan][:cardiovascular_disease]['activities'], time, 'reasons' => [entity[:careplan][:cardiovascular_disease]['reasons']])
           else
             entity.record_synthea.update_careplan_reasons(:cardiovascular_disease, entity[:careplan][:cardiovascular_disease]['reasons'], time)
           end

--- a/lib/records/record.rb
+++ b/lib/records/record.rb
@@ -124,14 +124,15 @@ module Synthea
         end
       end
 
-      def careplan_start(type, activities, time, reason)
+      def careplan_start(type, activities, time, options = {})
         @careplans << {
           'type' => type,
           'activities' => activities,
           'time' => time,
           'start_time' => time,
-          'reasons' => reason
-        }
+          'reasons' => [],
+          'goals' => []
+        }.merge(options)
       end
 
       def careplan_active?(type)

--- a/lib/tasks/graphviz.rb
+++ b/lib/tasks/graphviz.rb
@@ -360,6 +360,21 @@ module Synthea
             details = details + activity['system'] + "[" + activity['code'] + "]: " + activity['display'] + "\\l"
           end
         end
+        if state.has_key? 'goals'
+          details = details + "\\lGoals:\\l"
+          state['goals'].each do |goal|
+            if goal['text']
+              details = details + goal['text'] + "\\l"
+            elsif goal['codes']
+              code = goal['codes'][0]
+              details = details + code['system'] + "[" + code['code'] + "]: " + code['display'] + "\\l"
+            elsif goal['observation']
+              logic = goal['observation']
+              obs = find_referenced_type(logic)
+              details = details + "Observation #{obs} \\#{logic['operator']} #{logic['value']}\\l"
+            end
+          end
+        end
         if state.has_key? 'duration'
           d = state['duration']
           details = details + "\\lDuration: #{d['low']} - #{d['high']} #{d['unit']}\\l"

--- a/test/unit/exporter_test.rb
+++ b/test/unit/exporter_test.rb
@@ -58,10 +58,10 @@ class ExporterTest < Minitest::Test
   end
 
   def test_export_filter_should_keep_old_active_careplan
-    @record.careplan_start(:stop_smoking, [:activity1], @time - 10.years, :smoking_is_bad_mkay)
+    @record.careplan_start(:stop_smoking, [:activity1], @time - 10.years, 'reasons' => [:smoking_is_bad_mkay])
     @record.careplan_stop(:stop_smoking, @time - 8.years)
 
-    @record.careplan_start(:healthy_diet, [:eat_food_mostly_plants], @time - 12.years, :reason1)
+    @record.careplan_start(:healthy_diet, [:eat_food_mostly_plants], @time - 12.years, 'reasons' => [:reason1])
 
     filtered = Synthea::Output::Exporter.filter_for_export(@patient)
 
@@ -71,7 +71,7 @@ class ExporterTest < Minitest::Test
   end
 
   def test_export_filter_should_keep_careplan_that_ended_during_target
-    @record.careplan_start(:stop_smoking, [:activity1], @time - 10.years, :smoking_is_bad_mkay)
+    @record.careplan_start(:stop_smoking, [:activity1], @time - 10.years, 'reasons' => [:smoking_is_bad_mkay])
     @record.careplan_stop(:stop_smoking, @time - 1.years)
 
     filtered = Synthea::Output::Exporter.filter_for_export(@patient)

--- a/test/unit/generic_logic_test.rb
+++ b/test/unit/generic_logic_test.rb
@@ -293,7 +293,7 @@ class GenericLogicTest < Minitest::Test
     refute(do_test('diabetesCarePlanTest'))
     refute(do_test('anginaCarePlanTest'))
 
-    @patient.record_synthea.careplan_start(:diabetes_self_management_plan, [:diabetic_diet], @time, []) # no reasons given
+    @patient.record_synthea.careplan_start(:diabetes_self_management_plan, [:diabetic_diet], @time) # no reasons given
     assert(do_test('diabetesCarePlanTest'))
     refute(do_test('anginaCarePlanTest'))
 
@@ -302,7 +302,7 @@ class GenericLogicTest < Minitest::Test
     @patient.record_synthea.careplan_stop(:diabetes_self_management_plan, @time)
     refute(do_test('diabetesCarePlanTest'))
 
-    @patient.record_synthea.careplan_start(:angina_careplan, [:healthy_diet], @time, []) # no reasons given
+    @patient.record_synthea.careplan_start(:angina_careplan, [:healthy_diet], @time) # no reasons given
     @patient['Angina_CarePlan'] = :angina_careplan
     assert(do_test('anginaCarePlanTest'))
   end

--- a/test/unit/generic_states_test.rb
+++ b/test/unit/generic_states_test.rb
@@ -718,7 +718,7 @@ class GenericStatesTest < Minitest::Test
 
     # Now process the careplan
     plan = Synthea::Generic::States::CarePlanStart.new(ctx, "Diabetes_Self_Management")
-    @patient.record_synthea.expect(:careplan_start, nil, ['diabetes_self_management_plan'.to_sym, [:diabetic_diet], @time, [condition_id]])
+    @patient.record_synthea.expect(:careplan_start, nil, ['diabetes_self_management_plan'.to_sym, [:diabetic_diet], @time, 'reasons' => [condition_id], 'goals' => []])
     assert(plan.process(@time, @patient))
     ctx.history << plan
 
@@ -765,7 +765,7 @@ class GenericStatesTest < Minitest::Test
     # Now process the careplan
     plan_id = 'diabetes_self_management_plan'.to_sym
     plan = Synthea::Generic::States::CarePlanStart.new(ctx, "CarePlan1_Start")
-    @patient.record_synthea.expect(:careplan_start, nil, [plan_id, [:diabetic_diet], @time, []])  # no reasons provided
+    @patient.record_synthea.expect(:careplan_start, nil, [plan_id, [:diabetic_diet], @time, 'reasons' => [], 'goals' => []])  # no reasons provided
     assert(plan.run(@time, @patient)) # have to use run not process here because the entity attribute stuff happens in run
     ctx.history << plan
 
@@ -806,7 +806,7 @@ class GenericStatesTest < Minitest::Test
     # Now process the careplan
     plan_id = 'angina_self_management_plan'.to_sym
     plan = Synthea::Generic::States::CarePlanStart.new(ctx, "CarePlan2_Start")
-    @patient.record_synthea.expect(:careplan_start, nil, [plan_id, [:exercise_therapy, :healthy_diet], @time, []])  # no reasons provided
+    @patient.record_synthea.expect(:careplan_start, nil, [plan_id, [:exercise_therapy, :healthy_diet], @time, 'reasons' => [], 'goals' => []])  # no reasons provided
     assert(plan.process(@time, @patient))
     ctx.history << plan
 
@@ -845,7 +845,7 @@ class GenericStatesTest < Minitest::Test
     # Now process the careplan
     plan_id = 'immunological_care_management'.to_sym
     plan = Synthea::Generic::States::CarePlanStart.new(ctx, "CarePlan3_Start")
-    @patient.record_synthea.expect(:careplan_start, nil, [plan_id, [:allergen_immunotherapy_drugs_band_1], @time, []])  # no reasons provided
+    @patient.record_synthea.expect(:careplan_start, nil, [plan_id, [:allergen_immunotherapy_drugs_band_1], @time, 'reasons' => [], 'goals' => []])  # no reasons provided
     assert(plan.process(@time, @patient))
     ctx.history << plan
 

--- a/test/unit/record_test.rb
+++ b/test/unit/record_test.rb
@@ -6,8 +6,8 @@ class RecordTest < Minitest::Test
     @record = Synthea::Output::Record.new
     @record.medication_start(:warfarin, @time, [:prediabetes, :coronary_heart_disease])
     @record.medication_start(:sglt2i, @time, [:diabetes, :coronary_heart_disease])
-    @record.careplan_start(:diabetes, [:exercise, :diabetic_diet], @time, [:diabetes])
-    @record.careplan_start(:cardiovascular_disease, [:stress_management, :stop_smoking], @time, [:coronary_heart_disease])
+    @record.careplan_start(:diabetes, [:exercise, :diabetic_diet], @time, 'reasons' => [:diabetes])
+    @record.careplan_start(:cardiovascular_disease, [:stress_management, :stop_smoking], @time, 'reasons' => [:coronary_heart_disease])
   end
 
   def test_medication_stop
@@ -43,7 +43,7 @@ class RecordTest < Minitest::Test
     @record.careplan_stop(:diabetes, @time + 5.minutes)
     assert_equal(@time+5.minutes, @record.careplans[0]['stop'])
     assert_equal(nil, @record.careplans[1]['stop'])
-    @record.careplan_start(:diabetes, [:exercise, :diabetic_diet], @time+10.minutes, :diabetes)
+    @record.careplan_start(:diabetes, [:exercise, :diabetic_diet], @time+10.minutes, 'reasons' => [:diabetes])
     @record.careplan_stop(:diabetes, @time + 15.minutes)
     assert_equal(@time+5.minutes, @record.careplans[0]['stop'])
   end


### PR DESCRIPTION
Introduces Goals within CarePlans. A goal can be defined by an observation with a target value (ex. "get HbA1c below 7.0"), a LOINC code, or free text (ex "Address patient knowledge deficit on diabetic self-care").   

Adds specific goals to Diabetes care plan, based on sample care plans at https://github.com/clinical-cloud/sample-careplans .

Note that in this implementation, goals are set at CarePlanStart and are active until the CarePlanEnd state (if any).  In the future I expect we will want to make these more dynamic - ie, allow different people to have different sets of targeted goals, do different logic based on what goals are active, etc.

![diabetes_caregoals](https://cloud.githubusercontent.com/assets/13512036/23904761/6c42d72a-089f-11e7-9eea-9880202e4c0b.JPG)