### PR TITLE
Add cause of death code to condition lookup, fixes #141

### DIFF
--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -747,6 +747,7 @@ module Synthea
           elsif @condition_onset
             @reason = @context.most_recent_by_name(@condition_onset).symbol
           elsif @codes
+            add_lookup_code(Synthea::COND_LOOKUP)
             @reason = symbol
           end
 

--- a/test/fixtures/generic/death_reason.json
+++ b/test/fixtures/generic/death_reason.json
@@ -29,8 +29,8 @@
             "type": "Death",
             "codes": [{
                 "system": "SNOMED-CT",
-                "code": "73211009",
-                "display": "Diabetes mellitus"
+                "code": "987654321",
+                "display": "Some undiscovered condition"
             }],
             "direct_transition": "Terminal"
         },

--- a/test/unit/generic_states_test.rb
+++ b/test/unit/generic_states_test.rb
@@ -1007,13 +1007,11 @@ class GenericStatesTest < Minitest::Test
     assert(condition.run(@time, @patient))
     ctx.history << condition
 
-    condition_id = :diabetes_mellitus
-
     # Now process the end of the condition
     death = Synthea::Generic::States::Death.new(ctx, "Death_by_Code")
     @patient.record_synthea.expect(:death, nil, [@time])
     @patient.record_synthea.expect(:encounter, nil, [:death_certification, @time])
-    @patient.record_synthea.expect(:observation, nil, [:cause_of_death, @time, :diabetes_mellitus, 'fhir' => :observation, 'ccda' => :no_action])
+    @patient.record_synthea.expect(:observation, nil, [:cause_of_death, @time, :some_undiscovered_condition, 'fhir' => :observation, 'ccda' => :no_action])
     @patient.record_synthea.expect(:diagnostic_report, nil, [:death_certificate, @time, 1])
     assert(death.process(@time, @patient))
 


### PR DESCRIPTION
When a Death state contains a code, that code should be added to the condition LOOKUP so it's available later in the fhir exporter