### PR TITLE
 Add cause of death code to condition lookup, fixes #141 

### DIFF
--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -747,6 +747,7 @@ module Synthea
           elsif @condition_onset
             @reason = @context.most_recent_by_name(@condition_onset).symbol
           elsif @codes
+            add_lookup_code(Synthea::COND_LOOKUP)
             @reason = symbol
           end
 

--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -325,6 +325,7 @@ module Synthea
         metadata 'target_encounter', reference_to_state_type: 'Encounter', min: 0, max: 1
 
         def process(time, entity)
+          add_lookup_code(Synthea::COND_LOOKUP)
           diagnose(time, entity) if concurrent_with_target_encounter(time)
           true
         end
@@ -332,7 +333,6 @@ module Synthea
 
       class ConditionOnset < OnsetState
         def diagnose(time, entity)
-          add_lookup_code(Synthea::COND_LOOKUP)
           entity.record_synthea.condition(symbol, time)
           @diagnosed = true
         end
@@ -364,7 +364,6 @@ module Synthea
 
       class AllergyOnset < OnsetState
         def diagnose(time, entity)
-          add_lookup_code(Synthea::COND_LOOKUP)
           entity.record_synthea.condition(symbol, time, :allergy, :condition)
           @diagnosed = true
         end

--- a/lib/modules/cardiovascular_disease.rb
+++ b/lib/modules/cardiovascular_disease.rb
@@ -442,7 +442,7 @@ module Synthea
 
         if entity[:careplan] && entity[:careplan][:cardiovascular_disease]
           if !entity.record_synthea.careplan_active?(:cardiovascular_disease)
-            entity.record_synthea.careplan_start(:cardiovascular_disease, entity[:careplan][:cardiovascular_disease]['activities'], time, 'reasons' => [entity[:careplan][:cardiovascular_disease]['reasons']])
+            entity.record_synthea.careplan_start(:cardiovascular_disease, entity[:careplan][:cardiovascular_disease]['activities'], time, 'reasons' => entity[:careplan][:cardiovascular_disease]['reasons'])
           else
             entity.record_synthea.update_careplan_reasons(:cardiovascular_disease, entity[:careplan][:cardiovascular_disease]['reasons'], time)
           end

--- a/test/fixtures/generic/death_reason.json
+++ b/test/fixtures/generic/death_reason.json
@@ -29,8 +29,8 @@
             "type": "Death",
             "codes": [{
                 "system": "SNOMED-CT",
-                "code": "73211009",
-                "display": "Diabetes mellitus"
+                "code": "987654321",
+                "display": "Some undiscovered condition"
             }],
             "direct_transition": "Terminal"
         },

--- a/test/unit/generic_states_test.rb
+++ b/test/unit/generic_states_test.rb
@@ -1007,13 +1007,11 @@ class GenericStatesTest < Minitest::Test
     assert(condition.run(@time, @patient))
     ctx.history << condition
 
-    condition_id = :diabetes_mellitus
-
     # Now process the end of the condition
     death = Synthea::Generic::States::Death.new(ctx, "Death_by_Code")
     @patient.record_synthea.expect(:death, nil, [@time])
     @patient.record_synthea.expect(:encounter, nil, [:death_certification, @time])
-    @patient.record_synthea.expect(:observation, nil, [:cause_of_death, @time, :diabetes_mellitus, 'fhir' => :observation, 'ccda' => :no_action])
+    @patient.record_synthea.expect(:observation, nil, [:cause_of_death, @time, :some_undiscovered_condition, 'fhir' => :observation, 'ccda' => :no_action])
     @patient.record_synthea.expect(:diagnostic_report, nil, [:death_certificate, @time, 1])
     assert(death.process(@time, @patient))
 


### PR DESCRIPTION
When a Death state contains a code, that code should be added to the condition LOOKUP so it's available later in the fhir exporter. Tweaks the ConditionOnset and AllergyOnset state so their codes are added to LOOKUP when the state is processed, not when the condition is diagnosed. 

Also fixed another small bug where the cardiovascular disease careplan reasons were "double-wrapped" in arrays.