### PR TITLE
Add Osteoporosis module

### DIFF
--- a/lib/generic/modules/injuries.json
+++ b/lib/generic/modules/injuries.json
@@ -1225,8 +1225,119 @@
           ]
         }
       ],
-      "direct_transition": "End_Broken_Bone_Encounter"
+      "direct_transition": "Consider_Osteoporosis"
     },
+
+    "Consider_Osteoporosis" : {
+      "type" : "Simple",
+      "complex_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Active Condition",
+            "codes" : [{
+              "system" : "SNOMED-CT",
+              "code" : "64859006",
+              "display" : "Osteoporosis (disorder)"
+            }]
+          },
+          "transition" : "Diagnose_Fracture_Due_to_Osteoporosis"
+        },
+        {
+          "condition": {
+            "condition_type": "Age",
+            "operator": ">",
+            "quantity": 50,
+            "unit": "years"
+          },
+          "transition" : "Osteoporosis_Workup"
+        },
+        {
+          "distributions" : [
+            { "distribution" : 0.02, "transition" : "Osteoporosis_Workup"},
+            { "distribution" : 0.98, "transition" : "End_Broken_Bone_Encounter"}
+          ],
+          "remarks" : ["Give all people a small chance to check for osteoporosis",
+                       "Frequent checks are not valuable -- ",
+                       "https://www.nih.gov/news-events/nih-research-matters/how-often-should-women-have-bone-tests"]
+        }
+      ]
+    },
+
+    "Osteoporosis_Workup" : {
+      "type" : "Procedure",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "312681000",
+        "display" : "Bone density scan (procedure)"
+      }],
+      "reason" : "broken_bone",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Attribute",
+            "attribute" : "osteoporosis",
+            "operator" : "==",
+            "value" : true
+          },
+          "transition" : "Low_Bone_Density"
+        },
+        {
+          "transition" : "High_Bone_Density"
+        }
+      ]
+    },
+
+    "High_Bone_Density" : {
+      "type" : "Observation",
+      "category" : "procedure",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "38265-5",
+        "display" : "DXA [T-score] Bone density"
+      }],
+      "remarks" : ["TODO - This code is specifically for radius/ulna.",
+                   "Future impl may want to use a different code depending on what bone was broken"],
+      "range" : { "low" :  -0.5, "high" : 0.5 },
+      "unit" : "{T-score}",
+      "direct_transition" : "End_Broken_Bone_Encounter"
+    },
+
+    "Low_Bone_Density" : {
+      "type" : "Observation",
+      "category" : "procedure",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "38265-5",
+        "display" : "DXA [T-score] Bone density"
+      }],
+      "range" : { "low" :  -3.8, "high" : -2.5 },
+      "unit" : "{T-score}",
+      "remarks" : ["WHO definition of osteoporosis is a T-score < 2.5",
+                   "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1963365/"],
+      "direct_transition" : "Diagnose_Osteoporosis"
+    },
+
+
+    "Diagnose_Osteoporosis" : {
+      "type" : "ConditionOnset",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "64859006",
+        "display" : "Osteoporosis (disorder)"
+      }],
+      "direct_transition" : "Diagnose_Fracture_Due_to_Osteoporosis"
+    },
+
+    "Diagnose_Fracture_Due_to_Osteoporosis" : {
+      "type" : "ConditionOnset",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "443165006",
+        "display" : "Pathological fracture due to osteoporosis (disorder)"
+      }],
+      "direct_transition" : "End_Broken_Bone_Encounter"
+    },
+
 
     "End_Broken_Bone_Encounter" : {
       "type" : "EncounterEnd",
@@ -1260,6 +1371,27 @@
     "End_Broken_Bone_Injury": {
       "type": "ConditionEnd",
       "referenced_by_attribute": "broken_bone",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Active Condition",
+            "codes" : [{
+              "system" : "SNOMED-CT",
+              "code" : "443165006",
+              "display" : "Pathological fracture due to osteoporosis (disorder)"
+            }]
+          },
+          "transition" : "End_Osteoporosis_Fracture"
+        },
+        {
+          "transition" : "End_Broken_Bone_Followup"
+        }
+      ]
+    },
+
+    "End_Osteoporosis_Fracture" : {
+      "type" : "ConditionEnd",
+      "condition_onset" : "Diagnose_Fracture_Due_to_Osteoporosis",
       "direct_transition": "End_Broken_Bone_Followup"
     },
 

--- a/lib/generic/modules/injuries.json
+++ b/lib/generic/modules/injuries.json
@@ -251,59 +251,131 @@
       "remarks": [
         "The incidence rates for elderly (65+)."
       ],
-      "distributed_transition": [
+      "complex_transition": [
         {
-          "distribution": 0.000153,
-          "transition": "Spinal_Injury"
+          "condition" : {
+            "condition_type" : "Attribute",
+            "attribute" : "osteoporosis",
+            "operator" : "==",
+            "value" : true
+          },
+          "distributions" : [
+            {
+              "distribution": 0.000153,
+              "transition": "Spinal_Injury"
+            },
+            {
+              "distribution": 0.000318,
+              "transition": "Gunshot_Injury"
+            },
+            {
+              "distribution": 0.0051,
+              "transition": "Concussion_Injury"
+            },
+            {
+              "distribution": 0.00478,
+              "transition": "Whiplash_Injury"
+            },
+            {
+              "distribution": 0.06,
+              "remarks": [
+                "Highest probability for elderly with osteoporosis.",
+                "see also http://www.shef.ac.uk/FRAX/charts.aspx",
+                "10-yr probability of major fracture varies significantly based on age & bone density",
+                "assume a medium risk of 40% chance over 10 years ~~> 6% chance per yr"
+              ],
+              "transition": "Broken_Bone_Injury"
+            },
+            {
+              "distribution": 0.00398,
+              "transition": "Burn_Injury"
+            },
+            {
+              "distribution": 0.015,
+              "transition": "Laceration_Injury"
+            },
+            {
+              "distribution": 0.0125,
+              "transition": "Sprain_Injury"
+            },
+            {
+              "distribution": 0.00229,
+              "transition": "Knee_Injury"
+            },
+            {
+              "distribution": 0.00147,
+              "transition": "Shoulder_Injury"
+            },
+            {
+              "distribution": 0.5,
+              "transition": "Wait_For_Injury",
+              "remarks": [
+                "The GMF's distributed transition will take this transition and automatically adjust the distribution ",
+                "out of 1.0 if none of the other transitions are taken, see: ",
+                "https://github.com/synthetichealth/synthea/wiki/Generic-Module-Framework%3A-Transitions#distributed"
+              ]
+            }
+          ]
         },
         {
-          "distribution": 0.000318,
-          "transition": "Gunshot_Injury"
-        },
-        {
-          "distribution": 0.0051,
-          "transition": "Concussion_Injury"
-        },
-        {
-          "distribution": 0.00478,
-          "transition": "Whiplash_Injury"
-        },
-        {
-          "distribution": 0.0583,
-          "remarks": [
-            "Retain highest probability for elderly."
-          ],
-          "transition": "Broken_Bone_Injury"
-        },
-        {
-          "distribution": 0.00398,
-          "transition": "Burn_Injury"
-        },
-        {
-          "distribution": 0.015,
-          "transition": "Laceration_Injury"
-        },
-        {
-          "distribution": 0.0125,
-          "transition": "Sprain_Injury"
-        },
-        {
-          "distribution": 0.00229,
-          "transition": "Knee_Injury"
-        },
-        {
-          "distribution": 0.00147,
-          "transition": "Shoulder_Injury"
-        },
-        {
-          "distribution": 0.5,
-          "transition": "Wait_For_Injury",
-          "remarks": [
-            "The GMF's distributed transition will take this transition and automatically adjust the distribution ",
-            "out of 1.0 if none of the other transitions are taken, see: ",
-            "https://github.com/synthetichealth/synthea/wiki/Generic-Module-Framework%3A-Transitions#distributed"
+          "remarks" : ["elderly patients who do not have osteoporosis"],
+          "distributions" : [
+            {
+              "distribution": 0.000153,
+              "transition": "Spinal_Injury"
+            },
+            {
+              "distribution": 0.000318,
+              "transition": "Gunshot_Injury"
+            },
+            {
+              "distribution": 0.0051,
+              "transition": "Concussion_Injury"
+            },
+            {
+              "distribution": 0.00478,
+              "transition": "Whiplash_Injury"
+            },
+            {
+              "distribution": 0.035,
+              "remarks": [
+                "Retain high probability for elderly - reduced somewhat here since these are the patients without osteoporosis"
+              ],
+              "transition": "Broken_Bone_Injury"
+            },
+            {
+              "distribution": 0.00398,
+              "transition": "Burn_Injury"
+            },
+            {
+              "distribution": 0.015,
+              "transition": "Laceration_Injury"
+            },
+            {
+              "distribution": 0.0125,
+              "transition": "Sprain_Injury"
+            },
+            {
+              "distribution": 0.00229,
+              "transition": "Knee_Injury"
+            },
+            {
+              "distribution": 0.00147,
+              "transition": "Shoulder_Injury"
+            },
+            {
+              "distribution": 0.5,
+              "transition": "Wait_For_Injury",
+              "remarks": [
+                "The GMF's distributed transition will take this transition and automatically adjust the distribution ",
+                "out of 1.0 if none of the other transitions are taken, see: ",
+                "https://github.com/synthetichealth/synthea/wiki/Generic-Module-Framework%3A-Transitions#distributed"
+              ]
+            }
           ]
         }
+
+
       ]
     },
 
@@ -1002,30 +1074,76 @@
         "4. Hip (but this occurs mostly in older women with osteoporosis) ",
         "5. Ankle "
       ],
-      "distributed_transition": [
+      "complex_transition": [
         {
-          "distribution": 0.2,
-          "transition": "Broken_Clavicle"
+          "condition" : {
+            "condition_type" : "Attribute",
+            "attribute" : "osteoporosis",
+            "operator" : "==",
+            "value" : true
+          },
+          "remarks" : ["For the year 2000, there were an estimated 9 million new osteoporotic fractures, ",
+                       "of which 1.6 million were at the hip, 1.7 million were at the forearm ",
+                       "and 1.4 million were clinical vertebral fractures. ",
+                       "-- https://www.iofbonehealth.org/facts-statistics",
+                       "1.6 / 9 == 18%, 1.7/9 == 19%. ",
+                       "4.7 million not included in that stat, so we assume the distribution of the rest"],
+          "distributions" : [
+            {
+              "distribution": 0.1,
+              "transition": "Broken_Clavicle"
+            },
+            {
+              "distribution": 0.415,
+              "transition": "Broken_Arm",
+              "remarks" : [".225 normally + .19 new"]
+            },
+            {
+              "distribution": 0.1,
+              "transition": "Broken_Wrist"
+            },
+            {
+              "distribution": 0.1,
+              "transition": "Broken_Ankle"
+            },
+            {
+              "distribution": 0.05,
+              "transition": "Broken_Rib"
+            },
+            {
+              "distribution": 0.23,
+              "transition": "Broken_Hip",
+              "remarks" : [".05 below + .18 new"]
+            }
+          ]
         },
         {
-          "distribution": 0.2,
-          "transition": "Broken_Arm"
-        },
-        {
-          "distribution": 0.2,
-          "transition": "Broken_Wrist"
-        },
-        {
-          "distribution": 0.2,
-          "transition": "Broken_Ankle"
-        },
-        {
-          "distribution": 0.1,
-          "transition": "Broken_Rib"
-        },
-        {
-          "distribution": 0.1,
-          "transition": "Broken_Hip"
+          "distributions" : [
+            {
+              "distribution": 0.225,
+              "transition": "Broken_Clavicle"
+            },
+            {
+              "distribution": 0.225,
+              "transition": "Broken_Arm"
+            },
+            {
+              "distribution": 0.2,
+              "transition": "Broken_Wrist"
+            },
+            {
+              "distribution": 0.2,
+              "transition": "Broken_Ankle"
+            },
+            {
+              "distribution": 0.1,
+              "transition": "Broken_Rib"
+            },
+            {
+              "distribution": 0.05,
+              "transition": "Broken_Hip"
+            }
+          ]
         }
       ]
     },

--- a/lib/generic/modules/osteoporosis.json
+++ b/lib/generic/modules/osteoporosis.json
@@ -1,0 +1,177 @@
+{
+  "name" : "Osteoporosis",
+  "remarks" : ["This very basic module uses pure prevalence stats to just set osteoporosis on patients based on age/sex",
+               "https://www.iofbonehealth.org/facts-statistics",
+               "In reality osteoporosis is progressive and gets worse over time, it doesn't suddenly onset one day"],
+  "states" : {
+
+    "Initial" : {
+      "type" : "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Gender",
+            "gender": "M"
+          },
+          "transition": "Male"
+        },
+        {
+          "condition": {
+            "condition_type": "Gender",
+            "gender": "F"
+          },
+          "transition": "Female"
+        }
+      ]
+    },
+
+    "Female" : {
+      "type" : "Simple",
+      "remarks" : ["Osteoporosis is estimated to affect 200 million women worldwide",
+                   "approximately one-tenth of women aged 60, one-fifth of women aged 70, ",
+                   "two-fifths of women aged 80 and two-thirds of women aged 90",
+                   "https://www.iofbonehealth.org/facts-statistics"],
+      "distributed_transition" : [
+        { "distribution" : 0.1, "transition" : "Onset_Age_60" },
+        { "distribution" : 0.1, "transition" : "Onset_Age_70", "remarks" : "== 1/5 minus the 1/10 from the previous entry" },
+        { "distribution" : 0.2, "transition" : "Onset_Age_80", "remarks" : "== 2/5 minus the 1/5 from the previous entry"  },
+        { "distribution" : 0.2667, "transition" : "Onset_Age_90", "remarks" : "== 2/3 minus the 2/5 from the previous entry"  },
+        { "distribution" : 0.3333, "transition" : "Terminal" }
+      ]
+    },
+
+    "Male" : {
+      "type" : "Simple",
+      "remarks" : ["statistics for men are not as easy to find as for women",
+                  "Worldwide, 1 in 3 women over age 50 will experience osteoporotic fractures, as will 1 in 5 men aged over 50",
+                  "so for this model we scale the %s for women by .6 (.333 * .6 = .2)"],
+      "distributed_transition" : [
+        { "distribution" : 0.06, "transition" : "Onset_Age_60" },
+        { "distribution" : 0.06, "transition" : "Onset_Age_70" },
+        { "distribution" : 0.12, "transition" : "Onset_Age_80" },
+        { "distribution" : 0.16, "transition" : "Onset_Age_90" },
+        { "distribution" : 0.44, "transition" : "Terminal" }
+      ]
+    },
+
+    "Onset_Age_60" : {
+      "type" : "Delay",
+      "exact" : { "quantity" : 60, "unit" : "years" },
+      "direct_transition" : "Onset_Osteoporosis"
+    },
+
+    "Onset_Age_70" : {
+      "type" : "Delay",
+      "exact" : { "quantity" : 70, "unit" : "years" },
+      "direct_transition" : "Onset_Osteoporosis"
+    },
+
+    "Onset_Age_80" : {
+      "type" : "Delay",
+      "exact" : { "quantity" : 80, "unit" : "years" },
+      "direct_transition" : "Onset_Osteoporosis"
+    },
+
+    "Onset_Age_90" : {
+      "type" : "Delay",
+      "exact" : { "quantity" : 90, "unit" : "years" },
+      "direct_transition" : "Onset_Osteoporosis"
+    },
+
+    "Onset_Osteoporosis" : {
+      "type" : "SetAttribute",
+      "attribute" : "osteoporosis",
+      "value" : true,
+      "direct_transition" : "Wellness_Encounter"
+    },
+
+    "Wellness_Encounter" : {
+      "type" : "Encounter",
+      "wellness" : true,
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type" : "Active Condition",
+            "codes" : [{
+              "system" : "SNOMED-CT",
+              "code" : "64859006",
+              "display" : "Osteoporosis (disorder)"
+            }]
+          },
+          "transition" : "Consider_Medication"
+        },
+        {
+          "transition" : "Osteoporosis_Workup"
+        }
+      ]
+    },
+
+    "Osteoporosis_Workup" : {
+      "type" : "Procedure",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "312681000",
+        "display" : "Bone density scan (procedure)"
+      }],
+      "direct_transition" : "Bone_Density"
+    },
+
+    "Bone_Density" : {
+      "type" : "Observation",
+      "category" : "procedure",
+      "codes" : [{
+        "system" : "LOINC",
+        "code" : "38265-5",
+        "display" : "DXA [T-score] Bone density"
+      }],
+      "range" : { "low" :  -3.8, "high" : -2.5 },
+      "unit" : "{T-score}",
+      "remarks" : ["WHO definition of osteoporosis is a T-score < 2.5",
+                   "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1963365/"],
+      "direct_transition" : "Diagnose_Osteoporosis"
+    },
+
+    "Diagnose_Osteoporosis" : {
+      "type" : "ConditionOnset",
+      "codes" : [{
+        "system" : "SNOMED-CT",
+        "code" : "64859006",
+        "display" : "Osteoporosis (disorder)"
+      }],
+      "direct_transition" : "Consider_Medication"
+    },
+
+    "Consider_Medication" : {
+      "type" : "Simple",
+      "conditional_transition" : [
+        {
+          "condition" : {
+            "condition_type": "Date",
+            "operator": ">=",
+            "year": 1995
+          },
+          "transition" : "Prescribe_Bisphosphate"
+        },
+        {
+          "transition" : "Terminal",
+          "remarks" : "bisphosphates are the best medicine for osteoporosis, but not available until ~1995"
+        }
+      ]
+    },
+
+    "Prescribe_Bisphosphate" : {
+      "type" : "MedicationOrder",
+      "codes" : [{
+        "system" : "RxNorm",
+        "code" : "904420",
+        "display" : "Alendronic acid 10 MG [Fosamax]"
+      }],
+      "direct_transition" : "Terminal"
+    },
+
+    "Terminal" : {
+      "type" : "Terminal"
+    }
+
+  }
+}


### PR DESCRIPTION
Based on feedback that fractures should trigger an osteoporosis workup in the elderly:

 - Adds a simple module that onsets Osteoporosis at realistic prevalences by age
 - Adds a section in the Injuries module following broken bones that can result in a diagnosis of osteoporosis.

Injuries snippet:
![injuries_snippet](https://cloud.githubusercontent.com/assets/13512036/24213498/07af5548-0f09-11e7-98b1-595ee6e3c8b5.png)


Osteoporosis module:
![osteoporosis](https://cloud.githubusercontent.com/assets/13512036/24213504/0c709a74-0f09-11e7-9480-388efb97d340.png)

