### PR TITLE
fix minitest warnings, resolves #155

### DIFF
--- a/test/unit/generic_context_test.rb
+++ b/test/unit/generic_context_test.rb
@@ -19,7 +19,7 @@ class GenericContextTest < Minitest::Test
     assert_equal("Examplitis", ctx.name)
     assert_equal("example_module", ctx.current_module)
     assert_equal("Initial", ctx.current_state.name)
-    assert_equal(nil, ctx.current_encounter)
+    assert_nil ctx.current_encounter
     assert_equal([], ctx.history)
     assert(ctx.active?)
     refute(ctx.active_submodule?)
@@ -176,7 +176,7 @@ class GenericContextTest < Minitest::Test
 
     assert_equal("Terminal", ctx.current_state.name)
     assert_equal(@time.advance(days: 5), ctx.current_state.entered)
-    assert_equal(nil, ctx.current_state.exited)
+    assert_nil ctx.current_state.exited
   end
 
   def test_call_submodule
@@ -219,7 +219,7 @@ class GenericContextTest < Minitest::Test
     # Should block in the encounter submodule, before the encounter
     ctx.run(@time, @patient)
     assert(ctx.active_submodule?)
-    assert_equal(nil, ctx.current_encounter)
+    assert_nil ctx.current_encounter
     assert_equal("Delay", ctx.current_state.name)
     assert_equal("Initial", ctx.history.last.name) # the submodule's initial state
 

--- a/test/unit/generic_states_test.rb
+++ b/test/unit/generic_states_test.rb
@@ -875,7 +875,7 @@ class GenericStatesTest < Minitest::Test
     set2 = Synthea::Generic::States::SetAttribute.new(ctx, "Set_Attribute_2")
     assert(set2.process(@time, @patient))
 
-    assert_equal(nil, @patient['Current Opioid Prescription'])
+    assert_nil @patient['Current Opioid Prescription']
   end
 
   def test_procedure_assigns_entity_attribute

--- a/test/unit/record_test.rb
+++ b/test/unit/record_test.rb
@@ -42,7 +42,7 @@ class RecordTest < Minitest::Test
   def test_careplan_stop
     @record.careplan_stop(:diabetes, @time + 5.minutes)
     assert_equal(@time+5.minutes, @record.careplans[0]['stop'])
-    assert_equal(nil, @record.careplans[1]['stop'])
+    assert_nil @record.careplans[1]['stop']
     @record.careplan_start(:diabetes, [:exercise, :diabetic_diet], @time+10.minutes, 'reasons' => [:diabetes])
     @record.careplan_stop(:diabetes, @time + 15.minutes)
     assert_equal(@time+5.minutes, @record.careplans[0]['stop'])


### PR DESCRIPTION
fixes the warnings in the test suite about "Use assert_nil if expecting nil from [...] This will fail in MT6."