### PR TITLE
Rename generation tasks, resolves #179

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,16 @@ bundle install
 ```
 
 ### Generate Synthetic Patients
-Generating an entire population at once...
+Generating the population one at a time...
 
 ```
 bundle exec rake synthea:generate
-```
-Or generating the population one at a time...
-
-```
-bundle exec rake synthea:sequential
 ```
 
 Or generating the population for a county and time based on census statistics...
 
 ```
-bundle exec rake synthea:sequential['./config/Suffolk_County.json']
+bundle exec rake synthea:generate['./config/Suffolk_County.json']
 ```
 
 Some settings can be changed in `./config/synthea.yml`.

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -19,8 +19,8 @@ namespace :synthea do
     Synthea::Tasks::Concepts.inventory
   end
 
-  desc 'generate'
-  task :generate, [] do |_t, _args|
+  desc 'generate the whole population at once'
+  task :population, [] do |_t, _args|
     clear_output
     Synthea::Output::CsvRecord.open_csv_files if Synthea::Config.exporter.csv.export
     start = Time.now
@@ -36,11 +36,18 @@ namespace :synthea do
     puts 'Finished.'
   end
 
-  desc 'sequential generation'
+  desc 'sequential generation, one patient at a time'
+  task :generate, [:datafile] do |_t, args|
+    args.with_defaults(datafile: nil)
+    run_synthea_sequential(args.datafile)
+  end
+
   task :sequential, [:datafile] do |_t, args|
     args.with_defaults(datafile: nil)
+    run_synthea_sequential(args.datafile)
+  end
 
-    datafile = args.datafile
+  def run_synthea_sequential(datafile)
     if datafile
       raise "File not found: #{datafile}" unless File.file?(datafile)
       datafile = File.read(datafile)


### PR DESCRIPTION
Renames the `generate` task to `population` and renames the `sequential` task to `generate`. We really only use the sequential generation, so it makes more sense for that to be "generate". Sequential can still be called from the `sequential` task, just in case anyone had any scripts using that.

Updated the README with the new name. I didn't mention the `population` task since it's temporarily deprecated.

Closes #179