### PR TITLE
Typo

### DIFF
--- a/lib/generic/modules/dementia.json
+++ b/lib/generic/modules/dementia.json
@@ -246,7 +246,7 @@
         {
           "system": "SNOMED-CT",
           "code": "710125008",
-          "display": "Promotion of use of memeory skills"
+          "display": "Promotion of use of memory skills"
         },
         {
           "system": "SNOMED-CT",

--- a/lib/modules/lifecycle.rb
+++ b/lib/modules/lifecycle.rb
@@ -280,7 +280,7 @@ module Synthea
         range = Synthea::Config.metabolic.basic_panel.microalbumin_creatine_ratio.normal
         entity.set_vital_sign(:microalbumin_creatine_ratio, rand(range.first..range.last), 'mg/g')
         if creatinine_clearance > 60
-          entity.set_vital_sign(:egfr, '>60', 'mL/min/{1.73_m2}')
+          entity.set_vital_sign(:egfr, 60, 'mL/min/{1.73_m2}')
         else
           entity.set_vital_sign(:egfr, creatinine_clearance, 'mL/min/{1.73_m2}')
         end


### PR DESCRIPTION
Fixes a misspelling in the dementia module and changes EGRF to an integer because the FHIR exporter only handles `Observation.valueQuantity` and `'>60'` is a String which would produce invalid resources.