### PR TITLE
Add MRN to patients

### DIFF
--- a/config/synthea.yml
+++ b/config/synthea.yml
@@ -7,6 +7,7 @@ synthea:
       export: true
       upload: null # url of the server, ex 'http://fhirserver.example.com:8080'
       use_shr_extensions: true
+      include_mrn: true
     html:
       export: false
     text:

--- a/lib/records/fhir.rb
+++ b/lib/records/fhir.rb
@@ -148,6 +148,11 @@ module Synthea
           patient_resource.identifier << FHIR::Identifier.new('type' => { 'coding' => [{ 'system' => 'http://hl7.org/fhir/v2/0203', 'code' => 'PPN' }] },
                                                               'system' => "#{SHR_EXT}passportNumber", 'value' => entity[:identifier_passport])
         end
+        # add medical record number
+        if Synthea::Config.exporter.fhir.include_mrn
+          patient_resource.identifier << FHIR::Identifier.new('type' => { 'coding' => [{ 'system' => 'http://hl7.org/fhir/v2/0203', 'code' => 'MR' }] },
+                                                              'system' => 'http://hospital.smarthealthit.org', 'value' => entity.record_synthea.patient_info[:uuid])
+        end
         # add biometric data
         if entity[:fingerprint]
           patient_resource.photo << FHIR::Attachment.new('contentType' => 'image/png', 'title' => 'Biometrics.Fingerprint',


### PR DESCRIPTION
Currently the patients do not have an MRN identifier. While this is valid, the issue is that there are many existing FHIR applications that (incorrectly) assume that all the patients do have MRN.
Since we are trying to make the transition to STU3 as smooth as possible, I have added an MRN to the patient identifiers which will use the  uuid as it's value. There is also an option to turn this off in the config file.