### PR TITLE
update version built on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.1.0
+  - 2.1.10
   - 2.4.1
   - jruby-9.1.5.0
 script:


### PR DESCRIPTION
Travis is migrating from their default build system being Ubuntu 12.04 to 14.04. 14.04 doesn't have a precompiled version of ruby 2.1.0 so builds are failing right now. 

```
$ rvm use 2.1.0 --install --binary --fuzzy
ruby-2.1.0 is not installed - installing.
Searching for binary rubies, this might take some time.
Requested binary installation but no rubies are available to download, consider skipping --binary flag.
Gemset '' does not exist, 'rvm ruby-2.1.0 do rvm gemset create ' first, or append '--create'.

The command "rvm use 2.1.0 --install --binary --fuzzy" failed and exited with 2 during .
```
(see https://travis-ci.org/synthetichealth/synthea/jobs/257874893 )

The simplest fix is to bump the ruby version that travis builds with to 2.1.10 which is available as a precompiled ruby on 14.04.

For more info:
https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default
http://rubies.travis-ci.org/