### PR TITLE
graphviz handles named transition probabilities

### DIFF
--- a/lib/tasks/graphviz.rb
+++ b/lib/tasks/graphviz.rb
@@ -226,10 +226,24 @@ module Synthea
             end
           elsif state.has_key? 'distributed_transition'
             state['distributed_transition'].each do |t|
-              pct = t['distribution'] * 100
-              pct = pct.to_i if pct == pct.to_i
+              distribution = t['distribution']
+              if distribution.is_a?(Hash)
+                # named attribute transition
+                dist_label = "p(#{distribution['attribute']})"
+
+                if distribution['default']
+                  pct = distribution['default'] * 100
+                  pct = pct.to_i if pct == pct.to_i
+                  dist_label << ", default #{pct}%" 
+                end
+              else
+                pct = distribution * 100
+                pct = pct.to_i if pct == pct.to_i
+                dist_label = "#{pct}%"
+              end
+
               begin
-                g.add_edges( nodeMap[name], nodeMap[t['transition']], label("#{pct}%") )
+                g.add_edges( nodeMap[name], nodeMap[t['transition']], label( dist_label ) )
               rescue
                 raise "State '#{name}' is transitioning to an unknown state: '#{t['transition']}'"
               end


### PR DESCRIPTION
Adds named transition probability support to the graphviz rake task. While named transitions are currently only supported in the java version of synthea, we'll need some way to visualize modules with these named transitions until the java version supports graphviz.

Sample: (see branch at top of image)

![lung cancer](https://user-images.githubusercontent.com/13512036/30392209-1f0b2fcc-988a-11e7-97b6-86c4863f8991.png)
