### PR TITLE
Workaround for issue #222

### DIFF
--- a/lib/generic/states.rb
+++ b/lib/generic/states.rb
@@ -197,7 +197,13 @@ module Synthea
           if @expiration.nil?
             if !@range.nil?
               # choose a random duration within the specified range
-              @expiration = @range.value.since(@start_time)
+              selected = @range.value
+
+              # TODO: sometimes instead of an ActiveSupport::Duration we get a Float back
+              # so this is a hack to force it to a Duration
+              selected = selected.seconds if selected.class == Float
+
+              @expiration = selected.since(@start_time)
             elsif !@exact.nil?
               @expiration = @exact.value.since(@start_time)
             else


### PR DESCRIPTION
Due to a bug somewhere, there's an issue where `rand()` called with a `Range` of `ActiveSupport::Duration`s occasionally returns a `Float` instead of an `ActiveSupport::Duration` as would be expected. This is a hack to check for that scenario and create a Duration from the Float so we can use it as expected. 