### PR TITLE
Update version of jruby used by travis.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,29 @@ Documentation:
 Metrics:
   Enabled: false
 
+Style/ConditionalAssignment:
+  Enabled: false
 Style/GuardClause:
   Enabled: false
 Style/HashSyntax:
+  Enabled: false
+Style/IdenticalConditionalBranches:
+  Enabled: false
+Style/InverseMethods:
+  Enabled: false
+Style/MultilineIfModifier:
+  Enabled: false
+Style/MultipleComparison:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Style/RedundantReturn:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/YodaCondition:
+  Enabled: false
+Bundler/OrderedGems:
+  Enabled: false
+Security/YAMLLoad:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.1.10
   - 2.4.1
-  - jruby-9.1.5.0
+  - jruby-9.1.7.0
 script:
   - bundle exec rake test
 after_success:

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'rubocop', '~> 0.49.0', require: false
   gem 'cane', '~> 2.3.0'
   gem 'simplecov', require: false
-  gem 'minitest', '~> 5.3'
+  gem 'minitest'
   gem 'minitest-reporters'
   gem 'awesome_print', require: 'ap'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'distribution', '~> 0.7.3'
 # gem 'byebug'
 
 group :test do
-  gem 'rubocop', '~> 0.43.0', require: false
+  gem 'rubocop', '~> 0.49.0', require: false
   gem 'cane', '~> 2.3.0'
   gem 'simplecov', require: false
   gem 'minitest', '~> 5.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
+    ffi (1.9.18)
     ffi (1.9.18-java)
     ffi (1.9.18-x64-mingw32)
     fhir_client (3.0.2)
@@ -150,8 +151,8 @@ GEM
       rack (>= 1.2, < 3)
     origin (2.3.1)
     parallel (1.11.2)
-    parser (2.4.0.0)
-      ast (~> 2.2)
+    parser (2.4.0.2)
+      ast (~> 2.3)
     pickup (0.0.11)
     powerpack (0.1.1)
     protected_attributes (1.0.9)
@@ -180,8 +181,9 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rubocop (0.43.0)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -208,7 +210,7 @@ GEM
     unf (0.1.4-java)
     unf_ext (0.0.7.4)
     unf_ext (0.0.7.4-x64-mingw32)
-    unicode-display_width (1.2.1)
+    unicode-display_width (1.3.0)
     uuid (2.3.8)
       macaddr (~> 1.0)
     zip-zip (0.3)
@@ -235,10 +237,10 @@ DEPENDENCIES
   rack (~> 1.6)
   rake
   recursive-open-struct
-  rubocop (~> 0.43.0)
+  rubocop (~> 0.49.0)
   simplecov
   synthea!
   tilt
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     method_source (0.8.2)
     mime-types (2.99.3)
     mini_portile2 (2.1.0)
-    minitest (5.10.2)
+    minitest (5.10.3)
     minitest-reporters (1.1.14)
       ansi
       builder
@@ -229,7 +229,7 @@ DEPENDENCIES
   faker
   georuby
   health-data-standards!
-  minitest (~> 5.3)
+  minitest
   minitest-reporters
   net-sftp
   pickup

--- a/test/unit/generic_logic_test.rb
+++ b/test/unit/generic_logic_test.rb
@@ -231,7 +231,7 @@ class GenericLogicTest < Minitest::Test
 
   def test_vital_signs
     @patient[:vital_signs] = {}
-    assert_raises { do_test('SystolicBloodPressureGt120') }
+    assert_raises (NoMethodError) { do_test('SystolicBloodPressureGt120') }
 
     @patient.set_vital_sign(:systolic_blood_pressure, 100, 'mmHg')
     refute(do_test('SystolicBloodPressureGt120'))
@@ -242,7 +242,7 @@ class GenericLogicTest < Minitest::Test
 
   def test_observations
     @patient.record_synthea.observations = []
-    assert_raises { do_test('mmseObservationGt22') }
+    assert_raises (RuntimeError) { do_test('mmseObservationGt22') }
 
     @patient.record_synthea.observation(:mini_mental_state_examination, @time, 12)
     refute(do_test('mmseObservationGt22'))

--- a/test/unit/metadata_test.rb
+++ b/test/unit/metadata_test.rb
@@ -81,10 +81,10 @@ class MetadataTest < Minitest::Test
     assert_equal '(gold and silver)', obj.to_string(and: [:gold, :silver])
     assert_equal '((salt and pepper) or (sugar and spice))', obj.to_string( or: [{ and: [:salt, :pepper] }, { and: [:sugar, :spice] }])
 
-    assert_raises { obj.to_string([:this, :that]) }
-    assert_raises { obj.to_string('string') }
-    assert_raises { obj.to_string({ or: [:this, :that], and: [:something_else] }) } # note this is 2 entries in 1 hash
-    assert_raises { obj.to_string({}) }
+    assert_raises (RuntimeError) { obj.to_string([:this, :that]) }
+    assert_raises (RuntimeError) { obj.to_string('string') }
+    assert_raises (RuntimeError) { obj.to_string({ or: [:this, :that], and: [:something_else] }) } # note this is 2 entries in 1 hash
+    assert_raises (RuntimeError) { obj.to_string({}) }
 
 
 


### PR DESCRIPTION
JRuby build on Travis is failing now due to unit test failures. I have no idea why because those unit tests and associated code haven't changed in a year and the vanilla Ruby builds work correctly.

I tried the latest version of JRuby on my local machine and all the unit tests pass without problem, so I'm updating the travis file to see if this will resolve the issue.