### PR TITLE
Version.txt fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ task versionTxt() {
     }
 }
 
-assemble.dependsOn versionTxt
+compileJava.dependsOn versionTxt
 
 task cleanOutput {
   doLast {


### PR DESCRIPTION
Changes the version.txt generation task so that it always runs before compiling java code. Currently it is set to run before the "assemble" task, but the assemble task is not always run before running the code.  
In other words, someone cloning synthea today and calling the run_synthea script right away will see the error:
```
java.lang.IllegalArgumentException: resource version.txt not found.
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:204)
        at com.google.common.io.Resources.getResource(Resources.java:197)
        at org.mitre.synthea.helpers.Utilities.readResource(Utilities.java:212)
        at org.mitre.synthea.helpers.Utilities.getSyntheaVersion(Utilities.java:194)
        at org.mitre.synthea.helpers.Utilities.<clinit>(Utilities.java:187)
        at org.mitre.synthea.world.geography.Demographics.load(Demographics.java:382)
        at org.mitre.synthea.world.geography.Location.<init>(Location.java:42)
        at org.mitre.synthea.engine.Generator.init(Generator.java:128)
        at org.mitre.synthea.engine.Generator.<init>(Generator.java:99)
        at App.main(App.java:62)
```

This change will ensure the version.txt file is always created (and updated on git pulls, etc) before running synthea via gradle