### PR TITLE
Fix growth calculations according to CDC growth chart formulas.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,8 @@ dependencies {
 	// CSV Stuff
 	compile group: 'org.apache.commons', name: 'commons-csv', version: '1.5'
 	compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.8.8'
-
   compile group: 'org.yaml', name: 'snakeyaml', version: '1.19'
+  compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
 
   // Use JUnit test framework
   testCompile 'junit:junit:4.12'

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -45,6 +45,10 @@ public class Location {
       // because allDemographics will only contain that 1 city
       this.demographics = allDemographics.row(state);
 
+      if (city != null && !demographics.containsKey(city)) {
+        throw new Exception("The city " + city + " was not found in the demographics file.");
+      }
+
       long runningPopulation = 0;
       populationByCity = new LinkedHashMap<>(); // linked to ensure consistent iteration order
       for (Demographics d : this.demographics.values()) {

--- a/src/test/java/org/mitre/synthea/modules/GrowthChartTest.java
+++ b/src/test/java/org/mitre/synthea/modules/GrowthChartTest.java
@@ -6,20 +6,56 @@ import org.junit.Test;
 
 public class GrowthChartTest {
   @Test
+  public void testZScores() throws Exception {
+    /* Z is the z-score that corresponds to the percentile.
+    * z-scores correspond exactly to percentiles, e.g.,
+    * z-scores of:
+    * -1.881, // 3rd
+    * -1.645, // 5th
+    * -1.282, // 10th
+    * -0.674, // 25th
+    *  0,     // 50th
+    *  0.674, // 75th
+    *  1.036, // 85th
+    *  1.282, // 90th
+    *  1.645, // 95th
+    *  1.881  // 97th
+    */
+    double[] zscores = {-1.881, -1.645, -1.282, -0.674,  0.0, 0.674, 1.036, 1.282, 1.645, 1.881};
+    double[] percent = { 0.03, 0.05, 0.10, 0.25, 0.50, 0.75, 0.85, 0.90, 0.95, 0.97};
+    for (int i = 0; i < percent.length; i++) {
+      double z = LifecycleModule.calculateZScore(percent[i]);
+      assertEquals(zscores[i], z, 0.01);
+    }
+  }
+
+  @Test
   public void testGrowthChartLookupMin() throws Exception {
     double height = LifecycleModule.lookupGrowthChart("height", "M", 20, 0.0);
+    assertEquals(74.23114138, height, 0.01);
+  }
+
+  @Test
+  public void testGrowthChartLookupLow() throws Exception {
+    double height = LifecycleModule.lookupGrowthChart("height", "M", 20, 0.03);
     assertEquals(78.06971429, height, 0.01);
   }
 
   @Test
   public void testGrowthChartLookupMiddle() throws Exception {
-    double height = LifecycleModule.lookupGrowthChart("height", "M", 20, 0.6);
+    double height = LifecycleModule.lookupGrowthChart("height", "M", 20, 0.5);
     assertEquals(84.24783394, height, 0.01);
+  }
+
+  @Test
+  public void testGrowthChartLookupHigh() throws Exception {
+    double height = LifecycleModule.lookupGrowthChart("height", "M", 20, 0.97);
+    assertEquals(90.68153436, height, 0.01);
   }
 
   @Test
   public void testGrowthChartLookupMax() throws Exception {
     double height = LifecycleModule.lookupGrowthChart("height", "M", 20, 1.0);
-    assertEquals(90.68153436, height, 0.01);
+    assertEquals(94.95447906, height, 0.01);
   }
 }


### PR DESCRIPTION
Changes the growth from looking up bucket values to calculating the growth according to the CDC formulas. This will give more varied growth to the population.