### PR TITLE
Fix Java 9 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,11 @@ dependencies {
   compile group: 'org.yaml', name: 'snakeyaml', version: '1.19'
   compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
 
+  // Java 9 no longer includes these APIs by default
+  compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.0'
+  compile 'org.glassfish.jaxb:jaxb-runtime:2.3.0'
+  compile 'javax.activation:activation:1.1.1'
+
   // Use JUnit test framework
   testCompile 'junit:junit:4.12'
   testCompile fileTree(dir: 'lib/mdhtruntime/mdht', include: '*.jar')

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,11 @@ dependencies {
   compile 'org.glassfish.jaxb:jaxb-runtime:2.3.0'
   compile 'javax.activation:activation:1.1.1'
 
+  // get rid of SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
+  // if we switch to a real logging framework we may want to switch this
+  compile "org.slf4j:slf4j-api:1.6.1"
+  compile "org.slf4j:slf4j-nop:1.6.1"
+
   // Use JUnit test framework
   testCompile 'junit:junit:4.12'
   testCompile fileTree(dir: 'lib/mdhtruntime/mdht', include: '*.jar')


### PR DESCRIPTION
Synthea doesn't work out of the box on Java 9, since Java 9 marked certain XML libraries as "deprecated" and they are no longer included by default. The recommended fix for maximum compatibility is to manually include these libraries as they are likely to be removed entirely in Java 10.

More info:
https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j/48136912#48136912


Also adds a couple more libraries to get rid of the following error lines at startup, while I was modifying build.gradle anyway:
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```
More info: https://stackoverflow.com/questions/7421612/slf4j-failed-to-load-class-org-slf4j-impl-staticloggerbinder