### PR TITLE
Add modules to concepts list.

### DIFF
--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -25,7 +25,7 @@ public class HealthRecord {
   /**
    * HealthRecord.Code represents a system, code, and display value.
    */
-  public static class Code {
+  public static class Code implements Comparable<Code> {
     /** Code System (e.g. LOINC, RxNorm, SNOMED) identifier (typically a URI) */
     public String system;
     /** The code itself. */
@@ -75,6 +75,15 @@ public class HealthRecord {
         codes.add(new Code((JsonObject) item));
       });
       return codes;
+    }
+
+    @Override
+    public int compareTo(Code other) {
+      int compare = this.system.compareTo(other.system);
+      if (compare == 0) {
+        compare = this.code.compareTo(other.code);
+      }
+      return compare;
     }
   }
 


### PR DESCRIPTION
This reworks the `Concepts` class a little bit. Drops the use of `Table` to use `Map`:

```java
Map<Code,Set<String>> concepts;
```

This allows us to easily track which concepts appear in which modules. Most codes only appear in a single module, but some appear in many.

I also added `Comparable<Code>` to `Code` so that codes could be sorted alphabetically by system and then by code.