### PR TITLE
Claims Revisited

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.UUID;
 
 import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.concepts.Costs;
 import org.mitre.synthea.world.concepts.HealthRecord;
 import org.mitre.synthea.world.concepts.HealthRecord.CarePlan;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
@@ -137,7 +138,7 @@ public class CSVExporter {
     patients.write(NEWLINE);
     allergies.write("START,STOP,PATIENT,ENCOUNTER,CODE,DESCRIPTION");
     allergies.write(NEWLINE);
-    medications.write("START,STOP,PATIENT,ENCOUNTER,CODE,DESCRIPTION,REASONCODE,REASONDESCRIPTION");
+    medications.write("START,STOP,PATIENT,ENCOUNTER,CODE,DESCRIPTION,COST,REASONCODE,REASONDESCRIPTION");
     medications.write(NEWLINE);
     conditions.write("START,STOP,PATIENT,ENCOUNTER,CODE,DESCRIPTION");
     conditions.write(NEWLINE);
@@ -146,11 +147,11 @@ public class CSVExporter {
     careplans.write(NEWLINE);
     observations.write("DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,VALUE,UNITS");
     observations.write(NEWLINE);
-    procedures.write("DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,REASONCODE,REASONDESCRIPTION");
+    procedures.write("DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,COST,REASONCODE,REASONDESCRIPTION");
     procedures.write(NEWLINE);
-    immunizations.write("DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION");
+    immunizations.write("DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,COST");
     immunizations.write(NEWLINE);
-    encounters.write("ID,DATE,PATIENT,CODE,DESCRIPTION,REASONCODE,REASONDESCRIPTION");
+    encounters.write("ID,DATE,PATIENT,CODE,DESCRIPTION,COST,REASONCODE,REASONDESCRIPTION");
     encounters.write(NEWLINE);
   }
   
@@ -288,7 +289,7 @@ public class CSVExporter {
    * @throws IOException if any IO error occurs
    */
   private String encounter(String personID, Encounter encounter) throws IOException {
-    // ID,DATE,PATIENT,CODE,DESCRIPTION,REASONCODE,REASONDESCRIPTION
+    // ID,DATE,PATIENT,CODE,DESCRIPTION,COST,REASONCODE,REASONDESCRIPTION
     StringBuilder s = new StringBuilder();
     
     String encounterID = UUID.randomUUID().toString();
@@ -299,7 +300,9 @@ public class CSVExporter {
     Code coding = encounter.codes.get(0);
     s.append(coding.code).append(',');
     s.append(clean(coding.display)).append(',');
-    
+
+    s.append(String.format("%.2f", Costs.calculateCost(encounter, true))).append(',');
+
     if (encounter.reason == null) {
       s.append(','); // reason code & desc
     } else {
@@ -427,7 +430,7 @@ public class CSVExporter {
    */
   private void procedure(String personID, String encounterID,
       Procedure procedure) throws IOException {
-    // DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,REASONCODE,REASONDESCRIPTION
+    // DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,COST,REASONCODE,REASONDESCRIPTION
     StringBuilder s = new StringBuilder();
     
     s.append(dateFromTimestamp(procedure.start)).append(',');
@@ -438,7 +441,9 @@ public class CSVExporter {
 
     s.append(coding.code).append(',');
     s.append(clean(coding.display)).append(',');
-    
+
+    s.append(String.format("%.2f", Costs.calculateCost(procedure, true))).append(',');
+
     if (procedure.reasons.isEmpty()) {
       s.append(','); // reason code & desc
     } else {
@@ -461,7 +466,7 @@ public class CSVExporter {
    */
   private void medication(String personID, String encounterID,
       Medication medication) throws IOException {
-    // START,STOP,PATIENT,ENCOUNTER,CODE,DESCRIPTION,REASONCODE,REASONDESCRIPTION
+    // START,STOP,PATIENT,ENCOUNTER,CODE,DESCRIPTION,COST,REASONCODE,REASONDESCRIPTION
     StringBuilder s = new StringBuilder();
     
     s.append(dateFromTimestamp(medication.start)).append(',');
@@ -476,7 +481,9 @@ public class CSVExporter {
 
     s.append(coding.code).append(',');
     s.append(clean(coding.display)).append(',');
-    
+
+    s.append(String.format("%.2f", Costs.calculateCost(medication, true))).append(',');
+
     if (medication.reasons.isEmpty()) {
       s.append(','); // reason code & desc
     } else {
@@ -499,7 +506,7 @@ public class CSVExporter {
    */
   private void immunization(String personID, String encounterID,
       Entry immunization) throws IOException  {
-    // DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION
+    // DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,COST
     StringBuilder s = new StringBuilder();
     
     s.append(dateFromTimestamp(immunization.start)).append(',');
@@ -509,8 +516,10 @@ public class CSVExporter {
     Code coding = immunization.codes.get(0);
 
     s.append(coding.code).append(',');
-    s.append(clean(coding.display));
-    
+    s.append(clean(coding.display)).append(',');
+
+    s.append(String.format("%.2f", Costs.calculateCost(immunization, true)));
+
     s.append(NEWLINE);
     write(s.toString(), immunizations);
   }

--- a/src/main/java/org/mitre/synthea/modules/Immunizations.java
+++ b/src/main/java/org/mitre/synthea/modules/Immunizations.java
@@ -45,7 +45,7 @@ public class Immunizations {
     }
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({ "unchecked", "rawtypes" })
   public static void performEncounter(Person person, long time) {
     Map<String, List<Long>> immunizationsGiven;
     if (person.attributes.containsKey(IMMUNIZATIONS)) {
@@ -59,7 +59,7 @@ public class Immunizations {
       if (immunizationDue(immunization, person, time, immunizationsGiven)) {
         List<Long> history = immunizationsGiven.get(immunization);
         history.add(time);
-        HealthRecord.Entry entry = person.record.immunization(time, immunization);
+        HealthRecord.Immunization entry = person.record.immunization(time, immunization);
         Map code = (Map) immunizationSchedule.get(immunization).get("code");
         HealthRecord.Code immCode = new HealthRecord.Code(code.get("system").toString(),
             code.get("code").toString(), code.get("display").toString());

--- a/src/main/java/org/mitre/synthea/world/concepts/Costs.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/Costs.java
@@ -68,6 +68,19 @@ public class Costs {
   }
 
   /**
+   * Whether or not this HealthRecord.Entry has an associated cost on a claim.
+   * Billing cost is not necessarily reimbursed cost or paid cost.
+   * @param entry HealthRecord.Entry
+   * @return true if the entry has a cost; false otherwise
+   */
+  public static boolean hasCost(Entry entry) {
+    return (entry instanceof HealthRecord.Procedure)
+        || (entry instanceof HealthRecord.Medication)
+        || (entry instanceof HealthRecord.Encounter)
+        || (entry instanceof HealthRecord.Immunization);
+  }
+
+  /**
    * Calculate the cost of this Procedure, Encounter, Medication, etc.
    * 
    * @param entry Entry to calculate cost of.
@@ -83,10 +96,10 @@ public class Costs {
       return MEDICATION_COSTS.getOrDefault(code, DEFAULT_MEDICATION_COST);
     } else if (entry instanceof HealthRecord.Encounter) {
       return ENCOUNTER_COSTS.getOrDefault(code, DEFAULT_ENCOUNTER_COST);
-    } else {
-      // Immunizations, Conditions, and Allergies are all just Entries,
-      // but this should only be called for Immunizations
+    } else if (entry instanceof HealthRecord.Immunization) {
       return IMMUNIZATION_COSTS.getOrDefault(code, DEFAULT_IMMUNIZATION_COST);
+    } else {
+      return 0;
     }
   }
 }

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -138,6 +138,12 @@ public class HealthRecord {
     }
   }
 
+  public class Immunization extends Entry {
+    public Immunization(long start, String type) {
+      super(start, type);
+    }
+  }
+
   public class Procedure extends Entry {
     public List<Code> reasons;
 
@@ -211,16 +217,11 @@ public class HealthRecord {
     }
 
     public BigDecimal cost() {
-      if (entry instanceof Procedure) {
-        if (cost == null) {
-          cost = BigDecimal.valueOf(Costs.calculateCost(entry, true));
-          cost = cost.setScale(2, RoundingMode.DOWN); // truncate to 2 decimal places
-        }
-
-        return cost;
+      if (cost == null) {
+        cost = BigDecimal.valueOf(Costs.calculateCost(entry, true));
+        cost = cost.setScale(2, RoundingMode.DOWN); // truncate to 2 decimal places
       }
-
-      return BigDecimal.ZERO;
+      return cost;
     }
   }
 
@@ -464,9 +465,11 @@ public class HealthRecord {
     }
   }
 
-  public Entry immunization(long time, String type) {
-    Entry immunization = new Entry(time, type);
-    currentEncounter(time).immunizations.add(immunization);
+  public Immunization immunization(long time, String type) {
+    Immunization immunization = new Immunization(time, type);
+    Encounter encounter = currentEncounter(time);
+    encounter.immunizations.add(immunization);
+    encounter.claim.addItem(immunization);
     return immunization;
   }
 


### PR DESCRIPTION
This pull request fixes some oddities in Claims representations in FHIR and adds costs to CSV export.

The CSV costs are added directly into the encounters, immunizations, medications, and procedures csv tables. There is no separate claims table with aggregated costs.

The FHIR costs were also changed, as I noticed some weird things while looking at claims in general. Foremost is that now FHIR claims also include charges for immunizations. Second, is that DSTU2 claims were not linked to an Encounter... which doesn't make a whole lot of sense. The individual entries were also using example bindings, where it makes more sense to bind directly to the codes of the services provided (e.g. the procedure code).
