### PR TITLE
VA facilities

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -472,7 +472,7 @@ public abstract class State implements Cloneable {
           person.setCurrentEncounter(module, encounter);
 
           // find closest provider and increment encounters count
-          Provider provider = person.getAmbulatoryProvider();
+          Provider provider = person.getAmbulatoryProvider(time);
           person.addCurrentProvider(module.name, provider);
           int year = Utilities.getYear(time);
           provider.incrementEncounters("wellness", year);
@@ -494,7 +494,7 @@ public abstract class State implements Cloneable {
         person.setCurrentEncounter(module, encounter);
 
         // find closest provider and increment encounters count
-        Provider provider = person.getProvider(encounterClass);
+        Provider provider = person.getProvider(encounterClass, time);
         person.addCurrentProvider(module.name, provider);
         int year = Utilities.getYear(time);
         provider.incrementEncounters(encounterClass, year);
@@ -804,7 +804,7 @@ public abstract class State implements Cloneable {
       Provider medicationProvider = person.getCurrentProvider(module.name);
       if (medicationProvider == null) {
         // no provider associated with encounter or medication order
-        medicationProvider = person.getAmbulatoryProvider();
+        medicationProvider = person.getAmbulatoryProvider(time);
       }
 
       int year = Utilities.getYear(time);
@@ -1010,7 +1010,7 @@ public abstract class State implements Cloneable {
       if (person.getCurrentProvider(module.name) != null) {
         provider = person.getCurrentProvider(module.name);
       } else { // no provider associated with encounter or procedure
-        provider = person.getAmbulatoryProvider();
+        provider = person.getAmbulatoryProvider(time);
       }
       int year = Utilities.getYear(time);
       provider.incrementProcedures(year);
@@ -1214,7 +1214,7 @@ public abstract class State implements Cloneable {
       if (person.getCurrentProvider(module.name) != null) {
         provider = person.getCurrentProvider(module.name);
       } else { // no provider associated with encounter or procedure
-        provider = person.getAmbulatoryProvider();
+        provider = person.getAmbulatoryProvider(time);
       }
       int year = Utilities.getYear(time);
       provider.incrementLabs(year);

--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -500,7 +500,7 @@ public class FhirDstu2 {
             .setServiceProvider(new ResourceReferenceDt(providerOrganization.getFullUrl()));
       }
     } else { // no associated provider, patient goes to ambulatory provider
-      Provider provider = person.getAmbulatoryProvider();
+      Provider provider = person.getAmbulatoryProvider(encounter.start);
       String providerFullUrl = findProviderUrl(provider, bundle);
 
       if (providerFullUrl != null) {

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -598,7 +598,7 @@ public class FhirStu3 {
         encounterResource.setServiceProvider(new Reference(providerOrganization.getFullUrl()));
       }
     } else { // no associated provider, patient goes to ambulatory provider
-      Provider provider = person.getAmbulatoryProvider();
+      Provider provider = person.getAmbulatoryProvider(encounter.start);
       String providerFullUrl = findProviderUrl(provider, bundle);
 
       if (providerFullUrl != null) {

--- a/src/main/java/org/mitre/synthea/export/TextExporter.java
+++ b/src/main/java/org/mitre/synthea/export/TextExporter.java
@@ -226,7 +226,7 @@ public class TextExporter {
     textRecord.add("Marital Status:      "
         + person.attributes.getOrDefault(Person.MARITAL_STATUS, "S"));
 
-    Provider prov = person.getAmbulatoryProvider();
+    Provider prov = person.getAmbulatoryProvider(endTime);
     if (prov != null) {
       textRecord.add("Outpatient Provider: " + prov.name);
     }

--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -734,7 +734,7 @@ public final class CardiovascularDiseaseModule extends Module {
           Provider provider = person.getCurrentProvider("Cardiovascular Disease Module");
           // no provider associated with encounter or procedure
           if (provider == null) {
-            provider = person.getAmbulatoryProvider();
+            provider = person.getAmbulatoryProvider(time);
           }
           provider.incrementPrescriptions(year);
         }
@@ -765,7 +765,7 @@ public final class CardiovascularDiseaseModule extends Module {
             Provider provider = person.getCurrentProvider("Cardiovascular Disease Module");
             // no provider associated with encounter or procedure
             if (provider == null) {
-              provider = person.getAmbulatoryProvider();
+              provider = person.getAmbulatoryProvider(time);
             }
             provider.incrementProcedures(year);
           }
@@ -781,7 +781,7 @@ public final class CardiovascularDiseaseModule extends Module {
    * @param diagnosis The diagnosis to be made.
    */
   public static void performEmergency(Person person, long time, String diagnosis) {
-    Provider provider = person.getEmergencyProvider();
+    Provider provider = person.getEmergencyProvider(time);
 
     int year = Utilities.getYear(time);
 

--- a/src/main/java/org/mitre/synthea/modules/EncounterModule.java
+++ b/src/main/java/org/mitre/synthea/modules/EncounterModule.java
@@ -105,7 +105,7 @@ public final class EncounterModule extends Module {
 
   public static void emergencyEncounter(Person person, long time) {
     // find closest service provider with emergency service
-    Provider provider = person.getEmergencyProvider();
+    Provider provider = person.getEmergencyProvider(time);
     provider.incrementEncounters("emergency", Utilities.getYear(time));
 
     Encounter encounter = person.record.encounterStart(time, "emergency");

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -289,30 +289,30 @@ public class Person implements Serializable, QuadTreeData {
   public static final String PREFERREDINPATIENTPROVIDER = "preferredInpatientProvider";
   public static final String PREFERREDEMERGENCYPROVIDER = "preferredEmergencyProvider";
 
-  public Provider getProvider(String encounterClass) {
+  public Provider getProvider(String encounterClass, long time) {
     switch (encounterClass) {
       case Provider.AMBULATORY:
-        return this.getAmbulatoryProvider();
+        return this.getAmbulatoryProvider(time);
       case Provider.EMERGENCY:
-        return this.getEmergencyProvider();
+        return this.getEmergencyProvider(time);
       case Provider.INPATIENT:
-        return this.getInpatientProvider();
+        return this.getInpatientProvider(time);
       case Provider.WELLNESS:
-        return this.getAmbulatoryProvider();
+        return this.getAmbulatoryProvider(time);
       default:
-        return this.getAmbulatoryProvider();
+        return this.getAmbulatoryProvider(time);
     }
   }
 
-  public Provider getAmbulatoryProvider() {
+  public Provider getAmbulatoryProvider(long time) {
     if (!attributes.containsKey(PREFERREDAMBULATORYPROVIDER)) {
-      setAmbulatoryProvider();
+      setAmbulatoryProvider(time);
     }
     return (Provider) attributes.get(PREFERREDAMBULATORYPROVIDER);
   }
 
-  private void setAmbulatoryProvider() {
-    Provider provider = Provider.findClosestService(this, Provider.AMBULATORY);
+  private void setAmbulatoryProvider(long time) {
+    Provider provider = Provider.findClosestService(this, Provider.AMBULATORY, time);
     attributes.put(PREFERREDAMBULATORYPROVIDER, provider);
   }
 
@@ -320,15 +320,15 @@ public class Person implements Serializable, QuadTreeData {
     attributes.put(PREFERREDAMBULATORYPROVIDER, provider);
   }
 
-  public Provider getInpatientProvider() {
+  public Provider getInpatientProvider(long time) {
     if (!attributes.containsKey(PREFERREDINPATIENTPROVIDER)) {
-      setInpatientProvider();
+      setInpatientProvider(time);
     }
     return (Provider) attributes.get(PREFERREDINPATIENTPROVIDER);
   }
 
-  private void setInpatientProvider() {
-    Provider provider = Provider.findClosestService(this, Provider.INPATIENT);
+  private void setInpatientProvider(long time) {
+    Provider provider = Provider.findClosestService(this, Provider.INPATIENT, time);
     attributes.put(PREFERREDINPATIENTPROVIDER, provider);
   }
 
@@ -336,22 +336,19 @@ public class Person implements Serializable, QuadTreeData {
     attributes.put(PREFERREDINPATIENTPROVIDER, provider);
   }
 
-  public Provider getEmergencyProvider() {
+  public Provider getEmergencyProvider(long time) {
     if (!attributes.containsKey(PREFERREDEMERGENCYPROVIDER)) {
-      setEmergencyProvider();
+      setEmergencyProvider(time);
     }
     return (Provider) attributes.get(PREFERREDEMERGENCYPROVIDER);
   }
 
-  private void setEmergencyProvider() {
-    Provider provider = Provider.findClosestService(this, Provider.EMERGENCY);
+  private void setEmergencyProvider(long time) {
+    Provider provider = Provider.findClosestService(this, Provider.EMERGENCY, time);
     attributes.put(PREFERREDEMERGENCYPROVIDER, provider);
   }
 
   public void setEmergencyProvider(Provider provider) {
-    if (provider == null) {
-      provider = Provider.findClosestService(this, Provider.EMERGENCY);
-    }
     attributes.put(PREFERREDEMERGENCYPROVIDER, provider);
   }
 

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -109,14 +109,18 @@ public class Provider implements QuadTreeData {
       return null;
     }
   }
+  
+  public boolean accepts(Person person, long time) {
+    return true;
+  }
 
-  public static Provider findClosestService(Person person, String service) {
+  public static Provider findClosestService(Person person, String service, long time) {
     double maxDistance = 500;
     double distance = 100;
     double step = 100;
     Provider provider = null;
     while (provider == null && distance <= maxDistance) {
-      provider = findService(person.getLatLon(), service, distance);
+      provider = findService(person, service, distance, time);
       if (provider != null) {
         return provider;
       }
@@ -132,8 +136,9 @@ public class Provider implements QuadTreeData {
    * @param searchDistance in kilometers
    * @return Service provider or null if none is available.
    */
-  private static Provider findService(DirectPosition2D coord,
-      String service, double searchDistance) {
+  private static Provider findService(Person person,
+      String service, double searchDistance, long time) {
+    DirectPosition2D coord = person.getLatLon();
     List<QuadTreeData> results = providerMap.queryByPointRadius(coord, searchDistance);
 
     Provider closest = null;
@@ -143,7 +148,8 @@ public class Provider implements QuadTreeData {
 
     for (QuadTreeData item : results) {
       provider = (Provider) item;
-      if (provider.hasService(service) || service == null) {
+      if (provider.accepts(person, time)
+          && (provider.hasService(service) || service == null)) {
         distance = item.getLatLon().distance(coord);
         if (distance < minDistance) {
           closest = (Provider) item;

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -161,15 +161,24 @@ public class Provider implements QuadTreeData {
   public static void loadProviders(String state) {
     try {
       String abbreviation = Location.getAbbreviation(state);
-      loadHospitals(state, abbreviation);
+      String hospitalFile = Config.get("generate.providers.hospitals.default_file");
+      loadProviders(state, abbreviation, hospitalFile);
     } catch (IOException e) {
       System.err.println("ERROR: unable to load providers for state: " + state);
       e.printStackTrace();
     }
   }
 
-  private static void loadHospitals(String state, String abbreviation) throws IOException {
-    String filename = Config.get("generate.providers.hospitals.default_file");
+  /**
+   * Read the providers from the given resource file, only importing the ones for the given state.
+   * 
+   * @param state Name of the current state, ex "Massachusetts"
+   * @param abbreviation State abbreviation, ex "MA"
+   * @param filename Location of the file, relative to src/main/resources
+   * @throws IOException if the file cannot be read
+   */
+  public static void loadProviders(String state, String abbreviation, String filename)
+      throws IOException {
     String resource = Utilities.readResource(filename);
     List<? extends Map<String,String>> csv = SimpleCSV.parse(resource);
 
@@ -184,7 +193,7 @@ public class Provider implements QuadTreeData {
         parsed.servicesProvided.add(Provider.AMBULATORY);
         parsed.servicesProvided.add(Provider.INPATIENT);
         parsed.servicesProvided.add(Provider.WELLNESS);
-        if (row.get("emergency").equals("Yes")) {
+        if ("Yes".equals(row.get("emergency"))) {
           parsed.servicesProvided.add(Provider.EMERGENCY);
         }
         providerList.add(parsed);

--- a/src/main/resources/providers/rehab.csv
+++ b/src/main/resources/providers/rehab.csv
@@ -1,4 +1,4 @@
-,id,name,address,city,state,zip,county,phone,ownership,startdate,lat,lon,hospital,rehab
+,id,name,address,city,state,zip,county,phone,ownership,startdate,LAT,LON,hospital,rehab
 0,36T180,CLEVELAND CLINIC - MAIN,9500 EUCLID AVENUE,CLEVELAND,OH,44195,Cuyahoga,(216) 445-0708,Non-profit,01/01/2011,41.505546, -81.6915,false,true
 1,44T156,PARKRIDGE MEDICAL CENTER,2333 MCCALLIE AVE,CHATTANOOGA,TN,37404,Hamilton,(423) 493-6822,For profit,04/01/2003,35.045756, -85.308287,false,true
 2,04R319,DEQUEEN MEDICAL CENTER,1306 WEST COLLIN RAYE DRIVE,DEQUEEN,AR,71832,Sevier,(870) 584-0299,For profit,10/01/2006,34.03776, -94.341528,false,true

--- a/src/main/resources/providers/va_facilities.csv
+++ b/src/main/resources/providers/va_facilities.csv
@@ -12,7 +12,7 @@
 405,"White River Junction VA Medical Center","163 Veterans Drive","White River Junction",VT,"05009","802-295-9363 Or 802-295-9363","VA Facility",Government,no,"Not Available",43.648075,-72.34463
 523BZ,"Causeway OPC","251 Causeway St.",Boston,MA,"02114",800-865-3384,"VA Facility",Government,no,"Not Available",42.3665,-71.05931
 402F,"Fort Kent Access Point Clinic","3 Mountain View Drive","Fort Kent",ME,"04743",207-834-1572,"VA Facility",Government,no,"Not Available",47.2587,-68.5895
-4730,"Houlton Satellite Clinic","Houlton Regional Hospital - 20 Hartford Street",Houlton,ME,"04730","207-623-8411 X 7490 Or 877-421-8263 X 7490","VA Facility",Government,no,"Not Available",45.0743,-92.7505
+"04730","Houlton Satellite Clinic","Houlton Regional Hospital - 20 Hartford Street",Houlton,ME,"04730","207-623-8411 X 7490 Or 877-421-8263 X 7490","VA Facility",Government,no,"Not Available",45.0743,-92.7505
 402MMU,"Mobile Medical Unit","241 Main Street",Bingham,ME,"04920","207-623-8411 X 7490 Or 877-421-8263 X 7490","VA Facility",Government,no,"Not Available",45.053535,-69.88254
 518-vccc,"Lowell Veterans Community Care Center","130 Marshall Road",Lowell,MA,"01852",978-671-9000,"VA Facility",Government,no,"Not Available",42.62101,-71.31481
 402GD,"Aroostook County (Caribou) Community Based Outpatient Clinic","163 Van Buren Drive, Ste 6",Caribou,ME,"04736","207-623-8411 X 7490 Or 877-421-8263 X 7490","VA Facility",Government,no,"Not Available",46.9121,-68.0431
@@ -55,29 +55,29 @@
 689GC,"Willimantic Outpatient Clinic","1320 Main Street",Willimantic,CT,"06226",860-450-7583,"VA Facility",Government,no,"Not Available",41.715214,-72.22889
 689GD,"Winsted Outpatient Clinic","115 Spencer Street",Winsted,CT,"06908",860-738-6985,"VA Facility",Government,no,"Not Available",41.930405,-73.07571
 631GE,"Worcester Outpatient Clinic","605 Lincoln Street,",Worcester,MA,"01605","508-856-0104 Or 508-856-0104","VA Facility",Government,no,"Not Available",42.297756,-71.766815
-121,"Bangor Vet Center","615 Odlin Road, Suite 3",Bangor,ME,"04401","207-947-3391 Or 207-947-3391","VA Facility",Government,no,"Not Available",44.78075,-68.82331
-134,"Berlin Vet Center","515 Main Street Suite 2",Gorham,NH,"03581",603-752-2571,"VA Facility",Government,no,"Not Available",44.428604,-71.19247
+"0121","Bangor Vet Center","615 Odlin Road, Suite 3",Bangor,ME,"04401","207-947-3391 Or 207-947-3391","VA Facility",Government,no,"Not Available",44.78075,-68.82331
+"0134","Berlin Vet Center","515 Main Street Suite 2",Gorham,NH,"03581",603-752-2571,"VA Facility",Government,no,"Not Available",44.428604,-71.19247
 0101V,"Boston Vet Center","7 Drydock Ave, Suite 2070",Boston,MA,"02210",857-203-6461,"VA Facility",Government,no,"Not Available",42.34461,-71.03728
-104,"Brockton Vet Center","1041L Pearl St.",Brockton,MA,"02301","508-580-2730 Or 508-580-2730","VA Facility",Government,no,"Not Available",42.055134,-71.06661
-136,"Cape Cod Vet Center","474 West Main Street",Hyannis,MA,"02601","508-778-0124 Or 508-778-0124","VA Facility",Government,no,"Not Available",41.650307,-70.313515
-140,"Danbury Vet Center","457 North Main St., 1st Floor",Danbury,CT,"06811","203-790-4000 Or 203-790-4000","VA Facility",Government,no,"Not Available",41.40501,-73.462845
-117,"Hartford Vet Center","25 Elm Street, Suite A","Rocky Hill",CT,"06067",860-563-8800,"VA Facility",Government,no,"Not Available",41.664818,-72.64043
-1221,"Keene Vet Center Outstation","640 Marlboro Rd. (Route 101)",Keene,NH,"03431","603-358-4950 Or 603-358-4950","VA Facility",Government,no,"Not Available",40.3451,-81.8682
-129,"Lewiston Vet Center","35 Westminster St.",Lewiston,ME,"04240","207-783-0068 Or 207-783-0068","VA Facility",Government,no,"Not Available",44.075405,-70.17508
-125,"Lowell Vet Center","10 George Street, Gateway Center",Lowell,MA,"01852",978-453-1151,"VA Facility",Government,no,"Not Available",42.642513,-71.3062
-108,"Manchester Vet Center","1461 Hooksett Rd., B6",Hooksett,NH,"03106","603-668-7060 Or 603-668-7060","VA Facility",Government,no,"Not Available",43.07247,-71.454254
-128,"New Bedford Vet Center","73 Huttleton Ave., Unit 2",Fairhaven,MA,"02719","508-999-6920 Or 508-999-6920","VA Facility",Government,no,"Not Available",41.6318,-70.8801
-116,"New Haven Vet Center","291 South Lambert Road",Orange,CT,"06477",203-795-0148,"VA Facility",Government,no,"Not Available",41.262207,-73.00565
-119,"Northern Maine Vet Center","456 York Street",Caribou,ME,"04736",207-496-3900,"VA Facility",Government,no,"Not Available",46.9121,-68.0431
-127,"Norwich Vet Center","2 Cliff St.",Norwich,CT,"06360","860-887-1755 Or 860-887-1755","VA Facility",Government,no,"Not Available",41.52734,-72.06744
-115,"Portland Vet Center","475 Stevens Ave.",Portland,ME,"04103",207-780-3584,"VA Facility",Government,no,"Not Available",43.674862,-70.29505
-113,"Providence Vet Center","2038 Warwick Ave",Warwick,RI,"02889",401-739-0167,"VA Facility",Government,no,"Not Available",41.72111,-71.40386
+"0104","Brockton Vet Center","1041L Pearl St.",Brockton,MA,"02301","508-580-2730 Or 508-580-2730","VA Facility",Government,no,"Not Available",42.055134,-71.06661
+"0136","Cape Cod Vet Center","474 West Main Street",Hyannis,MA,"02601","508-778-0124 Or 508-778-0124","VA Facility",Government,no,"Not Available",41.650307,-70.313515
+"0140","Danbury Vet Center","457 North Main St., 1st Floor",Danbury,CT,"06811","203-790-4000 Or 203-790-4000","VA Facility",Government,no,"Not Available",41.40501,-73.462845
+"0117","Hartford Vet Center","25 Elm Street, Suite A","Rocky Hill",CT,"06067",860-563-8800,"VA Facility",Government,no,"Not Available",41.664818,-72.64043
+"01221","Keene Vet Center Outstation","640 Marlboro Rd. (Route 101)",Keene,NH,"03431","603-358-4950 Or 603-358-4950","VA Facility",Government,no,"Not Available",40.3451,-81.8682
+"0129","Lewiston Vet Center","35 Westminster St.",Lewiston,ME,"04240","207-783-0068 Or 207-783-0068","VA Facility",Government,no,"Not Available",44.075405,-70.17508
+"0125","Lowell Vet Center","10 George Street, Gateway Center",Lowell,MA,"01852",978-453-1151,"VA Facility",Government,no,"Not Available",42.642513,-71.3062
+"0108","Manchester Vet Center","1461 Hooksett Rd., B6",Hooksett,NH,"03106","603-668-7060 Or 603-668-7060","VA Facility",Government,no,"Not Available",43.07247,-71.454254
+"0128","New Bedford Vet Center","73 Huttleton Ave., Unit 2",Fairhaven,MA,"02719","508-999-6920 Or 508-999-6920","VA Facility",Government,no,"Not Available",41.6318,-70.8801
+"0116","New Haven Vet Center","291 South Lambert Road",Orange,CT,"06477",203-795-0148,"VA Facility",Government,no,"Not Available",41.262207,-73.00565
+"0119","Northern Maine Vet Center","456 York Street",Caribou,ME,"04736",207-496-3900,"VA Facility",Government,no,"Not Available",46.9121,-68.0431
+"0127","Norwich Vet Center","2 Cliff St.",Norwich,CT,"06360","860-887-1755 Or 860-887-1755","VA Facility",Government,no,"Not Available",41.52734,-72.06744
+"0115","Portland Vet Center","475 Stevens Ave.",Portland,ME,"04103",207-780-3584,"VA Facility",Government,no,"Not Available",43.674862,-70.29505
+"0113","Providence Vet Center","2038 Warwick Ave",Warwick,RI,"02889",401-739-0167,"VA Facility",Government,no,"Not Available",41.72111,-71.40386
 0100V,"RCS North Atlantic District 1, Zone 1 District Office","15 Dartmouth Drive, Suite 202",Auburn,NH,"03032","603-623-4204 Or 603-623-4204","VA Facility",Government,no,"Not Available",42.2514,-94.8778
-130,"Sanford Vet Center","628 Main Street",Springvale,ME,"04083","207-490-1513 Or 207-490-1513","VA Facility",Government,no,"Not Available",43.455822,-70.79014
-118,"South Burlington Vet Center","19 Gregory Drive Suite 201","South Burlington",VT,"05403",802-862-1806,"VA Facility",Government,no,"Not Available",44.455273,-73.13991
-103,"Springfield Vet Center","95 Ashley Avenue, Suite A","West Springfield",MA,"01089","413-737-5167 Or 413-737-5167","VA Facility",Government,no,"Not Available",42.139397,-72.62382
-122,"White River Junction Vet Center","118 Prospect Street Suite 100","White River Junction",VT,"05001","802-295-2908 Or 802-295-2908","VA Facility",Government,no,"Not Available",43.649,-72.3193
-126,"Worcester Vet Center","255 Park Ave Suite # 900",Worcester,MA,"01609",508-753-7902,"VA Facility",Government,no,"Not Available",42.265556,-71.818665
+"0130","Sanford Vet Center","628 Main Street",Springvale,ME,"04083","207-490-1513 Or 207-490-1513","VA Facility",Government,no,"Not Available",43.455822,-70.79014
+"0118","South Burlington Vet Center","19 Gregory Drive Suite 201","South Burlington",VT,"05403",802-862-1806,"VA Facility",Government,no,"Not Available",44.455273,-73.13991
+"0103","Springfield Vet Center","95 Ashley Avenue, Suite A","West Springfield",MA,"01089","413-737-5167 Or 413-737-5167","VA Facility",Government,no,"Not Available",42.139397,-72.62382
+"0122","White River Junction Vet Center","118 Prospect Street Suite 100","White River Junction",VT,"05001","802-295-2908 Or 802-295-2908","VA Facility",Government,no,"Not Available",43.649,-72.3193
+"0126","Worcester Vet Center","255 Park Ave Suite # 900",Worcester,MA,"01609",508-753-7902,"VA Facility",Government,no,"Not Available",42.265556,-71.818665
 10N2,"VISN 2: New York/New Jersey VA Health Care Network","130 W. Kingsbridge Road, Building 16",Bronx,NY,"10468",718-741-4134,"VA Facility",Government,no,"Not Available",40.869125,-73.90309
 620,"VA Hudson Valley Health Care System","2094 Albany Post Rd.",Montrose,NY,"10548",914-737-4400,"VA Facility",Government,no,"Not Available",41.2446,-73.926155
 561,"VA New Jersey Health Care System","385 Tremont Avenue","East Orange",NJ,"07018",973-676-1000,"VA Facility",Government,no,"Not Available",40.753803,-74.23407
@@ -157,26 +157,26 @@
 528G2,Westport,"7426 NYS Route 9N",Westport,NY,"12993",518-626-5236,"VA Facility",Government,no,"Not Available",41.3089,-73.3637
 526GA,"White Plains Community Clinic","23 South Broadway","White Plains",NY,"10601","914-421-1951 X 4300","VA Facility",Government,no,"Not Available",41.032364,-73.76228
 526GB,"Yonkers Community Clinic","124 New Main St.",Yonkers,NY,"10701","914-375-8055 X 4400","VA Facility",Government,no,"Not Available",40.93349,-73.89745
-111,"Albany Vet Center","17 Computer Drive West",Albany,NY,"12205",518-626-5130,"VA Facility",Government,no,"Not Available",42.72057,-73.8087
-120,"Babylon Vet Center","100 West Main Street",Babylon,NY,"11702","631-661-3930 Or 631-661-3930","VA Facility",Government,no,"Not Available",40.695957,-73.325325
-137,"Binghamton Vet Center","53 Chenango Street",Binghamton,NY,"13901","607-722-2393 Or 607-722-2393","VA Facility",Government,no,"Not Available",42.100487,-75.91025
-112,"Bloomfield Vet Center","2 Broad St. Suite 703",Bloomfield,NJ,"07003","973-748-0980 Or 973-748-0980","VA Facility",Government,no,"Not Available",40.793514,-74.19776
-110,"Bronx Vet Center","2471 Morris Ave., Suite 1A",Bronx,NY,"10468","718-367-3500 Or 718-367-3500","VA Facility",Government,no,"Not Available",40.86264,-73.89976
+"0111","Albany Vet Center","17 Computer Drive West",Albany,NY,"12205",518-626-5130,"VA Facility",Government,no,"Not Available",42.72057,-73.8087
+"0120","Babylon Vet Center","100 West Main Street",Babylon,NY,"11702","631-661-3930 Or 631-661-3930","VA Facility",Government,no,"Not Available",40.695957,-73.325325
+"0137","Binghamton Vet Center","53 Chenango Street",Binghamton,NY,"13901","607-722-2393 Or 607-722-2393","VA Facility",Government,no,"Not Available",42.100487,-75.91025
+"0112","Bloomfield Vet Center","2 Broad St. Suite 703",Bloomfield,NJ,"07003","973-748-0980 Or 973-748-0980","VA Facility",Government,no,"Not Available",40.793514,-74.19776
+"0110","Bronx Vet Center","2471 Morris Ave., Suite 1A",Bronx,NY,"10468","718-367-3500 Or 718-367-3500","VA Facility",Government,no,"Not Available",40.86264,-73.89976
 0105V,"Brooklyn Vet Center","25 Chapel St. Suite 604",Brooklyn,NY,"11201","718-630-2830 Or 718-630-2830","VA Facility",Government,no,"Not Available",40.697277,-73.98651
 0107V,"Buffalo Vet Center","2372 Sweet Home Road",Amherst,NY,"14228","716-862-7350 Or 716-862-7350","VA Facility",Government,no,"Not Available",43.024666,-78.79905
-133,"Harlem Vet Center","2279 - 3rd Avenue, 2nd Floor","New York",NY,"10035","646-273-8139 Or 646-273-8139","VA Facility",Government,no,"Not Available",40.7143,-74.006
-141,"Lakewood Vet Center","1255 NJ-70 Suite 22N",Lakewood,NJ,"08701","908-607-6364 Or 908-607-6364","VA Facility",Government,no,"Not Available",40.0979,-74.2176
-106,"Manhattan Vet Center","32 Broadway 2nd Floor - Suite 200","New York",NY,"10004","212-951-6866 Or 212-951-6866","VA Facility",Government,no,"Not Available",40.70634,-74.01284
-139,"Middletown Vet Center","726 East Main Street, Suite 203",Middletown,NY,"10940","845-342-9917 Or 845-342-9917","VA Facility",Government,no,"Not Available",41.43988,-74.36706
+"0133","Harlem Vet Center","2279 - 3rd Avenue, 2nd Floor","New York",NY,"10035","646-273-8139 Or 646-273-8139","VA Facility",Government,no,"Not Available",40.7143,-74.006
+"0141","Lakewood Vet Center","1255 NJ-70 Suite 22N",Lakewood,NJ,"08701","908-607-6364 Or 908-607-6364","VA Facility",Government,no,"Not Available",40.0979,-74.2176
+"0106","Manhattan Vet Center","32 Broadway 2nd Floor - Suite 200","New York",NY,"10004","212-951-6866 Or 212-951-6866","VA Facility",Government,no,"Not Available",40.70634,-74.01284
+"0139","Middletown Vet Center","726 East Main Street, Suite 203",Middletown,NY,"10940","845-342-9917 Or 845-342-9917","VA Facility",Government,no,"Not Available",41.43988,-74.36706
 0138V,"Nassau Vet Center","970 South Broadway",Hicksville,NY,"11801","516-348-0088 Or 516-348-0088","VA Facility",Government,no,"Not Available",40.7548,-73.6018
-109,"Queens Vet Center","75-10B 91 Avenue",Woodhaven,NY,"11421",718-296-2871,"VA Facility",Government,no,"Not Available",40.685898,-73.86519
-124,"Rochester Vet Center","2000 S. Winton Road, Bldg 5, Ste. 201",Rochester,NY,"14618",585-232-5040,"VA Facility",Government,no,"Not Available",43.107155,-77.57613
-102,"Secaucus Vet Center","110A Meadowlands Parkway, Suite 102",Secaucus,NJ,"07094","201-223-7787 Or 201-223-7787","VA Facility",Government,no,"Not Available",40.78257,-74.077415
-132,"Staten Island Vet Center","60 Bay Street","Staten Island",NY,"10301","718-816-4499 Or 718-816-4499","VA Facility",Government,no,"Not Available",40.64047,-74.07568
-131,"Syracuse Vet Center","109 Pine Street, Suite 101",Syracuse,NY,"13210",315-478-7127,"VA Facility",Government,no,"Not Available",43.050083,-76.129715
-114,"Trenton Vet Center","934 Parkway Ave. Suite 201",Ewing,NJ,"08618","609-882-5744 Or 609-882-5744","VA Facility",Government,no,"Not Available",40.255383,-74.79256
-135,"Watertown Vet Center","210 Court Street, Suite 20",Watertown,NY,"13601","315-782-5479 Or 315-782-5479","VA Facility",Government,no,"Not Available",43.976658,-75.91245
-123,"White Plains Vet Center","300 Hamilton Ave. Suite C","White Plains",NY,"10601",914-682-6250,"VA Facility",Government,no,"Not Available",41.03415,-73.767494
+"0109","Queens Vet Center","75-10B 91 Avenue",Woodhaven,NY,"11421",718-296-2871,"VA Facility",Government,no,"Not Available",40.685898,-73.86519
+"0124","Rochester Vet Center","2000 S. Winton Road, Bldg 5, Ste. 201",Rochester,NY,"14618",585-232-5040,"VA Facility",Government,no,"Not Available",43.107155,-77.57613
+"0102","Secaucus Vet Center","110A Meadowlands Parkway, Suite 102",Secaucus,NJ,"07094","201-223-7787 Or 201-223-7787","VA Facility",Government,no,"Not Available",40.78257,-74.077415
+"0132","Staten Island Vet Center","60 Bay Street","Staten Island",NY,"10301","718-816-4499 Or 718-816-4499","VA Facility",Government,no,"Not Available",40.64047,-74.07568
+"0131","Syracuse Vet Center","109 Pine Street, Suite 101",Syracuse,NY,"13210",315-478-7127,"VA Facility",Government,no,"Not Available",43.050083,-76.129715
+"0114","Trenton Vet Center","934 Parkway Ave. Suite 201",Ewing,NJ,"08618","609-882-5744 Or 609-882-5744","VA Facility",Government,no,"Not Available",40.255383,-74.79256
+"0135","Watertown Vet Center","210 Court Street, Suite 20",Watertown,NY,"13601","315-782-5479 Or 315-782-5479","VA Facility",Government,no,"Not Available",43.976658,-75.91245
+"0123","White Plains Vet Center","300 Hamilton Ave. Suite C","White Plains",NY,"10601",914-682-6250,"VA Facility",Government,no,"Not Available",41.03415,-73.767494
 10N4,"VISN 4: VA Healthcare - VISN 4","323 North Shore Drive, Suite 400",Pittsburgh,PA,"15212",412-822-3316,"VA Facility",Government,no,"Not Available",40.4344,-80.0248
 646,"VA Pittsburgh Healthcare System","University Drive",Pittsburgh,PA,"15240",412-822-2222,"VA Facility",Government,no,"Not Available",40.4344,-80.0248
 503,"Altoona - James E. Van Zandt VA Medical Center","2907 Pleasant Valley Boulevard",Altoona,PA,"16602","814-943-8164 Or 814-943-8164","VA Facility",Government,no,"Not Available",40.48913,-78.39827
@@ -233,14 +233,14 @@
 646GB,"Westmoreland County Outpatient Clinic","5274 Rt 30 East, Suite 10",Greensburg,PA,"15601",724-216-0317,"VA Facility",Government,no,"Not Available",40.3015,-79.5389
 693GB,"Williamsport OPC, Campus of Divine Providence Hospital (693GB)","1705 Warren Avenue, Werner Building - 3rd Floor (Suite 304)",Williamsport,PA,"17701",570-322-4791,"VA Facility",Government,no,"Not Available",41.260082,-76.98141
 595GE,"York VA Clinic (595GE)","2251 Eastern Blvd.",York,PA,"17402",717-840-2730,"VA Facility",Government,no,"Not Available",39.9719,-76.6848
-238,"Bucks County Vet Center","2 Canal's End Road, Suite 201B",Bristol,PA,"19007","215-823-4590 Or 215-823-4590","VA Facility",Government,no,"Not Available",39.2879,-80.524
-227,"DuBois Vet Center","100 Meadow Lane, Suite 8",DuBois,PA,"15801",814-372-2095,"VA Facility",Government,no,"Not Available",43.493,-109.6436
+"0238","Bucks County Vet Center","2 Canal's End Road, Suite 201B",Bristol,PA,"19007","215-823-4590 Or 215-823-4590","VA Facility",Government,no,"Not Available",39.2879,-80.524
+"0227","DuBois Vet Center","100 Meadow Lane, Suite 8",DuBois,PA,"15801",814-372-2095,"VA Facility",Government,no,"Not Available",43.493,-109.6436
 0222V,"Erie Vet Center","240 W. 11th St., Erie Metro Center, Suite 105",Erie,PA,"16501","814-453-7955 Or 814-453-7955","VA Facility",Government,no,"Not Available",42.12275,-80.0867
 0218V,"Harrisburg Vet Center","1500 N. Second Street Suite 2",Harrisburg,PA,"17102","717-782-3954 Or 717-782-3954","VA Facility",Government,no,"Not Available",40.27054,-76.89296
-242,"Lancaster County Vet Center","1817 Olde Homestead Lane, Suite 207",Lancaster,PA,"17601","717-283-0735 Or 717-283-0735","VA Facility",Government,no,"Not Available",38.5478,-87.8653
+"0242","Lancaster County Vet Center","1817 Olde Homestead Lane, Suite 207",Lancaster,PA,"17601","717-283-0735 Or 717-283-0735","VA Facility",Government,no,"Not Available",38.5478,-87.8653
 0239V,"Norristown Vet Center","320 E. Johnson Hwy, Suite 201",Norristown,PA,"19401","215-823-5245 Or 877-927-8387","VA Facility",Government,no,"Not Available",40.128048,-75.32217
 0219V,"Northeast Philadelphia Vet Center","101 E. Olney Avenue",Philadelphia,PA,"19120","215-924-4670 Or 215-924-4670","VA Facility",Government,no,"Not Available",40.035076,-75.11968
-210,"Philadelphia Vet Center","801 Arch Street Suite 502",Philadelphia,PA,"19107","215-627-0238 Or 215-627-0238","VA Facility",Government,no,"Not Available",39.95318,-75.15322
+"0210","Philadelphia Vet Center","801 Arch Street Suite 502",Philadelphia,PA,"19107","215-627-0238 Or 215-627-0238","VA Facility",Government,no,"Not Available",39.95318,-75.15322
 0211V,"Pittsburgh Vet Center","2500 Baldwick Rd, Suite 15",Pittsburgh,PA,"15205","412-920-1765 Or 412-920-1765","VA Facility",Government,no,"Not Available",40.426678,-80.05733
 0229V,"Scranton Vet Center","1002 Pittston Ave.",Scranton,PA,"18505","570-344-2676 Or 570-344-2676","VA Facility",Government,no,"Not Available",41.395813,-75.6689
 243V,"Sussex County Vet Center","20653 Dupont Blvd, Suite 1",Georgetown,DE,"19947","302-225-9110 Or 302-225-9110","VA Facility",Government,no,"Not Available",39.9376,-76.0833
@@ -289,7 +289,7 @@
 613GC,"Stephens City Outpatient Clinic","170 Prosperity Drive",Winchester,VA,"22602","304-263-0811 X 5130","VA Facility",Government,no,"Not Available",42.7734,-72.3831
 540GA,"Tucker County CBOC (540GA)","260 Spruce Street",Parsons,WV,"26287",304-478-2219,"VA Facility",Government,no,"Not Available",39.096973,-79.683685
 540GB,"Wood County CBOC (540GB)","2311 Ohio Avenue, Suite A",Parkersburg,WV,"26101",304-422-5114,"VA Facility",Government,no,"Not Available",39.282536,-81.549706
-2092,"Aberdeen Vet Center Outstation","223 W. Bel Air Avenue",Aberdeen,MD,"21001","410-272-6771 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.510605,-76.16716
+"02092","Aberdeen Vet Center Outstation","223 W. Bel Air Avenue",Aberdeen,MD,"21001","410-272-6771 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.510605,-76.16716
 0228V,"Alexandria Vet Center","6940 South Kings Highway #204",Alexandria,VA,"22310","703-360-8633 Or 703-360-8633","VA Facility",Government,no,"Not Available",38.768433,-77.11709
 0235V,"Annapolis Vet Center","100 Annapolis Street",Annapolis,MD,"21401","410-605-7826 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.990086,-76.50218
 0201V,"Baltimore Vet Center","1777 Reisterstown Road Suite 199",Baltimore,MD,"21208","410-764-9400 Or 410-764-9400","VA Facility",Government,no,"Not Available",39.383865,-76.73311
@@ -297,18 +297,18 @@
 0223V,"Charleston Vet Center","200 Tracy Way",Charleston,WV,"25311","304-343-3825 Or 304-343-3825","VA Facility",Government,no,"Not Available",38.35907,-81.59911
 0237V,"Clinton Vet Center","7905 Malcolm Road, Suite 101",Clinton,MD,"20735","301-856-7173 Or 301-856-7173","VA Facility",Government,no,"Not Available",38.782055,-76.889824
 0236V,"Dundalk Vet Center","1553 Merritt Blvd",Dundalk,MD,"21222","410-282-6144 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.27272,-76.5025
-209,"Elkton Vet Center","103 Chesapeake Blvd. Suite A",Elkton,MD,"21921","410-392-4485 Or 410-392-4485","VA Facility",Government,no,"Not Available",36.81,-87.1542
+"0209","Elkton Vet Center","103 Chesapeake Blvd. Suite A",Elkton,MD,"21921","410-392-4485 Or 410-392-4485","VA Facility",Government,no,"Not Available",36.81,-87.1542
 0208V,"Huntington Vet Center","3135 16th Street Road Suite 11",Huntington,WV,"25701","304-523-8387 Or 304-523-8387","VA Facility",Government,no,"Not Available",38.39435,-82.40953
 02231V,"Logan Vet Center Outstation","21 Veterans Avenue",Henlawson,WV,"25624","304-752-4453 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.9023,-81.9882
-224,"Martinsburg Vet Center","300 Foxcroft Ave. Suite 100A",Martinsburg,WV,"25401","304-263-6776 Or 304-263-6776","VA Facility",Government,no,"Not Available",39.462715,-77.986916
+"0224","Martinsburg Vet Center","300 Foxcroft Ave. Suite 100A",Martinsburg,WV,"25401","304-263-6776 Or 304-263-6776","VA Facility",Government,no,"Not Available",39.462715,-77.986916
 0216V,"Morgantown Vet Center","34 Commerce Drive, Suite 101",Morgantown,WV,"26501","304-291-4303 Or 304-291-4303","VA Facility",Government,no,"Not Available",39.6295,-79.9559
-2081,"Parkersburg Vet Center Outstation","2311 Ohio Avenue, Suite D",Pakersburg,WV,"26101","304-485-1599 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.282536,-81.549706
+"02081","Parkersburg Vet Center Outstation","2311 Ohio Avenue, Suite D",Pakersburg,WV,"26101","304-485-1599 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.282536,-81.549706
 0232V,"Princeton Vet Center","1511 North Walker Street",Princeton,WV,"24740",304-425-8098,"VA Facility",Government,no,"Not Available",37.367912,-81.10203
 0200V,"RCS North Atlantic District 1","305 W. Chesapeake Ave., Suite 300",Towson,MD,"21204","410-828-6619 Or 410-828-6619","VA Facility",Government,no,"Not Available",39.40007,-76.60994
-2091,"Salisbury Outstation","926 Snow Hill Road, Building 3",Salisbury,MD,"21804","410-912-7263 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.34735,-75.58189
+"02091","Salisbury Outstation","926 Snow Hill Road, Building 3",Salisbury,MD,"21804","410-912-7263 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.34735,-75.58189
 0213V,"Silver Spring Vet Center","2900 Linden Lane","Silver Spring",MD,"20910","301-589-1073 Or 301-589-1073","VA Facility",Government,no,"Not Available",39.014156,-77.05791
-213,"Washington DC Vet Center","1296 Upshur St NW",Washington,DC,"20011","202-726-5212 Or 202-463-0943","VA Facility",Government,no,"Not Available",38.941853,-77.029495
-233,"Wheeling Vet Center","1058 Bethlehem Blvd.",Wheeling,WV,"26003","304-232-0587 Or 304-232-0587","VA Facility",Government,no,"Not Available",40.053024,-80.701645
+"0213","Washington DC Vet Center","1296 Upshur St NW",Washington,DC,"20011","202-726-5212 Or 202-463-0943","VA Facility",Government,no,"Not Available",38.941853,-77.029495
+"0233","Wheeling Vet Center","1058 Bethlehem Blvd.",Wheeling,WV,"26003","304-232-0587 Or 304-232-0587","VA Facility",Government,no,"Not Available",40.053024,-80.701645
 10N6,"VISN 6: VA Mid-Atlantic Health Care Network","3518 Westgate Drive",Durham,NC,"27707",919-956-5541,"VA Facility",Government,no,"Not Available",35.968067,-78.96135
 637,"Asheville VA Medical Center","1100 Tunnel Road",Asheville,NC,"28805",828-298-7911,"VA Facility",Government,no,"Not Available",35.586716,-82.48251
 558,"Durham VA Medical Center","508 Fulton Street",Durham,NC,"27705","919-286-0411 Or 919-286-0411","VA Facility",Government,no,"Not Available",36.008934,-78.937294
@@ -357,16 +357,15 @@
 658GE,"Wytheville CBOC","165 Peppers Ferry Road",Wytheville,VA,"24382",276-223-5400,"VA Facility",Government,no,"Not Available",36.9498,-81.1289
 0317V,"Charlotte Vet Center","2114 Ben Craig Dr., Suite 300",Charlotte,NC,"28262","704-549-8025 Or 877-927-8387","VA Facility",Government,no,"Not Available",35.2271,-80.8431
 0315V,"Fayetteville Vet Center","2301 Robeson St. Suite 103",Fayetteville,NC,"28305","910-488-6252 Or 910-488-6252","VA Facility",Government,no,"Not Available",35.042355,-78.91646
-327,"Greensboro Vet Center","3515 W Market St., Suite 120",Greensboro,NC,"27406","336-323-2660 Or 877-927-8387","VA Facility",Government,no,"Not Available",36.0726,-79.792
+"0327","Greensboro Vet Center","3515 W Market St., Suite 120",Greensboro,NC,"27406","336-323-2660 Or 877-927-8387","VA Facility",Government,no,"Not Available",36.0726,-79.792
 0319V,"Greenville, NC Vet Center","1021 WH Smith Blvd., Suite #100",Greenville,NC,"27834","252-355-7920 Or 252-355-7920","VA Facility",Government,no,"Not Available",34.8526,-82.394
 0343V,"Jacksonville Vet Center","110A Branchwood Dr",Jacksonville,NC,"28546","910-577-1100 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.8137,-85.7613
 0207V,"Norfolk Vet Center","1711 Church Street, Suites A&B",Norfolk,VA,"23504","757-623-7584 Or 877-927-8387","VA Facility",Government,no,"Not Available",36.8468,-76.2852
 0328V,"Raleigh Vet Center","8851 Ellstree Lane, Suite 122",Raleigh,NC,"27617","919-361-6419 Or 877-927-8387","VA Facility",Government,no,"Not Available",35.7721,-78.6386
 0217V,"Richmond Vet Center","4902 Fitzhugh Avenue",Richmond,VA,"23230","804-353-8958 Or 804-353-8958","VA Facility",Government,no,"Not Available",37.579716,-77.495415
-226,"Roanoke Vet Center","350 Albemarle Ave., SW",Roanoke,VA,"24016","540-342-9726 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.263206,-79.94751
-3271,"Rutherford Vet Center Outstation","303 Fairground Road",Spindale,NC,"28160","828-288-2757 Or 828-288-2757","VA Facility",Government,no,"Not Available",35.3586,-81.9238
+"0226","Roanoke Vet Center","350 Albemarle Ave., SW",Roanoke,VA,"24016","540-342-9726 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.263206,-79.94751
+"03271","Rutherford Vet Center Outstation","303 Fairground Road",Spindale,NC,"28160","828-288-2757 Or 828-288-2757","VA Facility",Government,no,"Not Available",35.3586,-81.9238
 0240V,"Virginia Beach Vet Center","324 Southport Circle, Suite 102","Virginia Beach",VA,"23452","757-248-3665 Or 757-248-3665","VA Facility",Government,no,"Not Available",36.831814,-76.13131
-0315V,"Fayetteville (NC) Vet Center","2301 Robeson St., Suite 103",Fayetteville,NC,"28305","910-488-6252 Or 800-771-6106 X 7701","VA Facility",Government,no,"Not Available",35.042355,-78.91646
 0343V,"Jacksonville Vet Center","110A Branchwood Dr",Jacksonville,NC,"28345","910-577-1100 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.8137,-85.7613
 10N7,"VISN 7: VA Southeast Network","3700 Crestwood Parkway, NW, Suite 500",Duluth,GA,"30096",678-924-5700,"VA Facility",Government,no,"Not Available",33.94617,-84.13016
 508,"Atlanta VA Health Care System","1670 Clairmont Road",Decatur,GA,"30033",404-321-6111,"VA Facility",Government,no,"Not Available",33.8016,-84.30972
@@ -441,7 +440,7 @@
 0324V,"Columbia Vet Center","1710 Richland Street, Suite A",Columbia,SC,"29201","803-765-9944 Or 877-927-8387","VA Facility",Government,no,"Not Available",34.01316,-81.02945
 0349V,"Columbus Vet Center","2601 Cross Country Drive, Condominium B-2 Suite 900",Columbus,GA,"31906",706-596-7170,"VA Facility",Government,no,"Not Available",32.461,-84.9877
 0316V,"Greenville, SC Vet Center","3 Caledon Court, Suite B",Greenville,SC,"29615","864-271-2711 Or 864-271-2711","VA Facility",Government,no,"Not Available",34.861446,-82.339714
-738,"Huntsville Vet Center","415 Church Street, Bldg H, Suite 101",Huntsville,AL,"35801","256-539-5775 Or 256-539-5775","VA Facility",Government,no,"Not Available",34.73529,-86.591606
+"0738","Huntsville Vet Center","415 Church Street, Bldg H, Suite 101",Huntsville,AL,"35801","256-539-5775 Or 256-539-5775","VA Facility",Government,no,"Not Available",34.73529,-86.591606
 0329V,"Lawrenceville Vet Center","930 River Centre Place",Lawrenceville,GA,"30043","404-728-4195 Or 404-728-4195","VA Facility",Government,no,"Not Available",33.973522,-84.03296
 0333V,"Macon Vet Center","750 Riverside Drive",Macon,GA,"31201","478-477-3813 Or 877-927-8387","VA Facility",Government,no,"Not Available",32.841946,-83.62805
 0342V,"Marietta Vet Center","40 Dodd St., Suite 700",Marietta,GA,"30060","404-327-4954 Or 404-327-4954","VA Facility",Government,no,"Not Available",33.950397,-84.52376
@@ -529,7 +528,7 @@
 0332V,"Melbourne Vet Center","2098 Sarno Road",Melbourne,FL,"32935","321-254-3410 Or 877-927-8387","VA Facility",Government,no,"Not Available",28.12169,-80.65558
 0310V,"Miami Vet Center","8280 NW 27th St Suite 511",Miami,FL,"33122","305-718-3712 Or 305-718-3712","VA Facility",Government,no,"Not Available",25.799692,-80.336395
 0348V,"Naples Vet Center","2705 Horseshoe Dr. South, Suite #204",Naples,FL,"34104","239-403-2377 Or 877-927-8387","VA Facility",Government,no,"Not Available",26.16184,-81.77219
-344,"Ocala Vet Center","3300 SW 34th Avenue, Suite 140",Ocala,FL,"34474","352-237-1947 Or 877-927-8387","VA Facility",Government,no,"Not Available",29.151766,-82.17551
+"0344","Ocala Vet Center","3300 SW 34th Avenue, Suite 140",Ocala,FL,"34474","352-237-1947 Or 877-927-8387","VA Facility",Government,no,"Not Available",29.151766,-82.17551
 0314V,"Orlando Vet Center","5575 S. Semoran Blvd., Suite #30",Orlando,FL,"32822","407-857-2800 Or 407-857-2800","VA Facility",Government,no,"Not Available",28.48248,-81.310104
 0326V,"Palm Beach Vet Center","4996 10th Ave North, Suite 6",Greenacres,FL,"33463","561-422-1201 Or 561-422-1201","VA Facility",Government,no,"Not Available",26.631065,-80.122665
 0338V,"Pasco County Vet Center","5139 Deer Park Drive","New Port Richey",FL,"34653","727-372-1854 Or 727-372-1854","VA Facility",Government,no,"Not Available",28.2442,-82.7193
@@ -601,10 +600,10 @@
 603GC,"VA Healthcare Center, Shively Kentucky CBOC","3934 North Dixie Highway, Suite 210",Louisville,KY,"40216",502-287-6000,"VA Facility",Government,no,"Not Available",38.194138,-85.806725
 621,"Vansant Rural Outreach Clinic","1941 Lovers Gap Road, Suite A",Vansant,VA,"24656",276-597-2106,"VA Facility",Government,no,"Not Available",37.1942,-82.1322
 0722V,"Chattanooga Vet Center","951 Eastgate Loop Road Bldg. 5700 - Suite 300",Chattanooga,TN,"37411","423-855-6570 Or 423-855-6570","VA Facility",Government,no,"Not Available",35.009804,-85.21353
-701,"Johnson City Vet Center","2203 McKinley Road, Suite 254","Johnson City",TN,"37604","423-928-8387 Or 423-928-8387","VA Facility",Government,no,"Not Available",36.3134,-82.3535
-720,"Knoxville Vet Center","8033 Ray Mears Blvd",Knoxville,TN,"37914",865-633-0000,"VA Facility",Government,no,"Not Available",35.923336,-84.04693
-203,"Lexington Vet Center","1500 Leestown Rd Suite 104",Lexington,KY,"40511","859-253-0717 Or 859-253-0717","VA Facility",Government,no,"Not Available",38.065773,-84.523636
-202,"Louisville Vet Center","1347 S. Third Street",Louisville,KY,"40208","502-287-6710 Or 502-287-6710","VA Facility",Government,no,"Not Available",38.23077,-85.75937
+"0701","Johnson City Vet Center","2203 McKinley Road, Suite 254","Johnson City",TN,"37604","423-928-8387 Or 423-928-8387","VA Facility",Government,no,"Not Available",36.3134,-82.3535
+"0720","Knoxville Vet Center","8033 Ray Mears Blvd",Knoxville,TN,"37914",865-633-0000,"VA Facility",Government,no,"Not Available",35.923336,-84.04693
+"0203","Lexington Vet Center","1500 Leestown Rd Suite 104",Lexington,KY,"40511","859-253-0717 Or 859-253-0717","VA Facility",Government,no,"Not Available",38.065773,-84.523636
+"0202","Louisville Vet Center","1347 S. Third Street",Louisville,KY,"40208","502-287-6710 Or 502-287-6710","VA Facility",Government,no,"Not Available",38.23077,-85.75937
 0719V,"Memphis Vet Center","1407 Union Ave., Suite 410",Memphis,TN,"38104","901-522-3950 Or 901-522-3950","VA Facility",Government,no,"Not Available",35.136623,-90.01462
 0724V,"Nashville Vet Center","1420 Donelson Pike Suite A-5",Nashville,TN,"37217","615-366-1220 Or 615-366-1220","VA Facility",Government,no,"Not Available",36.097065,-86.67747
 487,"VISN 10: VA Healthcare System","11500 Northlake Drive, Suite 200",Cincinnati,OH,"45249",513-247-4621,"VA Facility",Government,no,"Not Available",39.276237,-84.34727
@@ -693,25 +692,25 @@
 515BY,"Wyoming Health Care Center","5838 Metro Way",Wyoming,MI,"49519",616-249-5300,"VA Facility",Government,no,"Not Available",37.5823,-81.6018
 553GA,"Yale VA Outpatient Clinic","7470 Brockway Road",Yale,MI,"48097",810-387-3211,"VA Facility",Government,no,"Not Available",43.138046,-82.79886
 757GA,"Zanesville Community Based Outpatient Clinic","2800 Maple Avenue",Zanesville,OH,"43701","740-453-7725 Or 888-615-9448 X 5751","VA Facility",Government,no,"Not Available",39.974194,-82.01204
-204,"Cincinnati Vet Center","801B W. 8th St. Suite 126",Cincinnati,OH,"45203","513-763-3500 Or 513-763-3500","VA Facility",Government,no,"Not Available",39.103344,-84.52966
+"0204","Cincinnati Vet Center","801B W. 8th St. Suite 126",Cincinnati,OH,"45203","513-763-3500 Or 513-763-3500","VA Facility",Government,no,"Not Available",39.103344,-84.52966
 0205V,"Cleveland Vet Center","5310 1/2 Warrensville Center Rd","Maple Heights",OH,"44137","216-707-7901 Or 216-707-7901","VA Facility",Government,no,"Not Available",41.41617,-81.53732
 0221V,"Columbus Vet Center","30 Spruce Street",Columbus,OH,"43215",614-257-5550,"VA Facility",Government,no,"Not Available",39.97233,-83.00369
 0225V,"Dayton Vet Center","627 Edwin C. Moses Blvd.,6th Floor, East Medical Plaza",Dayton,OH,"45417","937-461-9150 Or 937-461-9150","VA Facility",Government,no,"Not Available",39.74863,-84.19844
 0401V,"Dearborn Vet Center","19855 Outer Drive, Suite 105 W",Dearborn,MI,"48124","313-277-1428 Or 313-277-1428","VA Facility",Government,no,"Not Available",42.303585,-83.26335
-402,"Detroit Vet Center","11214 East Jefferson Avenue",Detroit,MI,"48214",313-822-1141,"VA Facility",Government,no,"Not Available",42.36637,-82.97188
+"0402","Detroit Vet Center","11214 East Jefferson Avenue",Detroit,MI,"48214",313-822-1141,"VA Facility",Government,no,"Not Available",42.36637,-82.97188
 0409V,"Fort Wayne Vet Center","5800 Fairfield Ave., Suite 265","Fort Wayne",IN,"46807","260-460-1456 Or 260-460-1456","VA Facility",Government,no,"Not Available",41.03154,-85.14336
-403,"Grand Rapids Vet Center","2050 Breton Rd SE","Grand Rapids",MI,"49546",616-285-5795,"VA Facility",Government,no,"Not Available",42.926167,-85.60905
+"0403","Grand Rapids Vet Center","2050 Breton Rd SE","Grand Rapids",MI,"49546",616-285-5795,"VA Facility",Government,no,"Not Available",42.926167,-85.60905
 0413V,"Indianapolis Vet Center","8330 Naab Road, Suite 103",Indianapolis,IN,"46260","317-988-1600 Or 317-988-1600","VA Facility",Government,no,"Not Available",39.911648,-86.198395
 0437V,"Macomb County Vet Center","42621 Garfield Rd. Suite 105","Clinton Township",MI,"48038","586-412-0107 Or 586-412-0107","VA Facility",Government,no,"Not Available",42.610115,-82.95288
 02061V,"McCafferty Vet Center Outstation","4242 Lorain Avenue Suite 203",Cleveland,OH,"44113","216-939-0784 Or 877-927-8387","VA Facility",Government,no,"Not Available",41.479897,-81.71472
 0206V,"Parma Vet Center","5700 Pearl Road Suite 102",Parma,OH,"44129","440-845-5023 Or 440-845-5023","VA Facility",Government,no,"Not Available",41.406796,-81.74186
 0417V,"Peoria Vet Center","8305 N. Allen Road, Suite 1",Peoria,IL,"61615","309-689-9708 Or 309-689-9708","VA Facility",Government,no,"Not Available",40.788372,-89.63111
 0438V,"Pontiac Vet Center","44200 Woodward Avenue, Suite 108",Pontiac,MI,"48341","248-874-1015 Or 248-874-1015","VA Facility",Government,no,"Not Available",36.5225,-92.5633
-433,"Saginaw Vet Center","5360 Hampton Place",Saginaw,MI,"48604","989-321-4650 Or 989-321-4650","VA Facility",Government,no,"Not Available",37.0239,-94.4683
+"0433","Saginaw Vet Center","5360 Hampton Place",Saginaw,MI,"48604","989-321-4650 Or 989-321-4650","VA Facility",Government,no,"Not Available",37.0239,-94.4683
 0421V,"Springfield, IL Vet Center","2980 Baker Drive",Springfield,IL,"62703","217-492-4955 Or 217-492-4955","VA Facility",Government,no,"Not Available",39.762154,-89.64444
 0241V,"Stark County Vet Center","601 Cleveland Ave N, Suite C",Canton,OH,"44702","330-454-3120 Or 330-454-3120","VA Facility",Government,no,"Not Available",40.79531,-81.37779
 0234V,"Toledo Vet Center","1565 S. Byrne Road, Suite 104",Toledo,OH,"43614","419-213-7533 Or 877-927-8387","VA Facility",Government,no,"Not Available",41.6112,-83.625755
-445,"Traverse City Vet Center","3766 N US 31 South","Traverse City",MI,"49684","231-935-0051 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.7631,-85.6206
+"0445","Traverse City Vet Center","3766 N US 31 South","Traverse City",MI,"49684","231-935-0051 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.7631,-85.6206
 506,"VA Ann Arbor - North Campus Research Complex","2800 Plymouth Road","Ann Arbor",MI,"48105",734-769-7100,"VA Facility",Government,no,"Not Available",42.30256,-83.705765
 506,"VA Ann Arbor - Offsite Warehouse","844 Highland Drive","Ann Arbor",MI,"48105",734-769-7100,"VA Facility",Government,no,"Not Available",42.22654,-83.72491
 506,"VA Ann Arbor Business Office","2200 Commonwealth Blvd","Ann Arbor",MI,"48105",734-769-7100,"VA Facility",Government,no,"Not Available",42.307255,-83.69625
@@ -784,8 +783,8 @@
 0411V,"Oak Park Vet Center","1515 South Harlem","Forest Park",IL,"60130",708-457-8805,"VA Facility",Government,no,"Not Available",33.6221,-84.3691
 0435V,"Orland Park Vet Center","8651 W.159th Street, Suite 1","Orland Park",IL,"60462",708-444-0561,"VA Facility",Government,no,"Not Available",41.60169,-87.83271
 0447V,"Rockford Vet Center","7015 Rote Road, Suite 105",Rockford,IL,"61107","815-395-1276 Or 877-927-8387","VA Facility",Government,no,"Not Available",45.0883,-93.7344
-444,"South Bend Vet Center","4727 Miami Street","South Bend",IN,"46614","574-231-8480 Or 877-927-8387","VA Facility",Government,no,"Not Available",41.627018,-86.234795
-4421,"Wausau Vet Center","605 S 24th Ave, Suite 24",Wausau,WI,"54401","715-842-1724 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.957066,-89.66565
+"0444","South Bend Vet Center","4727 Miami Street","South Bend",IN,"46614","574-231-8480 Or 877-927-8387","VA Facility",Government,no,"Not Available",41.627018,-86.234795
+"04421","Wausau Vet Center","605 S 24th Ave, Suite 24",Wausau,WI,"54401","715-842-1724 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.957066,-89.66565
 10N15,"VISN 15: VA Heartland Network","1201 Walnut St, Suite 800","Kansas City",MO,"64106",816-701-3000,"VA Facility",Government,no,"Not Available",39.099815,-94.582054
 657,"VA St. Louis Health Care System","1 Jefferson Barracks Drive","Saint Louis",MO,"63125",314-652-4100,"VA Facility",Government,no,"Not Available",38.509212,-90.28942
 657,"VA St. Louis Health Care System - John Cochran Division","915 North Grand Blvd.","Saint Louis",MO,"63106",314-652-4100,"VA Facility",Government,no,"Not Available",38.641426,-90.22986
@@ -930,7 +929,7 @@
 0734V,"Alexandria Vet Center","5803 Coliseum Blvd., Sute D",Alexandria,LA,"71303","318-466-4327 Or 877-927-8387","VA Facility",Government,no,"Not Available",31.295115,-92.49501
 0725V,"Baton Rouge Vet Center","7850 Anselmo Lane, Suite B","Baton Rouge",LA,"70810","225-761-3140 Or 225-761-3140","VA Facility",Government,no,"Not Available",30.392668,-91.100845
 0744v,"Bay County Vet Center","3109 Minnesota Ave, Suite 101","Panama City",FL,"32405","850-522-6102 Or 850-522-6102","VA Facility",Government,no,"Not Available",30.208765,-85.6455
-735,"Beaumont Vet Center","990 IH10 North, Suite 180",Beaumont,TX,"77702","409-347-0124 Or 409-347-0124","VA Facility",Government,no,"Not Available",30.0861,-94.1018
+"0735","Beaumont Vet Center","990 IH10 North, Suite 180",Beaumont,TX,"77702","409-347-0124 Or 409-347-0124","VA Facility",Government,no,"Not Available",30.0861,-94.1018
 0737V,"Biloxi Vet Center","288 Veterans Ave",Biloxi,MS,"39531","228-388-9938 Or 228-388-9938","VA Facility",Government,no,"Not Available",30.40239,-88.94716
 0727V,"Fayetteville Vet Center","1416 N. College Ave.",Fayetteville,AR,"72703","479-582-7152 Or 479-582-7152","VA Facility",Government,no,"Not Available",36.08108,-94.156654
 0710V,"Houston Southwest Vet Center","10103 Fondren Road, Suite 470",Houston,TX,"77096",713-523-0884,"VA Facility",Government,no,"Not Available",29.67084,-95.50856
@@ -1016,7 +1015,7 @@
 0714V,"Lubbock Vet Center","3106 50th st sute 400",Lubbock,TX,"79413","806-792-9782 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.54874,-101.881485
 0715V,"McAllen Vet Center","2108 S M Street, MedPoint Plaza, Unit 2",McAllen,TX,"78503","956-631-2147 Or 956-631-2147","VA Facility",Government,no,"Not Available",26.2034,-98.23
 0730V,"Mesquite Vet Center","502 West Kearney, Suite 300",Mesquite,TX,"75149","972-288-8030 Or 972-288-8030","VA Facility",Government,no,"Not Available",32.770718,-96.602806
-716,"Midland Vet Center","4400 N. Midland Drive, Suite 540",Midland,TX,"79707","432-697-8222 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.122,-87.1917
+"0716","Midland Vet Center","4400 N. Midland Drive, Suite 540",Midland,TX,"79707","432-697-8222 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.122,-87.1917
 0700V,"RCS Continental District 4, Zone 2 District Office","4500 S. Lancaster Rd. Building 69",Dallas,TX,"75216","214-857-1254 Or 214-857-1254","VA Facility",Government,no,"Not Available",32.694347,-96.79335
 0721V,"San Antonio Northeast Vet Center","9504 IH 35 N, Suite 214","San Antonio",TX,"78233","210-650-0422 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.1838,-122.5914
 0729V,"San Antonio Northwest Vet Center","9910 W Loop 1604 N, Suite 126","San Antonio",TX,"78254","210-688-0606 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.1838,-122.5914
@@ -1101,26 +1100,26 @@
 660GJ,"Western Salt Lake CBOC","2750 South 5600 West","West Valley City",UT,"84120",801-417-5734,"VA Facility",Government,no,"Not Available",40.709984,-112.02493
 635GB,"Wichita Falls VA Clinic","149 Hart Street","Sheppard Air Force Base",TX,"76311",940-257-0000,"VA Facility",Government,no,"Not Available",33.976726,-98.517373 
 0509V,"Billings Vet Center","2795 Enterprise Ave., Suite 1",Billings,MT,"59102","406-657-6071 Or 406-657-6071","VA Facility",Government,no,"Not Available",45.75003,-108.58542
-527,"Boulder Vet Center","4999 Pearl East Circle, Suite 106",Boulder,CO,"80301","303-440-7306 Or 877-927-8387","VA Facility",Government,no,"Not Available",40.02116,-105.23718
+"0527","Boulder Vet Center","4999 Pearl East Circle, Suite 106",Boulder,CO,"80301","303-440-7306 Or 877-927-8387","VA Facility",Government,no,"Not Available",40.02116,-105.23718
 0519V,"Casper Vet Center","1030 North Poplar, Suite B",Casper,WY,"82601","307-261-5355 Or 307-261-5355","VA Facility",Government,no,"Not Available",42.860615,-106.33267
 0501V,"Cheyenne Vet Center","3219 E Pershing Blvd",Cheyenne,WY,"82001","307-778-7370 Or 307-778-7370","VA Facility",Government,no,"Not Available",41.145607,-104.77146
-525,"Colorado Springs Vet Center","602 South Nevada Avenue","Colorado Springs",CO,"80903","719-471-9992 Or 719-471-9992","VA Facility",Government,no,"Not Available",38.82535,-104.822044
+"0525","Colorado Springs Vet Center","602 South Nevada Avenue","Colorado Springs",CO,"80903","719-471-9992 Or 719-471-9992","VA Facility",Government,no,"Not Available",38.82535,-104.822044
 0504V,"Denver Vet Center","7465 East First Avenue Suite B",Denver,CO,"80230",303-326-0645,"VA Facility",Government,no,"Not Available",39.718548,-104.90127
 0543V,"Fort Collins Vet Center","702 W Drake Builing C","Fort Collins",CO,"80526","970-221-5176 Or 970-221-5176","VA Facility",Government,no,"Not Available",40.552666,-105.087814
-526,"Grand Junction Vet Center","2472 Patterson Road Unit 16","Grand Junction",CO,"81505","970-245-4156 Or 970-245-4156","VA Facility",Government,no,"Not Available",39.091896,-108.59437
-538,"Great Falls Vet Center","615 2nd Avenue North","Great Falls",MT,"59401","406-452-9048 Or 406-452-9048","VA Facility",Government,no,"Not Available",47.507515,-111.29696
+"0526","Grand Junction Vet Center","2472 Patterson Road Unit 16","Grand Junction",CO,"81505","970-245-4156 Or 970-245-4156","VA Facility",Government,no,"Not Available",39.091896,-108.59437
+"0538","Great Falls Vet Center","615 2nd Avenue North","Great Falls",MT,"59401","406-452-9048 Or 406-452-9048","VA Facility",Government,no,"Not Available",47.507515,-111.29696
 5281,"Helena Outstation","1301 Elm Street Suite C",Helena,MT,"59601",406-457-8060,"VA Facility",Government,no,"Not Available",46.607727,-112.01875
-539,"Kalispell Vet Center","690 North Meridian Road, Suite 101",Kalispell,MT,"59901",406-257-7308,"VA Facility",Government,no,"Not Available",48.189045,-114.330666
+"0539","Kalispell Vet Center","690 North Meridian Road, Suite 101",Kalispell,MT,"59901",406-257-7308,"VA Facility",Government,no,"Not Available",48.189045,-114.330666
 0728V,"Lawton Vet Center","1016 SW C Avenue, Suite B",Lawton,OK,"73501",580-585-5880,"VA Facility",Government,no,"Not Available",34.605194,-98.40351
-528,"Missoula Vet Center","910 Brooks St.",Missoula,MT,"59801",406-721-4918,"VA Facility",Government,no,"Not Available",46.855923,-114.007286
+"0528","Missoula Vet Center","910 Brooks St.",Missoula,MT,"59801",406-721-4918,"VA Facility",Government,no,"Not Available",46.855923,-114.007286
 5141,"Ogden Outstation","2357 N 400 E Washington Blvd","North Ogden",UT,"84414",801-737-9737,"VA Facility",Government,no,"Not Available",41.30123,-111.968796
 0718V,"Oklahoma City Vet Center","6804 N. Robinson Avenue","Oklahoma City",OK,"73116","405-456-5184 Or 877-927-8387","VA Facility",Government,no,"Not Available",35.540695,-97.51643
-531,"Pocatello Vet Center","1800 Garrett Way, Suite 47",Pocatello,ID,"83201","208-232-0316 Or 208-232-0316","VA Facility",Government,no,"Not Available",42.87654,-112.458466
-532,"Provo Vet Center","360 S. State Street Bldg C Suite 103",Orem,UT,"84058",801-377-1117,"VA Facility",Government,no,"Not Available",40.29056,-111.69216
-542,"Pueblo Vet Center","1515 Fortino Blvd., Suite 130",Pueblo,CO,"81008",719-583-4058,"VA Facility",Government,no,"Not Available",38.312466,-104.62828
+"0531","Pocatello Vet Center","1800 Garrett Way, Suite 47",Pocatello,ID,"83201","208-232-0316 Or 208-232-0316","VA Facility",Government,no,"Not Available",42.87654,-112.458466
+"0532","Provo Vet Center","360 S. State Street Bldg C Suite 103",Orem,UT,"84058",801-377-1117,"VA Facility",Government,no,"Not Available",40.29056,-111.69216
+"0542","Pueblo Vet Center","1515 Fortino Blvd., Suite 130",Pueblo,CO,"81008",719-583-4058,"VA Facility",Government,no,"Not Available",38.312466,-104.62828
 0500V,"RCS Continental District 4 District Office","789 Sherman Street, Suite 570",Denver,CO,"80203","303-577-5205 Or 303-577-5207","VA Facility",Government,no,"Not Available",39.728817,-104.98489
 0540v,"Saint George Vet Center","1664 South Dixie Drive, Suite C-102","St. George",UT,"84770","435-673-4494 Or 435-673-4494","VA Facility",Government,no,"Not Available",56.6,-169.5417
-514,"Salt Lake Vet Center","22 West Fireclay Avenue",Murray,UT,"84107","801-266-1499 Or 877-927-8387","VA Facility",Government,no,"Not Available",40.677994,-111.89191
+"0514","Salt Lake Vet Center","22 West Fireclay Avenue",Murray,UT,"84107","801-266-1499 Or 877-927-8387","VA Facility",Government,no,"Not Available",40.677994,-111.89191
 0723V,"Tulsa Vet Center","14002 E. 21st Street",Tulsa,OK,"74134","918-628-2760 Or 918-628-2760","VA Facility",Government,no,"Not Available",36.13344,-95.82066
 10N20,"VISN 20: Northwest Network","1601 4th Plain Blvd Building 17, 4th Floor, Suite 403",Vancouver,WA,"98661",360-619-5925,"VA Facility",Government,no,"Not Available",45.6387,-122.6615
 463,"Alaska VA Healthcare System","1201 North Muldoon Road",Anchorage,AK,"99504","907-257-4700 Or 907-257-4700","VA Facility",Government,no,"Not Available",61.23116,-149.74269
@@ -1182,22 +1181,21 @@
 0522V,"Bellingham Vet Center","3800 Byron Ave Suite 124",Bellingham,WA,"98229","360-733-9226 Or 877-927-8387","VA Facility",Government,no,"Not Available",48.73362,-122.46637
 0503V,"Boise Vet Center","2424 Bank DrivE, Suite 100",Boise,ID,"83705","208-342-3612 Or 877-927-8387","VA Facility",Government,no,"Not Available",43.59107,-116.211555
 0622V,"Central Oregon Vet Center","1645 NE Forbes Rd. Suite 105",Bend,OR,"97701","541-749-2112 Or 541-749-2112","VA Facility",Government,no,"Not Available",31.0561,-98.509
-626,"Eugene Vet Center","190 East 11th Avenue",Eugene,OR,"97401","541-465-6918 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.0477,-123.08984
-529,"Everett Vet Center","3311 Wetmore Avenue",Everett,WA,"98201",425-252-9701,"VA Facility",Government,no,"Not Available",47.97373,-122.20698
+"0626","Eugene Vet Center","190 East 11th Avenue",Eugene,OR,"97401","541-465-6918 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.0477,-123.08984
+"0529","Everett Vet Center","3311 Wetmore Avenue",Everett,WA,"98201",425-252-9701,"VA Facility",Government,no,"Not Available",47.97373,-122.20698
 0511V,"Fairbanks Vet Center","540 4th Ave., Suite 100",Fairbanks,AK,"99701","907-456-4238 Or 877-927-8387","VA Facility",Government,no,"Not Available",64.842415,-147.71849
 0535V,"Federal Way Vet Center","32020 32nd Ave South Suite 110","Federal Way",WA,"98001","253-838-3090 Or 253-838-3090","VA Facility",Government,no,"Not Available",47.3223,-122.3126
-645,"Grants Pass Vet Center","211 S.E. 10th St.","Grants Pass",OR,"97526","541-479-6912 Or 877-927-8387","VA Facility",Government,no,"Not Available",42.43722,-123.322266
+"0645","Grants Pass Vet Center","211 S.E. 10th St.","Grants Pass",OR,"97526","541-479-6912 Or 877-927-8387","VA Facility",Government,no,"Not Available",42.43722,-123.322266
 05021V,"Kenai Vet Center Outstation","43299 Kalifornsky Beach Rd. Ste 4",Soldotna,AK,"99669","907-260-7640 Or 877-927-8387","VA Facility",Government,no,"Not Available",60.3208,-150.7989
 0617V,"Portland Vet Center","1505 NE 122nd Ave.",Portland,OR,"97230","503-688-5361 Or 877-927-8387 X 7","VA Facility",Government,no,"Not Available",45.53367,-122.53765
-640,"Salem Vet Center","2645 Portland Road NE, Suite 250",Salem,OR,"97301","503-362-9911 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.961227,-123.014565
+"0640","Salem Vet Center","2645 Portland Road NE, Suite 250",Salem,OR,"97301","503-362-9911 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.961227,-123.014565
 0507V,"Seattle Vet Center","4735 E Marginal Way S, Room 1102",Seattle,WA,"98134","206-658-4225 Or 877-927-8387","VA Facility",Government,no,"Not Available",47.6062,-122.3321
 0510V,"Spokane Vet Center","13109 E Mirabeau Parkway",Spokane,WA,"99216","509-444-8387 Or 509-444-8387","VA Facility",Government,no,"Not Available",47.6597,-117.4291
-508,"Tacoma Vet Center","4916 Center St. Suite E",Tacoma,WA,"98409","253-565-7038 Or 253-565-7038","VA Facility",Government,no,"Not Available",47.234417,-122.50397
+"0508","Tacoma Vet Center","4916 Center St. Suite E",Tacoma,WA,"98409","253-565-7038 Or 253-565-7038","VA Facility",Government,no,"Not Available",47.234417,-122.50397
 0541V,"Walla Walla County Vet Center","1104 West Poplar","Walla Walla",WA,"99362","509-526-8387 Or 509-526-8387","VA Facility",Government,no,"Not Available",46.059216,-118.35254
 0512V,"Wasilla Vet Center","851 E. West Point Drive Suite 102",Wasilla,AK,"99654","907-376-4318 Or 907-376-4318","VA Facility",Government,no,"Not Available",61.58227,-149.42818
-523,"Yakima Vet Center","2119 W. Lincoln Ave",Yakima,WA,"98902","509-457-2736 Or 509-457-2736","VA Facility",Government,no,"Not Available",46.603485,-120.537346
 687,687,"77 Wainwright Drive","Walla Walla",WA,"99362",,"VA Facility",Government,no,"Not Available",46.052536,-118.35569
-523,"Yakima Valley Vet Center","2119 West Lincoln Avenue",Yakima,WA,"98902",509-457-2736,"VA Facility",Government,no,"Not Available",46.603485,-120.53733
+"0523","Yakima Valley Vet Center","2119 West Lincoln Avenue",Yakima,WA,"98902",509-457-2736,"VA Facility",Government,no,"Not Available",46.603485,-120.53733
 10N21,"VISN 21: Sierra Pacific Network","201 Walnut Avenue","Mare Island",CA,"94592",707-562-8350,"VA Facility",Government,no,"Not Available", 38.100625,-122.273223 
 662,"San Francisco VA Health Care System","4150 Clement Street","San Francisco",CA,"94121",415-221-4810,"VA Facility",Government,no,"Not Available",37.781143,-122.504105
 570,"Central California VA Health Care System","2615 E. Clinton Avenue",Fresno,CA,"93703","559-225-6100 Or 559-225-6100","VA Facility",Government,no,"Not Available",36.77229,-119.78002
@@ -1253,29 +1251,29 @@
 459,"VA Kona Community Based Outpatient Clinic","35-377 Hualalai Road",Kailua-Kona,HI,"96740",808-329-0774,"VA Facility",Government,no,"Not Available",19.6406,-155.9956
 1396,"VA Leeward Community Based Outpatient Clinic","91-2135 Fort Weaver Road","Ewa Beach",HI,"96706",800-214-1306,"VA Facility",Government,no,"Not Available",21.369507,-158.02618
 459,"VA Maui Community Based Outpatient Clinic","203 Ho'ohana Street, Suite 303",Kahului,HI,"96732",808-871-2454,"VA Facility",Government,no,"Not Available",20.88696,-156.46333
-612,"Yuba City Outpatient Clinic","425 Plumas Street","Yuba City",CA,"95991",530-751-4500,"VA Facility",Government,no,"Not Available",39.130913,-121.614136
-649,"Chico Vet Center","250 Cohasset Road, Suite 40",Chico,CA,"95926","530-899-6300 Or 530-899-6300","VA Facility",Government,no,"Not Available",39.75176,-121.85193
-610,"Citrus Heights Vet Center","5650 Sunrise Blvd., Suite 150","Citrus Heights",CA,"95610","916-535-0420 Or 916-535-0420","VA Facility",Government,no,"Not Available",38.670345,-121.27155
-602,"Concord Vet Center","1333 Willow Pass Road, Suite 106",Concord,CA,"94520","925-680-4526 Or 925-680-4526","VA Facility",Government,no,"Not Available",37.972385,-122.05445
-644,"Eureka Vet Center","2830 G Street, Suite A",Eureka,CA,"95501","707-444-8271 Or 707-444-8271","VA Facility",Government,no,"Not Available",40.782574,-124.16242
-628,"Fresno Vet Center","1320 E. Shaw Ave, Suite 125",Fresno,CA,"93710","559-487-5660 Or 877-927-8387","VA Facility",Government,no,"Not Available",36.808594,-119.76464
-534,"Henderson Vet Center","400 North Stephanie, Suite 180",Henderson,NV,"89014","702-791-9100 Or 702-791-9100","VA Facility",Government,no,"Not Available",36.05657,-115.0462
-635,"Hilo Vet Center","70 Lanihuli Street, Suite 102",Hilo,HI,"96720","808-969-3833 Or 887-969-3833","VA Facility",Government,no,"Not Available",19.71111,-155.07872
-609,"Honolulu Vet Center","1680 Kapiolani Blvd. Suite F-3",Honolulu,HI,"96814","808-973-8387 Or 877-927-8387","VA Facility",Government,no,"Not Available",21.291153,-157.83807
+"0612","Yuba City Outpatient Clinic","425 Plumas Street","Yuba City",CA,"95991",530-751-4500,"VA Facility",Government,no,"Not Available",39.130913,-121.614136
+"0649","Chico Vet Center","250 Cohasset Road, Suite 40",Chico,CA,"95926","530-899-6300 Or 530-899-6300","VA Facility",Government,no,"Not Available",39.75176,-121.85193
+"0610","Citrus Heights Vet Center","5650 Sunrise Blvd., Suite 150","Citrus Heights",CA,"95610","916-535-0420 Or 916-535-0420","VA Facility",Government,no,"Not Available",38.670345,-121.27155
+"0602","Concord Vet Center","1333 Willow Pass Road, Suite 106",Concord,CA,"94520","925-680-4526 Or 925-680-4526","VA Facility",Government,no,"Not Available",37.972385,-122.05445
+"0644","Eureka Vet Center","2830 G Street, Suite A",Eureka,CA,"95501","707-444-8271 Or 707-444-8271","VA Facility",Government,no,"Not Available",40.782574,-124.16242
+"0628","Fresno Vet Center","1320 E. Shaw Ave, Suite 125",Fresno,CA,"93710","559-487-5660 Or 877-927-8387","VA Facility",Government,no,"Not Available",36.808594,-119.76464
+"0534","Henderson Vet Center","400 North Stephanie, Suite 180",Henderson,NV,"89014","702-791-9100 Or 702-791-9100","VA Facility",Government,no,"Not Available",36.05657,-115.0462
+"0635","Hilo Vet Center","70 Lanihuli Street, Suite 102",Hilo,HI,"96720","808-969-3833 Or 887-969-3833","VA Facility",Government,no,"Not Available",19.71111,-155.07872
+"0609","Honolulu Vet Center","1680 Kapiolani Blvd. Suite F-3",Honolulu,HI,"96814","808-973-8387 Or 877-927-8387","VA Facility",Government,no,"Not Available",21.291153,-157.83807
 0636V,"Kailua-Kona Vet Center","73-4976 Kamanu St",Kailua-Kona,HI,"96740",808-329-0574,"VA Facility",Government,no,"Not Available",19.687277,-156.01602
-633,"Kauai Vet Center","4485 Pahe'e St., Suite 101",Lihue,HI,"96766","808-246-1163 Or 877-927-8387","VA Facility",Government,no,"Not Available",21.968864,-159.38431
+"0633","Kauai Vet Center","4485 Pahe'e St., Suite 101",Lihue,HI,"96766","808-246-1163 Or 877-927-8387","VA Facility",Government,no,"Not Available",21.968864,-159.38431
 0505V,"Las Vegas Vet Center","7455 W. Washington Ave, Suite 240","Las Vegas",NV,"89128",702-791-9170,"VA Facility",Government,no,"Not Available",36.181328,-115.2531
-634,"Maui Vet Center","157 Ma'a Street",KAHULUI,HI,"96732",808-242-8557,"VA Facility",Government,no,"Not Available",20.8895,-156.4743
-650,"Modesto Vet Center","1219 N. Carpenter Rd., Suite 11-12",Modesto,CA,"95351","209-569-0713 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.652004,-121.031006
-646,"North Bay Vet Center","6010 Commerce Blvd., Ste. 145","Rohnert Park",CA,"94928",707-586-3295,"VA Facility",Government,no,"Not Available",38.352222,-122.71077
-612,"Oakland Vet Center","7700 Edgewater Drive, Suite 125",Oakland,CA,"94621","510-562-7906 Or 510-562-7906","VA Facility",Government,no,"Not Available",37.743034,-122.20435
-647,"Peninsula Vet Center","345 Middlefield Road, Building 1","Menlo Park",CA,"94025","650-617-4300 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.456406,-122.16773
+"0634","Maui Vet Center","157 Ma'a Street",KAHULUI,HI,"96732",808-242-8557,"VA Facility",Government,no,"Not Available",20.8895,-156.4743
+"0650","Modesto Vet Center","1219 N. Carpenter Rd., Suite 11-12",Modesto,CA,"95351","209-569-0713 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.652004,-121.031006
+"0646","North Bay Vet Center","6010 Commerce Blvd., Ste. 145","Rohnert Park",CA,"94928",707-586-3295,"VA Facility",Government,no,"Not Available",38.352222,-122.71077
+"0612","Oakland Vet Center","7700 Edgewater Drive, Suite 125",Oakland,CA,"94621","510-562-7906 Or 510-562-7906","VA Facility",Government,no,"Not Available",37.743034,-122.20435
+"0647","Peninsula Vet Center","345 Middlefield Road, Building 1","Menlo Park",CA,"94025","650-617-4300 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.456406,-122.16773
 0600V,"RCS Pacific District 5 District Office","420 Executive Court North Suite A",Fairfield,CA,"94534","707-646-2988 Or 707-646-2988","VA Facility",Government,no,"Not Available",38.230152,-122.12159
 0506V,"Reno Vet Center","5580 Mill St. Suite 600",Reno,NV,"89502","775-323-1294 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.3728,-81.3957
-638,"Sacramento Vet Center","1111 Howe Avenue Suite #390",Sacramento,CA,"95825","916-566-7430 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.584957,-121.41534
-620,"San Francisco Vet Center","505 Polk Street","San Francisco",CA,"94102","415-441-5051 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.78154,-122.418884
-615,"San Jose Vet Center","80 Great Oaks Blvd.","San Jose",CA,"95119","408-993-0729 Or 408-993-0729","VA Facility",Government,no,"Not Available",37.233974,-121.778854
-639,"Santa Cruz County Vet Center","1350 41st Ave, Suite 104",Capitola,CA,"95010","831-464-4575 Or 877-927-8387","VA Facility",Government,no,"Not Available",36.97057,-121.96488
+"0638","Sacramento Vet Center","1111 Howe Avenue Suite #390",Sacramento,CA,"95825","916-566-7430 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.584957,-121.41534
+"0620","San Francisco Vet Center","505 Polk Street","San Francisco",CA,"94102","415-441-5051 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.78154,-122.418884
+"0615","San Jose Vet Center","80 Great Oaks Blvd.","San Jose",CA,"95119","408-993-0729 Or 408-993-0729","VA Facility",Government,no,"Not Available",37.233974,-121.778854
+"0639","Santa Cruz County Vet Center","1350 41st Ave, Suite 104",Capitola,CA,"95010","831-464-4575 Or 877-927-8387","VA Facility",Government,no,"Not Available",36.97057,-121.96488
 0621V,"Western Oahu Vet Center","885 Kamokila Boulevard, Suite 105",Kapolei,HI,"96707","808-674-2414 Or 877-927-8387","VA Facility",Government,no,"Not Available",21.330032,-158.08583
 593GH,"Laughlin Rural Outreach Clinic","3650 South Point Circle, Building D, 2nd Floor, Suite 200",Laughlin,NV,"89029",702-298-1100,"VA Facility",Government,no,"Not Available",35.1678,-114.573
 10N22,"VISN 22: Desert Pacific Healthcare Network","300 Oceangate, Suite 700","Long Beach",CA,"90802",562-826-5963,"VA Facility",Government,no,"Not Available",33.766495,-118.1987
@@ -1358,33 +1356,33 @@
 600gd,"Whittier/Santa Fe Springs Clinic","10330 Pioneer Blvd Suite 180","Santa Fe Springs",CA,"90670",562-347-2200,"VA Facility",Government,no,"Not Available",33.9472,-118.0854
 470-8262,"Yuma Clinic","3111 S. 4th Avenue",Yuma,AZ,"85364",928-317-9973,"VA Facility",Government,no,"Not Available",32.672523,-114.62432
 0515V,"Albuquerque Vet Center","2001 Mountain Road NW",Albuquerque,NM,"87104","505-346-6562 Or 505-346-6562","VA Facility",Government,no,"Not Available",35.098385,-106.66792
-603,"Antelope Valley Vet Center","38925 Trade Center Drive, Suites I/J",Palmdale,CA,"93551","661-267-1026 Or 661-267-1026","VA Facility",Government,no,"Not Available",34.5794,-118.1165
-601,"Bakersfield Vet Center","1110 Golden State Ave.",Bakersfield,CA,"93301","661-323-8387 Or 661-323-8387","VA Facility",Government,no,"Not Available",44.782,-72.8029
+"0603","Antelope Valley Vet Center","38925 Trade Center Drive, Suites I/J",Palmdale,CA,"93551","661-267-1026 Or 661-267-1026","VA Facility",Government,no,"Not Available",34.5794,-118.1165
+"0601","Bakersfield Vet Center","1110 Golden State Ave.",Bakersfield,CA,"93301","661-323-8387 Or 661-323-8387","VA Facility",Government,no,"Not Available",44.782,-72.8029
 605,"Chatsworth Vet Center","20946 Devonshire St, Suite 101",Chatsworth,CA,"91311",818-576-0201,"VA Facility",Government,no,"Not Available",34.25723,-118.5896
 05161V,"Chinle Vet Center Outstation","Navajo Route 7, Old BIA Complex-B59",Chinle,AZ,"86503",844-286-7270,"VA Facility",Government,no,"Not Available",36.2391,-109.5747
-614,"Chula Vista Vet Center","180 Otay Lakes Road, Suite 108",Bonita,CA,"91902","877-618-6534 Or 877-618-6534","VA Facility",Government,no,"Not Available",32.659225,-117.03042
-611,"Corona Vet Center","800 Magnolia Avenue Suite 110",Corona,CA,"92879","951-734-0525 Or 951-734-0525","VA Facility",Government,no,"Not Available",33.85894,-117.55446
-607,"Culver City Vet Center","5730 Uplander Way Suite 100","Culver City",CA,"90230","310-641-0326 Or 310-641-0326","VA Facility",Government,no,"Not Available",33.986443,-118.38459
-623,"East Los Angeles Vet Center","5400 E. Olympic Blvd. Suite 140",Commerce,CA,"90022","323-728-9966 Or 323-728-9966","VA Facility",Government,no,"Not Available",34.015686,-118.1557
+"0614","Chula Vista Vet Center","180 Otay Lakes Road, Suite 108",Bonita,CA,"91902","877-618-6534 Or 877-618-6534","VA Facility",Government,no,"Not Available",32.659225,-117.03042
+"0611","Corona Vet Center","800 Magnolia Avenue Suite 110",Corona,CA,"92879","951-734-0525 Or 951-734-0525","VA Facility",Government,no,"Not Available",33.85894,-117.55446
+"0607","Culver City Vet Center","5730 Uplander Way Suite 100","Culver City",CA,"90230","310-641-0326 Or 310-641-0326","VA Facility",Government,no,"Not Available",33.986443,-118.38459
+"0623","East Los Angeles Vet Center","5400 E. Olympic Blvd. Suite 140",Commerce,CA,"90022","323-728-9966 Or 323-728-9966","VA Facility",Government,no,"Not Available",34.015686,-118.1557
 0516V,"Farmington Vet Center","4251 E. Main Suite A",Farmington,NM,"87402","505-327-9684 Or 505-327-9684","VA Facility",Government,no,"Not Available",36.759556,-108.15592
-613,"High Desert Vet Center","15095 Amargosa Rd, Suite 107",Victorville,CA,"92394","760-261-5925 Or 760-261-5925","VA Facility",Government,no,"Not Available",34.524727,-117.33031
-5162,"Hopi Vet Center Outstation","P.O. Box 929, 1 Main St.",Hotevilla,AZ,"86030","928-734-5166 Or 928-734-5166","VA Facility",Government,no,"Not Available",35.9278,-110.6729
-536,"Lake Havasu Vet Center","1720 Mesquite, Suite 101","Lake Havasu",AZ,"86403","928-505-0394 Or 928-505-0394","VA Facility",Government,no,"Not Available",34.478374,-114.34081
-530,"Las Cruces Vet Center","1120 Commerce Street, Suite B","Las Cruces",NM,"88001","575-523-9826 Or 575-523-9826","VA Facility",Government,no,"Not Available",32.3123,-106.7783
+"0613","High Desert Vet Center","15095 Amargosa Rd, Suite 107",Victorville,CA,"92394","760-261-5925 Or 760-261-5925","VA Facility",Government,no,"Not Available",34.524727,-117.33031
+"05162","Hopi Vet Center Outstation","P.O. Box 929, 1 Main St.",Hotevilla,AZ,"86030","928-734-5166 Or 928-734-5166","VA Facility",Government,no,"Not Available",35.9278,-110.6729
+"0536","Lake Havasu Vet Center","1720 Mesquite, Suite 101","Lake Havasu",AZ,"86403","928-505-0394 Or 928-505-0394","VA Facility",Government,no,"Not Available",34.478374,-114.34081
+"0530","Las Cruces Vet Center","1120 Commerce Street, Suite B","Las Cruces",NM,"88001","575-523-9826 Or 575-523-9826","VA Facility",Government,no,"Not Available",32.3123,-106.7783
 0606V,"Los Angeles Vet Center","1045 W. Redondo Beach Blvd. Suite 150",Gardena,CA,"90247","310-767-1221 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.89245,-118.29319
-524,"Mesa Vet Center","1303 South Longmore, Suite 5",Mesa,AZ,"85202","480-610-6727 Or 480-610-6727","VA Facility",Government,no,"Not Available",33.391068,-111.863785
-624,"North Orange County Vet Center","12453 Lewis St. Suite 101","Garden Grove",CA,"92840","714-776-0161 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.78244,-117.897484
+"0524","Mesa Vet Center","1303 South Longmore, Suite 5",Mesa,AZ,"85202","480-610-6727 Or 480-610-6727","VA Facility",Government,no,"Not Available",33.391068,-111.863785
+"0624","North Orange County Vet Center","12453 Lewis St. Suite 101","Garden Grove",CA,"92840","714-776-0161 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.78244,-117.897484
 0517V,"Phoenix Vet Center","4020 N. 20th St. #110",Phoenix,AZ,"85016","602-640-2981 Or 602-640-2981","VA Facility",Government,no,"Not Available",33.4934,-112.038925
 0518V,"Prescott Vet Center (Dr. Cameron K. McKinley Vet Center)","3180 Stillwater Drive, Suite A",Prescott,AZ,"86305","928-778-3469 Or 877-927-8387","VA Facility",Government,no,"Not Available",34.59808,-112.46729
-637,"San Bernardino Vet Center","1325 E. Cooley Drive, Suite 101",Colton,CA,"92324","909-801-5762 Or 877-927-8387","VA Facility",Government,no,"Not Available",34.054634,-117.30536
-618,"San Diego Vet Center","2790 Truxtun Road, Suite 130","San Diego",CA,"92106","858-642-1500 Or 858-642-1500","VA Facility",Government,no,"Not Available",32.740627,-117.21285
+"0637","San Bernardino Vet Center","1325 E. Cooley Drive, Suite 101",Colton,CA,"92324","909-801-5762 Or 877-927-8387","VA Facility",Government,no,"Not Available",34.054634,-117.30536
+"0618","San Diego Vet Center","2790 Truxtun Road, Suite 130","San Diego",CA,"92106","858-642-1500 Or 858-642-1500","VA Facility",Government,no,"Not Available",32.740627,-117.21285
 0619v,"San Luis Obispo Vet Center","1070 Southwood Drive","San Luis Obispo",CA,"93401","805-782-9101 Or 877-927-8387","VA Facility",Government,no,"Not Available",35.265366,-120.64087
-642,"San Marcos Vet Center","One Civic Center Dr., Suite 150","San Marcos",CA,"92069","855-898-6050 Or 877-927-8387","VA Facility",Government,no,"Not Available",29.8833,-97.9414
+"0642","San Marcos Vet Center","One Civic Center Dr., Suite 150","San Marcos",CA,"92069","855-898-6050 Or 877-927-8387","VA Facility",Government,no,"Not Available",29.8833,-97.9414
 0520V,"Santa Fe Vet Center","2209 Brothers Road Suite 110","Santa Fe",NM,"87505","505-988-6562 Or 505-988-6562","VA Facility",Government,no,"Not Available",35.65078,-105.95243
 5921,"South Orange County Vet Center","26431 Crown Valley Parkway, Suite 100","Mission Viejo",CA,"92691","949-348-6700 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.6,-117.672
-608,"Temecula Vet Center","40935 County Center Drive, Suite A/B",Temecula,CA,"92591","951-302-4849 Or 951-302-4849","VA Facility",Government,no,"Not Available",33.528206,-117.16034
+"0608","Temecula Vet Center","40935 County Center Drive, Suite A/B",Temecula,CA,"92591","951-302-4849 Or 951-302-4849","VA Facility",Government,no,"Not Available",33.528206,-117.16034
 0521V,"Tucson Vet Center","2525 E. Broadway Blvd Suite 100",Tucson,AZ,"85716",520-882-0333,"VA Facility",Government,no,"Not Available",32.221508,-110.93447
-643,"Ventura Vet Center","790 E. Santa Clara St. Suite 100",Ventura,CA,"93001","805-585-1860 Or 805-585-1860","VA Facility",Government,no,"Not Available",34.279526,-119.28866
+"0643","Ventura Vet Center","790 E. Santa Clara St. Suite 100",Ventura,CA,"93001","805-585-1860 Or 805-585-1860","VA Facility",Government,no,"Not Available",34.279526,-119.28866
 0533V,"West Valley Vet Center","14050 N. 83rd Avenue Suite 170",Peoria,AZ,"85381","623-398-8854 Or 623-398-8854","VA Facility",Government,no,"Not Available",33.612053,-112.23756
 0537V,"Yuma Vet Center","1450 E. 16th St, Suite 103",Yuma,AZ,"85365","928-271-8700 Or 928-271-8700","VA Facility",Government,no,"Not Available",32.69857,-114.60357
 678CG,"Casa Grande Rural Health Care Coordination Center","1179 E. Cottonwood Lane, Suite 1","Casa Grande",AZ,"85122","520-629-4801 Or 520-629-4801","VA Facility",Government,no,"Not Available",32.894085,-111.735535
@@ -1473,7 +1471,7 @@
 0406V,"Fargo Vet Center","3310 Fiechtner Drive. Suite 100",Fargo,ND,"58103","701-237-0942 Or 701-237-0942","VA Facility",Government,no,"Not Available",46.86399,-96.83272
 589GE,"Grand Forks Vet Center","3001 32nd Ave. S. Suite 6A","Grand Forks",ND,"58201","701-620-1448 Or 877-927-8387","VA Facility",Government,no,"Not Available",47.88944,-97.07062
 0427V,"Lincoln Vet Center","3119 O Street, Suite A",Lincoln,NE,"68510","402-476-9736 Or 402-476-9736","VA Facility",Government,no,"Not Available",40.813408,-96.67602
-4231,"Martin Outstation","P.O. Box 910 105 E. Hwy 18",Martin,SD,"57747","605-685-1300 Or 605-685-1300","VA Facility",Government,no,"Not Available",47.7686,-100.0911
+"04231","Martin Outstation","P.O. Box 910 105 E. Hwy 18",Martin,SD,"57747","605-685-1300 Or 605-685-1300","VA Facility",Government,no,"Not Available",47.7686,-100.0911
 0404V,"Minot Vet Center","1400 20th Avenue SW Ste 2",Minot,ND,"58701","701-852-0177 Or 877-927-8387","VA Facility",Government,no,"Not Available",48.210842,-101.31301
 0424V,"Omaha Vet Center","3047 S 72nd Street",Omaha,NE,"68124",402-346-6735,"VA Facility",Government,no,"Not Available",41.23105,-96.02388
 0430V,"Quad Cities Vet Center","465 Avenue of the Cities, Suite #140","East Moline",IL,"61244","309-755-3260 Or 309-755-3260","VA Facility",Government,no,"Not Available",41.5212,-90.3858
@@ -1482,5 +1480,3 @@
 0425V,"Sioux Falls Vet Center","3200 W 49th Street","Sioux Falls",SD,"57106","605-330-4552 Or 605-330-4552","VA Facility",Government,no,"Not Available",43.50762,-96.765205
 0416V,"St. Paul Vet Center","550 County Road D West, Suite 10","New Brighton",MN,"55112","651-644-4022 Or 651-644-4022","VA Facility",Government,no,"Not Available",40.7531,-80.2419
 438GE,"Wagner Outreach Clinic","400 West Hwy 46",Wagner,SD,"57380",605-384-2340,"VA Facility",Government,no,"Not Available",43.0401,-98.2874
-,,,,,,,,,,,,
-

--- a/src/main/resources/providers/va_facilities.csv
+++ b/src/main/resources/providers/va_facilities.csv
@@ -1,0 +1,1499 @@
+﻿id,name,address,city,state,zip,phone,type,ownership,emergency,quality,LAT,LON
+518,Edith Nourse Rogers Memorial Veterans Hospital (Bedford VA),200 Springs Rd.,Bedford,MA,1730,781-687-2000,VA Facility,Government,no,Not Available,42.503376,-71.272644
+608,Manchester VA Medical Center,718 Smyth Road,Manchester,NH,3104,603-624-4366 Or 603-624-4366,VA Facility,Government,no,Not Available,43.01192,-71.43939
+650,Providence VA Medical Center,830 Chalkstone Avenue,Providence,RI,2908,401-273-7100 Or 401-273-7100,VA Facility,Government,no,Not Available,41.83397,-71.43398
+523A5,"VA Boston Healthcare System, Brockton Campus",940 Belmont Street,Brockton,MA,2301,508-583-4500 Or 508-583-4500,VA Facility,Government,no,Not Available,42.065655,-71.05398
+523,"VA Boston Healthcare System, Jamaica Plain Campus",150 South Huntington Avenue,Jamaica Plain,MA,2130,617-232-9500,VA Facility,Government,no,Not Available,42.32809,-71.11076
+523A4,"VA Boston Healthcare System, West Roxbury Campus",1400 VFW Parkway,West Roxbury,MA,2132,617-323-7700,VA Facility,Government,no,Not Available,0,0
+631,VA Central Western Massachusetts Healthcare System,421 North Main Street,Leeds,MA,1053,413-584-4040,VA Facility,Government,no,Not Available,42.345066,-72.68291
+689A4,"VA Connecticut Healthcare System, Newington Campus",555 Willard Avenue,Newington,CT,6111,860-666-6951,VA Facility,Government,no,Not Available,41.702595,-72.73486
+689,"VA Connecticut Healthcare System, West Haven Campus",950 Campbell Avenue,West Haven,CT,6516,203-932-5711,VA Facility,Government,no,Not Available,41.28468,-72.95741
+402,VA Maine Healthcare System - Togus,1 VA Center,Augusta,ME,4330,207-623-8411 Or 207-623-8411,VA Facility,Government,no,Not Available,0,0
+405,White River Junction VA Medical Center,163 Veterans Drive,White River Junction,VT,5009,802-295-9363 Or 802-295-9363,VA Facility,Government,no,Not Available,43.648075,-72.34463
+523BZ,Causeway OPC,251 Causeway St.,Boston,MA,2114,800-865-3384,VA Facility,Government,no,Not Available,42.3665,-71.05931
+402F,Fort Kent Access Point Clinic,3 Mountain View Drive,Fort Kent,ME,4743,207-834-1572,VA Facility,Government,no,Not Available,0,0
+4730,Houlton Satellite Clinic,Houlton Regional Hospital - 20 Hartford Street,Houlton,ME,4730,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,0,0
+402MMU,Mobile Medical Unit,241 Main Street,Bingham,ME,4920,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,45.053535,-69.88254
+518-vccc,Lowell Veterans Community Care Center,130 Marshall Road,Lowell,MA,1852,978-671-9000,VA Facility,Government,no,Not Available,42.62101,-71.31481
+402GD,Aroostook County (Caribou) Community Based Outpatient Clinic,"163 Van Buren Drive, Ste 6",Caribou,ME,4736,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,0,0
+402HB,Bangor Community Based Outpatient Clinic,35 State Hospital Drive,Bangor,ME,4401,207-561-3600,VA Facility,Government,no,Not Available,44.802254,-68.769394
+405GA,Bennington Outpatient Clinic,186 North Street,Bennington,VT,5201,802-440-3300,VA Facility,Government,no,Not Available,42.879307,-73.1971
+405GC,Brattleboro Community Based Outpatient Clinic,71 GSP Drive,Brattleboro,VT,5301,802-251-2200,VA Facility,Government,no,Not Available,0,0
+405HA,Burlington Outpatient Lakeside Clinic,"128 Lakeside Avenue, Suite 260",Burlington,VT,5401,802-657-7000,VA Facility,Government,no,Not Available,44.46104,-73.22083
+402GB,Calais Outpatient Clinic,50 Union St,Calais,ME,4619,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,45.18957,-67.27797
+608GD,Conway Outpatient Clinic,71 Hobbs Street,Conway,NH,3818,800-892-8384 X 3199,VA Facility,Government,no,Not Available,0,0
+689GE,Danbury Outpatient Clinic,"7 Germantown Road, Ste 2B",Danbury,CT,6810,203-798-8422,VA Facility,Government,no,Not Available,41.40898,-73.43614
+518GG,Fitchburg Outpatient Clinic,881 Main Street,Fitchburg,MA,1420,978-342-9781 Or 978-342-9781,VA Facility,Government,no,Not Available,42.586487,-71.80521
+523GA,Framingham Outpatient Clinic,"61 Lincoln Street, Suite 112",Framingham,MA,1702,800-865-3384,VA Facility,Government,no,Not Available,42.28348,-71.41845
+518GE,Gloucester Community Based Outpatient Clinic (CBOC),199 Main Street,Gloucester,MA,1930,800-838-6331,VA Facility,Government,no,Not Available,42.613102,-70.66085
+631GD,Greenfield Outpatient Clinic,143 Munson Street,Greenfield,MA,1301,413-773-8428 Or 413-773-8428,VA Facility,Government,no,Not Available,42.580627,-72.623634
+518GB,Haverhill Community Based Outpatient Clinic (CBOC),108 Merrimack St.,Haverhill,MA,1830,800-838-6331,VA Facility,Government,no,Not Available,42.77449,-71.07901
+650GB,Hyannis Outpatient Clinic,233 Stevens St,Hyannis,MA,2601,508-771-3190,VA Facility,Government,no,Not Available,41.651745,-70.294235
+689HC,John J. McGuirk (New London) VA Outpatient Clinic,Shaw's Cove Four,New London,CT,6320,860-437-3611,VA Facility,Government,no,Not Available,0,0
+405K,Keene Outpatient Clinic,"640 Marlboro Street, Route 101",Keene,NH,3431,603-358-4900,VA Facility,Government,no,Not Available,42.91539,-72.24931
+402-al,Lewiston/ Auburn Community Based Outpatient Clinic,15 Challenger Drive,Lewiston,ME,4240,207-330-2700 Or 877-421-8263 X 2700,VA Facility,Government,no,Not Available,0,0
+402,Lincoln Community Based Outpatient Clinic,99 River Road,Lincoln,ME,4457,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,0,0
+405HC,Littleton Community Based Outpatient Clinic,264 Cottage Street,Littleton,NH,3561,603-575-6700,VA Facility,Government,no,Not Available,0,0
+523BY,Lowell Outpatient Clinic,130 Marshall Road,Lowell,MA,1852,800-865-3384,VA Facility,Government,no,Not Available,42.62101,-71.31481
+518GA,Lynn Community Based Outpatient Clinic (CBOC),"225 Boston Road, Suite 107",Lynn,MA,1904,800-838-6331,VA Facility,Government,no,Not Available,42.470093,-70.95994
+650GD,Middletown Outpatient Clinic,One Corporate Place,Middletown,RI,2842,401-847-6239,VA Facility,Government,no,Not Available,0,0
+650GA,New Bedford Outpatient Clinic,175 Elm Street,New Bedford,MA,2740,508-994-0217,VA Facility,Government,no,Not Available,41.635937,-70.92991
+405_Newport,Newport Community Based Outpatient Clinic,1734 Crawford Farm Rd.,Newport,VT,5855,802-624-2400,VA Facility,Government,no,Not Available,44.932266,-72.180824
+631GC,Pittsfield Outpatient Clinic,73 Eagle Street,Pittsfield,MA,1201,413-499-2672 Or 413-499-2672,VA Facility,Government,no,Not Available,42.451427,-73.25195
+523GD,Plymouth Outreach Clinic,116 Long Pond Road,Plymouth,MA,2360,800-865-3384,VA Facility,Government,no,Not Available,41.924313,-70.656654
+402-p,Portland Community Based Outpatient Clinic,144 Fore Street,Portland,ME,4101,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,43.65423,-70.26246
+608GA,Portsmouth Outpatient Clinic,Pease International Tradeport 302 Newmarket Street,Portsmouth,NH,3803,603-624-4366 X 3199,VA Facility,Government,no,Not Available,0,0
+523GC,Quincy Outpatient Clinic,110 West Squantum Street,Quincy,MA,2169,800-865-3384,VA Facility,Government,no,Not Available,42.272617,-71.03133
+402GC,Rumford Community Based Outpatient Clinic,431 Franklin St.,Rumford,ME,4726,207-369-3200,VA Facility,Government,no,Not Available,44.551373,-70.55676
+405HF,Rutland Community Based Outpatient Clinic,232 West St.,Rutland,VT,5701,802-772-2300,VA Facility,Government,no,Not Available,43.60715,-72.985634
+402GA,Saco Community Based Outpatient Clinic,655 Main Street,Saco,ME,4072,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,43.52166,-70.42791
+608GC,Somersworth Outpatient Clinic,200 Route 108,Somersworth,NH,3878,603-624-4366 X 3199,VA Facility,Government,no,Not Available,43.243023,-70.89857
+631BY,Springfield Outpatient Clinic,25 Bond Street,Springfield,MA,1104,413-731-6000 Or 413-731-6000,VA Facility,Government,no,Not Available,42.110065,-72.60007
+689gb,Stamford Outpatient Clinic,"1275 Summer St, Suite 102",Stamford,CT,6905,203-325-0649,VA Facility,Government,no,Not Available,41.06164,-73.541504
+608HA,Tilton Outpatient Clinic,"630 West Main Street, Suite 400",Tilton,NH,3276,603-624-4366 X 3199,VA Facility,Government,no,Not Available,43.447174,-71.62029
+689GA,Waterbury Outpatient Clinic,95 Scovill Street,Waterbury,CT,6706,203-465-5292,VA Facility,Government,no,Not Available,41.553574,-73.03762
+689GC,Willimantic Outpatient Clinic,1320 Main Street,Willimantic,CT,6226,860-450-7583,VA Facility,Government,no,Not Available,41.715214,-72.22889
+689GD,Winsted Outpatient Clinic,115 Spencer Street,Winsted,CT,6908,860-738-6985,VA Facility,Government,no,Not Available,41.930405,-73.07571
+631GE,Worcester Outpatient Clinic,"605 Lincoln Street,",Worcester,MA,1605,508-856-0104 Or 508-856-0104,VA Facility,Government,no,Not Available,42.297756,-71.766815
+121,Bangor Vet Center,"615 Odlin Road, Suite 3",Bangor,ME,4401,207-947-3391 Or 207-947-3391,VA Facility,Government,no,Not Available,44.78075,-68.82331
+134,Berlin Vet Center,515 Main Street Suite 2,Gorham,NH,3581,603-752-2571,VA Facility,Government,no,Not Available,44.428604,-71.19247
+0101V,Boston Vet Center,"7 Drydock Ave, Suite 2070",Boston,MA,2210,857-203-6461,VA Facility,Government,no,Not Available,42.34461,-71.03728
+104,Brockton Vet Center,1041L Pearl St.,Brockton,MA,2301,508-580-2730 Or 508-580-2730,VA Facility,Government,no,Not Available,42.055134,-71.06661
+136,Cape Cod Vet Center,474 West Main Street,Hyannis,MA,2601,508-778-0124 Or 508-778-0124,VA Facility,Government,no,Not Available,41.650307,-70.313515
+140,Danbury Vet Center,"457 North Main St., 1st Floor",Danbury,CT,6811,203-790-4000 Or 203-790-4000,VA Facility,Government,no,Not Available,41.40501,-73.462845
+117,Hartford Vet Center,"25 Elm Street, Suite A",Rocky Hill,CT,6067,860-563-8800,VA Facility,Government,no,Not Available,41.664818,-72.64043
+1221,Keene Vet Center Outstation,640 Marlboro Rd. (Route 101),Keene,NH,3431,603-358-4950 Or 603-358-4950,VA Facility,Government,no,Not Available,0,0
+129,Lewiston Vet Center,35 Westminster St.,Lewiston,ME,4240,207-783-0068 Or 207-783-0068,VA Facility,Government,no,Not Available,44.075405,-70.17508
+125,Lowell Vet Center,"10 George Street, Gateway Center",Lowell,MA,1852,978-453-1151,VA Facility,Government,no,Not Available,42.642513,-71.3062
+108,Manchester Vet Center,"1461 Hooksett Rd., B6",Hooksett,NH,3106,603-668-7060 Or 603-668-7060,VA Facility,Government,no,Not Available,43.07247,-71.454254
+128,New Bedford Vet Center,"73 Huttleton Ave., Unit 2",Fairhaven,MA,2719,508-999-6920 Or 508-999-6920,VA Facility,Government,no,Not Available,0,0
+116,New Haven Vet Center,291 South Lambert Road,Orange,CT,6477,203-795-0148,VA Facility,Government,no,Not Available,41.262207,-73.00565
+119,Northern Maine Vet Center,456 York Street,Caribou,ME,4736,207-496-3900,VA Facility,Government,no,Not Available,0,0
+127,Norwich Vet Center,2 Cliff St.,Norwich,CT,6360,860-887-1755 Or 860-887-1755,VA Facility,Government,no,Not Available,41.52734,-72.06744
+115,Portland Vet Center,475 Stevens Ave.,Portland,ME,4103,207-780-3584,VA Facility,Government,no,Not Available,43.674862,-70.29505
+113,Providence Vet Center,2038 Warwick Ave,Warwick,RI,2889,401-739-0167,VA Facility,Government,no,Not Available,41.72111,-71.40386
+0100V,"RCS North Atlantic District 1, Zone 1 District Office","15 Dartmouth Drive, Suite 202",Auburn,NH,3032,603-623-4204 Or 603-623-4204,VA Facility,Government,no,Not Available,0,0
+130,Sanford Vet Center,628 Main Street,Springvale,ME,4083,207-490-1513 Or 207-490-1513,VA Facility,Government,no,Not Available,43.455822,-70.79014
+118,South Burlington Vet Center,19 Gregory Drive Suite 201,South Burlington,VT,5403,802-862-1806,VA Facility,Government,no,Not Available,44.455273,-73.13991
+103,Springfield Vet Center,"95 Ashley Avenue, Suite A",West Springfield,MA,1089,413-737-5167 Or 413-737-5167,VA Facility,Government,no,Not Available,42.139397,-72.62382
+122,White River Junction Vet Center,118 Prospect Street Suite 100,White River Junction,VT,5001,802-295-2908 Or 802-295-2908,VA Facility,Government,no,Not Available,0,0
+126,Worcester Vet Center,255 Park Ave Suite # 900,Worcester,MA,1609,508-753-7902,VA Facility,Government,no,Not Available,42.265556,-71.818665
+10N2,VISN 2: New York/New Jersey VA Health Care Network,"130 W. Kingsbridge Road, Building 16",Bronx,NY,10468,718-741-4134,VA Facility,Government,no,Not Available,40.869125,-73.90309
+620,VA Hudson Valley Health Care System,2094 Albany Post Rd.,Montrose,NY,10548,914-737-4400,VA Facility,Government,no,Not Available,41.2446,-73.926155
+561,VA New Jersey Health Care System,385 Tremont Avenue,East Orange,NJ,7018,973-676-1000,VA Facility,Government,no,Not Available,40.753803,-74.23407
+630,VA NY Harbor Healthcare System,423 East 23rd Street,New York,NY,10010,,VA Facility,Government,no,Not Available,40.73663,-73.97797
+528,VA Western New York Healthcare System,3495 Bailey Avenue,Buffalo,NY,14215,716-834-9200 Or 800-532-8387,VA Facility,Government,no,Not Available,42.953728,-78.813774
+528A8,Albany VA Medical Center: Samuel S. Stratton,113 Holland Avenue,Albany,NY,12208,518-626-5000 Or 518-626-5000,VA Facility,Government,no,Not Available,42.649483,-73.77452
+528A6,Bath VA Medical Center,76 Veterans Avenue,Bath,NY,14810,607-664-4000 Or 607-664-4000,VA Facility,Government,no,Not Available,42.343426,-77.34615
+630A4,Brooklyn Campus of the VA NY Harbor Healthcare System,800 Poly Place,Brooklyn,NY,11209,718-836-6600,VA Facility,Government,no,Not Available,40.6099,-74.02558
+528A5,Canandaigua VA Medical Center,400 Fort Hill Avenue,Canandaigua,NY,14424,585-394-2000 Or 585-394-2000,VA Facility,Government,no,Not Available,42.90006,-77.27269
+620A4,Castle Point Campus of the VA Hudson Valley Health Care System,41 Castle Point Road,Wappingers Falls,NY,12590,845-831-2000,VA Facility,Government,no,Not Available,41.539974,-73.95949
+561,East Orange Campus of the VA New Jersey Health Care System,385 Tremont Avenue,East Orange,NJ,7018,973-676-1000,VA Facility,Government,no,Not Available,40.753803,-74.23407
+620,Franklin Delano Roosevelt Campus of the VA Hudson Valley Health Care System (Montrose),2094 Albany Post Rd.,Montrose,NY,10548,914-737-4400,VA Facility,Government,no,Not Available,41.2446,-73.926155
+526,"James J. Peters VA Medical Center (Bronx, NY)",130 West Kingsbridge Road,Bronx,NY,10468,718-584-9000,VA Facility,Government,no,Not Available,40.869102,-73.90305
+561A4,Lyons Campus of the VA New Jersey Health Care System,151 Knollcroft Road,Lyons,NJ,7939,908-647-0180,VA Facility,Government,no,Not Available,0,0
+630,Manhattan Campus of the VA NY Harbor Healthcare System,423 East 23rd Street,New York,NY,10010,212-686-7500,VA Facility,Government,no,Not Available,40.73663,-73.97797
+632,Northport VA Medical Center,79 Middleville Road,Northport,NY,11768,631-261-4400 Or 631-261-4400,VA Facility,Government,no,Not Available,0,0
+528A7,Syracuse VA Medical Center,800 Irving Avenue,Syracuse,NY,13210,315-425-4400 Or 315-425-4400,VA Facility,Government,no,Not Available,43.03934,-76.138054
+528A4,VA Western New York Healthcare System at Batavia,222 Richmond Avenue,Batavia,NY,14020,585-297-1000,VA Facility,Government,no,Not Available,43.009197,-78.198586
+528,VA Western New York Healthcare System at Buffalo,3495 Bailey Avenue,Buffalo,NY,14215,716-834-9200 Or 800-532-8387,VA Facility,Government,no,Not Available,42.953728,-78.813774
+630A5,St. Albans Community Living Center,179-00 Linden Blvd. & 179 Street,Jamaica,NY,11425,718-526-1000,VA Facility,Government,no,Not Available,0,0
+528,Behavioral Health Facility,620 Erie Blvd West,Syracuse,NY,13204,315-425-4400 X 53463,VA Facility,Government,no,Not Available,43.049225,-76.16408
+528G5,Auburn VA Outpatient Clinic,17 Lansing Street,Auburn,NY,13021,315-255-7002,VA Facility,Government,no,Not Available,42.9408,-76.56385
+528G3,Bainbridge VA Outpatient Clinic,109 North Main Street,Bainbridge,NY,13733,607-967-8590,VA Facility,Government,no,Not Available,42.300873,-75.47048
+632HC,Bay Shore Clinic,132 East Main Street,Bay Shore,NY,11706,631-754-7978,VA Facility,Government,no,Not Available,40.723354,-73.24521
+528GN,Binghamton VA Outpatient Clinic,203 Court Street,Binghamton,NY,13901,607-772-9100,VA Facility,Government,no,Not Available,42.100765,-75.90382
+528,CANI,19472 US Route 11,Watertown,NY,13601,315-782-0067,VA Facility,Government,no,Not Available,0,0
+620GB,Carmel Community Clinic/Putnam County,"1875 Route 6, Sterling Bank, (2nd Floor)",Carmel,NY,10512,845-228-5291,VA Facility,Government,no,Not Available,0,0
+528G7,Catskill VA Outpatient Clinic,"Columbia Greene Medical Arts Building, Suite D305, 159 Jefferson Hgts",Catskill,NY,12414,518-626-5240,VA Facility,Government,no,Not Available,0,0
+528GY,Clifton Park VA Outpatient Clinic,963 Route 146,Clifton Park,NY,12065,518-383-8506,VA Facility,Government,no,Not Available,42.868553,-73.80719
+528G4,Coudersport,"24 Maple View Lane, Suite 2",Coudersport,PA,16915,607-664-4670,VA Facility,Government,no,Not Available,41.72552,-78.02134
+528GC,Dunkirk VA Outpatient Clinic,166 East 4th Street,Dunkirk,NY,14048,716-203-6474,VA Facility,Government,no,Not Available,42.483982,-79.32886
+632GA,East Meadow Clinic,"2201 Hempstead Turnpike, Building Q",East Meadow,NY,11554,631-754-7978,VA Facility,Government,no,Not Available,40.725246,-73.55433
+620GH,Eastern Dutchess Pine Plains Community Clinic,"2881 Church St, Rt 199",Pine Plains,NY,12567,518-398-9240,VA Facility,Government,no,Not Available,41.98078,-73.66126
+561GB,Elizabeth CBOC,"654 East Jersey Street, Suite 2A",Elizabeth,NJ,7206,908-994-0120,VA Facility,Government,no,Not Available,40.658993,-74.19809
+528G4,Elmira VA Outpatient Clinic,1316 College Avenue,Elmira,NY,14901,877-845-3247,VA Facility,Government,no,Not Available,42.110176,-76.82008
+528G6,Fonda VA Outpatient Clinic,2623 State Highway 30A,Fonda,NY,12068,518-853-1247,VA Facility,Government,no,Not Available,42.961163,-74.38659
+528GT,Glens Falls VA Outpatient Clinic,84 Broad St.,Glens Falls,NY,12801,518-798-6066,VA Facility,Government,no,Not Available,43.30542,-73.65568
+620GD,Goshen Community Clinic,"30 Hatfield Lane, Suite 204",Goshen,NY,10924,845-294-6927,VA Facility,Government,no,Not Available,41.39409,-74.33894
+561GD,Hackensack CBOC,385 Prospect Avenue,Hackensack,NJ,7601,201-342-4536,VA Facility,Government,no,Not Available,40.895733,-74.05201
+561GA,Hamilton CBOC,3635 Quakerbridge Rd,Hamilton,NJ,8619,609-570-6600,VA Facility,Government,no,Not Available,40.259384,-74.6777
+630GA,Harlem Community Clinic,55 West 125th Street,New York,NY,10027,646-273-8125,VA Facility,Government,no,Not Available,0,0
+561BZ,"James J. Howard Community Clinic (Brick, NJ)",970 Rt. 70,Brick,NJ,8724,732-206-8900,VA Facility,Government,no,Not Available,40.073112,-74.1277
+528GB,Jamestown VA Outpatient Clinic,608 West 3rd Street,Jamestown,NY,14701,716-338-1511,VA Facility,Government,no,Not Available,42.0942,-79.254395
+561GE,Jersey City CBOC,"115 Christopher Columbus Drive, Suite #201",Jersey,NJ,7302,201-435-3055,VA Facility,Government,no,Not Available,40.716923,-74.03316
+528GZ,Kingston VA Outpatient Clinic,324 Plaza Road,Kingston,NY,12401,845-331-8322,VA Facility,Government,no,Not Available,0,0
+528GQ,Lackawanna VA Outpatient Clinic,1234 Abbott Road,Lackawanna,NY,14218,716-821-7815,VA Facility,Government,no,Not Available,42.83065,-78.80516
+528GK,Lockport VA Outpatient Clinic,5883 Snyder Drive,Lockport,NY,14094,716-438-3890,VA Facility,Government,no,Not Available,0,0
+528GL,Massena VA Outpatient Clinic,6100 St. Lawrence Centre,Massena,NY,13662,315-705-6666,VA Facility,Government,no,Not Available,0,0
+620GF,Monticello Community Clinic,55 Sturgis Road,Monticello,NY,12701,845-791-4936,VA Facility,Government,no,Not Available,41.660187,-74.694954
+561GH,Morristown CBOC,540 West Hanover Ave,Morristown,NJ,7960,973-539-9791 Or 973-539-9791,VA Facility,Government,no,Not Available,0,0
+620GA,New City Community Clinic,"345 North Main Street, Upper Level",New City,NY,10956,845-634-8942,VA Facility,Government,no,Not Available,41.167606,-73.98805
+528GD,Niagara Falls VA Outpatient Clinic,2201 Pine Avenue,Niagara Falls,NY,14301,716-862-8580,VA Facility,Government,no,Not Available,43.09509,-79.0356
+528GR,Olean VA Outpatient Clinic,"VA Outpatient Clinic, 465 North Union Street",Olean,NY,14760,716-373-7709,VA Facility,Government,no,Not Available,0,0
+528GP,Oswego VA Outpatient Clinic,437 State Route 104 E,Oswego,NY,13126,315-207-0120,VA Facility,Government,no,Not Available,0,0
+632HD,Patchogue Community Clinic,4 Phyllis Drive,Patchogue,NY,11772,631-754-7978,VA Facility,Government,no,Not Available,40.76871,-72.99638
+561GJ,Paterson CBOC,"11 Getty Avenue, Building #275, St. Joseph's Hospital & Medical Center",Paterson,NJ,7503,973-247-1666,VA Facility,Government,no,Not Available,0,0
+561GF,Piscataway CBOC,"14 WILLS WAY, BUILDING 5",Piscataway,NJ,8854,732-981-8193,VA Facility,Government,no,Not Available,0,0
+528GV,Plattsburgh VA Outpatient Clinic,80 Sharron Avenue,Plattsburgh,NY,12901,518-561-6247,VA Facility,Government,no,Not Available,44.677174,-73.45478
+620GE,Port Jervis Community Clinic,150 Pike St.,Port Jervis,NY,12771,845-856-5396,VA Facility,Government,no,Not Available,41.376755,-74.69058
+620GG,Poughkeepsie Community Clinic,"488 Freedom Plains Rd., Suite 120",Poughkeepsie,NY,12603,845-452-5151,VA Facility,Government,no,Not Available,41.68009,-73.85433
+632HX,Riverhead Clinic,300 Center Drive,Riverhead,NY,11901,631-754-7978,VA Facility,Government,no,Not Available,0,0
+528GE,Rochester VA Outpatient Clinic,465 Westfall Road,Rochester,NY,14620,585-463-2600,VA Facility,Government,no,Not Available,43.114918,-77.60952
+528GM,Rome - Donald J. Mitchell VA Outpatient Clinic,"125 Brookley Road, Building 510",Rome,NY,13441,315-334-7100,VA Facility,Government,no,Not Available,43.21298,-75.418465
+528G2,Saranac Lake,33 Depot St.,Saranac Lake,NY,12983,518-626-5237,VA Facility,Government,no,Not Available,44.330322,-74.13204
+528GW,Schenectady VA Outpatient Clinic,"1346 Gerling Street, Sheridan Plaza",Schenectady,NY,12308,518-346-3334,VA Facility,Government,no,Not Available,42.823162,-73.90894
+528GQ,Springville,15 Commerce Drive,Springville,NY,14141,716-592-2409,VA Facility,Government,no,Not Available,42.504112,-78.682884
+132V,Staten Island Community Clinic,"1150 South Ave, 3rd Floor – Suite 301",Staten Island,NY,10314,718-761-2973,VA Facility,Government,no,Not Available,40.61044,-74.17705
+561GK,Sussex Outpatient Clinic,222 High Street,Newton,NJ,7860,973-756-1504,VA Facility,Government,no,Not Available,41.05696,-74.76037
+526GD,Thomas B. Noonan Community Clinic (Queens),"47-01 Queens Blvd, Room 301",Sunnyside,NY,11104,718-741-4800,VA Facility,Government,no,Not Available,40.743057,-73.91779
+561GI,Tinton Falls Community Based Outpatient Clinic,55 Gilbert St,Tinton Falls,NJ,7701,732-842-4751,VA Facility,Government,no,Not Available,40.3257,-74.07658
+528G9,Tompkins/Cortland County,1451 Dryden Road,Freeville,NY,13068,607-347-4101,VA Facility,Government,no,Not Available,42.4734,-76.395645
+528GX,Troy VA Outpatient Clinic,295 River Street,Troy,NY,12180,518-274-7707,VA Facility,Government,no,Not Available,42.73243,-73.690384
+632HA,Valley Stream Clinic,99 South Central Avenue,Valley Stream,NY,11580,631-754-7978,VA Facility,Government,no,Not Available,40.664974,-73.70841
+528,Watertown VA Outpatient Clinic,144 Eastern Blvd.,Watertown,NY,13601,315-221-7026,VA Facility,Government,no,Not Available,43.968388,-75.88106
+528A5,Wellsboro,1835 Shumway Hill Road,Wellsboro,PA,16901,607-664-4680 Or 877-845-3247 X 44680,VA Facility,Government,no,Not Available,41.737938,-77.26959
+528,Wellsville VA Outpatient Clinic,"3458 Riverside Drive, Route 19",Wellsville,NY,14895,607-664-4660 Or 607-664-4660,VA Facility,Government,no,Not Available,42.148464,-77.97374
+528G2,Westport,7426 NYS Route 9N,Westport,NY,12993,518-626-5236,VA Facility,Government,no,Not Available,0,0
+526GA,White Plains Community Clinic,23 South Broadway,White Plains,NY,10601,914-421-1951 X 4300,VA Facility,Government,no,Not Available,41.032364,-73.76228
+526GB,Yonkers Community Clinic,124 New Main St.,Yonkers,NY,10701,914-375-8055 X 4400,VA Facility,Government,no,Not Available,40.93349,-73.89745
+111,Albany Vet Center,17 Computer Drive West,Albany,NY,12205,518-626-5130,VA Facility,Government,no,Not Available,42.72057,-73.8087
+120,Babylon Vet Center,100 West Main Street,Babylon,NY,11702,631-661-3930 Or 631-661-3930,VA Facility,Government,no,Not Available,40.695957,-73.325325
+137,Binghamton Vet Center,53 Chenango Street,Binghamton,NY,13901,607-722-2393 Or 607-722-2393,VA Facility,Government,no,Not Available,42.100487,-75.91025
+112,Bloomfield Vet Center,2 Broad St. Suite 703,Bloomfield,NJ,7003,973-748-0980 Or 973-748-0980,VA Facility,Government,no,Not Available,40.793514,-74.19776
+110,Bronx Vet Center,"2471 Morris Ave., Suite 1A",Bronx,NY,10468,718-367-3500 Or 718-367-3500,VA Facility,Government,no,Not Available,40.86264,-73.89976
+0105V,Brooklyn Vet Center,25 Chapel St. Suite 604,Brooklyn,NY,11201,718-630-2830 Or 718-630-2830,VA Facility,Government,no,Not Available,40.697277,-73.98651
+0107V,Buffalo Vet Center,2372 Sweet Home Road,Amherst,NY,14228,716-862-7350 Or 716-862-7350,VA Facility,Government,no,Not Available,43.024666,-78.79905
+133,Harlem Vet Center,"2279 - 3rd Avenue, 2nd Floor",New York,NY,10035,646-273-8139 Or 646-273-8139,VA Facility,Government,no,Not Available,0,0
+141,Lakewood Vet Center,1255 NJ-70 Suite 22N,Lakewood,NJ,8701,908-607-6364 Or 908-607-6364,VA Facility,Government,no,Not Available,0,0
+106,Manhattan Vet Center,32 Broadway 2nd Floor - Suite 200,New York,NY,10004,212-951-6866 Or 212-951-6866,VA Facility,Government,no,Not Available,40.70634,-74.01284
+139,Middletown Vet Center,"726 East Main Street, Suite 203",Middletown,NY,10940,845-342-9917 Or 845-342-9917,VA Facility,Government,no,Not Available,41.43988,-74.36706
+0138V,Nassau Vet Center,970 South Broadway,Hicksville,NY,11801,516-348-0088 Or 516-348-0088,VA Facility,Government,no,Not Available,0,0
+109,Queens Vet Center,75-10B 91 Avenue,Woodhaven,NY,11421,718-296-2871,VA Facility,Government,no,Not Available,40.685898,-73.86519
+124,Rochester Vet Center,"2000 S. Winton Road, Bldg 5, Ste. 201",Rochester,NY,14618,585-232-5040,VA Facility,Government,no,Not Available,43.107155,-77.57613
+102,Secaucus Vet Center,"110A Meadowlands Parkway, Suite 102",Secaucus,NJ,7094,201-223-7787 Or 201-223-7787,VA Facility,Government,no,Not Available,40.78257,-74.077415
+132,Staten Island Vet Center,60 Bay Street,Staten Island,NY,10301,718-816-4499 Or 718-816-4499,VA Facility,Government,no,Not Available,40.64047,-74.07568
+131,Syracuse Vet Center,"109 Pine Street, Suite 101",Syracuse,NY,13210,315-478-7127,VA Facility,Government,no,Not Available,43.050083,-76.129715
+114,Trenton Vet Center,934 Parkway Ave. Suite 201,Ewing,NJ,8618,609-882-5744 Or 609-882-5744,VA Facility,Government,no,Not Available,40.255383,-74.79256
+135,Watertown Vet Center,"210 Court Street, Suite 20",Watertown,NY,13601,315-782-5479 Or 315-782-5479,VA Facility,Government,no,Not Available,43.976658,-75.91245
+123,White Plains Vet Center,300 Hamilton Ave. Suite C,White Plains,NY,10601,914-682-6250,VA Facility,Government,no,Not Available,41.03415,-73.767494
+10N4,VISN 4: VA Healthcare - VISN 4,"323 North Shore Drive, Suite 400",Pittsburgh,PA,15212,412-822-3316,VA Facility,Government,no,Not Available,0,0
+646,VA Pittsburgh Healthcare System,University Drive,Pittsburgh,PA,15240,412-822-2222,VA Facility,Government,no,Not Available,0,0
+503,Altoona - James E. Van Zandt VA Medical Center,2907 Pleasant Valley Boulevard,Altoona,PA,16602,814-943-8164 Or 814-943-8164,VA Facility,Government,no,Not Available,40.48913,-78.39827
+542,Coatesville VA Medical Center,1400 Black Horse Hill Road,Coatesville,PA,19320,610-384-7711 Or 610-384-7711,VA Facility,Government,no,Not Available,39.998657,-75.80052
+562,Erie VA Medical Center,135 East 38th Street,Erie,PA,16504,800-274-8387 Or 800-274-8387,VA Facility,Government,no,Not Available,42.10296,-80.064835
+595,Lebanon VA Medical Center,1700 South Lincoln Avenue,Lebanon,PA,17042,717-272-6621 Or 717-272-6621,VA Facility,Government,no,Not Available,40.312363,-76.40701
+642,Philadelphia VA Medical Center,3900 Woodland Avenue,Philadelphia,PA,19104,215-823-5800 Or 215-823-5800,VA Facility,Government,no,Not Available,39.94543,-75.208595
+529,VA Butler Health Care Center,353 North Duffy Road,Butler,PA,16001,800-362-8262,VA Facility,Government,no,Not Available,40.888596,-79.9412
+646A4,"VA Pittsburgh Healthcare System, H.J. Heinz Campus",1010 Delafield Road,Pittsburgh,PA,15215,412-822-2222 Or 866-482-7488,VA Facility,Government,no,Not Available,40.496925,-79.89144
+646,"VA Pittsburgh Healthcare System, University Drive Campus",University Drive,Pittsburgh,PA,15240,412-822-2222 Or 866-482-7488,VA Facility,Government,no,Not Available,0,0
+693,Wilkes-Barre VA Medical Center,1111 East End Blvd.,Wilkes-Barre,PA,18711,570-824-3521 Or 570-824-3521,VA Facility,Government,no,Not Available,41.249058,-75.833755
+460,Wilmington VA Medical Center,1601 Kirkwood Highway,Wilmington,DE,19805,302-994-2511 Or 302-994-2511,VA Facility,Government,no,Not Available,39.73866,-75.606384
+642GF,Camden VA Outpatient Clinic,"300 Broadway, Suite 103",Camden,NJ,8104,877-232-5240,VA Facility,Government,no,Not Available,0,0
+642GE,Philadelphia MultiService Center (Philadelphia County),213-217 North 4th Street,Philadelphia,PA,19106,215-923-1163,VA Facility,Government,no,Not Available,39.954792,-75.14627
+693B4,Allentown VA Outpatient Clinic (693B4),3110 Hamilton Boulevard,Allentown,PA,18103,610-776-4304,VA Facility,Government,no,Not Available,40.58205,-75.51892
+529GC,Armstrong County VA Outpatient Clinic,11 Hilltop Plaza,Kittanning,PA,16201,724-545-8420,VA Facility,Government,no,Not Available,40.81212,-79.54405
+562GB,Ashtabula County VA Clinic,2044 Lambros Lane,Ashtabula,OH,44004,866-463-0912,VA Facility,Government,no,Not Available,0,0
+460HE,Atlantic County CBOC,1909 New Road,Northfield,NJ,8225,800-461-8262 X 2800,VA Facility,Government,no,Not Available,39.36886,-74.56026
+646GC,Beaver County Outpatient Clinic,"300 Brighton Ave., Suite 110",Rochester,PA,15074,724-709-6005,VA Facility,Government,no,Not Available,40.701736,-80.28499
+646GA,Belmont County Outpatient Clinic,103 Plaza Dr. Suite A,St. Clairsville,OH,43950,740-695-9321,VA Facility,Government,no,Not Available,40.07729,-80.91738
+642GA,Burlington County CBOC,3000 Lincoln Drive East,Marlton,NJ,8053,844-441-5499,VA Facility,Government,no,Not Available,39.913647,-74.94009
+595GA,Camp Hill VA Clinic (595GA),25 N. 32nd Street,Camp Hill,PA,17011,717-730-9782,VA Facility,Government,no,Not Available,0,0
+460GD,Cape May County CBOC,1 Monro Avenue,Cape May,NJ,8204,800-461-8262 X 2850,VA Facility,Government,no,Not Available,0,0
+529GD,Clarion County VA Outpatient Clinic,"56 Clarion Plaza, Suite 115",Monroe Township,PA,16214,814-226-3900,VA Facility,Government,no,Not Available,0,0
+693GF,Columbia County Outpatient Clinic,"Alley Medical Center, 301 West Third Street",Berwick,PA,18603,570-759-0351,VA Facility,Government,no,Not Available,0,0
+529GF,Cranberry Township VA Outpatient Clinic,"900 Commonwealth Drive, Suite 900",Cranberry Township,PA,16066,724-742-3500 Or 724-741-3131,VA Facility,Government,no,Not Available,0,0
+562GA,Crawford County Primary Care Clinic,16954 Conneaut Lake Road,Meadville,PA,16335,866-962-3210,VA Facility,Government,no,Not Available,0,0
+460HG,Cumberland County CBOC,79 W. Landis Avenue,Vineland,NJ,8360,800-461-8262 X 6500,VA Facility,Government,no,Not Available,39.48669,-75.03702
+503GB,DuBois (Clearfield County) VA Outpatient Clinic (503GB),5690 Shaffer Road,DuBois,PA,15801,877-626-2500,VA Facility,Government,no,Not Available,0,0
+646GE,Fayette County Outpatient Clinic,635 Pittsburgh Road,Uniontown,PA,15401,724-439-4990,VA Facility,Government,no,Not Available,39.92053,-79.72622
+503GD,Huntingdon County CBOC,13903 William Penn Highway,Mapleton Depot,PA,17052,814-542-2800,VA Facility,Government,no,Not Available,0,0
+503GE,Indiana County CBOC,1570 Oakland Avenue,Indiana,PA,15701,724-349-8900,VA Facility,Government,no,Not Available,40.61499,-79.171394
+503GA,Johnstown VA Outpatient Clinic (Cambria County) (503GA),"598 Galleria Drive, Next to Gander Mountain",Johnstown,PA,15904,877-626-2500,VA Facility,Government,no,Not Available,40.303246,-78.83298
+460GC,Kent County CBOC,"1198 S. Governors Avenue, Suite 201",Dover,DE,19901,800-461-8262 X 2400,VA Facility,Government,no,Not Available,0,0
+595GC,Lancaster VA Clinic (595GC),"1861 Charter Lane, Green Field Corporate Center, Suite 120",Lancaster,PA,17601,717-290-6900,VA Facility,Government,no,Not Available,40.052605,-76.25084
+529GB,Lawrence County VA Outpatient Clinic,"Ridgewood Professional Centre, 1750 New Butler Road",New Castle,PA,16101,724-598-6080,VA Facility,Government,no,Not Available,0,0
+562GC,McKean County Primary Care Clinic,23 Kennedy Street,Bradford,PA,16701,814-368-3019,VA Facility,Government,no,Not Available,41.95659,-78.64741
+529GA,Mercer County VA Outpatient Clinic,"295 N. Kerrwood Drive, Suite 110",Hermitage,PA,16148,724-346-1569,VA Facility,Government,no,Not Available,41.237286,-80.46313
+693GG,Northampton County Outpatient Clinic,Phoebe Slate Belt Nursing Home & Rehab Center 701 Slate Belt Boulevard,Bangor,PA,18013,610-599-0127,VA Facility,Government,no,Not Available,0,0
+595GF,Pottsville VA Clinic (595GF),"1410 Laurel Blvd., Suite 2",Pottsville,PA,17901,570-628-5374,VA Facility,Government,no,Not Available,40.68376,-76.211494
+595GD,Reading VA Clinic (595GD),2762 Century Boulevard,Wyomissing,PA,19610,484-220-2572,VA Facility,Government,no,Not Available,0,0
+693GA,Sayre VA Outpatient Clinic (693GA),1537 Elmira Street,Sayre,PA,18840,570-888-6803,VA Facility,Government,no,Not Available,41.974503,-76.540665
+542GE,Spring City VA Outpatient Clinic (542GE),11 Independence Drive,Spring City,PA,19475,610-383-0239,VA Facility,Government,no,Not Available,40.187653,-75.565445
+542GA,Springfield VA Outpatient Clinic (542GA),"Crozer Keystone Healthplex 194 W. Sproul Road, Suite 105",Springfield,PA,19064,610-383-0239,VA Facility,Government,no,Not Available,0,0
+503GC,State College (Centre County) VA Outpatient Clinic (503GC),2581 Clyde Avenue,State College,PA,16801,877-626-2500,VA Facility,Government,no,Not Available,40.82724,-77.804794
+460GA,Sussex County CBOC,21748 Roth Ave,Georgetown,DE,19947,800-461-8262 X 2300,VA Facility,Government,no,Not Available,0,0
+693GC,Tobyhanna Army Depot (693GC),Building 220,Tobyhanna,PA,18466,570-615-8341,VA Facility,Government,no,Not Available,0,0
+562GD,Venango County VA Clinic,464 Allegheny Boulevard,Franklin,PA,16323,866-962-3260,VA Facility,Government,no,Not Available,41.401962,-79.80932
+642GD,Veterans Health Clinic at Gloucester County (642GD),211 County House Road,Sewell,NJ,8080,877-823-5230 Or 877-823-5230,VA Facility,Government,no,Not Available,39.778458,-75.102425
+642GC,Victor J. Saracini VA Outpatient Clinic (Montgomery County),433 Caredean Dr.,Horsham,PA,19044,215-823-6050,VA Facility,Government,no,Not Available,40.202858,-75.175896
+562GE,Warren CBOC,3 Farm Colony Dr,Warren,PA,16365,866-682-3250,VA Facility,Government,no,Not Available,41.832176,-79.14865
+646GD,Washington County Outpatient Clinic,"1500 West Chestnut St., Room 450",Washington,PA,15301,724-250-7790,VA Facility,Government,no,Not Available,40.164463,-80.274345
+693QA,Wayne County Outpatient Clinic,600 Maple Ave. Suite 2,Honesdale,PA,18431,570-251-6543,VA Facility,Government,no,Not Available,0,0
+646GB,Westmoreland County Outpatient Clinic,"5274 Rt 30 East, Suite 10",Greensburg,PA,15601,724-216-0317,VA Facility,Government,no,Not Available,0,0
+693GB,"Williamsport OPC, Campus of Divine Providence Hospital (693GB)","1705 Warren Avenue, Werner Building - 3rd Floor (Suite 304)",Williamsport,PA,17701,570-322-4791,VA Facility,Government,no,Not Available,41.260082,-76.98141
+595GE,York VA Clinic (595GE),2251 Eastern Blvd.,York,PA,17402,717-840-2730,VA Facility,Government,no,Not Available,39.9719,-76.6848
+238,Bucks County Vet Center,"2 Canal's End Road, Suite 201B",Bristol,PA,19007,215-823-4590 Or 215-823-4590,VA Facility,Government,no,Not Available,0,0
+227,DuBois Vet Center,"100 Meadow Lane, Suite 8",DuBois,PA,15801,814-372-2095,VA Facility,Government,no,Not Available,0,0
+0222V,Erie Vet Center,"240 W. 11th St., Erie Metro Center, Suite 105",Erie,PA,16501,814-453-7955 Or 814-453-7955,VA Facility,Government,no,Not Available,42.12275,-80.0867
+0218V,Harrisburg Vet Center,1500 N. Second Street Suite 2,Harrisburg,PA,17102,717-782-3954 Or 717-782-3954,VA Facility,Government,no,Not Available,40.27054,-76.89296
+242,Lancaster County Vet Center,"1817 Olde Homestead Lane, Suite 207",Lancaster,PA,17601,717-283-0735 Or 717-283-0735,VA Facility,Government,no,Not Available,0,0
+0239V,Norristown Vet Center,"320 E. Johnson Hwy, Suite 201",Norristown,PA,19401,215-823-5245 Or 877-927-8387,VA Facility,Government,no,Not Available,40.128048,-75.32217
+0219V,Northeast Philadelphia Vet Center,101 E. Olney Avenue,Philadelphia,PA,19120,215-924-4670 Or 215-924-4670,VA Facility,Government,no,Not Available,40.035076,-75.11968
+210,Philadelphia Vet Center,801 Arch Street Suite 502,Philadelphia,PA,19107,215-627-0238 Or 215-627-0238,VA Facility,Government,no,Not Available,39.95318,-75.15322
+0211V,Pittsburgh Vet Center,"2500 Baldwick Rd, Suite 15",Pittsburgh,PA,15205,412-920-1765 Or 412-920-1765,VA Facility,Government,no,Not Available,40.426678,-80.05733
+0229V,Scranton Vet Center,1002 Pittston Ave.,Scranton,PA,18505,570-344-2676 Or 570-344-2676,VA Facility,Government,no,Not Available,41.395813,-75.6689
+243V,Sussex County Vet Center,"20653 Dupont Blvd, Suite 1",Georgetown,DE,19947,302-225-9110 Or 302-225-9110,VA Facility,Government,no,Not Available,0,0
+0230V,Ventnor Vet Center,"6601 Ventnor Ave. Suite 105, Ventnor Professional Plaza",Ventnor,NJ,8406,609-487-8387,VA Facility,Government,no,Not Available,39.337135,-74.484406
+0220V,White Oak Vet Center,"2001 Lincoln Way, Suite 21",White Oak,PA,15131,412-678-7704 Or 412-678-7704,VA Facility,Government,no,Not Available,40.337463,-79.80879
+0212V,Williamsport Vet Center,49 E. Fourth Street Suite 104,Williamsport,PA,17701,570-327-5281 Or 570-327-5281,VA Facility,Government,no,Not Available,41.242813,-77.00096
+0215V,Wilmington Vet Center,"2710 Centerville Road, Suite 103",Wilmington,DE,19808,302-994-1660 Or 302-994-1660,VA Facility,Government,no,Not Available,39.75347,-75.62461
+10N5,VISN 5: VA Capitol Health Care Network,"849 International Drive, Suite 275",Linthicum,MD,21090,410-691-1131,VA Facility,Government,no,Not Available,39.206387,-76.674095
+58101,"Homeless Veterans Resource Center (Huntington, WV)",624 9th Street,Huntington,WV,25701,304-529-9142,VA Facility,Government,no,Not Available,38.417686,-82.44307
+512,VA Maryland Health Care System,10 North Greene Street,Baltimore,MD,21201,410-605-7000,VA Facility,Government,no,Not Available,39.28936,-76.623726
+512,Baltimore VA Medical Center - VA Maryland Health Care System,10 North Greene Street,Baltimore,MD,21201,410-605-7000 Or 410-605-7000,VA Facility,Government,no,Not Available,39.28936,-76.623726
+517,Beckley VA Medical Center,200 Veterans Avenue,Beckley,WV,25801,304-255-2121 Or 304-255-2121,VA Facility,Government,no,Not Available,0,0
+540,Clarksburg - Louis A. Johnson VA Medical Center,One Medical Center Drive,Clarksburg,WV,26301,304-623-3461 Or 800-733-0512,VA Facility,Government,no,Not Available,0,0
+581,Huntington VA Medical Center,1540 Spring Valley Drive,Huntington,WV,25704,304-429-6741,VA Facility,Government,no,Not Available,38.384087,-82.51794
+512GB,Loch Raven VA Medical Center - VA Maryland Health Care System,3900 Loch Raven Boulevard,Baltimore,MD,21218,410-605-7000 Or 410-605-7000,VA Facility,Government,no,Not Available,39.33639,-76.59441
+613,Martinsburg VA Medical Center,510 Butler Avenue,Martinsburg,WV,25405,304-263-0811 Or 800-817-3807,VA Facility,Government,no,Not Available,39.4139,-77.9135
+512A5,Perry Point VA Medical Center - VA Maryland Health Care System,VA Medical Center,Perry Point,MD,21902,410-642-2411 Or 410-642-2411,VA Facility,Government,no,Not Available,0,0
+688,Washington DC VA Medical Center,"50 Irving Street, NW",Washington,DC,20422,202-745-8000,VA Facility,Government,no,Not Available,38.931225,-77.012024
+581,Gallipolis VA Clinic,323A Upper River Road,Gallipolis,OH,45631,740-446-3934,VA Facility,Government,no,Not Available,38.83184,-82.15734
+581,Lenore VA Clinic,2867 Route 65,Lenore,WV,25676,304-475-3000,VA Facility,Government,no,Not Available,0,0
+512AX,Baltimore VA Annex,209 West Fayette Street,Baltimore,MD,21201,410-605-7000 Or 800-463-6295,VA Facility,Government,no,Not Available,39.290485,-76.61795
+540GC,Braxton County CBOC (540GC),40 Reston Place,Gassaway,WV,26624,304-364-4500,VA Facility,Government,no,Not Available,0,0
+512GA,Cambridge VA Outpatient Clinic,830 Chesapeake Drive,Cambridge,MD,21613,410-228-6243 Or 877-864-9611,VA Facility,Government,no,Not Available,38.553482,-76.060234
+581GB,Charleston VA Clinic,700 Technology Drive,South Charleston,WV,25309,304-746-5300,VA Facility,Government,no,Not Available,0,0
+688GB,Community Clinic-Southeast,"820 Chesapeake Street, S.E.",Washington,DC,20032,202-745-8685,VA Facility,Government,no,Not Available,38.829216,-76.993225
+688GG,Community Resource and Referral Center (CRRC),"1500 Franklin St., NE",Washington,DC,20018,202-636-7660,VA Facility,Government,no,Not Available,38.925674,-76.98309
+613GA,Cumberland Outpatient Clinic,200 Glenn Street,Cumberland,MD,21502,304-263-0811 X 5130,VA Facility,Government,no,Not Available,39.653942,-78.75825
+512GF,Eastern Baltimore County VA Outpatient Clinic,5253 King Avenue,Rosedale,MD,21237,410-477-1800 Or 410-477-1800,VA Facility,Government,no,Not Available,39.35733,-76.46929
+688,Fort Belvoir Outpatient Clinic,9300 DeWitt Loop Sunrise Pavilion,Fort Belvoir,VA,22060,571-231-2408,VA Facility,Government,no,Not Available,0,0
+613GG,Fort Detrick VA Outpatient Clinic,1433 Porter Street,Frederick,MD,21702,304-263-0811 X 5130,VA Facility,Government,no,Not Available,0,0
+6192,Fort Meade VA Outpatient Clinic,2479 5th Street,Fort Meade,MD,20755,410-305-5300,VA Facility,Government,no,Not Available,0,0
+613GD,Franklin Community Based Outpatient Clinic,91 Pine Street,Franklin,WV,26807,304-263-0811 X 5130,VA Facility,Government,no,Not Available,0,0
+512GC,Glen Burnie VA Outpatient Clinic,"808 Landmark Drive, Suite 128",Glen Burnie,MD,21061,410-590-4140,VA Facility,Government,no,Not Available,39.1484,-76.642006
+517GB,Greenbrier County VA Clinic,228 Shamrock Lane,Ronceverte,WV,24970,304-497-3900,VA Facility,Government,no,Not Available,0,0
+613GB,Hagerstown Outpatient Clinic,"Hub Plaza Bldg, 1101 Opal Ct",Hagerstown,MD,21742,304-263-0811 X 5130,VA Facility,Government,no,Not Available,0,0
+613GF,Harrisonburg Outpatient Clinic,1755 S. High Street,Harrisonburg,VA,22801,304-263-0811 X 5130 Or 800-817-3807 X 5130,VA Facility,Government,no,Not Available,38.432823,-78.90089
+512GD,Loch Raven VA Outpatient Clinic,3901 The Alameda,Baltimore,MD,21218,410-605-7650 Or 410-605-7650,VA Facility,Government,no,Not Available,0,0
+540GD,Monongalia County (540GD),"40 Commerce Drive, Suite 101",Westover,WV,26501,304-292-7535,VA Facility,Government,no,Not Available,0,0
+613GE,Petersburg Community Based Outpatient Clinic,15 Grant St.,Petersburg,WV,26847,304-263-0811 X 5130,VA Facility,Government,no,Not Available,38.99487,-79.11806
+512GE,Pocomoke City VA Outpatient Clinic,"1701 Market Street, Unit 211",Pocomoke,MD,21851,410-957-6718 Or 866-441-0287,VA Facility,Government,no,Not Available,0,0
+581GA,Prestonsburg VA Clinic,5230 KY RT 321,Prestonsburg,KY,41653,606-886-1970,VA Facility,Government,no,Not Available,0,0
+517QA,Princeton VA Clinic,1511 North Walker Street,Princeton,WV,24740,304-255-2121 X 3404,VA Facility,Government,no,Not Available,37.367912,-81.10203
+540,Rural Mobile Unit (540),1 Medical Center Drive,Clarksburg,WV,26301,304-623-3461,VA Facility,Government,no,Not Available,39.269535,-80.36269
+688GD,Southern Maryland VA Outpatient Clinic,29431 Charlotte Hall Road,Charlotte Hall,MD,20622,301-884-7102,VA Facility,Government,no,Not Available,38.47783,-76.77777
+688,Southern PG County Outpatient Clinic,5801 Allentown Road,Camp Springs,MD,20746,301-423-3700,VA Facility,Government,no,Not Available,38.8073,-76.89988
+613GC,Stephens City Outpatient Clinic,170 Prosperity Drive,Winchester,VA,22602,304-263-0811 X 5130,VA Facility,Government,no,Not Available,0,0
+540GA,Tucker County CBOC (540GA),260 Spruce Street,Parsons,WV,26287,304-478-2219,VA Facility,Government,no,Not Available,39.096973,-79.683685
+540GB,Wood County CBOC (540GB),"2311 Ohio Avenue, Suite A",Parkersburg,WV,26101,304-422-5114,VA Facility,Government,no,Not Available,39.282536,-81.549706
+2092,Aberdeen Vet Center Outstation,223 W. Bel Air Avenue,Aberdeen,MD,21001,410-272-6771 Or 877-927-8387,VA Facility,Government,no,Not Available,39.510605,-76.16716
+0228V,Alexandria Vet Center,6940 South Kings Highway #204,Alexandria,VA,22310,703-360-8633 Or 703-360-8633,VA Facility,Government,no,Not Available,38.768433,-77.11709
+0235V,Annapolis Vet Center,100 Annapolis Street,Annapolis,MD,21401,410-605-7826 Or 877-927-8387,VA Facility,Government,no,Not Available,38.990086,-76.50218
+0201V,Baltimore Vet Center,1777 Reisterstown Road Suite 199,Baltimore,MD,21208,410-764-9400 Or 410-764-9400,VA Facility,Government,no,Not Available,39.383865,-76.73311
+0231V,Beckley Vet Center,1000 Johnstown Road,Beckley,WV,25801,304-252-8220 Or 877-927-8387,VA Facility,Government,no,Not Available,37.780453,-81.16978
+0223V,Charleston Vet Center,200 Tracy Way,Charleston,WV,25311,304-343-3825 Or 304-343-3825,VA Facility,Government,no,Not Available,38.35907,-81.59911
+0237V,Clinton Vet Center,"7905 Malcolm Road, Suite 101",Clinton,MD,20735,301-856-7173 Or 301-856-7173,VA Facility,Government,no,Not Available,38.782055,-76.889824
+0236V,Dundalk Vet Center,1553 Merritt Blvd,Dundalk,MD,21222,410-282-6144 Or 877-927-8387,VA Facility,Government,no,Not Available,39.27272,-76.5025
+209,Elkton Vet Center,103 Chesapeake Blvd. Suite A,Elkton,MD,21921,410-392-4485 Or 410-392-4485,VA Facility,Government,no,Not Available,0,0
+0208V,Huntington Vet Center,3135 16th Street Road Suite 11,Huntington,WV,25701,304-523-8387 Or 304-523-8387,VA Facility,Government,no,Not Available,38.39435,-82.40953
+02231V,Logan Vet Center Outstation,21 Veterans Avenue,Henlawson,WV,25624,304-752-4453 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+224,Martinsburg Vet Center,300 Foxcroft Ave. Suite 100A,Martinsburg,WV,25401,304-263-6776 Or 304-263-6776,VA Facility,Government,no,Not Available,39.462715,-77.986916
+0216V,Morgantown Vet Center,"34 Commerce Drive, Suite 101",Morgantown,WV,26501,304-291-4303 Or 304-291-4303,VA Facility,Government,no,Not Available,0,0
+2081,Parkersburg Vet Center Outstation,"2311 Ohio Avenue, Suite D",Pakersburg,WV,26101,304-485-1599 Or 877-927-8387,VA Facility,Government,no,Not Available,39.282536,-81.549706
+0232V,Princeton Vet Center,1511 North Walker Street,Princeton,WV,24740,304-425-8098,VA Facility,Government,no,Not Available,37.367912,-81.10203
+0200V,RCS North Atlantic District 1,"305 W. Chesapeake Ave., Suite 300",Towson,MD,21204,410-828-6619 Or 410-828-6619,VA Facility,Government,no,Not Available,39.40007,-76.60994
+2091,Salisbury Outstation,"926 Snow Hill Road, Building 3",Salisbury,MD,21804,410-912-7263 Or 877-927-8387,VA Facility,Government,no,Not Available,38.34735,-75.58189
+0213V,Silver Spring Vet Center,2900 Linden Lane,Silver Spring,MD,20910,301-589-1073 Or 301-589-1073,VA Facility,Government,no,Not Available,39.014156,-77.05791
+213,Washington DC Vet Center,1296 Upshur St NW,Washington,DC,20011,202-726-5212 Or 202-463-0943,VA Facility,Government,no,Not Available,38.941853,-77.029495
+233,Wheeling Vet Center,1058 Bethlehem Blvd.,Wheeling,WV,26003,304-232-0587 Or 304-232-0587,VA Facility,Government,no,Not Available,40.053024,-80.701645
+10N6,VISN 6: VA Mid-Atlantic Health Care Network,3518 Westgate Drive,Durham,NC,27707,919-956-5541,VA Facility,Government,no,Not Available,35.968067,-78.96135
+637,Asheville VA Medical Center,1100 Tunnel Road,Asheville,NC,28805,828-298-7911,VA Facility,Government,no,Not Available,35.586716,-82.48251
+558,Durham VA Medical Center,508 Fulton Street,Durham,NC,27705,919-286-0411 Or 919-286-0411,VA Facility,Government,no,Not Available,36.008934,-78.937294
+565,Fayetteville VA Medical Center,2300 Ramsey Street,Fayetteville,NC,28301,910-488-2120 Or 910-488-2120,VA Facility,Government,no,Not Available,35.089222,-78.87833
+590,Hampton VA Medical Center,100 Emancipation Drive,Hampton,VA,23667,757-722-9961,VA Facility,Government,no,Not Available,37.0225,-76.330826
+652,Hunter Holmes McGuire VA Medical Center,1201 Broad Rock Boulevard,Richmond,VA,23249,804-675-5000,VA Facility,Government,no,Not Available,0,0
+658,Salem VA Medical Center,1970 Roanoke Boulevard,Salem,VA,24153,540-982-2463 Or 888-982-2463,VA Facility,Government,no,Not Available,37.276184,-80.02463
+659,Salisbury - W.G. (Bill) Hefner VA Medical Center,1601 Brenner Avenue,Salisbury,NC,28144,704-638-9000 Or 704-638-9000,VA Facility,Government,no,Not Available,35.683815,-80.48607
+558,Blind Rehabilitation Outpatient Clinic,8081 Arco Corporate Drive,Raleigh,NC,27617,919-286-5235,VA Facility,Government,no,Not Available,0,0
+558,Brier Creek Dialysis Clinic,"8081 Arco Corporate Drive, Suite 130",Raleigh,NC,27617,919-286-5220,VA Facility,Government,no,Not Available,0,0
+565,Fayetteville Dialysis Clinic,2301 Robeson Street,Fayetteville,NC,28305,910-483-9727,VA Facility,Government,no,Not Available,35.042355,-78.91646
+565GL,Fayetteville Health Care Center,7300 South Raeford Road,Fayetteville,NC,28304,910-488-2120 Or 800-771-6106,VA Facility,Government,no,Not Available,35.033398,-79.03128
+565QD,Fayetteville Rehabilitation Clinic,"4101 Raeford Road, Suite 100-B",Fayetteville,NC,28304,910-908-2222,VA Facility,Government,no,Not Available,35.0437,-78.947235
+558GA,Greenville Health Care Center,401 Moye Blvd,Greenville,NC,27834,252-830-2149,VA Facility,Government,no,Not Available,35.613003,-77.40099
+637GC,Hickory CBOC,2440 Century Place SE,Hickory,NC,28602,828-431-5600,VA Facility,Government,no,Not Available,0,0
+590,Albemarle Primary OPC,1845 W City Dr,Elizabeth City,NC,27909,757-722-9961,VA Facility,Government,no,Not Available,0,0
+565,Brunswick County,18 Doctors Circle (Units 2 & 3),Supply,NC,28462,910-754-6141,VA Facility,Government,no,Not Available,0,0
+659GA,Charlotte CBOC,8601 University East Drive,Charlotte,NC,28213,704-597-3500,VA Facility,Government,no,Not Available,0,0
+659BZ,Charlotte Health Care Center,3506 West Tyvola Road,Charlotte,NC,28208,704-329-1300,VA Facility,Government,no,Not Available,35.20241,-80.91191
+652,Charlottesville CBOC,"590 Peter Jefferson Pkwy, 2nd Floor, Suite 250",Charlottesville,VA,22911,434-293-3890,VA Facility,Government,no,Not Available,38.023098,-78.43744
+590GD,Chesapeake CBOC,1987 S. Military Hwy,Chesapeake,VA,23320,757-722-9961,VA Facility,Government,no,Not Available,36.783978,-76.25732
+658GB,Danville CBOC,705 Piney Forest Rd,Danville,VA,24540,434-710-4210,VA Facility,Government,no,Not Available,36.61081,-79.4059
+558,Durham Clinic,1824 Hillandale Road,Durham,NC,27705,919-383-6107,VA Facility,Government,no,Not Available,36.028954,-78.93582
+652GF,Emporia CBOC,1746 East Atlantic,Emporia,VA,23847,434-348-1055,VA Facility,Government,no,Not Available,36.68982,-77.52629
+637,Franklin CBOC,647 Wayah St,Franklin,NC,28734,828-369-1781,VA Facility,Government,no,Not Available,35.17557,-83.37493
+652gb,Fredericksburg at Southpoint CBOC,"10401 Spotsylvania Ave., Suite 300",Fredericksburg,VA,22408,540-693-3140,VA Facility,Government,no,Not Available,0,0
+652GA,Fredericksburg CBOC,130 Executive Center Parkway,Fredericksburg,VA,22401,540-370-4468,VA Facility,Government,no,Not Available,0,0
+565GF,Goldsboro Community Based Outpatient Clinic,2610 Hospital Road,Goldsboro,NC,27534,919-731-4809,VA Facility,Government,no,Not Available,0,0
+565GD,Hamlet CBOC,100 Jefferson Street,Hamlet,NC,28345,910-582-3536,VA Facility,Government,no,Not Available,34.885742,-79.70201
+558,Hillandale Road Outpatient Clinics 1 & II,1824 Hillandale Road,Durham,NC,27705,919-383-6107,VA Facility,Government,no,Not Available,36.028954,-78.93582
+565GA,Jacksonville CBOC,4006 Henderson Drive,Jacksonville,NC,28546,910-353-6406,VA Facility,Government,no,Not Available,0,0
+659BY,Kernersville Health Care Center,1695 Kernersville Medical Parkway,Kernersville,NC,27284,336-515-5000,VA Facility,Government,no,Not Available,0,0
+658,Lynchburg CBOC,1600 Lakeside Dr,Lynchburg,VA,24501,434-316-5000,VA Facility,Government,no,Not Available,37.40173,-79.18849
+558,Morehead City CBOC,5420 Highway 70,Morehead City,NC,28557,252-240-2349,VA Facility,Government,no,Not Available,0,0
+558,Raleigh CBOC,3305 Sungate Blvd,Raleigh,NC,27610,919-212-0129,VA Facility,Government,no,Not Available,0,0
+558,Raleigh II CBOC,3040 Hammond Business Place Suite 105,Raleigh,NC,27603,919-899-6259,VA Facility,Government,no,Not Available,0,0
+558GG,Raleigh III CBOC,"2600 Atlantic Ave., Suite 200",Raleigh,NC,27604,919-755-2620,VA Facility,Government,no,Not Available,35.82258,-78.60943
+558GG,Raleigh III Clinic,"2600 Atlantic Ave., Ste. 200",Raleigh,NC,27604,919-755-2620,VA Facility,Government,no,Not Available,35.82258,-78.60943
+565 GE,Robeson County CBOC,139 Three Hunts Drive,Pembroke,NC,28372,910-272-3220,VA Facility,Government,no,Not Available,0,0
+637GB,Rutherford County CBOC,374 Charlotte Road,Rutherfordton,NC,28139,828-288-2780,VA Facility,Government,no,Not Available,0,0
+565GG,Sanford CBOC,3112 Tramway Road,Sanford,NC,27332,919-775-6160,VA Facility,Government,no,Not Available,35.43814,-79.2131
+658GD,Staunton CBOC,102 Lacy B. King Way,Staunton,VA,24401,540-886-5777,VA Facility,Government,no,Not Available,0,0
+658GA,Tazewell VA Clinic,388 Ben Bolt Ave,Tazewell,VA,24651,276-988-8860,VA Facility,Government,no,Not Available,0,0
+590,Virginia Beach CBOC,244 Clearfield Ave,Virginia Beach,VA,23462,757-722-9961,VA Facility,Government,no,Not Available,0,0
+565GC,Wilmington HCC,1705 Gardner Road,Wilmington,NC,28405,910-343-5300,VA Facility,Government,no,Not Available,0,0
+658GE,Wytheville CBOC,165 Peppers Ferry Road,Wytheville,VA,24382,276-223-5400,VA Facility,Government,no,Not Available,0,0
+0317V,Charlotte Vet Center,"2114 Ben Craig Dr., Suite 300",Charlotte,NC,28262,704-549-8025 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0315V,Fayetteville Vet Center,2301 Robeson St. Suite 103,Fayetteville,NC,28305,910-488-6252 Or 910-488-6252,VA Facility,Government,no,Not Available,35.042355,-78.91646
+327,Greensboro Vet Center,"3515 W Market St., Suite 120",Greensboro,NC,27406,336-323-2660 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0319V,"Greenville, NC Vet Center","1021 WH Smith Blvd., Suite #100",Greenville,NC,27834,252-355-7920 Or 252-355-7920,VA Facility,Government,no,Not Available,0,0
+0343V,Jacksonville Vet Center,110A Branchwood Dr,Jacksonville,NC,28546,910-577-1100 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0207V,Norfolk Vet Center,"1711 Church Street, Suites A&B",Norfolk,VA,23504,757-623-7584 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0328V,Raleigh Vet Center,"8851 Ellstree Lane, Suite 122",Raleigh,NC,27617,919-361-6419 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0217V,Richmond Vet Center,4902 Fitzhugh Avenue,Richmond,VA,23230,804-353-8958 Or 804-353-8958,VA Facility,Government,no,Not Available,37.579716,-77.495415
+226,Roanoke Vet Center,"350 Albemarle Ave., SW",Roanoke,VA,24016,540-342-9726 Or 877-927-8387,VA Facility,Government,no,Not Available,37.263206,-79.94751
+3271,Rutherford Vet Center Outstation,303 Fairground Road,Spindale,NC,28160,828-288-2757 Or 828-288-2757,VA Facility,Government,no,Not Available,0,0
+0240V,Virginia Beach Vet Center,"324 Southport Circle, Suite 102",Virginia Beach,VA,23452,757-248-3665 Or 757-248-3665,VA Facility,Government,no,Not Available,36.831814,-76.13131
+0315V,Fayetteville (NC) Vet Center,"2301 Robeson St., Suite 103",Fayetteville,NC,28305,910-488-6252 Or 800-771-6106 X 7701,VA Facility,Government,no,Not Available,35.042355,-78.91646
+0343V,Jacksonville Vet Center,110A Branchwood Dr,Jacksonville,NC,28345,910-577-1100 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+10N7,VISN 7: VA Southeast Network,"3700 Crestwood Parkway, NW, Suite 500",Duluth,GA,30096,678-924-5700,VA Facility,Government,no,Not Available,33.94617,-84.13016
+508,Atlanta VA Health Care System,1670 Clairmont Road,Decatur,GA,30033,404-321-6111,VA Facility,Government,no,Not Available,33.8016,-84.30972
+521,Birmingham VA Medical Center,700 S. 19th Street,Birmingham,AL,35233,205-933-8101,VA Facility,Government,no,Not Available,33.511967,-86.89478
+557,Carl Vinson VA Medical Center,1826 Veterans Blvd.,Dublin,GA,31021,478-272-1210,VA Facility,Government,no,Not Available,32.54052,-82.94631
+619A4,Central Alabama Veterans Health Care System East Campus,2400 Hospital Road,Tuskegee,AL,36083,334-727-0550 Or 334-727-0550,VA Facility,Government,no,Not Available,0,0
+619,Central Alabama Veterans Health Care System West Campus,215 Perry Hill Road,Montgomery,AL,36109,334-272-4670 Or 334-272-4670,VA Facility,Government,no,Not Available,32.37902,-86.246376
+509,Charlie Norwood VA Medical Center,1 Freedom Way,Augusta,GA,30904,706-733-0188 Or 706-733-0188,VA Facility,Government,no,Not Available,33.468346,-82.02534
+534,Ralph H. Johnson VA Medical Center,109 Bee Street,Charleston,SC,29401,843-577-5011 Or 843-577-5011,VA Facility,Government,no,Not Available,32.785133,-79.95385
+679,Tuscaloosa VA Medical Center,"3701 Loop Road, East",Tuscaloosa,AL,35404,205-554-2000 Or 205-554-2000,VA Facility,Government,no,Not Available,33.19277,-87.48909
+544,Wm. Jennings Bryan Dorn VA Medical Center,6439 Garners Ferry Road,Columbia,SC,29209,803-776-4000,VA Facility,Government,no,Not Available,33.980034,-80.96186
+509GA,Athens Clinic,9249 Highway 29 North,Athens,GA,30601,706-227-4534,VA Facility,Government,no,Not Available,0,0
+619GB,Dothan Mental Health Clinic,"3753 Ross Clark Cir., Suite 4",Dothan,AL,36303,334-678-1933,VA Facility,Government,no,Not Available,31.252869,-85.415695
+534,Hinesville Clinic,500 East Oglethorpe Highway,Hinesville,GA,31313,912-408-2900,VA Facility,Government,no,Not Available,31.838243,-81.595215
+508,Rome VA Clinic,"30 Chateau Dr, SE",Rome,GA,30161,404-329-2222,VA Facility,Government,no,Not Available,34.220844,-85.15464
+679A1,Selma Outpatient Clinic,206 Vaughan Memorial Drive,Selma,AL,36701,205-554-2000 X 6601 Or 205-554-2000 X 6607,VA Facility,Government,no,Not Available,0,0
+534GF,Trident VA Clinic,9237 University Blvd,North Charleston,SC,29406,843-789-6400,VA Facility,Government,no,Not Available,32.97779,-80.0726
+534QB,Trident VA Clinic – 9229 University Blvd,"9229 University Blvd., Bldg. F, Suite 2A",North Charleston,SC,29406,843-789-6400,VA Facility,Government,no,Not Available,32.977776,-80.07254
+508GK,Trinka Davis Veterans Village Clinic,180 Martin Dr,Carrollton,GA,30117,678-423-4970 X 2155 Or 678-423-4970 X 2156,VA Facility,Government,no,Not Available,33.63418,-85.19058
+534QC,VA Community Resource and Referral Center,2424 City Hall Lane,North Charleston,SC,29405,,VA Facility,Government,no,Not Available,0,0
+509GB,Aiken Community Based Outpatient Clinic,951 Millbrook Avenue,Aiken,SC,29803,803-643-9016,VA Facility,Government,no,Not Available,33.52147,-81.71997
+557GB,Albany Clinic,"814 Radford Blvd., Building 7000",Albany,GA,31701,229-446-9000,VA Facility,Government,no,Not Available,31.55069,-84.063835
+544GD,Anderson County Clinic,3030 North Highway 81,Anderson,SC,29621,864-224-5450,VA Facility,Government,no,Not Available,0,0
+521GE,Anniston/Oxford Clinic,96 Ali Way Creekside South,Oxford,AL,36203,256-832-4141,VA Facility,Government,no,Not Available,0,0
+508QF,Atlanta VA Clinic,250 N. Arcadia Avenue,Decatur,GA,30030,404-329-2222,VA Facility,Government,no,Not Available,33.780342,-84.27822
+508GF,Austell VA CBOC,2041 Mesa Valley Way Suite 185,Austell,GA,30082,404-329-2222,VA Facility,Government,no,Not Available,0,0
+534,Beaufort Clinic,1 Pinckney Blvd,Beaufort,SC,29902,843-770-0444,VA Facility,Government,no,Not Available,0,0
+521GG,Bessemer CBOC,"975 9th Avenue, SW-Suite 400 at UAB West Medical Center West",Bessemer,AL,32055,205-428-3495,VA Facility,Government,no,Not Available,0,0
+521GJ,Birmingham VA Clinic,2415 7th Avenue South,Birmingham,AL,35233,205-933-8101,VA Facility,Government,no,Not Available,33.508595,-86.79411
+508GJ,Blairsville VA CBOC,"1294 Highway 515 East, Suite 100",Blairsville,GA,30512,404-329-2222,VA Facility,Government,no,Not Available,0,0
+557GD,Brunswick,"1111 Glynco Parkway, Bldg. 2, Suite 200",Brunswick,GA,31525,912-261-2355,VA Facility,Government,no,Not Available,0,0
+521GH,Childersburg CBOC,151 9th Ave NW,Childersburg,AL,35044,256-378-9026,VA Facility,Government,no,Not Available,33.27733,-86.35565
+31902,Columbus Clinic,1310 13th AVENUE,Columbus,GA,31901,706-257-7205,VA Facility,Government,no,Not Available,32.47083,-84.97439
+619GB,Dothan,2020 Alexander Drive,Dothan,AL,36301,334-673-4166,VA Facility,Government,no,Not Available,31.21237,-85.36345
+508QB,East Point VA Clinic,"2675 N. Martin St., Building 700 Suite A",East Point,GA,30344,,VA Facility,Government,no,Not Available,33.68299,-84.438034
+544GB,Florence CBOC,1822 Sally Hill Farms Road,Florence,SC,29501,843-292-8383,VA Facility,Government,no,Not Available,34.25562,-79.773415
+508GA,Fort McPherson VA Campus,"1701 Hardee Ave., SW",Atlanta,GA,30310,404-321-6111 X 2222,VA Facility,Government,no,Not Available,0,0
+619QB,Ft. Benning VA Clinic,"6635 Bass Road, Bldg. 9214",Ft. Benning,GA,31905,706-257-7205,VA Facility,Government,no,Not Available,0,0
+508QD,Fulton County VA Clinic,"1513 Cleveland Ave., Building 300",East Point,GA,30344,,VA Facility,Government,no,Not Available,33.679413,-84.43989
+521GD,Gadsden CBOC,206 Rescia Ave,Gadsden,AL,35906,256-413-7154,VA Facility,Government,no,Not Available,33.963287,-86.03298
+534GD,Goose Creek CBOC,2418 NNPTC Circle,Goose Creek,SC,29445,843-577-5011 X 3100,VA Facility,Government,no,Not Available,0,0
+544BZ,Greenville Clinic,41 Park Creek Drive,Greenville,SC,29605,864-299-1600,VA Facility,Government,no,Not Available,34.75783,-82.39619
+619GE,"Guntersville, AL CBOC",101 Judy Smith Drive,Guntersville,AL,35976,256-582-4033,VA Facility,Government,no,Not Available,0,0
+508QE,Gwinnett County VA Clinic,1970 Riverside Parkway,Lawrenceville,GA,30043,404-329-2222,VA Facility,Government,no,Not Available,33.981247,-84.02569
+508QC,Henderson Mill VA Clinic,2296 Henderson Mill Road,Atlanta,GA,30345,,VA Facility,Government,no,Not Available,33.852135,-84.258965
+521GA,Huntsville Clinic,"500 Markaview Drive, NW",Huntsville,AL,35805,256-533-8477,VA Facility,Government,no,Not Available,0,0
+521GF,Jasper Clinic,1454 Jones Dairy Rd,Jasper,AL,35501,205-221-7384,VA Facility,Government,no,Not Available,0,0
+508GH,Lawrenceville VA Clinic,"455 Philip Blvd, Suite 200",Lawrenceville,GA,30046,404-329-2222,VA Facility,Government,no,Not Available,0,0
+557GA,Macon Clinic,5566 Thomaston Road,Macon,GA,31220,478-476-8868,VA Facility,Government,no,Not Available,32.834206,-83.744354
+557GF,Milledgeville Community Based Outpatient Clinic,2249 Vinson Hwy SE,Milledgeville,GA,31061,478-414-4540,VA Facility,Government,no,Not Available,33.047714,-83.212585
+619GF,Montgomery VA Clinic,8105 Veterans Way,Montgomery,AL,36117,800-214-8387,VA Facility,Government,no,Not Available,0,0
+534GB,Myrtle Beach CBOC,3381 Phillis Blvd.,Myrtle Beach,SC,29577,843-477-0177,VA Facility,Government,no,Not Available,33.67208,-78.93672
+534QA,Myrtle Beach VA Clinic – Market Common,1101 Johnson Avenue,Myrtle Beach,SC,29577,843-477-0177,VA Facility,Government,no,Not Available,0,0
+508GI,Newnan VA Clinic,39-A Oak Hill Ct.,Newnan,GA,30265,404-329-2222,VA Facility,Government,no,Not Available,0,0
+508GE,Oakwood VA Clinic,4175 Tanners Creek Drive,Flowery Branch,GA,30542,404-329-2222,VA Facility,Government,no,Not Available,0,0
+544GE,Orangeburg County Clinic,1767 Villagepark Drive,Orangeburg,SC,29118,803-533-1335,VA Facility,Government,no,Not Available,33.5234,-80.85726
+557GC,Perry Outreach Clinic,2370 S. Houston Lake Road,Kathleen,GA,31047,478-224-1309,VA Facility,Government,no,Not Available,32.503242,-83.66276
+544GC,Rock Hill Clinic,2670 Mills Park Drive,Rock Hill,SC,29732,803-366-4848,VA Facility,Government,no,Not Available,34.977192,-81.024704
+534BY,Savannah Clinic,1170 Shawnee St.,Savannah,GA,31419,912-920-0214,VA Facility,Government,no,Not Available,31.986042,-81.173485
+521GC,Shoals Area (Florence) Clinic,422 DD Cox Blvd.,Sheffield,AL,35660,256-381-9055,VA Facility,Government,no,Not Available,0,0
+544,Spartanburg CBOC,279 North Grove Medical Park Drive,Spartanburg,SC,29303,864-582-7025,VA Facility,Government,no,Not Available,0,0
+509GC,Statesboro Clinic,658 Northside Drive East,Statesboro,GA,30458,912-871-8719 Or 706-733-0188 X 1132,VA Facility,Government,no,Not Available,32.43446,-81.75643
+508GG,Stockbridge VA Clinic,175 Medical Blvd.,Stockbridge,GA,30281,404-329-2222,VA Facility,Government,no,Not Available,33.512432,-84.22509
+544,Sumter County Clinic,407 North Salem Avenue,Sumter,SC,29150,803-938-9901,VA Facility,Government,no,Not Available,33.929115,-80.350685
+6426,Tifton VA Clinic,1824 Ridge Avenue North,Tifton,GA,31794,229-391-6080 Or 229-391-6080,VA Facility,Government,no,Not Available,31.441685,-83.51968
+619,VA Outpatient Clinic Monroeville (CBOC),159 Whetstone Street,Monroeville,AL,36400,251-743-5861 Or 251-743-5862,VA Facility,Government,no,Not Available,0,0
+619,Wiregrass CBOC,301 Andrews Avenue,Fort Rucker,AL,36362,800-214-8387 X 7831,VA Facility,Government,no,Not Available,0,0
+0304V,Atlanta Vet Center,"1800 Phoenix Boulevard, Building 400, Suite 404 Box 55",Atlanta,GA,30349,404-417-5414 Or 404-417-5414,VA Facility,Government,no,Not Available,33.614666,-84.442856
+509,Augusta Vet Center,"2050 Walton Way, Suite 100",Augusta,GA,30904,706-729-5762 Or 706-729-5762,VA Facility,Government,no,Not Available,33.475864,-82.00829
+0739V,Birmingham Vet Center,"400 Emery Drive, Suite 200",Hoover,AL,35244,205-212-3122 Or 205-212-3122,VA Facility,Government,no,Not Available,0,0
+0303V,Charleston Vet Center,3625 West Montague Avenue,North Charleston,SC,29418,843-789-7000 Or 843-789-7000,VA Facility,Government,no,Not Available,32.861355,-80.02741
+0324V,Columbia Vet Center,"1710 Richland Street, Suite A",Columbia,SC,29201,803-765-9944 Or 877-927-8387,VA Facility,Government,no,Not Available,34.01316,-81.02945
+0349V,Columbus Vet Center,"2601 Cross Country Drive, Condominium B-2 Suite 900",Columbus,GA,31906,706-596-7170,VA Facility,Government,no,Not Available,0,0
+0316V,"Greenville, SC Vet Center","3 Caledon Court, Suite B",Greenville,SC,29615,864-271-2711 Or 864-271-2711,VA Facility,Government,no,Not Available,34.861446,-82.339714
+738,Huntsville Vet Center,"415 Church Street, Bldg H, Suite 101",Huntsville,AL,35801,256-539-5775 Or 256-539-5775,VA Facility,Government,no,Not Available,34.73529,-86.591606
+0329V,Lawrenceville Vet Center,930 River Centre Place,Lawrenceville,GA,30043,404-728-4195 Or 404-728-4195,VA Facility,Government,no,Not Available,33.973522,-84.03296
+0333V,Macon Vet Center,750 Riverside Drive,Macon,GA,31201,478-477-3813 Or 877-927-8387,VA Facility,Government,no,Not Available,32.841946,-83.62805
+0342V,Marietta Vet Center,"40 Dodd St., Suite 700",Marietta,GA,30060,404-327-4954 Or 404-327-4954,VA Facility,Government,no,Not Available,33.950397,-84.52376
+0740V,Montgomery Vet Center,4405 Atlanta Highway,Montgomery,AL,36109,334-273-7796 Or 877-927-8387,VA Facility,Government,no,Not Available,32.381733,-86.2297
+0347V,Myrtle Beach Vet Center,"2024 Corporate Centre Dr, Suite 103",Myrtle Beach,SC,29577,843-232-2441 Or 843-232-2441,VA Facility,Government,no,Not Available,33.709522,-78.88358
+0323V,Savannah Vet Center,321 Commercial Dr,Savannah,GA,31406,912-961-5800 Or 912-961-5800,VA Facility,Government,no,Not Available,32.006786,-81.10781
+485,VISN 8: VA Sunshine Healthcare Network,"140 Fountain Parkway, Ste. 600",St. Petersburg,FL,33716,727-575-8069,VA Facility,Government,no,Not Available,27.890217,-82.66082
+516,Bay Pines VA Healthcare System,10000 Bay Pines Blvd,Bay Pines,FL,33744,727-398-6661 Or 727-398-6661,VA Facility,Government,no,Not Available,27.8139,-82.770836
+573,North Florida/South Georgia Veterans Health System,1601 S.W. Archer Road,Gainesville,FL,32608,352-376-1611,VA Facility,Government,no,Not Available,29.639143,-82.34345
+672,VA Caribbean Healthcare System,10 Casia Street,San Juan,PR,921,787-641-7582 Or 787-641-7582,VA Facility,Government,no,Not Available,0,0
+673,James A. Haley Veterans' Hospital,13000 Bruce B. Downs,Tampa,FL,33612,813-972-2000,VA Facility,Government,no,Not Available,28.065699,-82.42611
+673QJ,James A. Haley Veterans' Hospital Primary Care Annex,13515 Lake Terrace Lane,Tampa,FL,33637,813-998-8000,VA Facility,Government,no,Not Available,0,0
+573A4,"Lake City VAMC, NF/SGVHS",619 S. Marion Avenue,Lake City,FL,32025,386-755-3016 Or 800-308-8387,VA Facility,Government,no,Not Available,30.183418,-82.63701
+573,"Malcom Randall VAMC, NF/SGVHS",1601 S.W. Archer Road,Gainesville,FL,32608,352-376-1611 Or 800-324-8387,VA Facility,Government,no,Not Available,29.639143,-82.34345
+546,Miami VA Healthcare System,1201 N.W. 16th St.,Miami,FL,33125,305-575-7000 Or 305-575-7000,VA Facility,Government,no,Not Available,25.790472,-80.215126
+675,Orlando VA Medical Center,13800 Veterans Way,Orlando,FL,32827,407-631-1000,VA Facility,Government,no,Not Available,0,0
+548,West Palm Beach VAMC,7305 N. Military Trail,West Palm Beach,FL,33410,561-422-8262 Or 561-422-8262,VA Facility,Government,no,Not Available,26.784203,-80.10725
+548ZZ1,Clewiston Outpatient Clinic,1100 Olympia Street,Clewiston,FL,33440,,VA Facility,Government,no,Not Available,0,0
+573BY,Jacksonville OPC,1536 N Jefferson St,Jacksonville,FL,32209,877-870-5048 Or 904-475-5800,VA Facility,Government,no,Not Available,30.344486,-81.66289
+675GG,Lake Baldwin OPC,5201 Raymond Street,Orlando,FL,32803,407-646-5500,VA Facility,Government,no,Not Available,28.578913,-81.32207
+516BZ,Lee County VA Healthcare Center,2489 Diplomat Parkway East,Cape Coral,FL,33909,239-652-1800,VA Facility,Government,no,Not Available,0,0
+672BZ,Mayaguez OPC,175 Algarrobo Ave.,Mayaguez,PR,682,787-641-7582 X 48501,VA Facility,Government,no,Not Available,0,0
+673BZ,New Port Richey OPC,9912 Little Road,New Port Richey,FL,34654,727-869-4100,VA Facility,Government,no,Not Available,28.294464,-82.67542
+672BO,Ponce OPC,Paseo Del Veterano #1010,Ponce,PR,716,787-641-7582 X 44001 Or 787-641-7582 X 44002,VA Facility,Government,no,Not Available,0,0
+573BY,Southpoint Clinic,6900 Southpoint Dr North,Jacksonville,FL,32209,904-470-6900,VA Facility,Government,no,Not Available,30.255903,-81.5878
+573GF,Tallahassee HCC,2181 East Orange Avenue,Tallahassee,FL,32311,800-541-8387 Or 850-878-0191,VA Facility,Government,no,Not Available,0,0
+573GI,The Villages OPC,8900 SE 165th Mulberry Ln.,The Villages,FL,32162,877-649-0024 Or 352-674-5000,VA Facility,Government,no,Not Available,0,0
+672,Utuado VA Rural Outpatient Clinic,Isaac Gonzalez Street Equina Ledesma,Utuado,PR,641,787-522-2650 Or 787-522-2650,VA Facility,Government,no,Not Available,0,0
+548ZZ2,VA Moore Haven Outpatient Clinic,1021 Health Park Drive,Moore Haven,FL,33471,,VA Facility,Government,no,Not Available,0,0
+675GA,Viera OPC,2900 Veterans Way,Viera,FL,32940,321-637-3788,VA Facility,Government,no,Not Available,28.251802,-80.742805
+675GB,"William V. Chappell, Jr., VA OPC",551 National Health Care Drive,Daytona Beach,FL,32114,386-323-7500,VA Facility,Government,no,Not Available,29.205873,-81.06211
+548,St Lucie County PTSD Clinical Team (PCT) Outpatient Program,126 SW Chamber Court,Port St Lucie,FL,34986,772-878-7876,VA Facility,Government,no,Not Available,0,0
+672GC,Arecibo CBOC,"Road PR-10, Puerto Rico",Arecibo,PR,612,787-641-7582 X 28683 Or 800-449-8729 X 28678,VA Facility,Government,no,Not Available,0,0
+548GD,Boca Raton CBOC,901 Meadows Road,Boca Raton,FL,33433,561-416-8995,VA Facility,Government,no,Not Available,26.358753,-80.10404
+516GD,Bradenton Community-Based Outpatient Clinic,5520 S.R. 64 Suite 101,Bradenton,FL,34208,941-721-0649,VA Facility,Government,no,Not Available,0,0
+673GC,Brooksville CBOC,"14540 Cortez Blvd., Suite 108",Brooksville,FL,34613,352-597-8287,VA Facility,Government,no,Not Available,28.53387,-82.48409
+672GD,Ceiba Community Based Outpatient Clinic,"PR-3, Km. 54.9 Lot#3",Pueblo Ward,PR,735,787-641-7582 X 29001 Or 800-449-8729 X 29001,VA Facility,Government,no,Not Available,0,0
+672GD,Ceiba Community Based Outpatient Clinic,"PR-3, Km. 54.9 Lot#3",Pueblo Ward,PR,735,800-449-8729 X 29001,VA Facility,Government,no,Not Available,0,0
+6298,Ceiba VA Community Based Outpatient Clinic,"PR-3, Km. 54.9, Lot #3",Pueblo Ward,PR,735,800-449-8729 X 29001,VA Facility,Government,no,Not Available,0,0
+5924,Clermont Community Based Outpatient Clinic,805 Oakley Seaver Drive,Clermont,FL,34711,352-536-8200,VA Facility,Government,no,Not Available,0,0
+714,Comerio Rural Outpatient Clinic,15 De Diego Street,Comerio,PR,782,787-522-2660,VA Facility,Government,no,Not Available,0,0
+3333,Crossroads Annex,925 South Semoran Blvd Suite 114,Winter Park,FL,32792,866-998-4365,VA Facility,Government,no,Not Available,28.583382,-81.30698
+546GH,Deerfield Beach VA Community Based Outpatient Clinic,2100 S.W. 10th St.,Deerfield Beach,FL,33442,954-570-5572,VA Facility,Government,no,Not Available,26.30437,-80.13228
+548GB,Delray Beach CBOC,"4800 Linton Blvd., Building E, Suite 300",Delray Beach,FL,33445,561-495-1973,VA Facility,Government,no,Not Available,26.439363,-80.11655
+548GA,Fort Pierce CBOC,"1901 South 25th Street, Suite 103",Ft. Pierce,FL,34947,772-595-5150,VA Facility,Government,no,Not Available,27.467018,-80.34966
+672GE,Guayama CBOC,"FISA Bldg 1st Fl, Paseo Del Pueblo, km 0.3, lote no 6",Guayama,PR,784,787-866-8886,VA Facility,Government,no,Not Available,0,0
+546GA,Healthcare for Homeless Veterans,"1492 W. Flagler St., Suite 101",Miami,FL,33135,305-541-5864,VA Facility,Government,no,Not Available,25.773327,-80.21949
+546,Healthcare for Homeless Veterans,1492 Flagler St,Miami,FL,33135,305-541-5864,VA Facility,Government,no,Not Available,25.773329,-80.21944
+546,Hollywood VA Community Based Outpatient Clinic,"3702 Washington St., Suite 201",Hollywood,FL,33021,954-986-1811,VA Facility,Government,no,Not Available,26.00302,-80.18108
+546GC,Homestead VA Community Based Outpatient Clinic,"950 Krome Ave., Suite 401",Homestead,FL,33030,305-248-0874,VA Facility,Government,no,Not Available,0,0
+673QJ,James A. Haley Veterans' Hospital Primary Care Annex,13515 Lake Terrace Lane,Tampa,FL,33637,813-998-8000,VA Facility,Government,no,Not Available,0,0
+546GE,Key Largo VA Community Based Outpatient Clinic,105662 Overseas Highway,Key Largo,FL,33037,305-451-0164,VA Facility,Government,no,Not Available,25.161482,-80.38247
+546GB,Key West VA Outpatient Clinic,"1300 Douglas Circle, Building L-15",Key West,FL,33040,305-293-4863,VA Facility,Government,no,Not Available,24.568449,-81.75187
+675GC,Kissimmee CBOC,2285 North Central Avenue,Kissimmee,FL,34741,407-518-5004,VA Facility,Government,no,Not Available,28.312544,-81.40857
+673GB,Lakeland CBOC,4237 South Pipkin Rd,Lakeland,FL,33811,863-701-2470,VA Facility,Government,no,Not Available,27.994333,-81.996185
+573GG,Lecanto CBOC,"2804 W. Marc Knighton Ct., Suite A",Lecanto,FL,34461,352-746-8000,VA Facility,Government,no,Not Available,28.905931,-82.48029
+573GK,Marianna CBOC,4970 Highway 90,Marianna,FL,32446,850-718-5620,VA Facility,Government,no,Not Available,30.75043,-85.189995
+516GF,Naples Community-Based Outpatient Clinic,2685 Horseshoe Drive South - Suite 101,Naples,FL,34104,239-659-9188,VA Facility,Government,no,Not Available,26.161837,-81.772446
+573GD,Ocala CBOC,1515 Silver Springs Blvd.,Ocala,FL,34470,352-369-3320,VA Facility,Government,no,Not Available,29.187044,-82.11808
+548GF,Okeechobee CBOC,1201 N. Parrot Avenue,Okeechobee,FL,34972,863-824-3232,VA Facility,Government,no,Not Available,27.25645,-80.82994
+675GD,Orange City CBOC,"2583 South Volusia Ave (17-92), Suite 300",Orange City,FL,32763,386-456-2080,VA Facility,Government,no,Not Available,0,0
+573GL,Palatka CBOC,"400 North State Road 19, Suite 48",Palatka,FL,32177,386-329-8800,VA Facility,Government,no,Not Available,0,0
+516GC,Palm Harbor Community-Based Outpatient Clinic,35209 US Highway 19 North,Palm Harbor,FL,34684,727-734-5276,VA Facility,Government,no,Not Available,0,0
+546GD,Pembroke Pines VA Community Based Outpatient Clinic,"7369 W. Sheridan St., Suite 102",Hollywood,FL,33024,954-894-1668,VA Facility,Government,no,Not Available,26.031391,-80.23594
+573GN,Perry CBOC,1224 N. Peacock Ave.,Perry,FL,32347,850-223-8387,VA Facility,Government,no,Not Available,30.120272,-83.576454
+516GE,Port Charlotte Community-Based Outpatient Clinic,4161 Tamiami Trail Suite 401 & Suite 602 (Annex Bldg),Port Charlotte,FL,33952,941-235-2710,VA Facility,Government,no,Not Available,0,0
+548,Port St Lucie PTSD Clinical Team (PCT) Outpatient Program,128 SW Chamber Court,Port Saint Lucie,FL,34986,772-344-9288,VA Facility,Government,no,Not Available,0,0
+573GE,Saint Augustine CBOC,195 Southpark Blvd.,St. Augustine,FL,32086,866-401-8387 Or 904-829-0814,VA Facility,Government,no,Not Available,29.862272,-81.32687
+672GA,Saint Croix CBOC,"Box 12, RR-02, The Village Mall #113",Kings Hill,VI,850,340-778-5553,VA Facility,Government,no,Not Available,0,0
+672GB,Saint Thomas CBOC,Medical Foundation Building Suite 101,St. Thomas,VI,802,340-776-7072,VA Facility,Government,no,Not Available,0,0
+516GA,Sarasota Community-Based Outpatient Clinic,"5682 Bee Ridge Road, Suite 100",Sarasota,FL,34233,941-371-3349,VA Facility,Government,no,Not Available,27.29881,-82.45636
+516GH,Sebring Community-Based Outpatient Clinic,5901 U.S. Highway 27 South,Sebring,FL,33870,863-471-6227,VA Facility,Government,no,Not Available,0,0
+573,St Marys CBOC,"2603 Osbourne Road, Ste E",St Marys,GA,31558,912-510-3420,VA Facility,Government,no,Not Available,0,0
+516GB,St. Petersburg Community-Based Outpatient Clinic,840 Dr. MLK Jr. Street N,St. Petersburg,FL,33705,727-502-1700,VA Facility,Government,no,Not Available,0,0
+548GC,Stuart CBOC,3501 S E Willoughby Boulevard,Stuart,FL,34997,772-288-0304,VA Facility,Government,no,Not Available,0,0
+675GE,Tavares Community Based Outpatient Clinic,1390 E. Burleigh Blvd.,Tavares,FL,32778,352-253-2900,VA Facility,Government,no,Not Available,0,0
+573GA,Valdosta CBOC,2841 N. Patterson Street,Valdosta,GA,31602,229-293-0132 Or 877-303-8387,VA Facility,Government,no,Not Available,30.868034,-83.29001
+548GE,Vero Beach CBOC,372 17th Street,Vero Beach,FL,32960,772-299-4623,VA Facility,Government,no,Not Available,27.632372,-80.38043
+714,Vieques Rural Outpatient Clinic,Co.Destino Carretera #997,Vieques,PR,765,787-641-7582 X 28601,VA Facility,Government,no,Not Available,0,0
+573GM,Waycross CBOC,515B City Boulevard,Waycross,GA,31501,912-279-4400,VA Facility,Government,no,Not Available,31.231209,-82.34093
+546,William Bill Kling VA Clinic,9800 W. Commercial Blvd.,Sunrise,FL,33351,954-475-5500,VA Facility,Government,no,Not Available,0,0
+673GF,Zephyrhills CBOC,6937 Medical View Ln,Zephyrhills,FL,33541,813-780-2550,VA Facility,Government,no,Not Available,0,0
+0309V,Arecibo Vet Center,50 Gonzalo Marin St,Arecibo,PR,612,787-641-7582 X 28151,VA Facility,Government,no,Not Available,0,0
+0339V,Clearwater Vet Center,29259 US Hwy 19 North,Clearwater,FL,33761,727-549-3600 Or 727-549-3600,VA Facility,Government,no,Not Available,0,0
+675GF,Clermont Vet Center,"1655 East Highway 50, Suite 102",Clermont,FL,34711,352-536-6701 Or 877-927-8387,VA Facility,Government,no,Not Available,28.545898,-81.7555
+0341V,Daytona Beach Vet Center,"1620 Mason Ave., Suite C",Daytona Beach,FL,32117,386-366-6600 Or 386-366-6600,VA Facility,Government,no,Not Available,29.21203,-81.0657
+0311V,Fort Lauderdale Vet Center,3666 W. Oakland Park Blvd.,Lauderdale Lakes,FL,33311,954-714-2381,VA Facility,Government,no,Not Available,26.16532,-80.1985
+0330V,Fort Myers Vet Center,"4110 Center Pointe Drive, Unit 204",Ft. Myers,FL,33916,239-652-1861 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0331V,Gainesville Vet Center,"105 NW 75th Street, Suite #2",Gainesville,FL,32607,352-331-1408 Or 877-927-8387,VA Facility,Government,no,Not Available,29.6545,-82.422386
+0305V,Jacksonville Vet Center,"3728 Phillips Highway, Suite 31",Jacksonville,FL,32207,904-399-8351 Or 904-399-8351,VA Facility,Government,no,Not Available,30.28736,-81.63335
+0337V,Jupiter Vet Center,"6650 W. Indiantown Rd., Suite 120",Jupiter,FL,33458,561-422-1220 Or 561-422-1220,VA Facility,Government,no,Not Available,26.934444,-80.136856
+03101V,Key Largo Vet Center Outstation,105662 Overseas Hwy.,Key Largo,FL,33037,305-451-0164 Or 877-927-8387,VA Facility,Government,no,Not Available,25.161482,-80.38247
+0340V,Lakeland Vet Center,1370 Ariana St.,Lakeland,FL,33803,863-284-0841 Or 863-284-0841,VA Facility,Government,no,Not Available,28.025854,-81.97894
+0332V,Melbourne Vet Center,2098 Sarno Road,Melbourne,FL,32935,321-254-3410 Or 877-927-8387,VA Facility,Government,no,Not Available,28.12169,-80.65558
+0310V,Miami Vet Center,8280 NW 27th St Suite 511,Miami,FL,33122,305-718-3712 Or 305-718-3712,VA Facility,Government,no,Not Available,25.799692,-80.336395
+0348V,Naples Vet Center,"2705 Horseshoe Dr. South, Suite #204",Naples,FL,34104,239-403-2377 Or 877-927-8387,VA Facility,Government,no,Not Available,26.16184,-81.77219
+344,Ocala Vet Center,"3300 SW 34th Avenue, Suite 140",Ocala,FL,34474,352-237-1947 Or 877-927-8387,VA Facility,Government,no,Not Available,29.151766,-82.17551
+0314V,Orlando Vet Center,"5575 S. Semoran Blvd., Suite #30",Orlando,FL,32822,407-857-2800 Or 407-857-2800,VA Facility,Government,no,Not Available,28.48248,-81.310104
+0326V,Palm Beach Vet Center,"4996 10th Ave North, Suite 6",Greenacres,FL,33463,561-422-1201 Or 561-422-1201,VA Facility,Government,no,Not Available,26.631065,-80.122665
+0338V,Pasco County Vet Center,5139 Deer Park Drive,New Port Richey,FL,34653,727-372-1854 Or 727-372-1854,VA Facility,Government,no,Not Available,0,0
+0336V,Pompano Beach Vet Center,"2300 West Sample Road, Suite 102",Pompano,FL,33073,954-984-1669 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0312V,Ponce Vet Center,"35 Mayor Street, Suite 1",Ponce,PR,730,787-841-3260 Or 787-841-3260,VA Facility,Government,no,Not Available,0,0
+0300V,RCS Southeast District 2 District Office,"450 Carillon Parkway, Suite 150",St. Petersburg,FL,33716,727-398-9343 Or 727-398-9343,VA Facility,Government,no,Not Available,27.88889,-82.66944
+0307V,San Juan Vet Center,"Cond. Medical Center Plaza Suite LC 8, 9 & 11, Urb. La Riviera",Rio Piedras,PR,921,787-749-4409 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0320V,Sarasota Vet Center,4801 Swift Rd. Suite A,Sarasota,FL,34231,941-927-8285 Or 877-927-8387,VA Facility,Government,no,Not Available,27.283916,-82.514145
+03121V,St. Croix Vet Center Outstation,"The Village Mall, RR 2 Box 10553 Kingshill",St. Croix,VI,850,340-778-5553 Or 787-641-7582 X 25613,VA Facility,Government,no,Not Available,0,0
+0301V,St. Petersburg Vet Center,"6798 Crosswinds Drive, Bldg A",St. Petersburg,FL,33710,727-549-3633 Or 877-927-8387,VA Facility,Government,no,Not Available,27.79047,-82.7337
+03122V,St. Thomas Vet Center Outstation,"50 Estate Thomas, Medical Foundation Buiding Suite 101",St. Thomas,VI,802,340-774-5017 Or 787-641-7582 X 25507,VA Facility,Government,no,Not Available,0,0
+0325V,Tallahassee Vet Center,2002 Old St. Augustine Road,Tallahassee,FL,32301,850-942-8810,VA Facility,Government,no,Not Available,30.426197,-84.24688
+0318V,Tampa Vet Center,"Fountain Oaks Business Plaza; 3637 W. Waters Ave., Suite 600",Tampa,FL,33614,813-228-2621 Or 813-228-2621,VA Facility,Government,no,Not Available,0,0
+10N9,VISN 9: VA MidSouth Healthcare Network,"1801 West End Ave., Suite 600",Nashville,TN,37203,615-695-2200,VA Facility,Government,no,Not Available,0,0
+596,Lexington VA Medical Center,1101 Veterans Drive,Lexington,KY,40502,859-233-4511,VA Facility,Government,no,Not Available,0,0
+626,Tennessee Valley Healthcare System,1310 24th Avenue South,Nashville,TN,37212,615-327-4751,VA Facility,Government,no,Not Available,36.142414,-86.80479
+596A4,Lexington VAMC: Cooper Division,1101 Veterans Drive,Lexington,KY,40502,859-281-4900 Or 859-233-4511,VA Facility,Government,no,Not Available,0,0
+596,Lexington VAMC: Leestown Division,2250 Leestown Rd,Lexington,KY,40511,859-233-4511 Or 859-281-4900,VA Facility,Government,no,Not Available,38.077587,-84.54163
+614,Memphis VA Medical Center,1030 Jefferson Avenue,Memphis,TN,38104,901-523-8990 Or 901-523-8990,VA Facility,Government,no,Not Available,35.142464,-90.02515
+621,Mountain Home VAMC/Johnson City,Corner of Lamont Street and Veterans Way,Mountain Home,TN,37684,423-926-1171 Or 423-926-1171,VA Facility,Government,no,Not Available,0,0
+603,Robley Rex VA Medical Center,800 Zorn Avenue,Louisville,KY,40206,502-287-4000 Or 502-287-4000,VA Facility,Government,no,Not Available,38.270893,-85.6941
+626A4,Tennessee Valley Healthcare System - Alvin C. York (Murfreesboro) Campus,3400 Lebanon Pike,Murfreesboro,TN,37129,615-867-6000 Or 615-867-6000,VA Facility,Government,no,Not Available,35.908054,-86.38373
+626,Tennessee Valley Healthcare System - Nashville Campus,1310 24th Avenue South,Nashville,TN,37212,615-327-4751 Or 615-327-4751,VA Facility,Government,no,Not Available,36.142414,-86.80479
+621,"Bristol, Virginia OPC",2426 Lee Highway,Bristol,VA,24202,276-645-4520,VA Facility,Government,no,Not Available,36.62954,-82.14808
+626,Charlotte Avenue (Nashville) VA Clinic,1919 Charlotte Avenue,Nashville,TN,37203,615-873-6503,VA Facility,Government,no,Not Available,36.15748,-86.80191
+626GF,Chattanooga VA Clinic,6098 Debra Rd Suite 5200 Bldg 6200,Chattanooga,TN,37411,423-893-6500,VA Facility,Government,no,Not Available,0,0
+626GH,"Cookeville, Tennessee OPC",851 S. Willow Avenue Suite 108,Cookeville,TN,38501,931-284-4060,VA Facility,Government,no,Not Available,36.144985,-85.52289
+626GX,"Hopkinsville, Kentucky OPC",1002 South Virginia Street,Hopkinsville,KY,42240,270-885-2106,VA Facility,Government,no,Not Available,36.86455,-87.48827
+626GN,"McMinnville, Tennessee OPC",1014 S. Chancery Street,McMinnville,TN,37110,931-474-7700,VA Facility,Government,no,Not Available,35.66253,-85.78597
+626GO,Pointe Center Outpatient Clinic (Chattanooga),1208 Pointe Center Drive,Chattanooga,TN,37421,423-893-6500,VA Facility,Government,no,Not Available,0,0
+626,"Women Veterans Healthcare Center (Nashville, TN)","1919 Charlotte Avenue, Suite 300",Nashville,TN,37203,615-327-4751,VA Facility,Government,no,Not Available,0,0
+6301,Athens VA Clinic,1320 Decatur Pike,Athens,TN,37303,423-746-1410,VA Facility,Government,no,Not Available,35.44948,-84.6172
+626GC,Bowling Green VA Clinic,"600 US 31 West Bypass, Suite 12",Bowling Green,KY,42101,270-782-0120,VA Facility,Government,no,Not Available,0,0
+626,Clarksville Dental Clinic,"2291 Dalton Drive, Suite F.",Clarksville,TN,37043,,VA Facility,Government,no,Not Available,0,0
+626GE,Clarksville VA Clinic,782 Weatherly Dr.,Clarksville,TN,37043,931-645-3552,VA Facility,Government,no,Not Available,0,0
+614GE,"Covington, Tennessee (North Memphis), CBOC",3461 Austin Peay Highway,Memphis,TN,38127,901-261-4500,VA Facility,Government,no,Not Available,35.21992,-89.910416
+626GA,"Dover (Stewart County), Tennessee CBOC",1225 Spring Street,Dover,TN,37058,931-232-5138,VA Facility,Government,no,Not Available,36.479477,-87.81392
+614,"Dyersburg, Tennessee CBOC",433 East Parkview Street,Dyersburg,TN,38024,731-287-7289,VA Facility,Government,no,Not Available,36.046345,-89.37962
+626,Harriman Clinic,"2305 North Gateway Ave., Suite 2",Harriman,TN,37748,865-882-2010,VA Facility,Government,no,Not Available,0,0
+614,"Helena, Arkansas CBOC",131 Quarles Lane,Helena,AR,72342,870-228-3644,VA Facility,Government,no,Not Available,34.554462,-90.648125
+614,Holly Springs CBOC,1700 Crescent Meadow Dr,Holly Springs,MS,38635,662-252-2552,VA Facility,Government,no,Not Available,0,0
+626QC,International Plaza CBOC,"2 International Plaza, Suite 300",Nashville,TN,37217,615-367-5928,VA Facility,Government,no,Not Available,36.127193,-86.695755
+614GG,"Jackson, Tennessee CBOC",180 Old Hickory Blvd,Jackson,TN,38305,731-661-2750,VA Facility,Government,no,Not Available,35.65321,-88.83493
+614GB,"Jonesboro, Arkansas CBOC",2908 Caraway Road,Jonesboro,AR,72401,870-277-0778 Or 870-268-6962,VA Facility,Government,no,Not Available,35.80957,-90.67815
+621,Jonesville Rural Outreach Clinic,"32613 Wilderness Road, Suite 101",Jonesville,VA,24263,276-346-2595,VA Facility,Government,no,Not Available,0,0
+621,"Knoxville, Tennessee CBOC",8033 Ray Mears Blvd.,Knoxville,TN,37919,865-545-4592,VA Facility,Government,no,Not Available,35.923336,-84.04693
+621,"LaFollette (Campbell County), Tennessee CBOC",130 Independence Lane,LaFollette,TN,37757,423-563-7666,VA Facility,Government,no,Not Available,0,0
+621,Marion Rural Outreach Clinic,4451 Lee Highway,Marion,VA,24354,276-783-2756,VA Facility,Government,no,Not Available,0,0
+626,Maury County CBOC,833 Nashville Highway,Columbia,TN,38401,931-981-6930,VA Facility,Government,no,Not Available,35.62945,-87.02559
+626,Meharry (Nashville General),1810 Albion Street,Nashville,TN,37208,615-873-6700,VA Facility,Government,no,Not Available,36.16626,-86.80563
+621GE,"Morristown, Tennessee CBOC",925 E. Morris Boulevard,Morristown,TN,37813,423-586-9100,VA Facility,Government,no,Not Available,36.215782,-83.28268
+614GF,Nonconnah Boulevard Primary Care Clinic,1689 Nonconnah Boulevard,Memphis,TN,38132,901-271-4900,VA Facility,Government,no,Not Available,35.071,-90.00735
+621,"Norton, Virginia CBOC",654 Highway 58 East,Norton,VA,24273,276-679-8010,VA Facility,Government,no,Not Available,0,0
+621GA,"Rogersville, Tennessee CBOC",401 Scenic Drive,Rogersville,TN,37857,423-235-1471,VA Facility,Government,no,Not Available,36.40194,-83.01576
+614GD,"Savannah, Tennessee CBOC",765 Florence Rd,Savannah,TN,38372,731-925-2300,VA Facility,Government,no,Not Available,35.21224,-88.2393
+621,Sevierville Clinic,1124 Blanton Dr,Sevierville,TN,37862,865-286-6950,VA Facility,Government,no,Not Available,0,0
+626GG,"Tullahoma, Tennessee CBOC",225 Von Karman Rd,Arnold Air Force Base,TN,37389,931-454-6134,VA Facility,Government,no,Not Available,0,0
+614,Tupelo VA Clinic,1114 Commonwealth Blvd,Tupelo,MS,38804,662-840-6366,VA Facility,Government,no,Not Available,0,0
+596GD,VA Clinic Berea,209 Pauline Drive,Berea,KY,40403,859-986-1259,VA Facility,Government,no,Not Available,0,0
+596,VA Clinic Hazard,210 Black Gold Blvd,Hazard,KY,41701,606-436-2350,VA Facility,Government,no,Not Available,0,0
+596GB,VA Clinic Morehead,333 Beacon Hill Rd,Morehead,KY,40351,606-784-3004,VA Facility,Government,no,Not Available,0,0
+596GA,VA Clinic Somerset,163 Tower Circle,Somerset,KY,42503,606-676-0786,VA Facility,Government,no,Not Available,0,0
+603GH,"VA Healthcare Center, Carrollton",1911 US Highway 227,Carrollton,KY,41008,502-287-6060,VA Facility,Government,no,Not Available,0,0
+603GD,"VA Healthcare Center, Dupont Kentucky CBOC",4010 Dupont Circle,Louisville,KY,40207,502-287-6986,VA Facility,Government,no,Not Available,38.232937,-85.631355
+603GA,"VA Healthcare Center, Ft. Knox Kentucky",851 Ireland Loop,Ft Knox,KY,40121,502-624-9396,VA Facility,Government,no,Not Available,37.90122,-85.94276
+603GF,"VA Healthcare Center, Grayson",619 Elizabethtown Road,Clarkson,KY,42726,866-653-8232,VA Facility,Government,no,Not Available,0,0
+603GB,"VA Healthcare Center, New Albany IN",4347 Security Parkway,New Albany,IN,47150,502-287-4100 Or 502-287-4100,VA Facility,Government,no,Not Available,38.363068,-85.81108
+603GE,"VA Healthcare Center, Newburg Kentucky",3430 Newburg Road,Louisville,KY,40218,502-287-6223,VA Facility,Government,no,Not Available,38.197586,-85.681854
+603GG,"VA Healthcare Center, Scott County",1467 Scott Valley Drive,Scottsburg,IN,47170,877-690-1938 Or 877-690-1938,VA Facility,Government,no,Not Available,0,0
+603GC,"VA Healthcare Center, Shively Kentucky CBOC","3934 North Dixie Highway, Suite 210",Louisville,KY,40216,502-287-6000,VA Facility,Government,no,Not Available,38.194138,-85.806725
+621,Vansant Rural Outreach Clinic,"1941 Lovers Gap Road, Suite A",Vansant,VA,24656,276-597-2106,VA Facility,Government,no,Not Available,0,0
+0722V,Chattanooga Vet Center,951 Eastgate Loop Road Bldg. 5700 - Suite 300,Chattanooga,TN,37411,423-855-6570 Or 423-855-6570,VA Facility,Government,no,Not Available,35.009804,-85.21353
+701,Johnson City Vet Center,"2203 McKinley Road, Suite 254",Johnson City,TN,37604,423-928-8387 Or 423-928-8387,VA Facility,Government,no,Not Available,0,0
+720,Knoxville Vet Center,8033 Ray Mears Blvd,Knoxville,TN,37914,865-633-0000,VA Facility,Government,no,Not Available,35.923336,-84.04693
+203,Lexington Vet Center,1500 Leestown Rd Suite 104,Lexington,KY,40511,859-253-0717 Or 859-253-0717,VA Facility,Government,no,Not Available,38.065773,-84.523636
+202,Louisville Vet Center,1347 S. Third Street,Louisville,KY,40208,502-287-6710 Or 502-287-6710,VA Facility,Government,no,Not Available,38.23077,-85.75937
+0719V,Memphis Vet Center,"1407 Union Ave., Suite 410",Memphis,TN,38104,901-522-3950 Or 901-522-3950,VA Facility,Government,no,Not Available,35.136623,-90.01462
+0724V,Nashville Vet Center,1420 Donelson Pike Suite A-5,Nashville,TN,37217,615-366-1220 Or 615-366-1220,VA Facility,Government,no,Not Available,36.097065,-86.67747
+487,VISN 10: VA Healthcare System,"11500 Northlake Drive, Suite 200",Cincinnati,OH,45249,513-247-4621,VA Facility,Government,no,Not Available,39.276237,-84.34727
+10N11,VISN 11: Veterans In Partnership (Now VISN 10),"24 Frank Lloyd Wright Drive, Lobby L",Ann Arbor,MI,48113,,VA Facility,Government,no,Not Available,42.31775,-83.6821
+6463,"Homeless Team, Veteran Health Indiana",1099 N. Meridian St.,Indianapolis,IN,46204,317-988-5284 Or 317-988-5284,VA Facility,Government,no,Not Available,39.782703,-86.15747
+610,VA Northern Indiana Health Care System,2121 Lake Ave.,Fort Wayne,IN,46805,260-426-5431 Or 260-426-5431,VA Facility,Government,no,Not Available,41.08974,-85.11045
+655,Aleda E. Lutz VA Medical Center,1500 Weiss Street,Saginaw,MI,48602,989-497-2500 Or 800-406-5143,VA Facility,Government,no,Not Available,43.443695,-83.96086
+515,Battle Creek VA Medical Center,5500 Armstrong Road,Battle Creek,MI,49037,269-966-5600,VA Facility,Government,no,Not Available,0,0
+757,Chalmers P. Wylie Ambulatory Care Center,420 N James Road,Columbus,OH,43219,614-257-5200,VA Facility,Government,no,Not Available,39.980396,-82.91203
+538,Chillicothe VA Medical Center,17273 State Route 104,Chillicothe,OH,45601,740-773-1141,VA Facility,Government,no,Not Available,0,0
+539,Cincinnati VA Medical Center,3200 Vine Street,Cincinnati,OH,45220,513-861-3100,VA Facility,Government,no,Not Available,39.13792,-84.509514
+539A4,Cincinnati VA Medical Center-Fort Thomas,1000 S. Ft Thomas Ave,Ft. Thomas,KY,41075,859-572-6202,VA Facility,Government,no,Not Available,39.0889,-84.44801
+552,Dayton VA Medical Center,4100 W. 3rd Street,Dayton,OH,45428,937-268-6511 Or 937-268-6511,VA Facility,Government,no,Not Available,39.749374,-84.253174
+553,John D. Dingell VA Medical Center,4646 John R,Detroit,MI,48201,313-576-1000 Or 313-576-1000,VA Facility,Government,no,Not Available,42.355137,-83.06039
+541,Louis Stokes Cleveland VA Medical Center,10701 East Boulevard,Cleveland,OH,44106,216-791-3800,VA Facility,Government,no,Not Available,0,0
+583,Richard L. Roudebush VA Medical Center (Indianapolis VA Medical Center),1481 W. 10th Street,Indianapolis,IN,46202,317-554-0000 Or 317-554-0000,VA Facility,Government,no,Not Available,39.779716,-86.18758
+506,VA Ann Arbor Healthcare System,2215 Fuller Road,Ann Arbor,MI,48105,734-769-7100 Or 734-769-7100,VA Facility,Government,no,Not Available,42.28566,-83.71592
+610,VA Northern Indiana Health Care System - Marion Campus,1700 East 38th Street,Marion,IN,46953,765-674-3321 Or 765-674-3321,VA Facility,Government,no,Not Available,40.523746,-85.63726
+610A4,VA Northern Indiana Health Care System-Fort Wayne Campus,2121 Lake Ave.,Fort Wayne,IN,46805,260-426-5431 Or 260-426-5431,VA Facility,Government,no,Not Available,41.08974,-85.11045
+583QA,Bloomington Mental Health Outpatient Clinic,1332 West Arch Haven Avenue,Bloomington,IN,47403,812-349-4406,VA Facility,Government,no,Not Available,39.161076,-86.55194
+541BY,Canton Outpatient Clinic,733 Market Avenue South,Canton,OH,44702,330-489-4600,VA Facility,Government,no,Not Available,40.79339,-81.37653
+583QC,Terre Haute Mental Health Outpatient Clinic,70W Honey Creek Pkwy,Terre Haute,IN,47802,812-232-8325,VA Facility,Government,no,Not Available,39.42494,-87.41705
+506QB,VA Ann Arbor - Green Road Outpatient Clinic,2500 Green Road,Ann Arbor,MI,48105,734-769-7100,VA Facility,Government,no,Not Available,42.30916,-83.69277
+506QA,VA Ann Arbor - Packard Road Outpatient Clinic,3800 Packard Road,Ann Arbor,MI,48108,734-769-7100,VA Facility,Government,no,Not Available,42.24532,-83.687454
+506GA,VA Ann Arbor - Toledo Annex,2595 Arlington Avenue,Toledo,OH,43614,,VA Facility,Government,no,Not Available,41.623123,-83.60686
+583GF,Wakeman VA Clinic,Building 1010,Edinburgh,IN,46124,812-348-0300,VA Facility,Government,no,Not Available,0,0
+541BZ,Youngstown Outpatient Clinic,2031 Belmont Avenue,Youngstown,OH,44505,330-740-9200,VA Facility,Government,no,Not Available,41.126682,-80.66435
+541GG,Akron Community Based Outpatient Clinic,55 W. Waterloo,Akron,OH,44319,330-724-7715,VA Facility,Government,no,Not Available,41.02876,-81.52917
+538GA,Athens Community Based Outpatient Clinic,510 West Union Street,Athens,OH,45701,740-593-7314,VA Facility,Government,no,Not Available,39.331062,-82.12392
+655GF,Bad Axe Community Based Outpatient Clinic,"1142 S. Van Dyke RD, Suite 100",Bad Axe,MI,48413,989-269-7445,VA Facility,Government,no,Not Available,43.800236,-83.04325
+539GA,Bellevue Community Based Outpatient Clinic,"103 Landmark Drive, Suite 300",Bellevue,KY,41073,859-392-3840,VA Facility,Government,no,Not Available,39.10029,-84.48472
+515GC,Benton Harbor VA Outpatient Clinic,115 West Main Street,Benton Harbor,MI,49022,269-934-9123,VA Facility,Government,no,Not Available,42.11607,-86.455154
+583GB,Bloomington VA Clinic,455 South Landmark Avenue,Bloomington,IN,47403,812-336-5723,VA Facility,Government,no,Not Available,39.16402,-86.55629
+655GG,Cadillac Community Based Outpatient Clinic,1909 North Mitchell St,Cadillac,MI,49601,231-775-4401,VA Facility,Government,no,Not Available,44.278004,-85.406685
+538,Cambridge Community Based Outpatient Clinic,2146 Southgate Pkwy,Cambridge,OH,43725,740-432-1963,VA Facility,Government,no,Not Available,40.00885,-81.57982
+655GH,Cheboygan County Community Based Outpatient Clinic,14540 Mackinaw Hwy,Mackinaw City,MI,49701,231-436-5176,VA Facility,Government,no,Not Available,45.76145,-84.73206
+655GE,Clare Community Outpatient Clinic,11775 N Isabella Rd,Clare,MI,48617,989-386-8113,VA Facility,Government,no,Not Available,43.811226,-84.74836
+655GD,Clement C. Van Wagoner Outpatient Clinic,180 North State Avenue,Alpena,MI,49707,989-356-8720,VA Facility,Government,no,Not Available,45.061,-83.430756
+539GB,Clermont County Community Based Outpatient Clinic,4600 Beechwood Road,Cincinnati,OH,45244,513-943-3680,VA Facility,Government,no,Not Available,39.11444,-84.30561
+541GH,East Liverpool/Calcutta Community Based Outpatient Clinic,"15655 St Rt. 170, Suite A",Calcutta,OH,43920,330-386-4303,VA Facility,Government,no,Not Available,40.673294,-80.57691
+539,Florence Community Based Outpatient Clinic,7310 Turfway Rd.,Florence,KY,41042,859-282-4480,VA Facility,Government,no,Not Available,0,0
+655GA,Gaylord VA Outpatient Clinic,806 South Otsego,Gaylord,MI,49735,989-732-7525,VA Facility,Government,no,Not Available,0,0
+539GF,Georgetown Community Based Outpatient Clinic,474 Home Street,Georgetown,OH,45121,937-378-3413,VA Facility,Government,no,Not Available,38.856293,-83.898125
+610A4,Goshen VA Outpatient Clinic,2606 Peddlers Village Road Suite 210,Goshen,IN,46526,574-534-6108 Or 877-292-0968,VA Facility,Government,no,Not Available,0,0
+655QB,Grand Traverse VA Clinic,880 Munson Avenue,Traverse City,MI,49686,231-932-9720 Or 800-406-5143 X 11412,VA Facility,Government,no,Not Available,0,0
+655GI,Grayling Community Based Outpatient Clinic,1680 Hartwick Pines Road,Grayling,MI,49738,989-344-2002,VA Facility,Government,no,Not Available,44.70946,-84.71005
+757GB,Grove City Community Based Outpatient Clinic,1955 Ohio Drive,Grove City,OH,43123,614-257-5800 Or 888-615-9448 X 5800,VA Facility,Government,no,Not Available,39.880787,-83.05464
+539GE,Hamilton Community Based Outpatient Clinic,1750 South Erie Highway,Hamilton,OH,45011,513-870-9444,VA Facility,Government,no,Not Available,39.37911,-84.54975
+6464,Indy West VA Clinic,3850 Shore Dr. Suite 203,Indianapolis,IN,46254,317-988-1772 Or 317-988-1772,VA Facility,Government,no,Not Available,39.82476,-86.28068
+538GD,Lancaster Community Based Outpatient Clinic,1703 North Memorial Drive,Lancaster,OH,43130,740-653-6145,VA Facility,Government,no,Not Available,39.73196,-82.617905
+515GB,Lansing VA Outpatient Clinic,2025 South Washington Avenue,Lansing,MI,48910,517-267-3925,VA Facility,Government,no,Not Available,42.71088,-84.55337
+539GC,Lawrenceburg (Dearborn) Community Based Outpatient Clinic,1600 Flossie Drive,Greendale,IN,47025,812-539-2313,VA Facility,Government,no,Not Available,0,0
+552GB,Lima Community Based Outpatient Clinic,1303 Bellefontaine Ave,Lima,OH,45804,419-222-5788,VA Facility,Government,no,Not Available,40.731922,-84.081825
+6108,Lorain Community Based Outpatient Clinic,5255 N. Abbe Rd.,Sheffield Village,OH,44035,440-934-9158,VA Facility,Government,no,Not Available,41.426277,-82.07694
+541GD,Mansfield Community Based Outpatient Clinic,1025 South Trimble Rd.,Mansfield,OH,44906,419-529-4602,VA Facility,Government,no,Not Available,40.738087,-82.55166
+538GC,Marietta Community Based Outpatient Clinic,27843 State Route 7,Marietta,OH,45750,740-568-0412,VA Facility,Government,no,Not Available,0,0
+757,Marion Community Based Outpatient Clinic,"1203 Delaware Avenue, Corporate Center #2",Marion,OH,43302,740-223-8809 Or 888-615-9448 X 5920,VA Facility,Government,no,Not Available,40.569786,-83.12243
+583GC,Martinsville VA Outpatient Clinic,2200 John R. Wooden Drive,Martinsville,IN,46151,317-988-0120 Or 317-554-0000 X 80120,VA Facility,Government,no,Not Available,39.427006,-86.40602
+541GE,McCafferty Community Based Outpatient Clinic,4242 Lorain Avenue,Cleveland,OH,44113,216-939-0699,VA Facility,Government,no,Not Available,41.479897,-81.71472
+552GA,Middletown Community Based Outpatient Clinic,4337 N. Union Road,Middletown,OH,45005,513-423-8387,VA Facility,Government,no,Not Available,39.509254,-84.31619
+610,Muncie/Anderson VA Outpatient Clinic,2600 W White River Blvd,Muncie,IN,47303,765-254-5602,VA Facility,Government,no,Not Available,40.186367,-85.41668
+515GA,Muskegon VA Outpatient Clinic,5000 Hakes Dr.,Muskegon,MI,49441,231-798-4445,VA Facility,Government,no,Not Available,43.164448,-86.2334
+541,New Philadelphia Community Based Outpatient Clinic,"1260 Monroe Ave, Suite 1A",New Philadelphia,OH,44663,330-602-5339,VA Facility,Government,no,Not Available,0,0
+757-N,Newark Community Based Outpatient Clinic,1855 W. Main Street,Newark,OH,43055,740-788-8329 Or 888-615-9448 X 5900,VA Facility,Government,no,Not Available,40.041317,-82.4684
+655GC,Oscoda VA Outpatient Clinic,"5671 Skeel Avenue, Suite 4",Oscoda,MI,48750,989-747-0026,VA Facility,Government,no,Not Available,44.451687,-83.351974
+541GF,Painesville Community Based Outpatient Clinic,7 West Jackson Street,Painesville,OH,44077,440-357-6740,VA Facility,Government,no,Not Available,41.725227,-81.2485
+541GL,Parma Community Based Outpatient Clinic,8787 Brookpark Road,Parma,OH,44129,216-739-7000,VA Facility,Government,no,Not Available,0,0
+610GD,Peru Community Based Outpatient Clinic,750 N Broadway,Peru,IN,46970,765-472-8907,VA Facility,Government,no,Not Available,40.76819,-86.078384
+553,Pontiac VA Outpatient Clinic,"44200 Woodward Avenue, Suite 208",Pontiac,MI,48341,248-332-4540,VA Facility,Government,no,Not Available,0,0
+538GB,Portsmouth Community Based Outpatient Clinic,840 Gallia Street,Portsmouth,OH,45662,740-353-3236,VA Facility,Government,no,Not Available,38.734104,-82.99568
+541,Ravenna Community Based Outpatient Clinic,6751 N Chestnut St,Ravenna,OH,44266,330-296-3641,VA Facility,Government,no,Not Available,41.174595,-81.24526
+552GC,Richmond Community Based Outpatient Clinic,1010 N. J Street,Richmond,IN,47374,765-973-6915,VA Facility,Government,no,Not Available,39.84063,-84.888824
+655AA,Saginaw VA Healthcare Annex,4241 Barnard Road,Saginaw,MI,48603,800-406-5143 X 11230,VA Facility,Government,no,Not Available,43.468258,-83.96569
+541GC,Sandusky Community Based Outpatient Clinic,3416 Columbus Avenue,Sandusky,OH,44870,419-625-7350,VA Facility,Government,no,Not Available,41.41938,-82.69002
+610A4,South Bend VA Outpatient Clinic,333 W. Western Ave,South Bend,IN,46601,866-436-1291 Or 866-436-1291,VA Facility,Government,no,Not Available,41.67231,-86.25395
+552GD,Springfield Community Based Outpatient Clinic,512 South Burnett Road,Springfield,OH,45505,937-328-3385,VA Facility,Government,no,Not Available,39.915005,-83.77042
+610BY,St. Joseph County VA Clinic,1540 Trinity Place,Mishawaka,IN,46545,574-272-9000,VA Facility,Government,no,Not Available,0,0
+583GA,Terre Haute VA Clinic,110 W Honeycreek Pkwy,Terre Haute,IN,47802,812-232-2890,VA Facility,Government,no,Not Available,39.424934,-87.41767
+655GB,Traverse City VA Outpatient Clinic,3271 RACQUET CLUB DRIVE,Traverse City,MI,49684,231-932-9720 Or 800-406-5143 X 11412,VA Facility,Government,no,Not Available,0,0
+506GB,VA Ann Arbor - Flint Community Based Outpatient Clinic,2360 South Linden Road,Flint,MI,48532,810-720-2913,VA Facility,Government,no,Not Available,42.991943,-83.77245
+506GC,VA Ann Arbor - Jackson Community Based Outpatient Clinic,4328 Page Avenue,Michigan Center,MI,49254,517-764-3609,VA Facility,Government,no,Not Available,42.235546,-84.33686
+506GA,VA Ann Arbor - Toledo Community Based Outpatient Clinic,1200 South Detroit Avenue,Toledo,OH,43614,419-259-2000,VA Facility,Government,no,Not Available,0,0
+541GI,Warren Community Based Outpatient Clinic,1460 Tod Ave (NW),Warren,OH,44485,330-392-0311,VA Facility,Government,no,Not Available,41.246456,-80.83477
+583GE,West Lafayette VA Clinic,3851 N. River Road,Lafayette,IN,47906,,VA Facility,Government,no,Not Available,40.412487,-86.97694
+538GF,Wilmington Community-Based Outpatient Clinic,448 West Main Street,Wilmington,OH,45177,937-382-3949,VA Facility,Government,no,Not Available,39.44553,-83.8363
+515BY,Wyoming Health Care Center,5838 Metro Way,Wyoming,MI,49519,616-249-5300,VA Facility,Government,no,Not Available,0,0
+553GA,Yale VA Outpatient Clinic,7470 Brockway Road,Yale,MI,48097,810-387-3211,VA Facility,Government,no,Not Available,43.138046,-82.79886
+757GA,Zanesville Community Based Outpatient Clinic,2800 Maple Avenue,Zanesville,OH,43701,740-453-7725 Or 888-615-9448 X 5751,VA Facility,Government,no,Not Available,39.974194,-82.01204
+204,Cincinnati Vet Center,801B W. 8th St. Suite 126,Cincinnati,OH,45203,513-763-3500 Or 513-763-3500,VA Facility,Government,no,Not Available,39.103344,-84.52966
+0205V,Cleveland Vet Center,5310 1/2 Warrensville Center Rd,Maple Heights,OH,44137,216-707-7901 Or 216-707-7901,VA Facility,Government,no,Not Available,41.41617,-81.53732
+0221V,Columbus Vet Center,30 Spruce Street,Columbus,OH,43215,614-257-5550,VA Facility,Government,no,Not Available,39.97233,-83.00369
+0225V,Dayton Vet Center,"627 Edwin C. Moses Blvd.,6th Floor, East Medical Plaza",Dayton,OH,45417,937-461-9150 Or 937-461-9150,VA Facility,Government,no,Not Available,39.74863,-84.19844
+0401V,Dearborn Vet Center,"19855 Outer Drive, Suite 105 W",Dearborn,MI,48124,313-277-1428 Or 313-277-1428,VA Facility,Government,no,Not Available,42.303585,-83.26335
+402,Detroit Vet Center,11214 East Jefferson Avenue,Detroit,MI,48214,313-822-1141,VA Facility,Government,no,Not Available,42.36637,-82.97188
+0409V,Fort Wayne Vet Center,"5800 Fairfield Ave., Suite 265",Fort Wayne,IN,46807,260-460-1456 Or 260-460-1456,VA Facility,Government,no,Not Available,41.03154,-85.14336
+403,Grand Rapids Vet Center,2050 Breton Rd SE,Grand Rapids,MI,49546,616-285-5795,VA Facility,Government,no,Not Available,42.926167,-85.60905
+0413V,Indianapolis Vet Center,"8330 Naab Road, Suite 103",Indianapolis,IN,46260,317-988-1600 Or 317-988-1600,VA Facility,Government,no,Not Available,39.911648,-86.198395
+0437V,Macomb County Vet Center,42621 Garfield Rd. Suite 105,Clinton Township,MI,48038,586-412-0107 Or 586-412-0107,VA Facility,Government,no,Not Available,42.610115,-82.95288
+02061V,McCafferty Vet Center Outstation,4242 Lorain Avenue Suite 203,Cleveland,OH,44113,216-939-0784 Or 877-927-8387,VA Facility,Government,no,Not Available,41.479897,-81.71472
+0206V,Parma Vet Center,5700 Pearl Road Suite 102,Parma,OH,44129,440-845-5023 Or 440-845-5023,VA Facility,Government,no,Not Available,41.406796,-81.74186
+0417V,Peoria Vet Center,"8305 N. Allen Road, Suite 1",Peoria,IL,61615,309-689-9708 Or 309-689-9708,VA Facility,Government,no,Not Available,40.788372,-89.63111
+0438V,Pontiac Vet Center,"44200 Woodward Avenue, Suite 108",Pontiac,MI,48341,248-874-1015 Or 248-874-1015,VA Facility,Government,no,Not Available,0,0
+433,Saginaw Vet Center,5360 Hampton Place,Saginaw,MI,48604,989-321-4650 Or 989-321-4650,VA Facility,Government,no,Not Available,0,0
+0421V,"Springfield, IL Vet Center",2980 Baker Drive,Springfield,IL,62703,217-492-4955 Or 217-492-4955,VA Facility,Government,no,Not Available,39.762154,-89.64444
+0241V,Stark County Vet Center,"601 Cleveland Ave N, Suite C",Canton,OH,44702,330-454-3120 Or 330-454-3120,VA Facility,Government,no,Not Available,40.79531,-81.37779
+0234V,Toledo Vet Center,"1565 S. Byrne Road, Suite 104",Toledo,OH,43614,419-213-7533 Or 877-927-8387,VA Facility,Government,no,Not Available,41.6112,-83.625755
+445,Traverse City Vet Center,3766 N US 31 South,Traverse City,MI,49684,231-935-0051 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+506,VA Ann Arbor - North Campus Research Complex,2800 Plymouth Road,Ann Arbor,MI,48105,734-769-7100,VA Facility,Government,no,Not Available,42.30256,-83.705765
+506,VA Ann Arbor - Offsite Warehouse,844 Highland Drive,Ann Arbor,MI,48105,734-769-7100,VA Facility,Government,no,Not Available,42.22654,-83.72491
+506,VA Ann Arbor Business Office,2200 Commonwealth Blvd,Ann Arbor,MI,48105,734-769-7100,VA Facility,Government,no,Not Available,42.307255,-83.69625
+506,VA Ann Arbor Finance & Payroll Office,3001 Earhart Road,Ann Arbor,MI,48105,734-769-7100,VA Facility,Government,no,Not Available,42.325016,-83.68348
+10N12,VISN 12: VA Great Lakes Health Care System,"11301 W. Cermak Road, Suite 810",Westchester,IL,60154,708-492-3900,VA Facility,Government,no,Not Available,41.84804,-87.90505
+556,Captain James A. Lovell Federal Health Care Center,3001 Green Bay Road,North Chicago,IL,60064,847-688-1900 Or 847-688-1900,VA Facility,Government,no,Not Available,42.30826,-87.86246
+695,Clement J. Zablocki Veterans Affairs Medical Center,5000 West National Avenue,Milwaukee,WI,53295,414-384-2000,VA Facility,Government,no,Not Available,43.020367,-87.97142
+578,Edward Hines Jr. VA Hospital,5000 South 5th Ave,Hines,IL,60141,708-202-8387,VA Facility,Government,no,Not Available,0,0
+537,Jesse Brown VA Medical Center,820 South Damen Avenue,Chicago,IL,60612,312-569-8387 Or 312-569-8387,VA Facility,Government,no,Not Available,41.8712,-87.67639
+585,Oscar G. Johnson VA Medical Center,325 East H Street,Iron Mountain,MI,49801,906-774-3300,VA Facility,Government,no,Not Available,45.81145,-88.06337
+676,Tomah VA Medical Center,500 E. Veterans Street,Tomah,WI,54660,608-372-3971,VA Facility,Government,no,Not Available,44.00095,-90.50921
+550,VA Illiana Health Care System,1900 East Main Street,Danville,IL,61832,217-554-3000 Or 217-554-3000,VA Facility,Government,no,Not Available,0,0
+607,William S. Middleton Memorial Veterans Hospital,2500 Overlook Terrace,Madison,WI,53705,608-256-1901 Or 888-478-8321,VA Facility,Government,no,Not Available,43.073982,-89.429085
+1007,1007 USS Tranquillity,3420 Illinois Street,Great Lakes,IL,60088,847-688-6755,VA Facility,Government,no,Not Available,42.30789,-87.85014
+1523,1523 USS Red Rover,3350 Illinois Street,Great Lakes,IL,60088,847-688-5568,VA Facility,Government,no,Not Available,42.30791,-87.85014
+537BY,"Adam Benjamin, Jr. OPC",9301 Madison Street,Crown Point,IN,46307,219-662-5000,VA Facility,Government,no,Not Available,0,0
+695BY,Appleton Clinic (John H. Bradley),10 Tri-Park Way,Appleton,WI,54914,920-831-0070,VA Facility,Government,no,Not Available,44.281895,-88.453674
+537HA,Auburn Gresham (Chicago) Clinic,7731 S Halsted St,Chicago,IL,60620,773-962-3700,VA Facility,Government,no,Not Available,41.75367,-87.644104
+578GD,Aurora Clinic,161 South Lincolnway,North Aurora,IL,60542,630-859-2504,VA Facility,Government,no,Not Available,41.80079,-88.32549
+607GD,Baraboo Clinic,1670 South Blvd,Baraboo,WI,53913,608-356-9318,VA Facility,Government,no,Not Available,0,0
+607GE,Beaver Dam Clinic,"215 Corporate Drive, Suite D",Beaver Dam,WI,53916,920-356-9415,VA Facility,Government,no,Not Available,0,0
+537GA,Chicago Heights Clinic,30 E. 15th Street (Suite 314),Chicago Heights,IL,60411,708-754-8880,VA Facility,Government,no,Not Available,41.504265,-87.64218
+676GE,Clark County Outpatient Clinic,8 Johnson Street,Owen,WI,54460,715-229-4701,VA Facility,Government,no,Not Available,0,0
+695GC,Cleveland Clinic,1205 North Avenue,Cleveland,WI,53015,920-693-5600 Or 920-693-5600,VA Facility,Government,no,Not Available,43.92128,-87.75155
+556GA,Evanston Clinic,1942 Dempster Street,Evanston,IL,60202,847-869-6315,VA Facility,Government,no,Not Available,42.041096,-87.69995
+556,"Fisher Clinic, Bldg. 237",2470 Sampson Street,Great Lakes,IL,60088,847-688-2469,VA Facility,Government,no,Not Available,42.312874,-87.83964
+607GF,Freeport Clinic,"750 Kiwanis Drive, Suite 250",Freeport,IL,61032,815-235-4881,VA Facility,Government,no,Not Available,42.29079,-89.67082
+695GD,Green Bay Clinic (Milo C. Huempfner),2851 University Avenue,Green Bay,WI,54311,920-431-2500 Or 877-204-7970,VA Facility,Government,no,Not Available,44.5213,-87.94072
+585GA,Hancock Clinic,787 Market Street,Hancock,MI,49930,906-482-7762,VA Facility,Government,no,Not Available,0,0
+1231,Hoffman Estates,4885 Hoffman Blvd,Hoffman Estates,IL,60192,847-645-1443,VA Facility,Government,no,Not Available,0,0
+585GD,Ironwood Clinic,629 W. Cloverland Dr. Suite 1,Ironwood,MI,49938,906-932-0032,VA Facility,Government,no,Not Available,46.46337,-90.183044
+607GC,Janesville Clinic,2419 Morse Street,Janesville,WI,53545,608-758-9300,VA Facility,Government,no,Not Available,42.72222,-88.99433
+578GA,Joliet Clinic,1201 Eagle St,Joliet,IL,60432,815-740-8100,VA Facility,Government,no,Not Available,41.535557,-88.05301
+1111,Kankakee Clinic,"581 William Latham Drive, Suite 301",Bourbonnais,IL,60914,815-932-3823,VA Facility,Government,no,Not Available,41.162605,-87.8785
+556GD,Kenosha Clinic,8207 22nd Avenue,Kenosha,WI,53140,262-653-9286 Or 262-653-9286,VA Facility,Government,no,Not Available,42.555126,-87.83505
+537a,Lakeside Clinic,"211 E. Ontario St., 12th Floor",Chicago,IL,60611,312-469-4850,VA Facility,Government,no,Not Available,41.89342,-87.61852
+2970,LaSalle Clinic,4461 N Progress Blvd,Peru,IL,61354,815-223-9678,VA Facility,Government,no,Not Available,0,0
+585,Manistique Outreach Clinic,813 East Lakeshore Drive,Manistique,MI,49854,906-341-3420,VA Facility,Government,no,Not Available,45.948757,-86.23988
+585HA,Marquette Clinic,1414 W. Fair Ave Suite 285,Marquette,MI,49855,906-226-4618,VA Facility,Government,no,Not Available,46.5568,-87.416
+556GC,McHenry Clinic,3715 Municipal Drive,McHenry,IL,60050,815-759-2306,VA Facility,Government,no,Not Available,0,0
+585GC,Menominee Clinic,"1110 10th Avenue, Suite 101",Menominee,MI,49858,906-863-1286,VA Facility,Government,no,Not Available,45.10786,-87.616394
+578GG,Oak Lawn Clinic,10201 S. Cicero,Oak Lawn,IL,60453,708-499-3675,VA Facility,Government,no,Not Available,41.707726,-87.74034
+237,OHMD Occupational Health Medicine Department,2410 Sampson Street,Great Lakes,IL,60088,847-688-6712,VA Facility,Government,no,Not Available,42.312893,-87.83964
+585GB,Rhinelander Clinic,639 West Kemp Street,Rhinelander,WI,54501,715-362-4080,VA Facility,Government,no,Not Available,0,0
+676GC,River Valley Clinic,2600 State Road,La Crosse,WI,54601,608-784-3886,VA Facility,Government,no,Not Available,43.81284,-91.21725
+607HA,Rockford Clinic,816 Featherstone Road,Rockford,IL,61107,815-227-0081,VA Facility,Government,no,Not Available,42.27791,-88.9972
+585HB,Sault Ste. Marie Clinic,509 Osborn Blvd. Suite 306,Sault Ste. Marie,MI,49783,906-253-9383,VA Facility,Government,no,Not Available,46.498116,-84.34945
+695GA,Union Grove Clinic,21425 Spring Street,Union Grove,WI,53182,262-878-7000,VA Facility,Government,no,Not Available,42.698612,-88.08003
+556GE,USS Osborne Dental Clinic,3440 Ohio Street,Great Lakes,IL,60088,847-688-2100,VA Facility,Government,no,Not Available,0,0
+676GA,Wausau Clinic,515 South 32nd Avenue,Wausau,WI,54401,715-842-2834,VA Facility,Government,no,Not Available,44.958927,-89.67598
+676GD,Wisconsin Rapids Clinic,555 West Grand Ave.,Wisconsin Rapids,WI,54495,715-424-4682,VA Facility,Government,no,Not Available,44.394993,-89.830055
+695,Community Resource and Referral Center - Milwaukee,1818 Martin Luther King Jr. Drive,Milwaukee,WI,53212,414-263-7673,VA Facility,Government,no,Not Available,43.054127,-87.91425
+550BY,Bob Michel VA Outpatient Clinic,7717 N. Orange Prairie Road,Peoria,IL,61615,309-589-6800,VA Facility,Government,no,Not Available,0,0
+550GA,Decatur VA Outpatient Clinic,3035 East Mound Road,Decatur,IL,62526,217-875-2670,VA Facility,Government,no,Not Available,39.892822,-88.914024
+607AA,Madison Central Clinic,2500 Overlook Terrace,Madison,WI,53705,888-856-9039 X 17059,VA Facility,Government,no,Not Available,43.073982,-89.429085
+607AB,Madison West Annex Clinic,1 Science Court,Madison,WI,53711,608-280-7059,VA Facility,Government,no,Not Available,43.059372,-89.468864
+550GF,Mattoon Community Based Outpatient Clinic,501 Lakeland Blvd.,Mattoon,IL,61938,217-258-3370,VA Facility,Government,no,Not Available,39.478317,-88.37655
+550GD,Springfield VA Outpatient Clinic,"5850 South 6th Street, Suite A",Springfield,IL,62703,217-529-5046,VA Facility,Government,no,Not Available,0,0
+676,VA River Valley Integrated Health Center,1525 Losey Blvd South,LaCrosse,WI,54601,608-787-6411,VA Facility,Government,no,Not Available,43.79642,-91.21983
+0436V,Aurora Vet Center,"750 Shoreline Drive, Suite 150",Aurora,IL,60504,630-585-1853 Or 630-585-1853,VA Facility,Government,no,Not Available,41.74383,-88.22525
+0407V,Chicago Heights Vet Center,"1010 Dixie Hwy, 2nd Floor",Chicago Heights,IL,60411,708-754-8885 Or 708-754-8885,VA Facility,Government,no,Not Available,41.513294,-87.64522
+0410V,Chicago Vet Center,"3348 W. 87th Street, Suite 2",Chicago,IL,60652,773-962-3740 Or 773-962-3740,VA Facility,Government,no,Not Available,41.735046,-87.71181
+0434V,Escanaba Vet Center,"3500 Ludington Street, Suite # 110",Escanaba,MI,49829,906-233-0244 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0420V,Evanston Vet Center,1901 Howard St,Evanston,IL,60202,847-332-1019 Or 847-332-1019,VA Facility,Government,no,Not Available,42.01934,-87.69962
+0412V,Gary Area Vet Center,107 E. 93rd Ave,Crown Point,IN,46307,219-736-5633 Or 877-927-8387,VA Facility,Government,no,Not Available,41.449306,-87.33577
+0441V,Green Bay Vet Center,1600 S. Ashland Ave,Green Bay,WI,54304,920-435-5650 Or 920-435-5650,VA Facility,Government,no,Not Available,44.500378,-88.038445
+0442V,La Crosse Vet Center,20 Copeland Ave.,La Crosse,WI,54603,608-782-4403 Or 877-927-8387,VA Facility,Government,no,Not Available,43.821068,-91.24907
+0419V,Madison Vet Center,1291 N. Sherman Ave,Madison,WI,53704,608-264-5342 Or 608-264-5342,VA Facility,Government,no,Not Available,43.11412,-89.36377
+0415V,Milwaukee Vet Center,"7910 N. 76th Street, Suite 100",Milwaukee,WI,53223,414-902-5561,VA Facility,Government,no,Not Available,0,0
+0411V,Oak Park Vet Center,1515 South Harlem,Forest Park,IL,60130,708-457-8805,VA Facility,Government,no,Not Available,0,0
+0435V,Orland Park Vet Center,"8651 W.159th Street, Suite 1",Orland Park,IL,60462,708-444-0561,VA Facility,Government,no,Not Available,41.60169,-87.83271
+0447V,Rockford Vet Center,"7015 Rote Road, Suite 105",Rockford,IL,61107,815-395-1276 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+444,South Bend Vet Center,4727 Miami Street,South Bend,IN,46614,574-231-8480 Or 877-927-8387,VA Facility,Government,no,Not Available,41.627018,-86.234795
+4421,Wausau Vet Center,"605 S 24th Ave, Suite 24",Wausau,WI,54401,715-842-1724 Or 877-927-8387,VA Facility,Government,no,Not Available,44.957066,-89.66565
+10N15,VISN 15: VA Heartland Network,"1201 Walnut St, Suite 800",Kansas City,MO,64106,816-701-3000,VA Facility,Government,no,Not Available,39.099815,-94.582054
+657,VA St. Louis Health Care System,1 Jefferson Barracks Drive,Saint Louis,MO,63125,314-652-4100,VA Facility,Government,no,Not Available,38.509212,-90.28942
+657,VA St. Louis Health Care System - John Cochran Division,915 North Grand Blvd.,Saint Louis,MO,63106,314-652-4100,VA Facility,Government,no,Not Available,38.641426,-90.22986
+589A4,Harry S. Truman Memorial,800 Hospital Drive,Columbia,MO,65201,573-814-6000 Or 573-814-6000,VA Facility,Government,no,Not Available,38.937588,-92.32859
+657A4,John J. Pershing VA Medical Center,1500 N. Westwood Blvd.,Poplar Bluff,MO,63901,573-686-4151 Or 573-686-4151,VA Facility,Government,no,Not Available,36.7715,-90.418
+589,Kansas City VA Medical Center,4801 Linwood Boulevard,Kansas City,MO,64128,816-861-4700,VA Facility,Government,no,Not Available,39.067238,-94.52744
+657A5,Marion VA Medical Center,2401 West Main Street,Marion,IL,62959,618-997-5311 Or 618-997-5311,VA Facility,Government,no,Not Available,37.729828,-88.95548
+589A7,Robert J. Dole VA Medical Center,5500 E. Kellogg,Wichita,KS,67218,316-685-2221 Or 316-685-2221,VA Facility,Government,no,Not Available,0,0
+589A5,VA Eastern Kansas Health Care System - Colmery-O'Neil VA Medical Center,2200 SW Gage Boulevard,Topeka,KS,66622,785-350-3111 Or 785-350-3111,VA Facility,Government,no,Not Available,39.027374,-95.72494
+589A6,VA Eastern Kansas Health Care System - Dwight D. Eisenhower VA Medical Center,4101 S. 4th Street,Leavenworth,KS,66048,913-682-2000 Or 913-682-2000,VA Facility,Government,no,Not Available,39.279087,-94.9005
+657A0,VA St. Louis Health Care System - Jefferson Barracks Division,1 Jefferson Barracks Drive,Saint Louis,MO,63125,314-652-4100,VA Facility,Government,no,Not Available,38.509212,-90.28942
+657A5,Enterprise Way VA Clinic,1301 Enterprise Way Suite 68,Marion,IL,62959,618-993-1008,VA Facility,Government,no,Not Available,37.74047,-88.93996
+657J,Evansville Health Care Center,6211 E. Waterford Blvd.,Evansville,IN,47715,812-465-6202,VA Facility,Government,no,Not Available,0,0
+657A5,Heartland Street VA Clinic,3404 Heartland Street,Marion,IL,62959,,VA Facility,Government,no,Not Available,0,0
+589,Johnson County/Radiation Oncology VA Clinic,10500 Mastin St,Overland Park,KS,66212,816-922-2750,VA Facility,Government,no,Not Available,38.941135,-94.701965
+589JE,Platte City,2303 Higgins Suite F,Platte City,MO,64079,800-952-8387 X 59141,VA Facility,Government,no,Not Available,0,0
+657GA,Belleville Clinic,6500 W Main St,Belleville,IL,62223,314-286-6988,VA Facility,Government,no,Not Available,38.554073,-90.0401
+5240,Belton CBOC,209 Cunningham Industrial Parkway,Belton,MO,64012,816-922-2161,VA Facility,Government,no,Not Available,38.809227,-94.504654
+589GZ,Cameron Clinic,1111 Euclid Dr,Cameron,MO,64429,816-922-2500 X 54251,VA Facility,Government,no,Not Available,0,0
+657A4,Cape Girardeau Community-Based Outpatient Clinic,3051 William St.,Cape Girardeau,MO,63703,573-339-0909,VA Facility,Government,no,Not Available,37.30073,-89.568634
+657GT,Carbondale Community Based Outpatient Clinic,1130 East Walnut Street,Carbondale,IL,62901,618-351-1031,VA Facility,Government,no,Not Available,37.726982,-89.19631
+589GM,Chanute - Neosho Memorial Medical Center,629 South Plummer,Chanute,KS,66720,800-574-8387 X 54453,VA Facility,Government,no,Not Available,37.675755,-95.47092
+589G2,"Dodge City, Kansas CBOC",2201 Summerlon Circle,Dodge City,KS,67843,888-878-6881 X 57450,VA Facility,Government,no,Not Available,0,0
+657GM,Effingham Community Based Outpatient Clinic,1011 Ford Avenue,Effingham,IL,62401,217-347-7600,VA Facility,Government,no,Not Available,0,0
+589GN,Emporia CBOC,"919 W. 12th Avenue, Suite D",Emporia,KS,66801,800-574-8387 X 54451,VA Facility,Government,no,Not Available,38.412285,-96.19184
+589JB,Excelsior Springs MO CBOC,197 McCleary Rd,Excelsior Springs,MO,64024,816-922-2970 Or 816-861-4700 X 52970,VA Facility,Government,no,Not Available,39.341568,-94.26308
+657GI,Farmington CBOC,1580 W. Columbia St,Farmington,MO,63640,573-760-1365,VA Facility,Government,no,Not Available,37.77193,-90.444756
+589gf,Fort Leonard Wood CBOC,700 GW Lane Street,Waynesville,MO,65583,573-774-2285,VA Facility,Government,no,Not Available,0,0
+589GV,Ft Scott CBOC,902 Horton Street,Ft. Scott,KS,66701,800-574-8387 X 54750,VA Facility,Government,no,Not Available,37.830357,-94.713615
+589GP,Garnett - Anderson County Hospital,421 South Maple,Garnett,KS,66032,800-574-8387 X 54453,VA Facility,Government,no,Not Available,0,0
+657GO,Hanson Community Based Outpatient Clinic,926 Veterans Drive,Hanson,KY,42413,270-322-8019,VA Facility,Government,no,Not Available,0,0
+657GU,Harrisburg Community Based Outpatient Clinic,608 Rollie Moore Drive,Harrisburg,IL,62946,618-252-6150,VA Facility,Government,no,Not Available,0,0
+589A7,"Hays, Kansas CBOC",207-B E. 7th,Hays,KS,67601,888-878-6881 X 41000,VA Facility,Government,no,Not Available,38.86904,-99.33027
+589ZZ,Honor Annex,4251 Northern Avenue,Kansas City,MO,64133,816-861-4700,VA Facility,Government,no,Not Available,39.04498,-94.45213
+657,Hope Recovery Center VA St. Louis Health Care System,515 North Jefferson Avenue,St. Louis,MO,63103,314-652-4100 X 55500 Or 800-228-5459 X 55500,VA Facility,Government,no,Not Available,38.634754,-90.21337
+589,"Hutchinson, Kansas CBOC",1625 E 30th Ave,Hutchinson,KS,67502,888-878-6881 X 41100,VA Facility,Government,no,Not Available,38.08652,-97.89665
+589G8,Jefferson City VA CBOC,2707 W Edgewood Dr,Jefferson City,MO,65109,573-635-0233,VA Facility,Government,no,Not Available,38.570843,-92.21489
+589GR,Junction City,1169 Southwind Drive,Junction City,KS,66441,800-574-8387 X 54670,VA Facility,Government,no,Not Available,0,0
+589a4,Kirksville VA CBOC/North East Missouri Health Council,1510 North Crown Drive,Kirksville,MO,63501,660-627-8387,VA Facility,Government,no,Not Available,40.20692,-92.57394
+589GH,Lake of the Ozarks CBOC,940 Executive Drive,Osage Beach,MO,65065,573-302-7890,VA Facility,Government,no,Not Available,0,0
+589GU,Lawrence,2200 Harvard Road,Lawrence,KS,66049,800-574-8387 X 54650,VA Facility,Government,no,Not Available,38.9643,-95.26153
+589G3,"Liberal, Kansas CBOC","2 Rock Island Road, Suite 200",Liberal,KS,67901,888-878-6881 X 57400,VA Facility,Government,no,Not Available,37.038788,-100.92228
+5236,Louisburg-Paola Clinic,501 South Hospital Drive,Paola,KS,66071,816-922-2160,VA Facility,Government,no,Not Available,38.569992,-94.863716
+589JD,Marshfield VA Clinic,1240 Banning Street,Marshfield,MO,65706,417-468-1963,VA Facility,Government,no,Not Available,37.344913,-92.92716
+657GR,Mayfield Community Based Outpatient Clinic,1253 Paris Road Suite A,Mayfield,KY,42066,270-247-2455,VA Facility,Government,no,Not Available,36.72426,-88.62816
+589GX,Mexico VA CBOC,3460 South Clark Street,Mexico,MO,65265,573-581-9630,VA Facility,Government,no,Not Available,0,0
+589ZX,Mobile Medical Unit,4801 Linwood Blvd,Kansas City,MO,64128,816-861-4700 X 52977 Or 800-525-1483 X 52977,VA Facility,Government,no,Not Available,39.067238,-94.52744
+657GK,Mt. Vernon Community Based Outpatient Clinic,4105 N. Water Tower Place,Mt. Vernon,IL,62864,618-246-2910,VA Facility,Government,no,Not Available,38.307262,-88.941864
+589GD,Nevada Clinic,322 South Prewitt,Nevada,MO,64772,816-861-4700 X 54235,VA Facility,Government,no,Not Available,37.83659,-94.37613
+657GP,Owensboro Community Based Outpatient Clinic,3400 New Hartford Road,Owensboro,KY,42303,270-684-5034,VA Facility,Government,no,Not Available,37.7375,-87.09166
+657GL,Paducah Community Based Outpatient Clinic,2620 Perkins Creek Dr.,Paducah,KY,42001,270-444-8465,VA Facility,Government,no,Not Available,0,0
+657GG,Paragould Community-Based Outpatient Clinic,2420 Linwood Drive - Suite 3,Paragould,AR,72450,870-236-9756,VA Facility,Government,no,Not Available,0,0
+589G5,"Parsons, Kansas CBOC",1907 Harding Dr.,Parsons,KS,67357,888-878-6881 X 41060,VA Facility,Government,no,Not Available,0,0
+657GW,Pocahontas Community-Based Outpatient Clinic,300 Camp Rd,Pocahontas,AR,72455,870-248-0571,VA Facility,Government,no,Not Available,0,0
+657GN,Salem (MO) Community-Based Outpatient Clinic,35629 MO-Hwy 72,Salem,MO,65560,573-729-6626,VA Facility,Government,no,Not Available,0,0
+589GW,"Salina, Kansas CBOC","1410 E. Iron, Suite 1",Salina,KS,67401,888-878-6881 X 41020,VA Facility,Government,no,Not Available,38.840443,-97.589294
+589JA,Sedalia VA Clinic,3320 West 10th Street,Sedalia,MO,65301,660-826-3800,VA Facility,Government,no,Not Available,38.704,-93.27141
+589JC,Shawnee VA Clinic,6830 Anderson St,Shawnee,KS,66226,816-922-2750,VA Facility,Government,no,Not Available,0,0
+657GV,Sikeston CBOC,903 South Kingshighway,Sikeston,MO,63801,573-472-2139,VA Facility,Government,no,Not Available,36.886517,-89.5912
+657GD,St. Charles Clinic,844 Waterbury Falls Drive,O'Fallon,MO,63368,314-286-6988,VA Facility,Government,no,Not Available,0,0
+589GY,St. James VA Clinic,207 Matlock Drive,St. James,MO,65559,573-265-0448,VA Facility,Government,no,Not Available,0,0
+589GI,St. Joseph Clinic,3302 S. Belt Hwy Suite P,ST.JOSEPH,MO,64503,800-952-8387 X 56925,VA Facility,Government,no,Not Available,39.737244,-94.80113
+657DY,St. Louis CBOC,6854 Parker Road,Florissant,MO,63033,314-286-6988,VA Facility,Government,no,Not Available,38.796257,-90.23481
+657,VA St. Louis Health Care System Primary Care Team 1 Annex,4974 Manchester Avenue,St. Louis,MO,63110,314-289-6566,VA Facility,Government,no,Not Available,38.625465,-90.26762
+657,VA St. Louis Health Care System Primary Care Team 2 Annex,2727 Washington Avenue,St. Louis,MO,63103,314-289-7659,VA Facility,Government,no,Not Available,38.635654,-90.21635
+657GQ,Vincennes Community Based Outpatient Clinic,1813 Willow Street Suite 6A,Vincennes,IN,47591,812-882-0894,VA Facility,Government,no,Not Available,38.657276,-87.53027
+589G1,Warrensburg Clinic,702 E. Young St.,Warrensburg,MO,64093,816-922-2500 X 54281,VA Facility,Government,no,Not Available,38.77199,-93.720215
+657GS,Washington MO CBOC,1627 A Roy Drive,Washington,MO,63090,314-289-7950 Or 800-228-5459 X 57950,VA Facility,Government,no,Not Available,0,0
+657A4,West Plains CBOC,1801 E. State Route K,West Plains,MO,65775,417-257-2454,VA Facility,Government,no,Not Available,36.726402,-91.88993
+589GJ,Wyandotte CBOC,"21 N 12th Street, Bethany Medical Building, Suite 110",Kansas City,KS,66102,800-952-8387 X 56990,VA Facility,Government,no,Not Available,39.104305,-94.640076
+0443V,Columbia Vet Center,"4040 Rangeline Street, Suite 105",Columbia,MO,65202,573-814-6206 Or 573-814-6206,VA Facility,Government,no,Not Available,38.991932,-92.32376
+0422V,East St. Louis Vet Center,1265 N. 89th Street Suite 5,East St. Louis,IL,62203,618-397-6602 Or 877-927-8387,VA Facility,Government,no,Not Available,38.596157,-90.05323
+0418V,Evansville Vet Center,1100 N. Burkhardt Rd,Evansville,IN,47715,812-473-5993 Or 812-473-5993,VA Facility,Government,no,Not Available,37.986885,-87.474
+0408V,Kansas City Vet Center,"4800 Main Street, Suite 107",Kansas City,MO,64112,816-753-1866 Or 816-753-1866,VA Facility,Government,no,Not Available,39.03929,-94.587105
+0432V,Manhattan Vet Center,"205 South 4th Street, Suite B",Manhattan,KS,66502,785-350-4920 Or 785-350-4920,VA Facility,Government,no,Not Available,39.178177,-96.56182
+0400V,RCS Midwest District 3 District Office,"2122 Kratky Rd., Suite 130",St. Louis,MO,63114,314-894-6190,VA Facility,Government,no,Not Available,38.697098,-90.406784
+0414V,St. Louis Vet Center,2901 Olive,St. Louis,MO,63103,314-531-5355,VA Facility,Government,no,Not Available,38.634422,-90.22021
+0426V,Wichita Vet Center,251 N. Water St.,Wichita,KS,67202,316-265-0889 Or 877-927-8397,VA Facility,Government,no,Not Available,37.68888,-97.339554
+10N16,VISN 16: South Central VA Health Care Network,715 S. Pear Orchard Road,Ridgeland,MS,39157,601-206-6900,VA Facility,Government,no,Not Available,32.403606,-90.123535
+502,Alexandria VA Health Care System,2495 Shreveport Hwy 71 N,Pineville,LA,71360,318-473-0010,VA Facility,Government,no,Not Available,31.353516,-92.43374
+598,Central Arkansas Veterans Healthcare System Eugene J. Towbin Healthcare Center,2200 Fort Roots Drive,North Little Rock,AR,72114,501-257-1000,VA Facility,Government,no,Not Available,34.773396,-92.289375
+598,Central Arkansas Veterans Healthcare System John L. McClellan Memorial Veterans Hospital,4300 West 7th Street,Little Rock,AR,72205,501-257-1000,VA Facility,Government,no,Not Available,34.744892,-92.32114
+586,G.V. (Sonny) Montgomery VA Medical Center,1500 E. Woodrow Wilson Drive,Jackson,MS,39216,601-362-4471,VA Facility,Government,no,Not Available,32.32652,-90.165695
+520,Gulf Coast Veterans Health Care System,400 Veterans Avenue,Biloxi,MS,39531,228-523-5000,VA Facility,Government,no,Not Available,30.414478,-88.94722
+580,Michael E. DeBakey VA Medical Center,2002 Holcombe Blvd.,Houston,TX,77030,713-791-1414 Or 713-791-1414,VA Facility,Government,no,Not Available,29.705933,-95.39014
+667,Overton Brooks VA Medical Center,510 E. Stoner Ave.,Shreveport,LA,71101,318-221-8411 Or 318-221-8411,VA Facility,Government,no,Not Available,32.49999,-93.73993
+667,Shreveport,510 E Stoner Ave,Shreveport,LA,71101,,VA Facility,Government,no,Not Available,32.49999,-93.73993
+629,Southeast Louisiana Veterans Health Care System,2400 Canal Street,New Orleans,LA,70119,800-935-8387 Or 800-935-8387,VA Facility,Government,no,Not Available,29.963257,-90.08411
+564,Veterans Health Care System of the Ozarks,1100 N. College Avenue,Fayetteville,AR,72703,479-443-4301 Or 479-443-4301,VA Facility,Government,no,Not Available,36.077305,-94.157074
+580,Katy VA Outpatient Clinic,750 Westgreen Blvd,Katy,TX,77450,281-578-4600,VA Facility,Government,no,Not Available,29.778257,-95.73581
+629BY,Baton Rouge Outpatient Clinic,7968 Essen Park Ave.,Baton Rouge,LA,70809,225-761-3400,VA Facility,Government,no,Not Available,30.403616,-91.099525
+77701,Beaumont VA Outpatient Clinic,3420 Veterans Circle,Beaumont,TX,77707,409-981-8550 Or 800-833-7734,VA Facility,Government,no,Not Available,0,0
+629,Bogalusa VA Outpatient Clinic,521 Ontario Avenue,Bogalusa,LA,70427,985-735-9029,VA Facility,Government,no,Not Available,30.791603,-89.86743
+564,Branson OPC,5571 North Gretna Rd,Branson,MO,65616,417-243-2300 Or 417-243-2300,VA Facility,Government,no,Not Available,36.645756,-93.27286
+580BZ,Charles Wilson VA Outpatient Clinic,2206 North John Redditt Drive,Lufkin,TX,75904,936-671-4300 Or 800-209-3120,VA Facility,Government,no,Not Available,31.356213,-94.76453
+586GF,Columbus Clinic,824 Alabama St,Columbus,MS,39702,662-244-0391,VA Facility,Government,no,Not Available,33.493317,-88.36798
+580,Conroe VA Outpatient Clinic,"690 South Loop 336 West, 3rd & 4th Floors",Conroe,TX,77304,936-522-4000 Or 800-553-2278 X 10900,VA Facility,Government,no,Not Available,0,0
+598GG,Conway CBOC,1520 East Dave Ward Drive,Conway,AR,72032,501-548-0500,VA Facility,Government,no,Not Available,0,0
+520-GC,Eglin CBOC,100 Veterans Way,Eglin AFB,FL,32542,866-520-7359,VA Facility,Government,no,Not Available,0,0
+598GB,El Dorado CBOC,1702 North West Ave.,El Dorado,AR,71730,870-875-5900,VA Facility,Government,no,Not Available,33.228554,-92.665634
+502GF,Fort Polk CBOC,3353 University Parkway,Leesville,LA,71446,337-392-3800,VA Facility,Government,no,Not Available,0,0
+629,Franklin VA Outpatient Clinic,603 Haifleigh Street,Franklin,LA,70538,337-828-9092,VA Facility,Government,no,Not Available,29.805956,-91.49894
+564GB,Ft Smith OPC,1500 Dodson Ave Sparks Medical Plaza,Ft Smith,AR,72917,479-441-2600,VA Facility,Government,no,Not Available,0,0
+500GC,Galveston VA Outpatient Clinic,3828 Avenue N,Galveston,TX,77550,409-761-3200 Or 800-553-2278 X 11000,VA Facility,Government,no,Not Available,29.291033,-94.80806
+564BY,Gene Taylor CBOC,600 N Main,Mt Vernon,MO,65712,417-466-4000 Or 417-466-4000,VA Facility,Government,no,Not Available,37.108696,-93.818886
+586GC,Greenville CBOC,1502 S Colorado St,Greenville,MS,38703,662-332-9872,VA Facility,Government,no,Not Available,33.385975,-91.0301
+629,Hammond VA Outpatient Clinic,1131 South Morrison Boulevard,Hammond,LA,70403,985-902-5100,VA Facility,Government,no,Not Available,30.488743,-90.48272
+564GA,Harrison OPC,707 N Main St,Harrison,AR,72601,870-741-3592,VA Facility,Government,no,Not Available,36.236847,-93.10711
+586GD,Hattiesburg CBOC,"5003 Hardy Street, Tower B, Suite 402",Hattiesburg,MS,39402,601-296-3530,VA Facility,Government,no,Not Available,0,0
+598GC,Hot Springs CBOC,177 Sawtooth Oak St,Hot Springs,AR,71901,501-520-6250 Or 501-520-6250,VA Facility,Government,no,Not Available,0,0
+502GD,Houma CBOC,6433 West Park Avenue,Houma,LA,70364,985-851-0188 Or 800-935-8387 X 0,VA Facility,Government,no,Not Available,29.621208,-90.748245
+564GE,Jay CBOC,1569 N. Main St.,Jay,OK,74346,918-253-1900 Or 918-253-1900,VA Facility,Government,no,Not Available,36.43826,-94.78232
+502GA,Jennings Clinic,1907 Johnson St.,Jennings,LA,70546,337-824-1000,VA Facility,Government,no,Not Available,30.239265,-92.66137
+520BZ,Joint Ambulatory Care Center,790 Veterans Way,Pensacola,FL,32507,850-912-2000,VA Facility,Government,no,Not Available,30.397266,-87.29239
+667,Knight Street Clinic,3000 Knight Street Building 5,Shreveport,LA,71105,318-221-8411 X 7411,VA Facility,Government,no,Not Available,0,0
+586GA,Kosciusko CBOC,405 West Adams,Kosciusko,MS,39090,662-289-2880,VA Facility,Government,no,Not Available,0,0
+502GB,Lafayette CBOC Campus A—Specialty and Primary Care,3149 Ambassador Caffery Parkway,Lafayette,LA,70501,337-706-3415,VA Facility,Government,no,Not Available,30.18702,-92.075
+502GB,Lafayette CBOC Campus B—Mental Health,309 St. Julien Avenue,Lafayette,LA,70506,337-706-3415,VA Facility,Government,no,Not Available,30.213179,-92.02821
+502GL,Lake Charles CBOC,"3601 Gerstner Memorial Drive, Hwy14",Lake Charles,LA,70607,337-475-9500,VA Facility,Government,no,Not Available,30.158312,-93.15324
+580GF,Lake Jackson VA Outpatient Clinic,208 Oak Drive South,Lake Jackson,TX,77566,979-230-4852,VA Facility,Government,no,Not Available,29.031244,-95.45573
+667GC,Longview CBOC,1005 N. Eastman Rd.,Longview,TX,75601,903-247-8262 Or 800-957-8262,VA Facility,Government,no,Not Available,32.513065,-94.71108
+586GG,McComb,1308 Harrison Ave,McComb,MS,39648,601-250-0965,VA Facility,Government,no,Not Available,31.249437,-90.469894
+598GD,Mena CBOC,300 S. Morrow Road,Mena,AR,71953,501-609-2700 Or 855-838-2369,VA Facility,Government,no,Not Available,0,0
+586GB,Meridian CBOC,2103 13th St,Meridian,MS,39301,601-482-3275,VA Facility,Government,no,Not Available,32.36986,-88.699455
+520GA,Mobile Outpatient Clinic,1504 Springhill Ave.,Mobile,AL,36604,251-219-3900 Or 251-219-3900,VA Facility,Government,no,Not Available,30.692453,-88.07212
+667GB,Monroe CBOC,1691 Bienville Dr,Monroe,LA,71203,318-343-6100 Or 800-832-3525,VA Facility,Government,no,Not Available,0,0
+598GA,Mountain Home CBOC,759 Hwy 62 East,Mountain Home,AR,72653,870-594-8387 Or 877-338-8003,VA Facility,Government,no,Not Available,36.345554,-92.37713
+586GE,Natchez CBOC,"105 Northgate Drive, Suite 2",Natchez,MS,39120,601-442-7141,VA Facility,Government,no,Not Available,0,0
+502GG,Natchitoches CBOC,740 Keyser Avenue,Natchitoches,LA,71457,318-357-3300,VA Facility,Government,no,Not Available,31.753004,-93.07155
+629,New Orleans VA Outpatient Clinic,2400 Canal Street,New Orleans,LA,70119,,VA Facility,Government,no,Not Available,29.963257,-90.08411
+564,"Ozark, Arkansas OPC",2713 West Commercial,Ozark,AR,72949,479-508-1000 Or 479-508-1000,VA Facility,Government,no,Not Available,35.49001,-93.855194
+520GB,Panama City Outpatient Clinic,2600 Veterans Way(along Magnolia Beach Road),Panama City Beach,FL,32408,850-636-7000 Or 888-231-5047 X 7331,VA Facility,Government,no,Not Available,0,0
+598,Pine Bluff CBOC,4747 Dusty Lake Drive Suite 203,Pine Bluff,AR,71603,870-541-9300,VA Facility,Government,no,Not Available,0,0
+580,Richmond VA Outpatient Clinic,"22001 Southwest Freeway, Suite 200",Richmond,TX,77469,832-595-7700 Or 800-553-2278 X 10000,VA Facility,Government,no,Not Available,0,0
+598GH,Russellville CBOC,3106 West 2nd CT,Russellville,AR,72801,479-880-5100,VA Facility,Government,no,Not Available,35.28474,-93.16528
+598,Searcy CBOC,1120 S Main St,Searcy,AR,72143,501-207-4700,VA Facility,Government,no,Not Available,35.25888,-91.73588
+629E,Slidell VA Outpatient Clinic,60491 Doss Dr Ste B,Slidell,LA,70460,985-690-2626 Or 985-690-2626,VA Facility,Government,no,Not Available,0,0
+629,St. John VA Outpatient Clinic,4004 West Airline Hwy.,Reserve,LA,70084,504-565-4705,VA Facility,Government,no,Not Available,0,0
+667GA,Texarkana CBOC,910 Realtor Ave,Texarkana,AR,71854,870-216-2242 Or 800-571-8387,VA Facility,Government,no,Not Available,33.4701,-94.03299
+580,Texas City VA Outpatient Clinic,"9300 Emmett F. Lowry Expressway, Suite 206",Texas City,TX,77591,409-986-2900 Or 800-553-2278 X 10500,VA Facility,Government,no,Not Available,29.401304,-95.01783
+580GH,Tomball VA Outpatient Clinic,1200 W. Main Street,Tomball,TX,77375,281-516-1505,VA Facility,Government,no,Not Available,30.091705,-95.62763
+0734V,Alexandria Vet Center,"5803 Coliseum Blvd., Sute D",Alexandria,LA,71303,318-466-4327 Or 877-927-8387,VA Facility,Government,no,Not Available,31.295115,-92.49501
+0725V,Baton Rouge Vet Center,"7850 Anselmo Lane, Suite B",Baton Rouge,LA,70810,225-761-3140 Or 225-761-3140,VA Facility,Government,no,Not Available,30.392668,-91.100845
+0744v,Bay County Vet Center,"3109 Minnesota Ave, Suite 101",Panama City,FL,32405,850-522-6102 Or 850-522-6102,VA Facility,Government,no,Not Available,30.208765,-85.6455
+735,Beaumont Vet Center,"990 IH10 North, Suite 180",Beaumont,TX,77702,409-347-0124 Or 409-347-0124,VA Facility,Government,no,Not Available,0,0
+0737V,Biloxi Vet Center,288 Veterans Ave,Biloxi,MS,39531,228-388-9938 Or 228-388-9938,VA Facility,Government,no,Not Available,30.40239,-88.94716
+0727V,Fayetteville Vet Center,1416 N. College Ave.,Fayetteville,AR,72703,479-582-7152 Or 479-582-7152,VA Facility,Government,no,Not Available,36.08108,-94.156654
+0710V,Houston Southwest Vet Center,"10103 Fondren Road, Suite 470",Houston,TX,77096,713-523-0884,VA Facility,Government,no,Not Available,29.67084,-95.50856
+0731V,Houston Vet Center,"14300 Cornerstone Village Dr., Suite 110",Houston,TX,77014,281-537-7812 Or 281-537-7812,VA Facility,Government,no,Not Available,29.988022,-95.48308
+0711V,Houston West Vet Center,701 N. Post Oak Road Suite 102,Houston,TX,77024,713-682-2288 Or 713-682-2288,VA Facility,Government,no,Not Available,29.77968,-95.45675
+0709V,Jackson Vet Center,1755 Lelia Dr. Suite 104,Jackson,MS,39216,601-985-2560 Or 601-985-2560,VA Facility,Government,no,Not Available,32.33308,-90.144554
+0713V,Little Rock Vet Center,201 W. Broadway St. Suite A,North Little Rock,AR,72114,501-324-6395 Or 501-324-6395,VA Facility,Government,no,Not Available,34.756107,-92.26903
+0741V,Mobile Vet Center,"3221 Springhill Ave Bldg 2, Suite C",Mobile,AL,36607,251-478-5906 Or 251-478-5906,VA Facility,Government,no,Not Available,0,0
+0717V,New Orleans Vet Center,"1250 Poydras Street, 4th Floor, Suite 400",New Orleans,LA,70113,504-507-4977,VA Facility,Government,no,Not Available,0,0
+0743V,Okaloosa County Vet Center,"6 11th Avenue, Suite G 1",Shalimar,FL,32579,850-651-1000 Or 850-651-1000,VA Facility,Government,no,Not Available,30.447157,-86.57846
+0742V,Pensacola Vet Center,4504 Twin Oaks Drive,Pensacola,FL,32506,850-456-6113 Or 850-456-5886,VA Facility,Government,no,Not Available,30.409218,-87.27792
+0704V,Shreveport Vet Center,"2800 Youree Dr. Bldg. 1, Suite 105",Shreveport,LA,71104,318-861-1776 Or 318-861-1776,VA Facility,Government,no,Not Available,0,0
+0736V,"Springfield, MO Vet Center",3616 S. Campbell,Springfield,MO,65807,417-881-4197 Or 417-881-4197,VA Facility,Government,no,Not Available,37.14929,-93.29583
+10N17,VISN 17: VA Heart of Texas Health Care Network,"2301 East Lamar Blvd., Suite 650",Arlington,TX,76006,817-652-1111,VA Facility,Government,no,Not Available,32.761486,-97.07099
+504,Amarillo VA Health Care System,"6010 Amarillo Boulevard, West",Amarillo,TX,79106,806-355-9703 Or 806-355-9703,VA Facility,Government,no,Not Available,0,0
+674,Central Texas Veterans Health Care System,1901 Veterans Memorial Drive,Temple,TX,76504,254-778-4811 Or 254-778-4811,VA Facility,Government,no,Not Available,31.079578,-97.34862
+756,El Paso VA Health Care System,5001 North Piedras Street,El Paso,TX,79930,915-564-6100,VA Facility,Government,no,Not Available,31.820763,-106.46147
+671,South Texas Veterans Health Care System,7400 Merton Minter Blvd.,San Antonio,TX,78229,210-617-5300 Or 210-617-5300,VA Facility,Government,no,Not Available,0,0
+549,VA North Texas Health Care System,4500 South Lancaster Road,Dallas,TX,75216,800-849-3597 Or 214-742-8387,VA Facility,Government,no,Not Available,32.69437,-96.79336
+740,VA Texas Valley Coastal Bend Health Care System,2601 Veterans Drive,Harlingen,TX,78550,956-291-9000 Or 855-864-0516,VA Facility,Government,no,Not Available,0,0
+519,West Texas VA Health Care System,300 Veterans Blvd.,Big Spring,TX,79720,432-263-7361 Or 432-263-7361,VA Facility,Government,no,Not Available,32.23064,-101.47079
+549,Dallas VA Medical Center,4500 S. Lancaster Rd.,Dallas,TX,75216,800-849-3597 Or 800-849-3597,VA Facility,Government,no,Not Available,32.694347,-96.79335
+674A4,Doris Miller Department of Veterans Affairs Medical Center,4800 Memorial Drive,Waco,TX,76711,254-752-6581 Or 254-752-6581,VA Facility,Government,no,Not Available,31.513947,-97.16254
+671A4,Kerrville VA Hospital,3600 Memorial Blvd,Kerrville,TX,78028,866-487-1653,VA Facility,Government,no,Not Available,30.015045,-99.118126
+549A4,Sam Rayburn Memorial Veterans Center,1201 E. 9th St.,Bonham,TX,75418,800-924-8387 Or 800-924-8387,VA Facility,Government,no,Not Available,33.58155,-96.16723
+674BY,Austin Outpatient Clinic,7901 Metropolis Drive,Austin,TX,78744,512-823-4000 Or 800-423-2111,VA Facility,Government,no,Not Available,0,0
+671,Balcones Heights Outpatient Clinic,"4522 Fredericksburg Road, Suites A-10 and A-88",San Antonio,TX,78201,210-732-1802,VA Facility,Government,no,Not Available,29.492617,-98.55369
+740GC,Corpus Christi OPC,"5283 Old Brownsville Road,",Corpus Christi,TX,78405,361-806-5600,VA Facility,Government,no,Not Available,27.75859,-97.456085
+740,Corpus Christi PACT Annex,"5227 Old Brownsville Road, Suite 11",Corpus Christi,TX,78405,361-806-5600,VA Facility,Government,no,Not Available,27.759275,-97.45505
+740,Corpus Christi VA Speciality Outpatient Clinic,205 S. Enterprize Parkway,Corpus Christi,TX,78405,361-939-6510,VA Facility,Government,no,Not Available,0,0
+549,Fort Worth Outpatient Clinic,2201 SE Loop 820,Fort Worth,TX,76119,800-443-9672 Or 817-730-0000,VA Facility,Government,no,Not Available,32.66894,-97.29961
+671,Frank M. Tejeda VA Outpatient Clinic,5788 Eckhert Road,San Antonio,TX,78240,210-699-2100,VA Facility,Government,no,Not Available,29.517317,-98.59535
+740GD,Laredo Outpatient Clinic,4602 N. Bartlett,Laredo,TX,78041,956-523-7850,VA Facility,Government,no,Not Available,0,0
+504BY,Lubbock Clinic,6104 Avenue Q South Drive,Lubbock,TX,79412,806-472-3400,VA Facility,Government,no,Not Available,33.537964,-101.85425
+740GB,McAllen Outpatient Clinic,901 E. Hackberry Ave.,McAllen,TX,78503,956-618-7100,VA Facility,Government,no,Not Available,26.208422,-98.2105
+671,North Central Federal OPC,17440 Henderson Pass,San Antonio,TX,78232,210-483-2900,VA Facility,Government,no,Not Available,0,0
+549,Polk Street VA Clinic,4243 S. Polk Street,Dallas,TX,75224,214-372-8100,VA Facility,Government,no,Not Available,32.69242,-96.83995
+671,San Antonio Dental Clinic,8410 Data Point,San Antonio,TX,78229,210-949-8900,VA Facility,Government,no,Not Available,29.517626,-98.56916
+671,Shavano Park Outpatient Clinic,"4350 Lockhill-Selma Road, Suite 200",San Antonio,TX,78249,210-949-3773,VA Facility,Government,no,Not Available,0,0
+674,Temple VA Clinic Annex,"4501 South General Bruce Drive, Suite 75",Temple,TX,76502,254-743-1624 Or 254-743-1627,VA Facility,Government,no,Not Available,31.086763,-97.39863
+549GA,Tyler VA Primary Care Clinic,7916 S. Broadway Ave.,Tyler,TX,75703,855-375-6930 Or 903-266-5900,VA Facility,Government,no,Not Available,32.262688,-95.30751
+671,Victoria OPC,"1908 North Laurent Street, Suite 150",Victoria,TX,77901,361-582-7700,VA Facility,Government,no,Not Available,28.810976,-96.991264
+519HC,Abilene CBOC,3850 Ridgemont,Abilene,TX,79606,325-695-3252,VA Facility,Government,no,Not Available,32.404293,-99.76582
+671GH,Beeville CBOC,302 South Hillside Dr,Beeville,TX,78102,361-358-9912,VA Facility,Government,no,Not Available,28.406782,-97.73223
+549GE,Bridgeport CBOC,1713 South FM 51,Decatur,TX,76234,940-627-7001,VA Facility,Government,no,Not Available,0,0
+674GB,Brownwood CBOC,2600 Memorial Park Drive,Brownwood,TX,76801,325-641-0568,VA Facility,Government,no,Not Available,0,0
+674GC,Bryan/College Station CBOC,"1651 Rock Prairie Road, Ste. 100",College Station,TX,77845,979-680-0361,VA Facility,Government,no,Not Available,30.582659,-96.29087
+674GD,Cedar Park CBOC,600 N. Bell Boulevard,Cedar Park,TX,78613,512-219-2340,VA Facility,Government,no,Not Available,30.51541,-97.82645
+504GB,Childress Clinic,1001 Highway 83 North,Childress,TX,79201,940-937-8528,VA Facility,Government,no,Not Available,0,0
+504BZ,Clovis CBOC,921 East Llano Estacado,Clovis,NM,88101,575-763-4335,VA Facility,Government,no,Not Available,34.433884,-103.194916
+504HB,Dalhart VA Community Based Outpatient Clinic,325 Denver Ave,Dalhart,TX,79022,806-249-0673,VA Facility,Government,no,Not Available,36.06303,-102.5219
+549GD,Denton CBOC,2223 Colorado Blvd.,Denton,TX,76205,940-891-6350,VA Facility,Government,no,Not Available,0,0
+756GB,Eastside El Paso CBOC,"2400 Trawood Drive, Suite 200",El Paso,TX,79936,915-217-2428,VA Facility,Government,no,Not Available,31.76511,-106.315895
+519HB,Fort Stockton Clinic,2071 North Main,Fort Stockton,TX,79735,432-685-2110,VA Facility,Government,no,Not Available,0,0
+549GF,Granbury CBOC,601 Fall Creek Hwy.,Granbury,TX,76049,817-326-3902,VA Facility,Government,no,Not Available,32.469315,-97.69639
+549GH,Greenville CBOC,"4006 Wellington Rd., Suite 100A",Greenville,TX,75401,903-450-1143,VA Facility,Government,no,Not Available,33.129063,-96.12283
+519GB,Hobbs CBOC,1601 N Turner (4th Floor),Hobbs,NM,88240,575-391-0354,VA Facility,Government,no,Not Available,0,0
+674HB,LaGrange Rural OutReach Clinic,890 E Travis St,LaGrange,TX,78945,979-968-5878,VA Facility,Government,no,Not Available,29.90971,-96.868614
+756GA,Las Cruces CBOC,1635 Don Roser,Las Cruces,NM,88001,575-522-1241,VA Facility,Government,no,Not Available,0,0
+671GL,New Braunfels CBOC,"705 Landa Street, Suite C",New Braunfels,TX,78130,830-643-0717,VA Facility,Government,no,Not Available,29.705301,-98.13165
+671,NorthEast 410 /San Antonio Clinic,2391 NE Loop 410 Ste 101,San Antonio,TX,78217,210-590-0247,VA Facility,Government,no,Not Available,29.516327,-98.42043
+671,Northwest 410/San Antonio Clinic,4318 Woodcock Ste 120,San Antonio,TX,78228,210-736-4051,VA Facility,Government,no,Not Available,29.485802,-98.56912
+674GA,Palestine CBOC,"2000 So. Loop 256, Suite 124",Palestine,TX,75801,903-723-9006,VA Facility,Government,no,Not Available,0,0
+671,Pecan Valley CBOC,"4243 E. Southcross, Ste 204",San Antonio,TX,78222,210-337-4316,VA Facility,Government,no,Not Available,29.374807,-98.41205
+519GA,Permian Basin Community Based Outpatient Clinic,8050 E. Hwy 191,Odessa,TX,79762,432-685-2110,VA Facility,Government,no,Not Available,0,0
+6427,Plano CBOC,3804 W 15th Street,Plano,TX,75075,972-801-4200,VA Facility,Government,no,Not Available,0,0
+519HF,San Angelo Clinic,2018 Pulliam,San Angelo,TX,76905,325-658-6138,VA Facility,Government,no,Not Available,31.470688,-100.40485
+671,Seguin CBOC,526 E. Court Street,Seguin,TX,78155,830-372-1697,VA Facility,Government,no,Not Available,29.56896,-97.9608
+549GC,Sherman CBOC,3811 US 75 N,Sherman,TX,75090,903-487-0477,VA Facility,Government,no,Not Available,0,0
+671,South Bexar/San Antonio Clinic,4610 E Southcross Blvd Ste 100,San Antonio,TX,78222,210-648-1491,VA Facility,Government,no,Not Available,29.374544,-98.402145
+519AB,Stamford Clinic,1601 N Columbia,Stamford,TX,79553,325-695-3252,VA Facility,Government,no,Not Available,0,0
+671,SW Military CBOC,"1714 SW Military Dr., Suite 101",San Antonio,TX,78221,210-923-0777,VA Facility,Government,no,Not Available,29.35664,-98.51999
+733,Abilene Vet Center,3564 N. 6th St.,Abilene,TX,79603,325-232-7925 Or 325-232-7925,VA Facility,Government,no,Not Available,32.455303,-99.76634
+0702V,Amarillo Vet Center,3414 Olsen Blvd. Suite E,Amarillo,TX,79109,806-354-9779 Or 806-354-9779,VA Facility,Government,no,Not Available,35.185078,-101.88002
+0732V,Arlington Vet Center,3337 West Pioneer Parkway,Pantego,TX,76013,817-274-0981 Or 817-274-0981,VA Facility,Government,no,Not Available,32.711346,-97.16024
+0703V,Austin Vet Center,"2015 S. I.H. 35, Southcliff Bldg., Suite 101",Austin,TX,78741,512-416-1314 Or 512-416-1314,VA Facility,Government,no,Not Available,0,0
+0705V,Corpus Christi Vet Center,4646 Corona Suite 250,Corpus Christi,TX,78411,361-854-9961 Or 361-854-9961,VA Facility,Government,no,Not Available,27.713821,-97.38916
+5461,Dallas Vet Center,"8610 Greenville Ave., Suite 125",Dallas,TX,75243,214-361-5896 Or 214-361-5896,VA Facility,Government,no,Not Available,32.894432,-96.75287
+0707V,El Paso Vet Center,1155 Westmoreland Suite 121,El Paso,TX,79925,915-772-0013 Or 915-772-0013,VA Facility,Government,no,Not Available,31.778967,-106.38721
+0708V,Fort Worth Vet Center,6620 Hawk Creek Avenue,Westworth Village,TX,76114,817-921-9095 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0726V,Killeen Vet Center,"302 Millers Crossing, Suite #4",Harker Heights,TX,76548,254-953-7100 Or 877-927-8387,VA Facility,Government,no,Not Available,31.06693,-97.6638
+0712V,Laredo Vet Center,6999 McPherson Road Suite 102,Laredo,TX,78041,956-723-4680 Or 956-723-4680,VA Facility,Government,no,Not Available,27.572512,-99.47259
+0714V,Lubbock Vet Center,3106 50th st sute 400,Lubbock,TX,79413,806-792-9782 Or 877-927-8387,VA Facility,Government,no,Not Available,33.54874,-101.881485
+0715V,McAllen Vet Center,"2108 S M Street, MedPoint Plaza, Unit 2",McAllen,TX,78503,956-631-2147 Or 956-631-2147,VA Facility,Government,no,Not Available,0,0
+0730V,Mesquite Vet Center,"502 West Kearney, Suite 300",Mesquite,TX,75149,972-288-8030 Or 972-288-8030,VA Facility,Government,no,Not Available,32.770718,-96.602806
+716,Midland Vet Center,"4400 N. Midland Drive, Suite 540",Midland,TX,79707,432-697-8222 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0700V,"RCS Continental District 4, Zone 2 District Office",4500 S. Lancaster Rd. Building 69,Dallas,TX,75216,214-857-1254 Or 214-857-1254,VA Facility,Government,no,Not Available,32.694347,-96.79335
+0721V,San Antonio Northeast Vet Center,"9504 IH 35 N, Suite 214",San Antonio,TX,78233,210-650-0422 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0729V,San Antonio Northwest Vet Center,"9910 W Loop 1604 N, Suite 126",San Antonio,TX,78254,210-688-0606 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+10N19,VISN 19: Rocky Mountain Network,"4100 E. Mississippi Ave., 11th floor",Glendale,CO,80246,303-202-8165,VA Facility,Government,no,Not Available,39.696564,-104.939606
+623,Eastern Oklahoma VA Health Care System (Jack C. Montgomery VAMC),1011 Honor Heights Drive,Muskogee,OK,74401,918-577-3000 Or 918-577-3000,VA Facility,Government,no,Not Available,0,0
+635,Oklahoma City VA Health Care System,921 N.E. 13th Street,Oklahoma City,OK,73104,405-456-1000 Or 405-456-1000,VA Facility,Government,no,Not Available,35.48231,-97.49622
+554,VA Eastern Colorado Health Care System(ECHCS),1055 Clermont Street,Denver,CO,80220,303-399-8020,VA Facility,Government,no,Not Available,39.73255,-104.93508
+436,VA Montana Health Care System,3687 Veterans Drive,Fort Harrison,MT,59636,406-442-6410,VA Facility,Government,no,Not Available,0,0
+660,VA Salt Lake City Health Care System,500 Foothill Drive,Salt Lake City,UT,84148,801-582-1565,VA Facility,Government,no,Not Available,40.758488,-111.84073
+442,Cheyenne VA Medical,2360 E. Pershing Blvd.,Cheyenne,WY,82001,307-778-7550 Or 307-778-7550,VA Facility,Government,no,Not Available,41.145813,-104.7888
+575,Grand Junction VA Medical Center,2121 North Avenue,Grand Junction,CO,81501,970-242-0731 Or 970-242-0731,VA Facility,Government,no,Not Available,39.077374,-108.54048
+666,Sheridan VA Medical Center,1898 Fort Road,Sheridan,WY,82801,307-672-3473 Or 307-672-3473,VA Facility,Government,no,Not Available,44.826782,-106.98457
+666,Afton Outreach Clinic,125 South Washington,Afton,WY,83110,307-886-5266,VA Facility,Government,no,Not Available,0,0
+554GI,Burlington Telehealth Clinic,1177 Rose Avenue,Burlington,CO,80807,719-346-5239,VA Facility,Government,no,Not Available,39.300983,-102.265015
+6402,Ernest Childers VA Outpatient Clinic / Tulsa,9322 E. 41st St.,Tulsa,OK,74145,918-628-2518,VA Facility,Government,no,Not Available,36.104477,-95.87215
+666,Evanston Primary Care Telehealth Outreach Clinic,1565 South Highway 150 #E,Evanston,WY,82930,877-733-6128,VA Facility,Government,no,Not Available,0,0
+575,Glenwood Springs VA Telehealth Clinic,"2425 S Grand Ave., Suite 101",Glenwood Springs,CO,81601,970-945-1007,VA Facility,Government,no,Not Available,39.528496,-107.32537
+436,Hamilton Primary Care Telehealth Outreach Clinic,299 Fairgrounds Suite A,Hamilton,MT,59840,406-363-3352,VA Facility,Government,no,Not Available,46.25502,-114.15041
+436QC,Helena VA Sleep Clinic,2271 Deerfield Lane,Helena,MT,59601,406-447-7443,VA Facility,Government,no,Not Available,46.57023,-111.97614
+554,Jewell Clinic,14400 E Jewell Ave,Aurora,CO,80012,303-283-5400,VA Facility,Government,no,Not Available,39.682083,-104.82089
+442,Laramie Mobile Telehealth Clinic,2901 Armory Road,Laramie,WY,82702,888-483-9127 X 3816,VA Facility,Government,no,Not Available,0,0
+575,Moab VA Telehealth Clinic,702 South Main Street,Moab,UT,84532,435-719-4144,VA Facility,Government,no,Not Available,0,0
+436,Plentywood Primary Care Telehealth Outreach Clinic,440 West Laurel Ave.,Plentywood,MT,59254,406-765-3718,VA Facility,Government,no,Not Available,48.778694,-104.56304
+442,Rawlins PCTOC,1809 East Daley Street,Rawlins,WY,82301,307-324-5578,VA Facility,Government,no,Not Available,41.796143,-107.21673
+554,Salida Telehealth Clinic,920 Rush Drive,Salida,CO,81201,719-539-8666,VA Facility,Government,no,Not Available,0,0
+6422,South Oklahoma City VA Clinic,7919 Mid America Blvd.,Oklahoma City,OK,73135,405-855-6000,VA Facility,Government,no,Not Available,35.388805,-97.41268
+442,Sterling Mobile Telehealth Clinic,100 College Dr.,Sterling,CO,80751,888-483-9127 X 3816,VA Facility,Government,no,Not Available,40.637978,-103.19676
+442,Torrington Mobile Telehealth Clinic,908 West 25th Ave.,Torrington,WY,82240,888-483-9127 X 3816,VA Facility,Government,no,Not Available,42.068966,-104.19548
+623BY01,Tulsa Behavioral Medicine Clinic,10159 E 11th Street,Tulsa,OK,74128,918-610-2000 Or 918-610-2000,VA Facility,Government,no,Not Available,36.148,-95.86382
+436HC,"VA Montana Health Care System, Havre CBOC","130 13th Street, Suite 1",Havre,MT,59501,406-265-4304,VA Facility,Government,no,Not Available,48.53932,-109.6853
+442,Wheatland Mobile Telehealth Clinic,759 East Cole Street,Wheatland,WY,82201,888-483-9127 X 3816,VA Facility,Government,no,Not Available,42.045074,-104.95171
+666,Worland Primary Care Telehealth Outreach Clinic,"510 South 15th., Suite D",Worland,WY,82401,877-483-0370,VA Facility,Government,no,Not Available,44.01252,-107.94842
+635,Ada CBOC,717 Better Now Plaza,Ada,OK,74820,580-436-2262,VA Facility,Government,no,Not Available,0,0
+567GC,Alamosa /San Luis Valley Clinic/Sierra Blanca Clinic,622 Del Sol Drive,Alamosa,CO,81101,719-587-6800,VA Facility,Government,no,Not Available,0,0
+635GF,Altus VA Clinic,"1604 N. Main, Highway 283",Altus,OK,73521,580-482-0721,VA Facility,Government,no,Not Available,34.65482,-99.33396
+436GA,Anaconda VA Community Based Outpatient Clinic,"118 East 7th St., Suite 2A",Anaconda,MT,59711,406-496-3000,VA Facility,Government,no,Not Available,46.124325,-112.95442
+635HB,Ardmore VA Clinic,"2002 12th Ave NW, Suite E",Ardmore,OK,73401,580-222-0400,VA Facility,Government,no,Not Available,34.187466,-97.153885
+554GB,Aurora Outpatient Clinic,13701 E Mississippi Ave Gateway Medical Bldg #200,Aurora,CO,80012,303-398-6340,VA Facility,Government,no,Not Available,0,0
+436GH,Billings VA Community Based Outpatient Clinic with Specialty Clinic,Outpatient: 1775 Spring Creek Lane; Specialty Clinic: 1766 Majestic Lane,Billings,MT,59102,406-373-3500,VA Facility,Government,no,Not Available,0,0
+635GC,Blackwell VA Clinic,1009 W. Ferguson Ave.,Blackwell,OK,74631,580-363-0052,VA Facility,Government,no,Not Available,36.796967,-97.29587
+436GD,Bozeman VA Community Based Outpatient Clinic,"300 N. Willson, Suite 703G",Bozeman,MT,59715,406-582-5300,VA Facility,Government,no,Not Available,45.68204,-111.03872
+666GB,Casper Outpatient Clinic,4140 S. Poplar Str.,Casper,WY,82601,866-338-5168,VA Facility,Government,no,Not Available,42.81012,-106.343544
+666GD,Cody Outpatient Clinic,1432 Rumsey Avenue,Cody,WY,82421,307-587-4015,VA Facility,Government,no,Not Available,44.527145,-109.05949
+575GB,Craig Telehealth Clinic,785 Russell Street - Suite 400,Craig,CO,81625,970-824-6721,VA Facility,Government,no,Not Available,40.519424,-107.54609
+436,Cut Bank VA Community Based Outpatient Clinic,#8 2nd Ave SE,Cut Bank,MT,59427,406-873-9047,VA Facility,Government,no,Not Available,48.634796,-112.330124
+501GJ,Durango CCBOC,"1970 East Third Avenue, Suite 102",Durango,CO,81301,970-247-2214,VA Facility,Government,no,Not Available,37.2841,-107.874466
+660GK,Elko Outreach Clinic,2719 Argent Ave. #9,Elko,NV,89801,775-738-0188,VA Facility,Government,no,Not Available,40.841846,-115.78992
+5901,Enid VA Clinic,"915 E Owen K. Garriott, Suite G",Enid,OK,73701,580-977-1855,VA Facility,Government,no,Not Available,36.390648,-97.86482
+442GC,Fort Collins Outpatient Clinic,2509 Research Blvd.,Fort Collins,CO,80526,970-224-1550 Or 970-224-1550,VA Facility,Government,no,Not Available,40.555664,-105.08729
+666GB,Gillette Outpatient Clinic,604 express Drive,Gillette,WY,82718,866-621-1887,VA Facility,Government,no,Not Available,0,0
+436GI,Glasgow VA Community Based Outpatient Clinic,"630 Second Ave. South, Suite A",Glasgow,MT,59230,406-228-4101,VA Facility,Government,no,Not Available,48.1947,-106.63871
+436GK,Glendive VA Community Based Outpatient Clinic,2000 Montana Ave.,Glendive,MT,59330,406-377-4755,VA Facility,Government,no,Not Available,47.127228,-104.68935
+554/GC,Golden Outpatient Clinic,1020 Johnson Road,Golden,CO,80401,303-914-2680,VA Facility,Government,no,Not Available,39.74029,-105.20192
+436GB,Great Falls VA Community Based Outpatient Clinic,"1417 9th Street South, Suite 200 and 300",Great Falls,MT,59405,406-791-3200,VA Facility,Government,no,Not Available,47.48997,-111.29218
+623GA,Hartshorne VA Outpatient Clinic,1429 Pennsylvania Ave.,Hartshorne,OK,74547,888-878-1598,VA Facility,Government,no,Not Available,34.842693,-95.54845
+660,Idaho Falls Outreach Clinic,3544 East 17th Street,Idaho Falls,ID,83406,208-522-2922,VA Facility,Government,no,Not Available,43.48186,-111.961975
+6421,Jack C. Montgomery East,2414 E. Shawnee Bypass,Muskogee,OK,74403,918-577-3699,VA Facility,Government,no,Not Available,35.770924,-95.3399
+436GF,Kalispell VA Community Based Outpatient Clinic,"31 Three Mile Dr., Suite 102",Kalispell,MT,59901,406-758-2700,VA Facility,Government,no,Not Available,48.21142,-114.33203
+554GG,La Junta Outpatient Clinic,"1100 Carson Ave., Suite 104",La Junta,CO,81050,719-383-5195,VA Facility,Government,no,Not Available,37.978893,-103.54871
+554GH,Lamar Outpatient Clinic,"1401 South Main Street, Suite 2",Lamar,CO,81052,719-336-0315,VA Facility,Government,no,Not Available,38.07654,-102.618164
+635GA,Lawton/Ft. Sill VA Clinic,"4303 Pittman and Thomas, Building 4303",Fort Sill,OK,73503,580-585-5600,VA Facility,Government,no,Not Available,0,0
+436,Lewistown VA Community Based Outpatient Clinic,"629 NE Main St., Suite 1",Lewistown,MT,59457,406-535-4790,VA Facility,Government,no,Not Available,47.070553,-109.415794
+442,Loveland Community Clinic,5200 Hahns Peak Drive,Loveland,CO,80538,970-962-4900,VA Facility,Government,no,Not Available,40.412712,-105.00748
+623GC,McCurtain County Community Based Outpatient Clinic,903 SE Washington St.,Idabel,OK,74745,580-920-7200,VA Facility,Government,no,Not Available,33.895565,-94.81764
+436GJ,Miles City VA Community Based Outreach Clinic/ Nursing Home,210 S. Winchester,Miles City,MT,59301,406-874-5600,VA Facility,Government,no,Not Available,46.406296,-105.83044
+436GC,Missoula VA Community Based Outpatient Clinic,"2687 Palmer St., Suite C",Missoula,MT,59808,406-493-3700,VA Facility,Government,no,Not Available,46.887005,-114.03008
+575GA,Montrose Outpatient Clinic,154 Colorado Avenue,Montrose,CO,81401,970-249-7791,VA Facility,Government,no,Not Available,38.470642,-107.871895
+635,North May Oklahoma City VA Clinic,2915 Pine Ridge Road,Oklahoma City,OK,73120,405-752-6500,VA Facility,Government,no,Not Available,35.59251,-97.56757
+660GB,Ogden CBOC,982 Chambers Street,South Ogden,UT,84403,801-479-4105,VA Facility,Government,no,Not Available,41.166492,-111.95761
+660GE,Orem CBOC,"1443 West 800 North, Suite #302",Orem,UT,84057,801-235-0953,VA Facility,Government,no,Not Available,0,0
+554GE,PFC Floyd K. Lindstrom Clinic at Colorado Springs,3141 Centennial Boulevard,Colorado Springs,CO,80907,719-327-5660,VA Facility,Government,no,Not Available,0,0
+660GA,Pocatello CBOC,500 S 11th Ave,Pocatello,ID,83201,208-232-6214,VA Facility,Government,no,Not Available,42.86736,-112.43386
+660,Price CBOC,"189 South 600 West, Suite B",Price,UT,84501,435-613-0342,VA Facility,Government,no,Not Available,39.59684,-110.79974
+554GD,Pueblo Outpatient Clinic,4776 Eagleridge Circle,Pueblo,CO,81008,719-553-1000,VA Facility,Government,no,Not Available,0,0
+666GC,Riverton Outpatient Clinic,2300 Rose Lane,Riverton,WY,82501,866-338-2609,VA Facility,Government,no,Not Available,43.03563,-108.42055
+666GF,Rock Springs Outpatient Clinic,1401 Gateway,Rock Springs,WY,82901,866-381-2830,VA Facility,Government,no,Not Available,0,0
+660GD,Roosevelt CBOC,245 West 200 North,Roosevelt,UT,84066,435-725-1050,VA Facility,Government,no,Not Available,40.302086,-109.995995
+442GB,Sidney VA Outpatient Clinic,1116 10th Ave,Sidney,NE,69162,308-254-6085,VA Facility,Government,no,Not Available,41.140823,-102.976555
+660GG,St. George CBOC,"230 North 1680 East, Building N",St. George,UT,84790,435-634-7608,VA Facility,Government,no,Not Available,0,0
+635GE,Stillwater VA Clinic,320 N. Perkins Avenue,Stillwater,OK,74074,405-707-8100,VA Facility,Government,no,Not Available,0,0
+623,Vinita Outpatient Clinic,269 S 7th St,Vinita,OK,74301,918-713-5400,VA Facility,Government,no,Not Available,36.63692,-95.14327
+660GJ,Western Salt Lake CBOC,2750 South 5600 West,West Valley City,UT,84120,801-417-5734,VA Facility,Government,no,Not Available,40.709984,-112.02493
+635GB,Wichita Falls VA Clinic,149 Hart Street,Sheppard Air Force Base,TX,76311,940-257-0000,VA Facility,Government,no,Not Available,0,0
+0509V,Billings Vet Center,"2795 Enterprise Ave., Suite 1",Billings,MT,59102,406-657-6071 Or 406-657-6071,VA Facility,Government,no,Not Available,45.75003,-108.58542
+527,Boulder Vet Center,"4999 Pearl East Circle, Suite 106",Boulder,CO,80301,303-440-7306 Or 877-927-8387,VA Facility,Government,no,Not Available,40.02116,-105.23718
+0519V,Casper Vet Center,"1030 North Poplar, Suite B",Casper,WY,82601,307-261-5355 Or 307-261-5355,VA Facility,Government,no,Not Available,42.860615,-106.33267
+0501V,Cheyenne Vet Center,3219 E Pershing Blvd,Cheyenne,WY,82001,307-778-7370 Or 307-778-7370,VA Facility,Government,no,Not Available,41.145607,-104.77146
+525,Colorado Springs Vet Center,602 South Nevada Avenue,Colorado Springs,CO,80903,719-471-9992 Or 719-471-9992,VA Facility,Government,no,Not Available,38.82535,-104.822044
+0504V,Denver Vet Center,7465 East First Avenue Suite B,Denver,CO,80230,303-326-0645,VA Facility,Government,no,Not Available,39.718548,-104.90127
+0543V,Fort Collins Vet Center,702 W Drake Builing C,Fort Collins,CO,80526,970-221-5176 Or 970-221-5176,VA Facility,Government,no,Not Available,40.552666,-105.087814
+526,Grand Junction Vet Center,2472 Patterson Road Unit 16,Grand Junction,CO,81505,970-245-4156 Or 970-245-4156,VA Facility,Government,no,Not Available,39.091896,-108.59437
+538,Great Falls Vet Center,615 2nd Avenue North,Great Falls,MT,59401,406-452-9048 Or 406-452-9048,VA Facility,Government,no,Not Available,47.507515,-111.29696
+5281,Helena Outstation,1301 Elm Street Suite C,Helena,MT,59601,406-457-8060,VA Facility,Government,no,Not Available,46.607727,-112.01875
+539,Kalispell Vet Center,"690 North Meridian Road, Suite 101",Kalispell,MT,59901,406-257-7308,VA Facility,Government,no,Not Available,48.189045,-114.330666
+0728V,Lawton Vet Center,"1016 SW C Avenue, Suite B",Lawton,OK,73501,580-585-5880,VA Facility,Government,no,Not Available,34.605194,-98.40351
+528,Missoula Vet Center,910 Brooks St.,Missoula,MT,59801,406-721-4918,VA Facility,Government,no,Not Available,46.855923,-114.007286
+5141,Ogden Outstation,2357 N 400 E Washington Blvd,North Ogden,UT,84414,801-737-9737,VA Facility,Government,no,Not Available,41.30123,-111.968796
+0718V,Oklahoma City Vet Center,6804 N. Robinson Avenue,Oklahoma City,OK,73116,405-456-5184 Or 877-927-8387,VA Facility,Government,no,Not Available,35.540695,-97.51643
+531,Pocatello Vet Center,"1800 Garrett Way, Suite 47",Pocatello,ID,83201,208-232-0316 Or 208-232-0316,VA Facility,Government,no,Not Available,42.87654,-112.458466
+532,Provo Vet Center,360 S. State Street Bldg C Suite 103,Orem,UT,84058,801-377-1117,VA Facility,Government,no,Not Available,40.29056,-111.69216
+542,Pueblo Vet Center,"1515 Fortino Blvd., Suite 130",Pueblo,CO,81008,719-583-4058,VA Facility,Government,no,Not Available,38.312466,-104.62828
+0500V,RCS Continental District 4 District Office,"789 Sherman Street, Suite 570",Denver,CO,80203,303-577-5205 Or 303-577-5207,VA Facility,Government,no,Not Available,39.728817,-104.98489
+0540v,Saint George Vet Center,"1664 South Dixie Drive, Suite C-102",St. George,UT,84770,435-673-4494 Or 435-673-4494,VA Facility,Government,no,Not Available,0,0
+514,Salt Lake Vet Center,22 West Fireclay Avenue,Murray,UT,84107,801-266-1499 Or 877-927-8387,VA Facility,Government,no,Not Available,40.677994,-111.89191
+0723V,Tulsa Vet Center,14002 E. 21st Street,Tulsa,OK,74134,918-628-2760 Or 918-628-2760,VA Facility,Government,no,Not Available,36.13344,-95.82066
+10N20,VISN 20: Northwest Network,"1601 4th Plain Blvd Building 17, 4th Floor, Suite 403",Vancouver,WA,98661,360-619-5925,VA Facility,Government,no,Not Available,0,0
+463,Alaska VA Healthcare System,1201 North Muldoon Road,Anchorage,AK,99504,907-257-4700 Or 907-257-4700,VA Facility,Government,no,Not Available,61.23116,-149.74269
+648,Portland VA Medical Center,3710 SW U.S. Veterans Hospital Road,Portland,OR,97239,503-220-8262 Or 503-220-8262,VA Facility,Government,no,Not Available,45.49641,-122.68452
+663,VA Puget Sound Health Care System,1660 S. Columbian Way,Seattle,WA,98108,206-762-1010 Or 206-762-1010,VA Facility,Government,no,Not Available,47.56228,-122.311424
+663A4,VA Puget Sound Health Care System - American Lake Division,9600 Veterans Dr,Lakewood,WA,98493,253-582-8440 Or 253-582-8440,VA Facility,Government,no,Not Available,0,0
+663,VA Puget Sound Health Care System - Seattle Division,1660 S. Columbian Way,Seattle,WA,98108,206-762-1010 Or 206-762-1010,VA Facility,Government,no,Not Available,47.56228,-122.311424
+531,Boise VA Medical Center,500 West Fort Street,Boise,ID,83702,208-422-1000,VA Facility,Government,no,Not Available,43.61825,-116.194214
+687,Jonathan M. Wainwright Memorial VA Medical Center,77 Wainwright Drive,Walla Walla,WA,99362,888-687-8863 Or 509-525-5200,VA Facility,Government,no,Not Available,46.052536,-118.35569
+668,Mann-Grandstaff VA Medical Center,4815 N. Assembly Street,Spokane,WA,99205,509-434-7000,VA Facility,Government,no,Not Available,47.701454,-117.47557
+653,Roseburg VA Health Care System,913 NW Garden Valley Blvd.,Roseburg,OR,97471,541-440-1000,VA Facility,Government,no,Not Available,43.228924,-123.36807
+648A4,VA Portland Health Care System - Vancouver Campus,1601 E. Fourth Plain Blvd,Vancouver,WA,98661,360-696-4061,VA Facility,Government,no,Not Available,45.639336,-122.65486
+692,White City or VA Southern Oregon Rehabilitation Center,8495 Crater Lake Hwy.,White City,OR,97503,541-826-2111,VA Facility,Government,no,Not Available,42.440937,-122.834885
+531,Burns Oregon Outpatient Clinic,271 N Egan Ave,Burns,OR,97720,541-573-3339,VA Facility,Government,no,Not Available,43.588093,-119.059525
+463,Juneau VA Outreach Clinic,"709 West 9th Street, Suite 150",Juneau,AK,99801,907-796-4300 Or 907-796-4300,VA Facility,Government,no,Not Available,58.301617,-134.4209
+668,Libby RHC,211 E. Second St.,Libby,MT,59923,406-293-8711,VA Facility,Government,no,Not Available,48.393345,-115.548874
+531,Mountain Home Idaho Outpatient Clinic,815 North 6th East,Mountain Home,ID,83647,208-580-2001,VA Facility,Government,no,Not Available,43.137764,-115.69252
+648,Newport Outreach Clinic,1010 SW Coast Highway,Newport,OR,97365,541-265-4182,VA Facility,Government,no,Not Available,44.62718,-124.06144
+531,Salmon Idaho Outpatient Clinic,705 Lena Street,Salmon,ID,83467,208-756-8515,VA Facility,Government,no,Not Available,45.173313,-113.89316
+668,Sandpoint RHC,420 N. 2nd Ave. Suite-200,Sandpoint,ID,83864,208-263-0450,VA Facility,Government,no,Not Available,48.276367,-116.54873
+648GE,The Dalles Outreach Clinic,704 Veterans Drive,The Dalles,OR,97058,541-296-3937,VA Facility,Government,no,Not Available,45.600388,-121.12573
+648,West Linn CBOC,1750 SW Blankenship Rd Ste 300,West Linn,OR,97068,503-210-4900,VA Facility,Government,no,Not Available,0,0
+0523V,Yakima Valley Vet Center,2119 W. Lincoln,Yakima,WA,98902,509-457-2736,VA Facility,Government,no,Not Available,46.603485,-120.537346
+648GA,Bend CBOC,2650 NE Courtney Drive,Bend,OR,97701,541-647-5200 Or 855-213-8002,VA Facility,Government,no,Not Available,44.071987,-121.26456
+653BY,BHRRS - Behavioral Health Recovery & Reintegration Services,211 E 7th Ave Suite 118,Eugene,OR,97401,541-440-1000,VA Facility,Government,no,Not Available,44.052135,-123.089455
+663GB,Bremerton CBOC,925 Adele Avenue,Bremerton,WA,98312,360-473-0340,VA Facility,Government,no,Not Available,47.56878,-122.662964
+653GB,Brookings VA Clinic,840 Railroad St,Brookings,OR,97415,541-412-1152,VA Facility,Government,no,Not Available,42.05251,-124.28958
+531GG,Caldwell Idaho Outpatient Clinic,4521 Thomas Jefferson Drive,Caldwell,ID,83605,208-454-4820,VA Facility,Government,no,Not Available,0,0
+648ZZ,Community Resource and Referral Center (CRRC),308 SW 1st Ave,Portland,OR,97204,503-808-1256 Or 800-949-1004 X 51256,VA Facility,Government,no,Not Available,45.520313,-122.67219
+653BY,Eugene Health Care Center,3355 Chad Dr.,Eugene,OR,97408,541-607-0897,VA Facility,Government,no,Not Available,44.087612,-123.05653
+463GA,Fairbanks VA Community Based Outpatient Clinic,"Bldg 4076, Neeley Road, Room 1J-101",Fort Wainwright,AK,99703,907-361-6370 Or 907-361-6370,VA Facility,Government,no,Not Available,0,0
+648GE,Fairview Clinic,1800 NE Market Drive,Fairview,OR,97024,503-660-0600,VA Facility,Government,no,Not Available,0,0
+687,Grangeville (ID) VA Outpatient Clinic,711 West North Street,Grangeville,ID,83850,208-983-4671,VA Facility,Government,no,Not Available,45.927563,-116.12766
+692SS,Grants Pass West VA CBOC,1877 Williams Hwy,Grants Pass,OR,97527,541-955-5551,VA Facility,Government,no,Not Available,42.417038,-123.33931
+648GF,Hillsboro CBOC,"1925 NE Stucki Ave., Suite #300",Hillsboro,OR,97006,503-906-5000,VA Facility,Government,no,Not Available,0,0
+463GB,Kenai VA Community Based Outpatient Clinic,"11312 Kenai Spur Highway, Suite 39",Kenai,AK,99611,907-395-4100 Or 877-797-8924,VA Facility,Government,no,Not Available,60.55464,-151.25703
+692GA,Klamath Falls CBOC,2225 North El Dorado Blvd.,Klamath Falls,OR,97601,541-273-6206,VA Facility,Government,no,Not Available,42.24797,-121.7848
+687GC,La Grande (OR) Community Based Outpatient Clinic,202 12th Street,La Grande,OR,97850,541-963-0627,VA Facility,Government,no,Not Available,45.313206,-118.08635
+687GB,Lewiston (ID) Community Based Outpatient Clinic,"1630 23rd Avenue, Bldg. 2",Lewiston,ID,83501,208-746-7784,VA Facility,Government,no,Not Available,46.397305,-117.00901
+648GB,Lincoln City Clinic,"4422 NE Devils Lake Road, Suite 2",Lincoln City,OR,97367,541-265-0547,VA Facility,Government,no,Not Available,0,0
+463GC,Mat-Su VA Community Based Outpatient Clinic,"865 N. Seward Meridian Parkway, Suite 105",Wasilla,AK,99654,907-631-3100 Or 800-323-8648,VA Facility,Government,no,Not Available,61.5738,-149.35968
+687TH,Morrow County VA Telehealth Clinic (Boardman OR),"2 Marine Drive, Suite 103 ~ P.O. Box 1059",Boardman,OR,97818,541-481-2255,VA Facility,Government,no,Not Available,0,0
+663,Mount Vernon CBOC,"307 S. 13th St., Suite 200",Mount Vernon,WA,98274,360-848-8500,VA Facility,Government,no,Not Available,48.41875,-122.32529
+653GA,North Bend VA Clinic,2191 Marion Street,North Bend,OR,97459,541-756-8002,VA Facility,Government,no,Not Available,43.40408,-124.23651
+648GD,North Coast CBOC,"91400 N. Neacoxie Street, building 7315",Warrenton,OR,97146,503-220-8262 X 52593,VA Facility,Government,no,Not Available,0,0
+668GB (North Idaho),North Idaho CBOC,915 W. Emma Avenue,Coeur d 'Alene,ID,83814,208-665-1700,VA Facility,Government,no,Not Available,47.69261,-116.79611
+663GB,North Olympic Peninsula,1114 Georgiana St,Port Angeles,WA,98362,360-565-7420,VA Facility,Government,no,Not Available,48.11315,-123.41334
+687GA,Richland (WA) Community Based Outpatient Clinic,"825 Jadwin Ave., Ste. 250, Federal Bldg., 2nd Floor",Richland,WA,99352,509-946-1020,VA Facility,Government,no,Not Available,46.277122,-119.27524
+648GB,Salem CBOC,"1750 McGilchrist St. SE, Suite 130",Salem,OR,97302,971-304-2200,VA Facility,Government,no,Not Available,44.916733,-123.023155
+663GD,South Sound CBOC,151 NE Hampe Way,Chehalis,WA,98532,360-748-3049,VA Facility,Government,no,Not Available,0,0
+531GE,Twin Falls Idaho Outpatient Clinic,260 2nd Avenue East,Twin Falls,ID,83301,208-732-0959,VA Facility,Government,no,Not Available,42.5551,-114.46718
+663GA,Valor CBOC Bellevue,13033 Bel-Red Road Suite 210,Bellevue,WA,98005,425-214-1055 Or 425-214-1055,VA Facility,Government,no,Not Available,47.621864,-122.165504
+663GA,Valor CBOC Federal Way,34617 11th Place South Suite 301,Federal Way,WA,98003,253-336-4142,VA Facility,Government,no,Not Available,47.291386,-122.32083
+663GA,Valor CBOC North Seattle,"12360 Lake City Way NE, Suite 200",Seattle,WA,98125,206-384-4382,VA Facility,Government,no,Not Available,47.71814,-122.29588
+687TH,Wallowa County VA Telehealth Clinic (Enterprise OR),401 NE 1st Street,Enterprise,OR,97828,541-426-0219,VA Facility,Government,no,Not Available,45.428265,-117.27629
+668,Wenatchee CBOC,2530 Chester-Kimm Road,Wenatchee,WA,98801,509-663-7615 Or 509-663-7615,VA Facility,Government,no,Not Available,47.46406,-120.334
+687HA,Yakima (WA) Community Based Outpatient Clinic,717 Fruitvale Blvd.,Yakima,WA,98902,509-966-0199,VA Facility,Government,no,Not Available,46.612583,-120.5218
+0502V,Anchorage Vet Center,"4400 Business Park Blvd, Suite B-34",Anchorage,AK,99503,907-563-6966 Or 877-927-8387,VA Facility,Government,no,Not Available,61.180626,-149.88925
+0522V,Bellingham Vet Center,3800 Byron Ave Suite 124,Bellingham,WA,98229,360-733-9226 Or 877-927-8387,VA Facility,Government,no,Not Available,48.73362,-122.46637
+0503V,Boise Vet Center,"2424 Bank DrivE, Suite 100",Boise,ID,83705,208-342-3612 Or 877-927-8387,VA Facility,Government,no,Not Available,43.59107,-116.211555
+0622V,Central Oregon Vet Center,1645 NE Forbes Rd. Suite 105,Bend,OR,97701,541-749-2112 Or 541-749-2112,VA Facility,Government,no,Not Available,0,0
+626,Eugene Vet Center,190 East 11th Avenue,Eugene,OR,97401,541-465-6918 Or 877-927-8387,VA Facility,Government,no,Not Available,44.0477,-123.08984
+529,Everett Vet Center,3311 Wetmore Avenue,Everett,WA,98201,425-252-9701,VA Facility,Government,no,Not Available,47.97373,-122.20698
+0511V,Fairbanks Vet Center,"540 4th Ave., Suite 100",Fairbanks,AK,99701,907-456-4238 Or 877-927-8387,VA Facility,Government,no,Not Available,64.842415,-147.71849
+0535V,Federal Way Vet Center,32020 32nd Ave South Suite 110,Federal Way,WA,98001,253-838-3090 Or 253-838-3090,VA Facility,Government,no,Not Available,0,0
+645,Grants Pass Vet Center,211 S.E. 10th St.,Grants Pass,OR,97526,541-479-6912 Or 877-927-8387,VA Facility,Government,no,Not Available,42.43722,-123.322266
+05021V,Kenai Vet Center Outstation,43299 Kalifornsky Beach Rd. Ste 4,Soldotna,AK,99669,907-260-7640 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0617V,Portland Vet Center,1505 NE 122nd Ave.,Portland,OR,97230,503-688-5361 Or 877-927-8387 X 7,VA Facility,Government,no,Not Available,45.53367,-122.53765
+640,Salem Vet Center,"2645 Portland Road NE, Suite 250",Salem,OR,97301,503-362-9911 Or 877-927-8387,VA Facility,Government,no,Not Available,44.961227,-123.014565
+0507V,Seattle Vet Center,"4735 E Marginal Way S, Room 1102",Seattle,WA,98134,206-658-4225 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0510V,Spokane Vet Center,13109 E Mirabeau Parkway,Spokane,WA,99216,509-444-8387 Or 509-444-8387,VA Facility,Government,no,Not Available,0,0
+508,Tacoma Vet Center,4916 Center St. Suite E,Tacoma,WA,98409,253-565-7038 Or 253-565-7038,VA Facility,Government,no,Not Available,47.234417,-122.50397
+0541V,Walla Walla County Vet Center,1104 West Poplar,Walla Walla,WA,99362,509-526-8387 Or 509-526-8387,VA Facility,Government,no,Not Available,46.059216,-118.35254
+0512V,Wasilla Vet Center,851 E. West Point Drive Suite 102,Wasilla,AK,99654,907-376-4318 Or 907-376-4318,VA Facility,Government,no,Not Available,61.58227,-149.42818
+523,Yakima Vet Center,2119 W. Lincoln Ave,Yakima,WA,98902,509-457-2736 Or 509-457-2736,VA Facility,Government,no,Not Available,46.603485,-120.537346
+687,687,77 Wainwright Drive,Walla Walla,WA,99362,,VA Facility,Government,no,Not Available,46.052536,-118.35569
+523,Yakima Valley Vet Center,2119 West Lincoln Avenue,Yakima,WA,98902,509-457-2736,VA Facility,Government,no,Not Available,46.603485,-120.53733
+10N21,VISN 21: Sierra Pacific Network,201 Walnut Avenue,Mare Island,CA,94592,707-562-8350,VA Facility,Government,no,Not Available,0,0
+662,San Francisco VA Health Care System,4150 Clement Street,San Francisco,CA,94121,415-221-4810,VA Facility,Government,no,Not Available,37.781143,-122.504105
+570,Central California VA Health Care System,2615 E. Clinton Avenue,Fresno,CA,93703,559-225-6100 Or 559-225-6100,VA Facility,Government,no,Not Available,36.77229,-119.78002
+640,Livermore,4951 Arroyo Road,Livermore,CA,94550,925-373-4700,VA Facility,Government,no,Not Available,37.637985,-121.763985
+640,Menlo Park,795 Willow Road,Menlo Park,CA,94025,650-614-9997,VA Facility,Government,no,Not Available,37.46356,-122.15805
+612,VA Northern California Health Care System,10535 Hospital Way,Mather,CA,95655,800-382-8387 Or 916-843-7000,VA Facility,Government,no,Not Available,38.571793,-121.297386
+459,VA Pacific Islands Health Care System,459 Patterson Road,Honolulu,HI,96819,808-433-0600 Or 800-214-1306,VA Facility,Government,no,Not Available,21.36117,-157.88878
+640,VA Palo Alto Health Care System,3801 Miranda Avenue,Palo Alto,CA,94304,650-493-5000,VA Facility,Government,no,Not Available,37.402836,-122.14173
+654,VA Sierra Nevada Health Care System,975 Kirman Avenue,Reno,NV,89502,775-786-7200 Or 775-786-7200,VA Facility,Government,no,Not Available,39.515854,-119.79849
+593,VA Southern Nevada Healthcare System,6900 North Pecos Road,N. Las Vegas,NV,89086,702-791-9024,VA Facility,Government,no,Not Available,0,0
+640,Capitola Clinic,"1350 41st Avenue, Suite 102",Capitola,CA,95010,831-464-5519,VA Facility,Government,no,Not Available,36.97057,-121.96488
+612,Chico Outpatient Clinic,280 Cohasset Road,Chico,CA,95926,530-879-5000 X 9 Or 530-879-5000,VA Facility,Government,no,Not Available,39.751648,-121.85145
+612,Fairfield Outpatient Clinic,"103 Bodin Circle, Travis Air Force Base",Fairfield,CA,94535,707-437-1800 Or 707-437-1800,VA Facility,Government,no,Not Available,38.267887,-121.95876
+5199,Major General William H. Gourley VA-DoD Outpatient Clinic,201 Ninth Street,Marina,CA,93933,831-884-1000,VA Facility,Government,no,Not Available,0,0
+96440,Manila Outpatient Clinic,1501 Roxas Boulevard,Pasay City,PI,1302,632-550-3888,VA Facility,Government,no,Not Available,0,0
+612,Mare Island Outpatient Clinic,201 Walnut Avenue,Vallejo,CA,94592,707-562-8200 Or 707-562-8200,VA Facility,Government,no,Not Available,0,0
+612,Martinez Outpatient Clinic and Community Living Center,150 Muir Road,Martinez,CA,94553,925-372-2000 Or 925-372-2000,VA Facility,Government,no,Not Available,37.994648,-122.11164
+612,McClellan Dental Clinic - Sacramento,5401 Arnold Avenue,McClellan,CA,95652,916-333-5500,VA Facility,Government,no,Not Available,0,0
+612,McClellan Outpatient Clinic - Sacramento,5342 Dudley Blvd.,McClellan,CA,95652,916-561-7400 Or 916-561-7400,VA Facility,Government,no,Not Available,0,0
+640,Modesto Clinic,1225 Oakdale Road,Modesto,CA,95355,209-557-6200,VA Facility,Government,no,Not Available,37.662674,-120.95753
+459,National Center for PTSD - Pacific Islands Division,"3375 Koapaka Street, Suite I-560",Honolulu,HI,96819,808-566-1546,VA Facility,Government,no,Not Available,21.33633,-157.91733
+593GG,Northeast Primary Care Clinic,4461 E Charleston Blvd,Las Vegas,NV,89104,702-791-9050,VA Facility,Government,no,Not Available,36.158955,-115.07734
+593GD,Northwest Primary Care Clinic,3968 N Rancho Dr,Las Vegas,NV,89130,702-791-9020,VA Facility,Government,no,Not Available,36.230484,-115.22426
+612,Oakland Behavioral Health Clinic,525 21st Street,Oakland,CA,94612,510-587-3400 Or 510-587-3400,VA Facility,Government,no,Not Available,37.810413,-122.270035
+612,Oakland Outpatient Clinic,2221 Martin Luther King Jr. Way,Oakland,CA,94612,510-267-7800 Or 510-267-7800,VA Facility,Government,no,Not Available,37.812134,-122.27288
+612,Redding Outpatient Clinic,351 Hartnell Avenue,Redding,CA,96002,530-226-7555 Or 530-226-7555,VA Facility,Government,no,Not Available,40.56456,-122.367836
+612,Sacramento Mental Health Clinic at Mather,10535 Hospital Way,Mather,CA,95655,916-366-5420 Or 916-366-5420,VA Facility,Government,no,Not Available,38.571793,-121.297386
+640BY,San Jose Clinic,80 Great Oaks Boulevard,San Jose,CA,95119,408-363-3000,VA Facility,Government,no,Not Available,37.233974,-121.778854
+654GA,Sierra Foothills Outpatient Clinic,11985 Heritage Oak Place,Auburn,CA,95603,530-889-0872,VA Facility,Government,no,Not Available,38.940647,-121.099236
+640GB,Sonora Clinic,13663 Mono Way,Sonora,CA,95370,209-588-2600,VA Facility,Government,no,Not Available,0,0
+593GE,Southeast Primary Care Clinic,1020 S Boulder,Henderson,NV,89015,702-791-9030,VA Facility,Government,no,Not Available,36.029716,-114.97094
+593GF,Southwest Primary Care Clinic,7235 South Buffalo Drive,Las Vegas,NV,89113,702-791-9040,VA Facility,Government,no,Not Available,36.056946,-115.261024
+640,Stockton Clinic,7777 South Freedom Rd,French Camp,CA,95231,209-946-3400,VA Facility,Government,no,Not Available,0,0
+4201,VA Lanai Outreach Clinic,628-B Seventh Street,Lanai City,HI,96783,808-565-6423,VA Facility,Government,no,Not Available,20.826756,-156.91786
+4202,VA Molokai Outreach Clinic,280 Home Olu Place,Kaunakakai,HI,96748,808-553-3191,VA Facility,Government,no,Not Available,0,0
+612A,Yreka,101 E Oberlin Rd,Yreka,CA,96097,530-841-8500,VA Facility,Government,no,Not Available,41.716076,-122.63874
+662GG,Clearlake VA Outpatient Clinic,15145 Lakeshore Drive,Clearlake,CA,95422,707-995-7200,VA Facility,Government,no,Not Available,38.949894,-122.63026
+662GC,Eureka VA Outpatient Clinic,930 W. Harris,Eureka,CA,95503,707-269-7500,VA Facility,Government,no,Not Available,40.780552,-124.18108
+640GC,Fremont Clinic,"39199 Liberty Street, Building B",Fremont,CA,94538,510-791-4000,VA Facility,Government,no,Not Available,37.550194,-121.9808
+654,Lahontan Valley VA Clinic,"1020 New River Parkway, Suite 304",Fallon,NV,89406,775-326-2659,VA Facility,Government,no,Not Available,0,0
+570GA,Merced Community-Based Outpatient Clinic,340 E Yosemite Ave,Merced,CA,95340,209-381-0105,VA Facility,Government,no,Not Available,37.33211,-120.46582
+570GC,Oakhurst Community-Based Outpatient Clinic,40597 Westlake Drive,Oakhurst,CA,93644,559-683-5300,VA Facility,Government,no,Not Available,37.338547,-119.66928
+5119,Pahrump Community Based Outpatient Clinic,220 South Lola Lane,Pahrump,NV,89048,775-727-7535,VA Facility,Government,no,Not Available,0,0
+662GE,San Bruno VA Outpatient Clinic,"1001 Sneath Lane, Suite 300, Third Floor",San Bruno,CA,94066,650-615-6000,VA Facility,Government,no,Not Available,37.63524,-122.42477
+662GA,Santa Rosa VA Outpatient Clinic,3841 Brickway Blvd,Santa Rosa,CA,95403,707-569-2300,VA Facility,Government,no,Not Available,38.51461,-122.79337
+662BU,SFVA Downtown Clinic,401 3rd Street,San Francisco,CA,94107,415-281-5100,VA Facility,Government,no,Not Available,37.782543,-122.39735
+570,Tulare Community-Based Outpatient Clinic,1050 N. Cherry Street,Tulare,CA,93274,559-684-8703,VA Facility,Government,no,Not Available,36.22275,-119.33752
+662GD,Ukiah VA Outpatient Clinic,630 Kings Court,Ukiah,CA,95482,707-468-7700,VA Facility,Government,no,Not Available,39.14806,-123.1984
+459,VA American Samoa CBOC,Fiatele Teo Army Reserve Bldg,Pago Pago,AS,96799,684-699-3730,VA Facility,Government,no,Not Available,0,0
+654,VA Carson Valley Outpatient Clinic,"1330 Waterloo Lane, Suite 101",Gardnerville,NV,89410,775-782-5265,VA Facility,Government,no,Not Available,38.925064,-119.74963
+654GD,VA Diamond View Outpatient Clinic,110 Bella Way,Susanville,CA,96130,530-251-4550 Or 530-251-4550,VA Facility,Government,no,Not Available,0,0
+459,VA Guam Community Based Outpatient Clinic,498 Chalan Palayso,Agana Heights,GU,96910,671-475-5760,VA Facility,Government,no,Not Available,0,0
+459,VA Hilo Community Based Outpatient Clinic,"1285 Waianuenue Avenue, Suite 211",Hilo,HI,96720,808-935-3781,VA Facility,Government,no,Not Available,19.717466,-155.11314
+459,VA Kauai Community Based Outpatient Clinic,"4485 Pahe'e Street, Suite 150",Lihue,HI,96766,808-246-0497,VA Facility,Government,no,Not Available,21.968864,-159.38431
+459,VA Kona Community Based Outpatient Clinic,35-377 Hualalai Road,Kailua-Kona,HI,96740,808-329-0774,VA Facility,Government,no,Not Available,0,0
+1396,VA Leeward Community Based Outpatient Clinic,91-2135 Fort Weaver Road,Ewa Beach,HI,96706,800-214-1306,VA Facility,Government,no,Not Available,21.369507,-158.02618
+459,VA Maui Community Based Outpatient Clinic,"203 Ho'ohana Street, Suite 303",Kahului,HI,96732,808-871-2454,VA Facility,Government,no,Not Available,20.88696,-156.46333
+6307,VA Saipan Outreach Clinic,Marina Heights Business Park,Saipan,MP,96950,670-323-9000 Or 670-322-0035,VA Facility,Government,no,Not Available,0,0
+612,Yuba City Outpatient Clinic,425 Plumas Street,Yuba City,CA,95991,530-751-4500,VA Facility,Government,no,Not Available,39.130913,-121.614136
+616,American Samoa Vet Center,"Ottoville Road, P.O. Box 982942",Pago Pago,AS,96799,684-699-3760 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+649,Chico Vet Center,"250 Cohasset Road, Suite 40",Chico,CA,95926,530-899-6300 Or 530-899-6300,VA Facility,Government,no,Not Available,39.75176,-121.85193
+610,Citrus Heights Vet Center,"5650 Sunrise Blvd., Suite 150",Citrus Heights,CA,95610,916-535-0420 Or 916-535-0420,VA Facility,Government,no,Not Available,38.670345,-121.27155
+602,Concord Vet Center,"1333 Willow Pass Road, Suite 106",Concord,CA,94520,925-680-4526 Or 925-680-4526,VA Facility,Government,no,Not Available,37.972385,-122.05445
+644,Eureka Vet Center,"2830 G Street, Suite A",Eureka,CA,95501,707-444-8271 Or 707-444-8271,VA Facility,Government,no,Not Available,40.782574,-124.16242
+628,Fresno Vet Center,"1320 E. Shaw Ave, Suite 125",Fresno,CA,93710,559-487-5660 Or 877-927-8387,VA Facility,Government,no,Not Available,36.808594,-119.76464
+648,Guam Vet Center,"222 Chalan Santo Papa Street, Suite 201",Hagatna,GU,96910,671-472-7161,VA Facility,Government,no,Not Available,0,0
+534,Henderson Vet Center,"400 North Stephanie, Suite 180",Henderson,NV,89014,702-791-9100 Or 702-791-9100,VA Facility,Government,no,Not Available,36.05657,-115.0462
+635,Hilo Vet Center,"70 Lanihuli Street, Suite 102",Hilo,HI,96720,808-969-3833 Or 887-969-3833,VA Facility,Government,no,Not Available,19.71111,-155.07872
+609,Honolulu Vet Center,1680 Kapiolani Blvd. Suite F-3,Honolulu,HI,96814,808-973-8387 Or 877-927-8387,VA Facility,Government,no,Not Available,21.291153,-157.83807
+0636V,Kailua-Kona Vet Center,73-4976 Kamanu St,Kailua-Kona,HI,96740,808-329-0574,VA Facility,Government,no,Not Available,19.687277,-156.01602
+633,Kauai Vet Center,"4485 Pahe'e St., Suite 101",Lihue,HI,96766,808-246-1163 Or 877-927-8387,VA Facility,Government,no,Not Available,21.968864,-159.38431
+0505V,Las Vegas Vet Center,"7455 W. Washington Ave, Suite 240",Las Vegas,NV,89128,702-791-9170,VA Facility,Government,no,Not Available,36.181328,-115.2531
+634,Maui Vet Center,157 Ma'a Street,KAHULUI,HI,96732,808-242-8557,VA Facility,Government,no,Not Available,0,0
+650,Modesto Vet Center,"1219 N. Carpenter Rd., Suite 11-12",Modesto,CA,95351,209-569-0713 Or 877-927-8387,VA Facility,Government,no,Not Available,37.652004,-121.031006
+646,North Bay Vet Center,"6010 Commerce Blvd., Ste. 145",Rohnert Park,CA,94928,707-586-3295,VA Facility,Government,no,Not Available,38.352222,-122.71077
+612,Oakland Vet Center,"7700 Edgewater Drive, Suite 125",Oakland,CA,94621,510-562-7906 Or 510-562-7906,VA Facility,Government,no,Not Available,37.743034,-122.20435
+647,Peninsula Vet Center,"345 Middlefield Road, Building 1",Menlo Park,CA,94025,650-617-4300 Or 877-927-8387,VA Facility,Government,no,Not Available,37.456406,-122.16773
+0600V,RCS Pacific District 5 District Office,420 Executive Court North Suite A,Fairfield,CA,94534,707-646-2988 Or 707-646-2988,VA Facility,Government,no,Not Available,38.230152,-122.12159
+0506V,Reno Vet Center,5580 Mill St. Suite 600,Reno,NV,89502,775-323-1294 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+638,Sacramento Vet Center,1111 Howe Avenue Suite #390,Sacramento,CA,95825,916-566-7430 Or 877-927-8387,VA Facility,Government,no,Not Available,38.584957,-121.41534
+620,San Francisco Vet Center,505 Polk Street,San Francisco,CA,94102,415-441-5051 Or 877-927-8387,VA Facility,Government,no,Not Available,37.78154,-122.418884
+615,San Jose Vet Center,80 Great Oaks Blvd.,San Jose,CA,95119,408-993-0729 Or 408-993-0729,VA Facility,Government,no,Not Available,37.233974,-121.778854
+639,Santa Cruz County Vet Center,"1350 41st Ave, Suite 104",Capitola,CA,95010,831-464-4575 Or 877-927-8387,VA Facility,Government,no,Not Available,36.97057,-121.96488
+0621V,Western Oahu Vet Center,"885 Kamokila Boulevard, Suite 105",Kapolei,HI,96707,808-674-2414 Or 877-927-8387,VA Facility,Government,no,Not Available,21.330032,-158.08583
+593GH,Laughlin Rural Outreach Clinic,"3650 South Point Circle, Building D, 2nd Floor, Suite 200",Laughlin,NV,89029,702-298-1100,VA Facility,Government,no,Not Available,0,0
+10N22,VISN 22: Desert Pacific Healthcare Network,"300 Oceangate, Suite 700",Long Beach,CA,90802,562-826-5963,VA Facility,Government,no,Not Available,33.766495,-118.1987
+501,New Mexico VA Health Care System,"1501 San Pedro Drive, SE",Albuquerque,NM,87108,505-265-1711 Or 505-265-1711,VA Facility,Government,no,Not Available,35.056324,-106.577675
+649,Northern Arizona VA Health Care System,500 North Highway 89,Prescott,AZ,86313,928-445-4860 Or 928-445-4860,VA Facility,Government,no,Not Available,0,0
+644,Phoenix VA Health Care System,650 E. Indian School Road,Phoenix,AZ,85012,602-277-5551 Or 602-277-5551,VA Facility,Government,no,Not Available,33.494797,-112.0668
+678,Southern Arizona VA Health Care System,3601 South 6th Avenue,Tucson,AZ,85723,520-792-1450 Or 520-792-1450,VA Facility,Government,no,Not Available,32.18126,-110.96826
+691,VA Greater Los Angeles Healthcare System (GLA),11301 Wilshire Boulevard,Los Angeles,CA,90073,310-478-3711,VA Facility,Government,no,Not Available,0,0
+605,VA Loma Linda Healthcare System,11201 Benton Street,Loma Linda,CA,92357,909-825-7084 Or 909-825-7084,VA Facility,Government,no,Not Available,34.051037,-117.25238
+600,VA Long Beach Healthcare System,5901 E. 7th Street,Long Beach,CA,90822,562-826-8000 Or 562-826-8000,VA Facility,Government,no,Not Available,33.775333,-118.11876
+664,VA San Diego Healthcare System,3350 La Jolla Village Drive,San Diego,CA,92161,858-552-8585,VA Facility,Government,no,Not Available,0,0
+664,ASPIRE Center,2121 San Diego Avenue,San Diego,CA,92110,855-297-8397,VA Facility,Government,no,Not Available,32.746605,-117.18952
+605,Blythe Rural Health Clinic,1273 West Hobson Way,Blythe,CA,92225,760-921-1224,VA Facility,Government,no,Not Available,33.61016,-114.60913
+649,Chinle Comprehensive Care Facility (Indian Health Services),Hwy 191 and Hospital Drive,Chinle,AZ,86503,928-674-7675,VA Facility,Government,no,Not Available,0,0
+649GF,Holbrook VA Clinic,33 W. Vista Dr.,Holbrook,AZ,86025,928-524-1050,VA Facility,Government,no,Not Available,0,0
+691GA,Los Angeles Ambulatory Care Center,351 East Temple Street,Los Angeles,CA,90012,213-253-2677,VA Facility,Government,no,Not Available,34.05251,-118.239746
+649,Page VA Clinic,801 N Navajo Dr. Ste-B,Page,AZ,86040,928-645-4966,VA Facility,Government,no,Not Available,36.91684,-111.4514
+6381,Polacca VA Clinic,Highway 264 Mile Post 388,Polacca,AZ,86042,928-283-4465,VA Facility,Government,no,Not Available,0,0
+664,Rio Clinic,"8989 Rio San Diego, Suite 360",San Diego,CA,92108,619-228-8000,VA Facility,Government,no,Not Available,32.77582,-117.13689
+691A4,Sepulveda OPC and Nursing Home,16111 Plummer Street,North Hills,CA,91343,818-891-7711 Or 818-891-7711,VA Facility,Government,no,Not Available,34.24288,-118.48041
+649,Tuba City VA Clinic,167 N Main St P.O. Box 600,Tuba City,AZ,86045,928-283-4465,VA Facility,Government,no,Not Available,36.142876,-111.23962
+605BZ,VA Loma Linda Ambulatory Care Center,26001 Redlands Blvd.,Redlands,CA,92373,909-825-7084,VA Facility,Government,no,Not Available,34.063038,-117.23747
+691,VA West Los Angeles Healthcare Center,11301 Wilshire Blvd,Los Angeles,CA,90073,310-478-3711,VA Facility,Government,no,Not Available,0,0
+501GI,Alamogordo CCBOC,"3199 N. White Sands Blvd., Suite D10",Alamogordo,NM,88310,575-437-9195,VA Facility,Government,no,Not Available,32.933743,-105.96381
+600GA,Anaheim,2569 W Woodland Dr,Anaheim,CA,92801,714-763-5300,VA Facility,Government,no,Not Available,33.849346,-117.97515
+649GE,Anthem CBOC,"41810 North Venture Dr., Bldg. B",Anthem,AZ,85086,623-249-2300 Or 800-949-1005 X 2300,VA Facility,Government,no,Not Available,0,0
+501GA,Artesia Clinic,"2410 W. Main St.,",Artesia,NM,88210,575-746-3531,VA Facility,Government,no,Not Available,32.842644,-104.42751
+691GD,Bakersfield Community Based Outpatient Clinic,1801 Westwind Drive,Bakersfield,CA,93301,661-632-1800,VA Facility,Government,no,Not Available,35.376835,-119.04256
+678GC,Casa Grande CBOC,"1876 E. Sabin Drive, Building A Ste 15",Casa Grande,AZ,85122,520-836-2536,VA Facility,Government,no,Not Available,0,0
+664GC,Chula Vista Clinic,865 3rd Avenue,Chula Vista,CA,91910,619-409-1600,VA Facility,Government,no,Not Available,32.62196,-117.07232
+605GD,Corona,"2045 Compton Avenue, Bldg. 7, Suite 101",Corona,CA,92881,951-817-8820,VA Facility,Government,no,Not Available,33.853207,-117.536194
+649GE,Cottonwood CBOC,501 S. Willard,Cottonwood,AZ,86326,928-649-1523,VA Facility,Government,no,Not Available,34.73068,-112.02738
+691GF,East Los Angeles Community Based Outpatient Clinic,5426 E. Olympic Boulevard,City of Commerce,CA,90040,323-725-7372,VA Facility,Government,no,Not Available,34.015556,-118.155075
+664GD,Escondido,815 East Pennsylvania Avenue,Escondido,CA,92025,760-466-7020,VA Facility,Government,no,Not Available,33.127407,-117.072014
+501GE,Espanola CCBOC,105 S. Coronado Ave.,Espanola,NM,87532,505-367-4213,VA Facility,Government,no,Not Available,35.99053,-106.08518
+501GB,Farmington CBOC,3605 English Road,Farmington,NM,87402,505-326-4383,VA Facility,Government,no,Not Available,36.761497,-108.14833
+649GB,Flagstaff CBOC,1300 W. University Ave. Suite 200,Flagstaff,AZ,86001,928-226-1056 Or 800-949-1005 X 5650,VA Facility,Government,no,Not Available,35.184116,-111.670784
+501GD,Gallup CBOC,2075 NM Hwy 602,Gallup,NM,87301,505-722-7234,VA Facility,Government,no,Not Available,0,0
+691,Gardena Community Based Outpatient Clinic,1149 West 190th Street,Gardena,CA,90248,310-851-4705,VA Facility,Government,no,Not Available,33.858334,-118.29599
+644,Globe-Miami VA Health Care Clinic,"5860 S. Hospital Drive, Suite 111",Globe,AZ,85501,928-425-0027,VA Facility,Government,no,Not Available,33.40677,-110.82588
+678GE,Green Valley CBOC,380 W. Vista Hermosa Drive #140,Green Valley,AZ,85614,520-399-2291,VA Facility,Government,no,Not Available,31.854649,-110.99739
+664GA,Imperial Valley,1115 South 4th Street,El Centro,CA,92243,760-352-1506,VA Facility,Government,no,Not Available,32.78269,-115.55243
+6425,Kayenta VA Clinic,394.3 Highway 160,Kayenta,AZ,86033,928-445-4860 X 3392 Or 800-949-1005 X 3392,VA Facility,Government,no,Not Available,0,0
+649GA,Kingman CBOC,2668 Hualapai Mountain Road,Kingman,AZ,86401,928-718-7300,VA Facility,Government,no,Not Available,0,0
+600GE,Laguna Hills,25292 McIntyre Road,Laguna Hills,CA,92653,949-587-3700,VA Facility,Government,no,Not Available,33.596123,-117.67979
+649GC,Lake Havasu City CBOC,"2035 Mesquite, Suite D",Lake Havasu City,AZ,86403,928-505-7100 Or 800-949-1005 X 7100,VA Facility,Government,no,Not Available,34.47788,-114.33046
+691,Lancaster Community Based Outpatient Clinic,340 E Avenue I Suite 108,Lancaster,CA,93535,661-729-8655,VA Facility,Government,no,Not Available,34.70404,-118.12551
+501G2,Las Vegas CCBOC,"624 University Ave.,",Las Vegas,NM,87701,505-425-1910,VA Facility,Government,no,Not Available,35.595673,-105.21634
+644GH,Midtown VA Clinic,5040 N 15th Ave,Phoenix,AZ,85015,602-234-7080,VA Facility,Government,no,Not Available,33.51061,-112.09123
+664,Mission Valley Clinic,8810 Rio San Diego Drive,San Diego,CA,92108,619-400-5000,VA Facility,Government,no,Not Available,32.775913,-117.14002
+605GB,Murrieta,"28078 Baxter Rd., Suite 540",Murrieta,CA,92563,951-290-6500,VA Facility,Government,no,Not Available,0,0
+644GG,Northeast CBOC (Phoenix),11390 E. Via Linda Rd. Ste.105,Scottsdale,AZ,85259,480-579-2200,VA Facility,Government,no,Not Available,33.589054,-111.83652
+501GM,Northwest Metro,1760 Grande Blvd SE,Rio Rancho,NM,87124,505-896-7200,VA Facility,Government,no,Not Available,35.22997,-106.66115
+644GA,Northwest VA Health Care Clinic,"13985 W. Grand Avenue, Suite 101",Surprise,AZ,85374,623-251-2884,VA Facility,Government,no,Not Available,0,0
+664GB,Oceanside Clinic,1300 Rancho del Oro Drive,Oceanside,CA,92056,760-643-2000,VA Facility,Government,no,Not Available,0,0
+691gm,Oxnard Community Based Outpatient Clinic,1690 Universe Circle,Oxnard,CA,93033,805-204-9135,VA Facility,Government,no,Not Available,34.18277,-119.16113
+605GC,Palm Desert,"41-990 Cook St, Bldg F Ste 1004",Palm Desert,CA,92211,760-341-5570,VA Facility,Government,no,Not Available,0,0
+644GD,Payson VA Health Care Clinic,903 E Highway 260,Payson,AZ,85541,928-468-2100 Or 928-468-2100,VA Facility,Government,no,Not Available,34.251347,-111.32259
+605GE,Rancho Cucamonga,"8599 Haven Ave., Suite 102",Rancho Cucamonga,CA,91730,909-946-5348,VA Facility,Government,no,Not Available,34.095577,-117.57578
+501HB,Raton CBOC,1493 Whittier Street,Raton,NM,87440,575-445-2391,VA Facility,Government,no,Not Available,0,0
+678GD,Safford Clinic,355 N. 8th Avenue,Safford,AZ,85546,928-428-8010,VA Facility,Government,no,Not Available,32.835648,-109.71604
+691GK,San Luis Obispo Community Based Outpatient Clinic,"1288 Morro Street, Ste.200",San Luis Obispo,CA,93401,805-543-1233,VA Facility,Government,no,Not Available,35.279198,-120.660416
+600GB,Santa Ana,1506 Brookhollow Dr,Santa Ana,CA,92705,714-434-4600,VA Facility,Government,no,Not Available,33.71314,-117.84916
+691GB,Santa Barbara Community Based Outpatient Clinic,"4440 Calle Real,",Santa Barbara,CA,93110,805-683-1491,VA Facility,Government,no,Not Available,34.442417,-119.77877
+501GK,Santa Fe CBOC,5152 Beckner Road,Santa Fe,NM,87507,505-986-8645,VA Facility,Government,no,Not Available,0,0
+691,Santa Maria Community Based Outpatient Clinic,1550 East Main Street,Santa Maria,CA,93454,805-354-6000,VA Facility,Government,no,Not Available,34.96743,-120.42733
+644GB,Show Low VA Health Care Clinic,"5171 Cub Lake Road, Suite C380",Show Low,AZ,85901,928-532-1069,VA Facility,Government,no,Not Available,34.202072,-110.02095
+678GA,Sierra Vista Clinic,101 N. Coronado Drive Suite A,Sierra Vista,AZ,85635,520-459-1529,VA Facility,Government,no,Not Available,31.553316,-110.27763
+501GC,Silver City Clinic,2950 Leslie Road,Silver City,NM,88061,575-538-2921,VA Facility,Government,no,Not Available,32.79467,-108.26302
+664GE,Sorrento Valley Clinic,10455 Sorrento Valley Road,San Diego,CA,92121,858-552-7475,VA Facility,Government,no,Not Available,32.89261,-117.21451
+644BY,Southeast VA Health Care Clinic,3285 S. Val Vista Dr.,Gilbert,AZ,85297,480-397-2800,VA Facility,Government,no,Not Available,0,0
+644GC,Southwest Community Based Outpatient Clinic,9250 W. Thomas Rd.,Phoenix,AZ,85037,623-772-4000,VA Facility,Government,no,Not Available,33.47967,-112.25856
+501,Taos CCBOC,1353 Paseo Del Pueblo Sur,Taos,NM,87571,575-751-0328,VA Facility,Government,no,Not Available,36.37114,-105.595764
+644GE,Thunderbird VA Health Care Clinic,9424 N. 25th Ave.,Phoenix,AZ,85021,602-633-6900,VA Facility,Government,no,Not Available,33.571198,-112.11228
+501GH,Truth or Consequences CCBOC,1960 North Date Street,Truth or Consequences,NM,87901,575-894-7662,VA Facility,Government,no,Not Available,33.150505,-107.24602
+678GF,VA Northwest Tucson Clinic,2945 W. Ina Road,Tucson,AZ,85741,520-219-2418,VA Facility,Government,no,Not Available,32.33738,-111.03047
+678GG,VA Southeast Tucson Clinic,7395 S. Houghton Road Ste 129,Tucson,AZ,85747,520-664-1831,VA Facility,Government,no,Not Available,32.117203,-110.772675
+605GA,Victorville,"12138 Industrial Boulevard, Suite 120",Victorville,CA,92395,760-951-2599,VA Facility,Government,no,Not Available,34.472652,-117.2829
+600GC,Villages At Cabrillo,"2001 River Ave, Bldg 28",Long Beach,CA,90806,562-388-8000,VA Facility,Government,no,Not Available,0,0
+600gd,Whittier/Santa Fe Springs Clinic,10330 Pioneer Blvd Suite 180,Santa Fe Springs,CA,90670,562-347-2200,VA Facility,Government,no,Not Available,0,0
+470-8262,Yuma Clinic,3111 S. 4th Avenue,Yuma,AZ,85364,928-317-9973,VA Facility,Government,no,Not Available,32.672523,-114.62432
+0515V,Albuquerque Vet Center,2001 Mountain Road NW,Albuquerque,NM,87104,505-346-6562 Or 505-346-6562,VA Facility,Government,no,Not Available,35.098385,-106.66792
+603,Antelope Valley Vet Center,"38925 Trade Center Drive, Suites I/J",Palmdale,CA,93551,661-267-1026 Or 661-267-1026,VA Facility,Government,no,Not Available,0,0
+601,Bakersfield Vet Center,1110 Golden State Ave.,Bakersfield,CA,93301,661-323-8387 Or 661-323-8387,VA Facility,Government,no,Not Available,0,0
+605,Chatsworth Vet Center,"20946 Devonshire St, Suite 101",Chatsworth,CA,91311,818-576-0201,VA Facility,Government,no,Not Available,34.25723,-118.5896
+05161V,Chinle Vet Center Outstation,"Navajo Route 7, Old BIA Complex-B59",Chinle,AZ,86503,844-286-7270,VA Facility,Government,no,Not Available,0,0
+614,Chula Vista Vet Center,"180 Otay Lakes Road, Suite 108",Bonita,CA,91902,877-618-6534 Or 877-618-6534,VA Facility,Government,no,Not Available,32.659225,-117.03042
+611,Corona Vet Center,800 Magnolia Avenue Suite 110,Corona,CA,92879,951-734-0525 Or 951-734-0525,VA Facility,Government,no,Not Available,33.85894,-117.55446
+607,Culver City Vet Center,5730 Uplander Way Suite 100,Culver City,CA,90230,310-641-0326 Or 310-641-0326,VA Facility,Government,no,Not Available,33.986443,-118.38459
+623,East Los Angeles Vet Center,5400 E. Olympic Blvd. Suite 140,Commerce,CA,90022,323-728-9966 Or 323-728-9966,VA Facility,Government,no,Not Available,34.015686,-118.1557
+0516V,Farmington Vet Center,4251 E. Main Suite A,Farmington,NM,87402,505-327-9684 Or 505-327-9684,VA Facility,Government,no,Not Available,36.759556,-108.15592
+613,High Desert Vet Center,"15095 Amargosa Rd, Suite 107",Victorville,CA,92394,760-261-5925 Or 760-261-5925,VA Facility,Government,no,Not Available,34.524727,-117.33031
+5162,Hopi Vet Center Outstation,"P.O. Box 929, 1 Main St.",Hotevilla,AZ,86030,928-734-5166 Or 928-734-5166,VA Facility,Government,no,Not Available,0,0
+536,Lake Havasu Vet Center,"1720 Mesquite, Suite 101",Lake Havasu,AZ,86403,928-505-0394 Or 928-505-0394,VA Facility,Government,no,Not Available,34.478374,-114.34081
+530,Las Cruces Vet Center,"1120 Commerce Street, Suite B",Las Cruces,NM,88001,575-523-9826 Or 575-523-9826,VA Facility,Government,no,Not Available,0,0
+0606V,Los Angeles Vet Center,1045 W. Redondo Beach Blvd. Suite 150,Gardena,CA,90247,310-767-1221 Or 877-927-8387,VA Facility,Government,no,Not Available,33.89245,-118.29319
+524,Mesa Vet Center,"1303 South Longmore, Suite 5",Mesa,AZ,85202,480-610-6727 Or 480-610-6727,VA Facility,Government,no,Not Available,33.391068,-111.863785
+624,North Orange County Vet Center,12453 Lewis St. Suite 101,Garden Grove,CA,92840,714-776-0161 Or 877-927-8387,VA Facility,Government,no,Not Available,33.78244,-117.897484
+0517V,Phoenix Vet Center,4020 N. 20th St. #110,Phoenix,AZ,85016,602-640-2981 Or 602-640-2981,VA Facility,Government,no,Not Available,33.4934,-112.038925
+0518V,Prescott Vet Center (Dr. Cameron K. McKinley Vet Center),"3180 Stillwater Drive, Suite A",Prescott,AZ,86305,928-778-3469 Or 877-927-8387,VA Facility,Government,no,Not Available,34.59808,-112.46729
+637,San Bernardino Vet Center,"1325 E. Cooley Drive, Suite 101",Colton,CA,92324,909-801-5762 Or 877-927-8387,VA Facility,Government,no,Not Available,34.054634,-117.30536
+618,San Diego Vet Center,"2790 Truxtun Road, Suite 130",San Diego,CA,92106,858-642-1500 Or 858-642-1500,VA Facility,Government,no,Not Available,32.740627,-117.21285
+0619v,San Luis Obispo Vet Center,1070 Southwood Drive,San Luis Obispo,CA,93401,805-782-9101 Or 877-927-8387,VA Facility,Government,no,Not Available,35.265366,-120.64087
+642,San Marcos Vet Center,"One Civic Center Dr., Suite 150",San Marcos,CA,92069,855-898-6050 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+0520V,Santa Fe Vet Center,2209 Brothers Road Suite 110,Santa Fe,NM,87505,505-988-6562 Or 505-988-6562,VA Facility,Government,no,Not Available,35.65078,-105.95243
+5921,South Orange County Vet Center,"26431 Crown Valley Parkway, Suite 100",Mission Viejo,CA,92691,949-348-6700 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
+608,Temecula Vet Center,"40935 County Center Drive, Suite A/B",Temecula,CA,92591,951-302-4849 Or 951-302-4849,VA Facility,Government,no,Not Available,33.528206,-117.16034
+0521V,Tucson Vet Center,2525 E. Broadway Blvd Suite 100,Tucson,AZ,85716,520-882-0333,VA Facility,Government,no,Not Available,32.221508,-110.93447
+643,Ventura Vet Center,790 E. Santa Clara St. Suite 100,Ventura,CA,93001,805-585-1860 Or 805-585-1860,VA Facility,Government,no,Not Available,34.279526,-119.28866
+0533V,West Valley Vet Center,14050 N. 83rd Avenue Suite 170,Peoria,AZ,85381,623-398-8854 Or 623-398-8854,VA Facility,Government,no,Not Available,33.612053,-112.23756
+0537V,Yuma Vet Center,"1450 E. 16th St, Suite 103",Yuma,AZ,85365,928-271-8700 Or 928-271-8700,VA Facility,Government,no,Not Available,32.69857,-114.60357
+678CG,Casa Grande Rural Health Care Coordination Center,"1179 E. Cottonwood Lane, Suite 1",Casa Grande,AZ,85122,520-629-4801 Or 520-629-4801,VA Facility,Government,no,Not Available,32.894085,-111.735535
+600QA,Community Resource and Referral Center,888 W. Santa Ana Blvd. Suite 150,Santa Ana,CA,92701,844-838-8300 Or 844-838-8300,VA Facility,Government,no,Not Available,33.75201,-117.85871
+678SV,Sierra Vista Rural Health Care Coordination Center,"157 North Coronado Drive, Suite B",Sierra Vista,AZ,85635,520-629-4802 Or 520-629-4802,VA Facility,Government,no,Not Available,31.552668,-110.27763
+10N23,VISN 23: VA Midwest Health Care Network,"2805 Dodd Road, Suite 250",Eagan,MN,55121,651-405-5600,VA Facility,Government,no,Not Available,44.855087,-93.12877
+437,Fargo VA Health Care System,2101 Elm Street N.,Fargo,ND,58102,701-232-3241 Or 701-232-3241,VA Facility,Government,no,Not Available,46.90639,-96.776855
+636A8,Iowa City VA Health Care System,601 Highway 6 West,Iowa City,IA,52246,319-338-0581,VA Facility,Government,no,Not Available,0,0
+618,Minneapolis VA Health Care System,One Veterans Drive,Minneapolis,MN,55417,612-725-2000,VA Facility,Government,no,Not Available,0,0
+636,Omaha VA Medical Center--VA Nebraska-Western Iowa HCS,4101 Woolworth Avenue,Omaha,NE,68105,402-346-8800 Or 800-451-5796,VA Facility,Government,no,Not Available,41.245132,-95.97476
+656,St. Cloud VA Health Care System,4801 Veterans Drive,St. Cloud,MN,56303,320-252-1670 Or 320-252-1670,VA Facility,Government,no,Not Available,0,0
+568A4,VA Black Hills Health Care System - Hot Springs Campus,500 North 5th Street,Hot Springs,SD,57747,605-745-2000 Or 605-745-2000,VA Facility,Government,no,Not Available,43.435852,-103.47448
+568,VA Black Hills Health Care System - Fort Meade Campus,113 Comanche Road,Fort Meade,SD,57741,605-347-2511 Or 605-347-2511,VA Facility,Government,no,Not Available,44.412003,-103.46777
+636A6,VA Central Iowa Health Care System,3600 30th Street,Des Moines,IA,50310,515-699-5999 Or 515-699-5999,VA Facility,Government,no,Not Available,41.628147,-93.65877
+636A4,Grand Island VA Medical Center,2201 No. Broadwell Avenue,Grand Island,NE,68803,308-382-3660 Or 866-580-1810,VA Facility,Government,no,Not Available,40.942425,-98.35887
+438,Royal C. Johnson Veterans Memorial Medical Center,"2501 W. 22nd Street, PO Box 5046",Sioux Falls,SD,57117,605-336-3230,VA Facility,Government,no,Not Available,43.53304,-96.75647
+636A8,Coralville OPC,520 10 Ave Ste 200,Coralville,IA,52441,319-358-2406 Or 319-688-3365,VA Facility,Government,no,Not Available,0,0
+636A5,Lincoln VA Clinic,600 South 70th Street,Lincoln,NE,68510,402-489-3802 Or 866-851-6052,VA Facility,Government,no,Not Available,40.807457,-96.62502
+636QC,Community Resource and Referral Center - Cedar Rapids,1535 First Ave SE,Cedar Rapids,IA,52403,319-365-0898,VA Facility,Government,no,Not Available,41.988605,-91.651436
+636A6,Community Resource and Referral Center - Des Moines,1223 Center Street,Des Moines,IA,50309,515-699-5637,VA Facility,Government,no,Not Available,41.59168,-93.63398
+636QI,Community Resource and Referral Center - Quad Cities,415 North Perry Street,Davenport,IA,52801,563-328-5800,VA Facility,Government,no,Not Available,41.52367,-90.57259
+438GD,Aberdeen VA Clinic,"2301 8th Ave. NE, Suite 225",Aberdeen,SD,57401,605-229-3500,VA Facility,Government,no,Not Available,45.473736,-98.455605
+618GK,Albert Lea VA Clinic,1665 West Main St.,Albert Lea,MN,56007,507-377-6051,VA Facility,Government,no,Not Available,43.64646,-93.38959
+656,Alexandria Community Based Outpatient Clinic,515 22nd Avenue East,Alexandria,MN,56308,320-759-2640,VA Facility,Government,no,Not Available,45.867462,-95.37343
+636,Bellevue VA Clinic,"2206 Longo Drive, Suite 102",Bellevue,NE,68005,402-591-4500,VA Facility,Government,no,Not Available,41.15577,-95.92394
+437GE,Bemidji VA Community Based Outpatient Clinic,"1217 Anne St., Bemidji, MN 56601",Bemidji,MN,56601,218-755-6360,VA Facility,Government,no,Not Available,0,0
+636GF,Bettendorf VA Clinic,2979 Victoria Street,Bettendorf,IA,52722,563-332-8528,VA Facility,Government,no,Not Available,41.553448,-90.4971
+437GB,Bismarck VA Community Based Outpatient Clinic,"Gateway Mall, 2700 State Street, Suite F",Bismarck,ND,58503,701-221-9152,VA Facility,Government,no,Not Available,0,0
+656GA,Brainerd VA Clinic,722 NW 7th Street,Brainerd,MN,56401,218-855-1115,VA Facility,Government,no,Not Available,46.35942,-94.22238
+0405V,Carroll CBOC,"311 S Clark St, Suite 275",Carroll,IA,51401,712-794-6780 Or 855-794-6780,VA Facility,Government,no,Not Available,42.05701,-94.86798
+638A8,Cedar Rapids CBOC,2230 Wiley Blvd SW,Cedar Rapids,IA,52404,319-369-4340,VA Facility,Government,no,Not Available,41.95747,-91.72585
+618GE,Chippewa Valley VA Clinic,475 Chippewa Mall Drive Suite 418,Chippewa Falls,WI,54729,715-720-3780,VA Facility,Government,no,Not Available,44.92612,-91.38237
+636GU,Decorah VA Clinic,915 Short St.,Decorah,IA,52101,563-387-5840,VA Facility,Government,no,Not Available,43.291492,-91.797
+437GL,Devils Lake VA Community Based Outpatient Clinic,1031 7th St. NE,Devils Lake,ND,58301,701-662-5801,VA Facility,Government,no,Not Available,48.1148,-98.850716
+437,Dickinson VA Community Based Outpatient Clinic,528 - 21st St. W. Suite F,Dickinson,ND,58601,701-483-1850,VA Facility,Government,no,Not Available,46.905,-102.79279
+636GJ,Dubuque VA Clinic,"200 Mercy Dr, Ste 106",Dubuque,IA,52001,563-588-5520,VA Facility,Government,no,Not Available,42.492767,-90.673805
+618GB,Ely VA Clinic,720 Miners Drive East,Ely,MN,55731,218-365-0001,VA Facility,Government,no,Not Available,0,0
+437GC,Fergus Falls VA Community Based Outpatient Clinic,1839 N Park St,Fergus Falls,MN,56537,218-739-1400,VA Facility,Government,no,Not Available,46.302166,-96.07622
+636GK,Fort Dodge CBOC,2419 2nd Avenue N,Fort Dodge,IA,50501,515-576-2235 Or 877-578-8846,VA Facility,Government,no,Not Available,0,0
+636GI,Galesburg VA Clinic,310 Home Boulevard,Galesburg,IL,61401,309-343-0311 Or 309-343-0311,VA Facility,Government,no,Not Available,0,0
+568HB,Gordon VA Clinic,300 East 8th Street,Gordon,NE,69343,308-282-1442,VA Facility,Government,no,Not Available,42.811832,-102.200356
+437GA,Grafton VA Community Based Outpatient Clinic,1319 11th St. West,Grafton,ND,58237,701-352-4059,VA Facility,Government,no,Not Available,0,0
+437GI,Grand Forks VA Community Based Outpatient Clinic,"3221 32nd Avenue South, Suite 700",Grand Forks,ND,58201,701-335-4380,VA Facility,Government,no,Not Available,47.88944,-97.07383
+618GH,Hayward VA Clinic,15954 River's Edge Drive Suite 103,Hayward,WI,54843,715-934-5454,VA Facility,Government,no,Not Available,46.004047,-91.489845
+618GB,Hibbing VA Clinic,990 West 41st Street Suite 5,Hibbing,MN,55746,218-263-1400,VA Facility,Government,no,Not Available,47.4001,-92.961655
+636,Holdrege VA Clinic,1118 Burlington St,Holdrege,NE,68949,308-995-3760,VA Facility,Government,no,Not Available,40.44539,-99.37966
+437,Jamestown VA Community Based Outpatient,2422 20th St SW,Jamestown,ND,58401,701-952-4787,VA Facility,Government,no,Not Available,0,0
+636A7,Knoxville CBOC,1607 N. Lincoln Street,Knoxville,IA,50138,641-828-5019 Or 800-816-8878,VA Facility,Government,no,Not Available,0,0
+618GJ,Lyle C. Pearson VA Clinic,1961 Premier Dr Suite 330,Mankato,MN,56001,507-387-2939,VA Facility,Government,no,Not Available,44.179867,-93.94533
+618GD,Maplewood VA Clinic,"1725 Legacy Parkway, Suite 100",Maplewood,MN,55109,651-225-5420,VA Facility,Government,no,Not Available,0,0
+636GD,Marshalltown CBOC,101 Iowa Ave W,Marshalltown,IA,50158,641-754-6700 Or 877-424-4404,VA Facility,Government,no,Not Available,42.006947,-92.91202
+636GC,Mason City CBOC,"520 S. Pierce, Suite 150",Mason City,IA,50401,641-494-5000 Or 800-351-4671,VA Facility,Government,no,Not Available,43.147163,-93.22106
+568HK,McLaughlin VA Clinic,"Veterans Industries, Sales Barn Rd, P.O. Box 519",McLaughlin,SD,57642,605-823-4574,VA Facility,Government,no,Not Available,0,0
+437GD,Minot VA Community Based Outpatient Clinic,"5th Medical Group, 10 Missile Avenue",Minot,ND,58705,701-727-9800,VA Facility,Government,no,Not Available,0,0
+568HS,Mission CBOC,"Horizon Health Care, Inc. 153 Main Street",Mission,SD,57555,605-856-2295,VA Facility,Government,no,Not Available,0,0
+656GB,Montevideo VA Clinic,1025 North 13th Street,Montevideo,MN,56265,320-269-2222,VA Facility,Government,no,Not Available,44.95535,-95.71118
+568HA,Newcastle VA Clinic,1124 Washington Blvd.,Newcastle,WY,57555,307-746-4491,VA Facility,Government,no,Not Available,43.848816,-104.188515
+636GA,Norfolk VA Clinic,"710 S 13th, Suite 1200",Norfolk,NE,68701,402-370-4570,VA Facility,Government,no,Not Available,42.02499,-97.42654
+636GB,North Platte VA Clinic,"600 East Francis, Suite 3",North Platte,NE,69101,308-532-6906,VA Facility,Government,no,Not Available,41.122543,-100.75789
+618GI,Northwest Metro VA Clinic,7545 Veterans Drive,Ramsey,MN,55303,612-467-1100,VA Facility,Government,no,Not Available,0,0
+636PP,O'Neill Community-Based Outreach Clinic,555 E. John Street,O'Neill,NE,68763,402-336-2982,VA Facility,Government,no,Not Available,42.462406,-98.64539
+636GS,Ottumwa VA Clinic,1009 E Pennsylvania Ave,Ottumwa,IA,52501,641-683-4300,VA Facility,Government,no,Not Available,41.027508,-92.389656
+568HH,Panhandle of Nebraska CBOC,601 S 5th Ave,Scottsbluff,NE,69361,308-225-5330,VA Facility,Government,no,Not Available,41.85344,-103.65583
+568GB,Pierre VA Clinic,"Linn Medical Clinic, 1601 North Harrison, Suite 6",Pierre,SD,57501,605-945-1710,VA Facility,Government,no,Not Available,0,0
+568HF,Pine Ridge VA Clinic,Next to Dialysis Building across from IHS Hospital,Pine Ridge,SD,57770,605-867-2393 X 4033,VA Facility,Government,no,Not Available,0,0
+636GG,Quincy VA Clinic,721 Broadway Street,Quincy,IL,62301,217-224-3366,VA Facility,Government,no,Not Available,39.935753,-91.4044
+568GA,Rapid City VA Clinic,3625 5th Street,Rapid City,SD,57701,605-718-1095,VA Facility,Government,no,Not Available,44.05007,-103.22412
+618GH,Rice Lake VA Clinic,2700A College Drive,Rice Lake,WI,54868,715-236-3355,VA Facility,Government,no,Not Available,45.481583,-91.744316
+618GG,Rochester VA Clinic,3900 Fairway Place NW,Rochester,MN,55901,507-252-0885,VA Facility,Government,no,Not Available,0,0
+618GJ,Shakopee VA Clinic,1111 Shakopee Town Square,Shakopee,MN,55379,952-445-4070,VA Facility,Government,no,Not Available,0,0
+636,Shenandoah VA Clinic,512 S Fremont,Shenandoah,IA,51601,712-246-0092,VA Facility,Government,no,Not Available,40.758163,-95.37214
+438GC,Sioux City VA Clinic,"1551 Indian Hills Drive, Suite 206",Sioux City,IA,51104,712-258-4700,VA Facility,Government,no,Not Available,42.532574,-96.3904
+618GA,South Central VA Clinic,1212 Heckman Court,St. James,MN,56081,507-375-9670,VA Facility,Government,no,Not Available,43.970703,-94.618034
+438GA,Spirit Lake VA Clinic,1310 Lake Street,Spirit Lake,IA,51360,712-336-6400,VA Facility,Government,no,Not Available,0,0
+636GT,Sterling VA Outpatient Clinic,406 Avenue C,Sterling,IL,61081,815-632-6200,VA Facility,Government,no,Not Available,41.789516,-89.700195
+618BY,Twin Ports VA Clinic,3520 Tower Avenue,Superior,WI,54880,715-398-2400,VA Facility,Government,no,Not Available,0,0
+636GH,Waterloo VA Clinic,945 Tower Park Drive,Waterloo,IA,50701,319-235-1230,VA Facility,Government,no,Not Available,0,0
+438GF,Watertown CBOC,917 – 29th Street SE,Watertown,SD,57201,605-884-2420,VA Facility,Government,no,Not Available,0,0
+437GF,Williston VA Community Based Outpatient Clinic,205 Main Street,Williston,ND,58802,701-572-2470,VA Facility,Government,no,Not Available,48.1456,-103.62167
+568HP,Winner VA Clinic,660 West 2nd Street,Winner,SD,57580,605-842-2443,VA Facility,Government,no,Not Available,43.376553,-99.86538
+0446V,Bismarck Vet Center,"619 Riverwood Drive, Suite 105",Bismarck,ND,58504,701-224-9751 Or 701-224-9751,VA Facility,Government,no,Not Available,46.794674,-100.80184
+0439V,Brooklyn Park Vet Center,"7001 78th Avenue North, Suite 300",Brooklyn Park,MN,55445,763-503-2220 Or 877-927-8387,VA Facility,Government,no,Not Available,45.09529,-93.370834
+0431V,Cedar Rapids Vet Center,"4250 River Center Court NE, Suite D",Cedar Rapids,IA,52402,319-378-0016 Or 319-378-0016,VA Facility,Government,no,Not Available,42.019444,-91.70087
+0405V,Des Moines Vet Center,1821 22nd Street #115,Des Moines,IA,50266,515-284-4929 Or 515-284-4929,VA Facility,Government,no,Not Available,41.599247,-93.73604
+0429V,Duluth Vet Center,4402 Haines Road,Duluth,MN,55811,218-722-8654 Or 877-927-8387,VA Facility,Government,no,Not Available,46.829487,-92.174805
+0406V,Fargo Vet Center,3310 Fiechtner Drive. Suite 100,Fargo,ND,58103,701-237-0942 Or 701-237-0942,VA Facility,Government,no,Not Available,46.86399,-96.83272
+589GE,Grand Forks Vet Center,3001 32nd Ave. S. Suite 6A,Grand Forks,ND,58201,701-620-1448 Or 877-927-8387,VA Facility,Government,no,Not Available,47.88944,-97.07062
+0427V,Lincoln Vet Center,"3119 O Street, Suite A",Lincoln,NE,68510,402-476-9736 Or 402-476-9736,VA Facility,Government,no,Not Available,40.813408,-96.67602
+4231,Martin Outstation,P.O. Box 910 105 E. Hwy 18,Martin,SD,57747,605-685-1300 Or 605-685-1300,VA Facility,Government,no,Not Available,0,0
+0404V,Minot Vet Center,1400 20th Avenue SW Ste 2,Minot,ND,58701,701-852-0177 Or 877-927-8387,VA Facility,Government,no,Not Available,48.210842,-101.31301
+0424V,Omaha Vet Center,3047 S 72nd Street,Omaha,NE,68124,402-346-6735,VA Facility,Government,no,Not Available,41.23105,-96.02388
+0430V,Quad Cities Vet Center,"465 Avenue of the Cities, Suite #140",East Moline,IL,61244,309-755-3260 Or 309-755-3260,VA Facility,Government,no,Not Available,0,0
+0423V,Rapid City Vet Center,"621 6th St, Suite 101",Rapid City,SD,57701,605-348-0077 Or 877-927-8387,VA Facility,Government,no,Not Available,44.079773,-103.227394
+0428V,Sioux City Vet Center,1551 Indian Hills Drive Suite 214,Sioux City,IA,51104,712-255-3808 Or 712-255-3808,VA Facility,Government,no,Not Available,42.532574,-96.3904
+0425V,Sioux Falls Vet Center,3200 W 49th Street,Sioux Falls,SD,57106,605-330-4552 Or 605-330-4552,VA Facility,Government,no,Not Available,43.50762,-96.765205
+0416V,St. Paul Vet Center,"550 County Road D West, Suite 10",New Brighton,MN,55112,651-644-4022 Or 651-644-4022,VA Facility,Government,no,Not Available,0,0
+438GE,Wagner Outreach Clinic,400 West Hwy 46,Wagner,SD,57380,605-384-2340,VA Facility,Government,no,Not Available,0,0

--- a/src/main/resources/providers/va_facilities.csv
+++ b/src/main/resources/providers/va_facilities.csv
@@ -202,7 +202,7 @@
 460GD,"Cape May County CBOC","1 Monro Avenue","Cape May",NJ,"08204","800-461-8262 X 2850","VA Facility",Government,no,"Not Available",38.9351,-74.906
 529GD,"Clarion County VA Outpatient Clinic","56 Clarion Plaza, Suite 115","Monroe Township",PA,"16214",814-226-3900,"VA Facility",Government,no,"Not Available",40.3192,-74.4285
 693GF,"Columbia County Outpatient Clinic","Alley Medical Center, 301 West Third Street",Berwick,PA,"18603",570-759-0351,"VA Facility",Government,no,"Not Available",40.7796,-90.5437
-529GF,"Cranberry Township VA Outpatient Clinic","900 Commonwealth Drive, Suite 900","Cranberry Township",PA,"16066","724-742-3500 Or 724-741-3131","VA Facility",Government,no,"Not Available",0,0
+529GF,"Cranberry Township VA Outpatient Clinic","900 Commonwealth Drive, Suite 900","Cranberry Township",PA,"16066","724-742-3500 Or 724-741-3131","VA Facility",Government,no,"Not Available",40.6831,-80.1117
 562GA,"Crawford County Primary Care Clinic","16954 Conneaut Lake Road",Meadville,PA,"16335",866-962-3210,"VA Facility",Government,no,"Not Available",39.7925,-93.2925
 460HG,"Cumberland County CBOC","79 W. Landis Avenue",Vineland,NJ,"08360","800-461-8262 X 6500","VA Facility",Government,no,"Not Available",39.48669,-75.03702
 503GB,"DuBois (Clearfield County) VA Outpatient Clinic (503GB)","5690 Shaffer Road",DuBois,PA,"15801",877-626-2500,"VA Facility",Government,no,"Not Available",43.493,-109.6436
@@ -217,7 +217,7 @@
 529GA,"Mercer County VA Outpatient Clinic","295 N. Kerrwood Drive, Suite 110",Hermitage,PA,"16148",724-346-1569,"VA Facility",Government,no,"Not Available",41.237286,-80.46313
 693GG,"Northampton County Outpatient Clinic","Phoebe Slate Belt Nursing Home & Rehab Center 701 Slate Belt Boulevard",Bangor,PA,"18013",610-599-0127,"VA Facility",Government,no,"Not Available",40.8657,-75.2066
 595GF,"Pottsville VA Clinic (595GF)","1410 Laurel Blvd., Suite 2",Pottsville,PA,"17901",570-628-5374,"VA Facility",Government,no,"Not Available",40.68376,-76.211494
-595GD,"Reading VA Clinic (595GD)","2762 Century Boulevard",Wyomissing,PA,"19610",484-220-2572,"VA Facility",Government,no,"Not Available",0,0
+595GD,"Reading VA Clinic (595GD)","2762 Century Boulevard",Wyomissing,PA,"19610",484-220-2572,"VA Facility",Government,no,"Not Available",40.357185,-75.989094
 693GA,"Sayre VA Outpatient Clinic (693GA)","1537 Elmira Street",Sayre,PA,"18840",570-888-6803,"VA Facility",Government,no,"Not Available",41.974503,-76.540665
 542GE,"Spring City VA Outpatient Clinic (542GE)","11 Independence Drive","Spring City",PA,"19475",610-383-0239,"VA Facility",Government,no,"Not Available",40.187653,-75.565445
 542GA,"Springfield VA Outpatient Clinic (542GA)","Crozer Keystone Healthplex 194 W. Sproul Road, Suite 105",Springfield,PA,"19064",610-383-0239,"VA Facility",Government,no,"Not Available",39.7495,-89.606
@@ -280,7 +280,7 @@
 512GD,"Loch Raven VA Outpatient Clinic","3901 The Alameda",Baltimore,MD,"21218","410-605-7650 Or 410-605-7650","VA Facility",Government,no,"Not Available",39.2904,-76.6122
 540GD,"Monongalia County (540GD)","40 Commerce Drive, Suite 101",Westover,WV,"26501",304-292-7535,"VA Facility",Government,no,"Not Available",39.6001,-75.9369
 613GE,"Petersburg Community Based Outpatient Clinic","15 Grant St.",Petersburg,WV,"26847","304-263-0811 X 5130","VA Facility",Government,no,"Not Available",38.99487,-79.11806
-512GE,"Pocomoke City VA Outpatient Clinic","1701 Market Street, Unit 211",Pocomoke,MD,"21851","410-957-6718 Or 866-441-0287","VA Facility",Government,no,"Not Available",0,0
+512GE,"Pocomoke City VA Outpatient Clinic","1701 Market Street, Unit 211",Pocomoke,MD,"21851","410-957-6718 Or 866-441-0287","VA Facility",Government,no,"Not Available",38.062634,-75.547691
 581GA,"Prestonsburg VA Clinic","5230 KY RT 321",Prestonsburg,KY,"41653",606-886-1970,"VA Facility",Government,no,"Not Available",37.6656,-82.7716
 517QA,"Princeton VA Clinic","1511 North Walker Street",Princeton,WV,"24740","304-255-2121 X 3404","VA Facility",Government,no,"Not Available",37.367912,-81.10203
 540,"Rural Mobile Unit (540)","1 Medical Center Drive",Clarksburg,WV,"26301",304-623-3461,"VA Facility",Government,no,"Not Available",39.269535,-80.36269
@@ -463,31 +463,25 @@
 573BY,"Jacksonville OPC","1536 N Jefferson St",Jacksonville,FL,"32209","877-870-5048 Or 904-475-5800","VA Facility",Government,no,"Not Available",30.344486,-81.66289
 675GG,"Lake Baldwin OPC","5201 Raymond Street",Orlando,FL,"32803",407-646-5500,"VA Facility",Government,no,"Not Available",28.578913,-81.32207
 516BZ,"Lee County VA Healthcare Center","2489 Diplomat Parkway East","Cape Coral",FL,"33909",239-652-1800,"VA Facility",Government,no,"Not Available",26.5629,-81.9495
-672BZ,"Mayaguez OPC","175 Algarrobo Ave.",Mayaguez,PR,"00682","787-641-7582 X 48501","VA Facility",Government,no,"Not Available",0,0
+672BZ,"Mayaguez OPC","175 Algarrobo Ave.",Mayaguez,PR,"00682","787-641-7582 X 48501","VA Facility",Government,no,"Not Available",18.237088,-67.159446
 673BZ,"New Port Richey OPC","9912 Little Road","New Port Richey",FL,"34654",727-869-4100,"VA Facility",Government,no,"Not Available",28.294464,-82.67542
-672BO,"Ponce OPC","Paseo Del Veterano #1010",Ponce,PR,"00716","787-641-7582 X 44001 Or 787-641-7582 X 44002","VA Facility",Government,no,"Not Available",0,0
+672BO,"Ponce OPC","Paseo Del Veterano #1010",Ponce,PR,"00716","787-641-7582 X 44001 Or 787-641-7582 X 44002","VA Facility",Government,no,"Not Available",17.987974,-66.603875
 573BY,"Southpoint Clinic","6900 Southpoint Dr North",Jacksonville,FL,"32209",904-470-6900,"VA Facility",Government,no,"Not Available",30.255903,-81.5878
 573GF,"Tallahassee HCC","2181 East Orange Avenue",Tallahassee,FL,"32311","800-541-8387 Or 850-878-0191","VA Facility",Government,no,"Not Available",30.4383,-84.2807
 573GI,"The Villages OPC","8900 SE 165th Mulberry Ln.","The Villages",FL,"32162","877-649-0024 Or 352-674-5000","VA Facility",Government,no,"Not Available",28.9341,-81.9599
-672,"Utuado VA Rural Outpatient Clinic","Isaac Gonzalez Street Equina Ledesma",Utuado,PR,"00641","787-522-2650 Or 787-522-2650","VA Facility",Government,no,"Not Available",0,0
+672,"Utuado VA Rural Outpatient Clinic","Isaac Gonzalez Street Equina Ledesma",Utuado,PR,"00641","787-522-2650 Or 787-522-2650","VA Facility",Government,no,"Not Available",18.267224,-66.707528
 548ZZ2,"VA Moore Haven Outpatient Clinic","1021 Health Park Drive","Moore Haven",FL,"33471",,"VA Facility",Government,no,"Not Available",26.8331,-81.0931
 675GA,"Viera OPC","2900 Veterans Way",Viera,FL,"32940",321-637-3788,"VA Facility",Government,no,"Not Available",28.251802,-80.742805
 675GB,"William V. Chappell, Jr., VA OPC","551 National Health Care Drive","Daytona Beach",FL,"32114",386-323-7500,"VA Facility",Government,no,"Not Available",29.205873,-81.06211
 548,"St Lucie County PTSD Clinical Team (PCT) Outpatient Program","126 SW Chamber Court","Port St Lucie",FL,"34986",772-878-7876,"VA Facility",Government,no,"Not Available",27.2939,-80.3503
-672GC,"Arecibo CBOC","Road PR-10, Puerto Rico",Arecibo,PR,"00612","787-641-7582 X 28683 Or 800-449-8729 X 28678","VA Facility",Government,no,"Not Available",0,0
 548GD,"Boca Raton CBOC","901 Meadows Road","Boca Raton",FL,"33433",561-416-8995,"VA Facility",Government,no,"Not Available",26.358753,-80.10404
 516GD,"Bradenton Community-Based Outpatient Clinic","5520 S.R. 64 Suite 101",Bradenton,FL,"34208",941-721-0649,"VA Facility",Government,no,"Not Available",27.4989,-82.5748
 673GC,"Brooksville CBOC","14540 Cortez Blvd., Suite 108",Brooksville,FL,"34613",352-597-8287,"VA Facility",Government,no,"Not Available",28.53387,-82.48409
-672GD,"Ceiba Community Based Outpatient Clinic","PR-3, Km. 54.9 Lot#3","Pueblo Ward",PR,"00735","787-641-7582 X 29001 Or 800-449-8729 X 29001","VA Facility",Government,no,"Not Available",0,0
-672GD,"Ceiba Community Based Outpatient Clinic","PR-3, Km. 54.9 Lot#3","Pueblo Ward",PR,"00735","800-449-8729 X 29001","VA Facility",Government,no,"Not Available",0,0
-6298,"Ceiba VA Community Based Outpatient Clinic","PR-3, Km. 54.9, Lot #3","Pueblo Ward",PR,"00735","800-449-8729 X 29001","VA Facility",Government,no,"Not Available",0,0
 5924,"Clermont Community Based Outpatient Clinic","805 Oakley Seaver Drive",Clermont,FL,"34711",352-536-8200,"VA Facility",Government,no,"Not Available",28.5494,-81.7729
-714,"Comerio Rural Outpatient Clinic","15 De Diego Street",Comerio,PR,"00782",787-522-2660,"VA Facility",Government,no,"Not Available",0,0
 3333,"Crossroads Annex","925 South Semoran Blvd Suite 114","Winter Park",FL,"32792",866-998-4365,"VA Facility",Government,no,"Not Available",28.583382,-81.30698
 546GH,"Deerfield Beach VA Community Based Outpatient Clinic","2100 S.W. 10th St.","Deerfield Beach",FL,"33442",954-570-5572,"VA Facility",Government,no,"Not Available",26.30437,-80.13228
 548GB,"Delray Beach CBOC","4800 Linton Blvd., Building E, Suite 300","Delray Beach",FL,"33445",561-495-1973,"VA Facility",Government,no,"Not Available",26.439363,-80.11655
 548GA,"Fort Pierce CBOC","1901 South 25th Street, Suite 103","Ft. Pierce",FL,"34947",772-595-5150,"VA Facility",Government,no,"Not Available",27.467018,-80.34966
-672GE,"Guayama CBOC","FISA Bldg 1st Fl, Paseo Del Pueblo, km 0.3, lote no 6",Guayama,PR,"00784",787-866-8886,"VA Facility",Government,no,"Not Available",0,0
 546GA,"Healthcare for Homeless Veterans","1492 W. Flagler St., Suite 101",Miami,FL,"33135",305-541-5864,"VA Facility",Government,no,"Not Available",25.773327,-80.21949
 546,"Healthcare for Homeless Veterans","1492 Flagler St",Miami,FL,"33135",305-541-5864,"VA Facility",Government,no,"Not Available",25.773329,-80.21944
 546,"Hollywood VA Community Based Outpatient Clinic","3702 Washington St., Suite 201",Hollywood,FL,"33021",954-986-1811,"VA Facility",Government,no,"Not Available",26.00302,-80.18108
@@ -510,7 +504,6 @@
 516GE,"Port Charlotte Community-Based Outpatient Clinic","4161 Tamiami Trail Suite 401 & Suite 602 (Annex Bldg)","Port Charlotte",FL,"33952",941-235-2710,"VA Facility",Government,no,"Not Available",26.9762,-82.0906
 548,"Port St Lucie PTSD Clinical Team (PCT) Outpatient Program","128 SW Chamber Court","Port Saint Lucie",FL,"34986",772-344-9288,"VA Facility",Government,no,"Not Available",27.2939,-80.3503
 573GE,"Saint Augustine CBOC","195 Southpark Blvd.","St. Augustine",FL,"32086","866-401-8387 Or 904-829-0814","VA Facility",Government,no,"Not Available",29.862272,-81.32687
-672GA,"Saint Croix CBOC","Box 12, RR-02, The Village Mall #113","Kings Hill",VI,"00850",340-778-5553,"VA Facility",Government,no,"Not Available",0,0
 672GB,"Saint Thomas CBOC","Medical Foundation Building Suite 101","St. Thomas",VI,"00802",340-776-7072,"VA Facility",Government,no,"Not Available",48.6306,-97.4713
 516GA,"Sarasota Community-Based Outpatient Clinic","5682 Bee Ridge Road, Suite 100",Sarasota,FL,"34233",941-371-3349,"VA Facility",Government,no,"Not Available",27.29881,-82.45636
 516GH,"Sebring Community-Based Outpatient Clinic","5901 U.S. Highway 27 South",Sebring,FL,"33870",863-471-6227,"VA Facility",Government,no,"Not Available",27.4273,-81.3405
@@ -520,11 +513,9 @@
 675GE,"Tavares Community Based Outpatient Clinic","1390 E. Burleigh Blvd.",Tavares,FL,"32778",352-253-2900,"VA Facility",Government,no,"Not Available",28.776,-81.7152
 573GA,"Valdosta CBOC","2841 N. Patterson Street",Valdosta,GA,"31602","229-293-0132 Or 877-303-8387","VA Facility",Government,no,"Not Available",30.868034,-83.29001
 548GE,"Vero Beach CBOC","372 17th Street","Vero Beach",FL,"32960",772-299-4623,"VA Facility",Government,no,"Not Available",27.632372,-80.38043
-714,"Vieques Rural Outpatient Clinic","Co.Destino Carretera #997",Vieques,PR,"00765","787-641-7582 X 28601","VA Facility",Government,no,"Not Available",0,0
 573GM,"Waycross CBOC","515B City Boulevard",Waycross,GA,"31501",912-279-4400,"VA Facility",Government,no,"Not Available",31.231209,-82.34093
 546,"William Bill Kling VA Clinic","9800 W. Commercial Blvd.",Sunrise,FL,"33351",954-475-5500,"VA Facility",Government,no,"Not Available",26.134,-80.1131
 673GF,"Zephyrhills CBOC","6937 Medical View Ln",Zephyrhills,FL,"33541",813-780-2550,"VA Facility",Government,no,"Not Available",28.2059,-82.3201
-0309V,"Arecibo Vet Center","50 Gonzalo Marin St",Arecibo,PR,"00612","787-641-7582 X 28151","VA Facility",Government,no,"Not Available",0,0
 0339V,"Clearwater Vet Center","29259 US Hwy 19 North",Clearwater,FL,"33761","727-549-3600 Or 727-549-3600","VA Facility",Government,no,"Not Available",27.9658,-82.8001
 675GF,"Clermont Vet Center","1655 East Highway 50, Suite 102",Clermont,FL,"34711","352-536-6701 Or 877-927-8387","VA Facility",Government,no,"Not Available",28.545898,-81.7555
 0341V,"Daytona Beach Vet Center","1620 Mason Ave., Suite C","Daytona Beach",FL,"32117","386-366-6600 Or 386-366-6600","VA Facility",Government,no,"Not Available",29.21203,-81.0657
@@ -542,10 +533,9 @@
 0314V,"Orlando Vet Center","5575 S. Semoran Blvd., Suite #30",Orlando,FL,"32822","407-857-2800 Or 407-857-2800","VA Facility",Government,no,"Not Available",28.48248,-81.310104
 0326V,"Palm Beach Vet Center","4996 10th Ave North, Suite 6",Greenacres,FL,"33463","561-422-1201 Or 561-422-1201","VA Facility",Government,no,"Not Available",26.631065,-80.122665
 0338V,"Pasco County Vet Center","5139 Deer Park Drive","New Port Richey",FL,"34653","727-372-1854 Or 727-372-1854","VA Facility",Government,no,"Not Available",28.2442,-82.7193
-0336V,"Pompano Beach Vet Center","2300 West Sample Road, Suite 102",Pompano,FL,"33073","954-984-1669 Or 877-927-8387","VA Facility",Government,no,"Not Available",0,0
-0312V,"Ponce Vet Center","35 Mayor Street, Suite 1",Ponce,PR,"00730","787-841-3260 Or 787-841-3260","VA Facility",Government,no,"Not Available",0,0
+0336V,"Pompano Beach Vet Center","2300 West Sample Road, Suite 102",Pompano,FL,"33073","954-984-1669 Or 877-927-8387","VA Facility",Government,no,"Not Available",26.273829,-80.155570
+0312V,"Ponce Vet Center","35 Mayor Street, Suite 1",Ponce,PR,"00730","787-841-3260 Or 787-841-3260","VA Facility",Government,no,"Not Available",26.273932,-80.155644 
 0300V,"RCS Southeast District 2 District Office","450 Carillon Parkway, Suite 150","St. Petersburg",FL,"33716","727-398-9343 Or 727-398-9343","VA Facility",Government,no,"Not Available",27.88889,-82.66944
-0307V,"San Juan Vet Center","Cond. Medical Center Plaza Suite LC 8, 9 & 11, Urb. La Riviera","Rio Piedras",PR,"00921","787-749-4409 Or 877-927-8387","VA Facility",Government,no,"Not Available",0,0
 0320V,"Sarasota Vet Center","4801 Swift Rd. Suite A",Sarasota,FL,"34231","941-927-8285 Or 877-927-8387","VA Facility",Government,no,"Not Available",27.283916,-82.514145
 03121V,"St. Croix Vet Center Outstation","The Village Mall, RR 2 Box 10553 Kingshill","St. Croix",VI,"00850","340-778-5553 Or 787-641-7582 X 25613","VA Facility",Government,no,"Not Available",38.1765,-86.5826
 0301V,"St. Petersburg Vet Center","6798 Crosswinds Drive, Bldg A","St. Petersburg",FL,"33710","727-549-3633 Or 877-927-8387","VA Facility",Government,no,"Not Available",27.79047,-82.7337
@@ -585,7 +575,7 @@
 614GB,"Jonesboro, Arkansas CBOC","2908 Caraway Road",Jonesboro,AR,"72401","870-277-0778 Or 870-268-6962","VA Facility",Government,no,"Not Available",35.80957,-90.67815
 621,"Jonesville Rural Outreach Clinic","32613 Wilderness Road, Suite 101",Jonesville,VA,"24263",276-346-2595,"VA Facility",Government,no,"Not Available",34.836,-81.6809
 621,"Knoxville, Tennessee CBOC","8033 Ray Mears Blvd.",Knoxville,TN,"37919",865-545-4592,"VA Facility",Government,no,"Not Available",35.923336,-84.04693
-621,"LaFollette (Campbell County), Tennessee CBOC","130 Independence Lane",LaFollette,TN,"37757",423-563-7666,"VA Facility",Government,no,"Not Available",0,0
+621,"LaFollette (Campbell County), Tennessee CBOC","130 Independence Lane",LaFollette,TN,"37757",423-563-7666,"VA Facility",Government,no,"Not Available",36.352983,-84.158129 
 621,"Marion Rural Outreach Clinic","4451 Lee Highway",Marion,VA,"24354",276-783-2756,"VA Facility",Government,no,"Not Available",41.5637,-72.9257
 626,"Maury County CBOC","833 Nashville Highway",Columbia,TN,"38401",931-981-6930,"VA Facility",Government,no,"Not Available",35.62945,-87.02559
 626,"Meharry (Nashville General)","1810 Albion Street",Nashville,TN,"37208",615-873-6700,"VA Facility",Government,no,"Not Available",36.16626,-86.80563
@@ -595,7 +585,7 @@
 621GA,"Rogersville, Tennessee CBOC","401 Scenic Drive",Rogersville,TN,"37857",423-235-1471,"VA Facility",Government,no,"Not Available",36.40194,-83.01576
 614GD,"Savannah, Tennessee CBOC","765 Florence Rd",Savannah,TN,"38372",731-925-2300,"VA Facility",Government,no,"Not Available",35.21224,-88.2393
 621,"Sevierville Clinic","1124 Blanton Dr",Sevierville,TN,"37862",865-286-6950,"VA Facility",Government,no,"Not Available",35.8681,-83.5618
-626GG,"Tullahoma, Tennessee CBOC","225 Von Karman Rd","Arnold Air Force Base",TN,"37389",931-454-6134,"VA Facility",Government,no,"Not Available",0,0
+626GG,"Tullahoma, Tennessee CBOC","225 Von Karman Rd","Arnold Air Force Base",TN,"37389",931-454-6134,"VA Facility",Government,no,"Not Available",35.383858,-86.037065 
 614,"Tupelo VA Clinic","1114 Commonwealth Blvd",Tupelo,MS,"38804",662-840-6366,"VA Facility",Government,no,"Not Available",34.2499,-88.7168
 596GD,"VA Clinic Berea","209 Pauline Drive",Berea,KY,"40403",859-986-1259,"VA Facility",Government,no,"Not Available",39.1365,-80.9337
 596,"VA Clinic Hazard","210 Black Gold Blvd",Hazard,KY,"41701",606-436-2350,"VA Facility",Government,no,"Not Available",37.2495,-83.1932
@@ -1020,7 +1010,7 @@
 0705V,"Corpus Christi Vet Center","4646 Corona Suite 250","Corpus Christi",TX,"78411","361-854-9961 Or 361-854-9961","VA Facility",Government,no,"Not Available",27.713821,-97.38916
 5461,"Dallas Vet Center","8610 Greenville Ave., Suite 125",Dallas,TX,"75243","214-361-5896 Or 214-361-5896","VA Facility",Government,no,"Not Available",32.894432,-96.75287
 0707V,"El Paso Vet Center","1155 Westmoreland Suite 121","El Paso",TX,"79925","915-772-0013 Or 915-772-0013","VA Facility",Government,no,"Not Available",31.778967,-106.38721
-0708V,"Fort Worth Vet Center","6620 Hawk Creek Avenue","Westworth Village",TX,"76114","817-921-9095 Or 877-927-8387","VA Facility",Government,no,"Not Available",0,0
+0708V,"Fort Worth Vet Center","6620 Hawk Creek Avenue","Westworth Village",TX,"76114","817-921-9095 Or 877-927-8387","VA Facility",Government,no,"Not Available",32.756968,-97.428408 
 0726V,"Killeen Vet Center","302 Millers Crossing, Suite #4","Harker Heights",TX,"76548","254-953-7100 Or 877-927-8387","VA Facility",Government,no,"Not Available",31.06693,-97.6638
 0712V,"Laredo Vet Center","6999 McPherson Road Suite 102",Laredo,TX,"78041","956-723-4680 Or 956-723-4680","VA Facility",Government,no,"Not Available",27.572512,-99.47259
 0714V,"Lubbock Vet Center","3106 50th st sute 400",Lubbock,TX,"79413","806-792-9782 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.54874,-101.881485
@@ -1109,7 +1099,7 @@
 635GE,"Stillwater VA Clinic","320 N. Perkins Avenue",Stillwater,OK,"74074",405-707-8100,"VA Facility",Government,no,"Not Available",40.3234,-81.3084
 623,"Vinita Outpatient Clinic","269 S 7th St",Vinita,OK,"74301",918-713-5400,"VA Facility",Government,no,"Not Available",36.63692,-95.14327
 660GJ,"Western Salt Lake CBOC","2750 South 5600 West","West Valley City",UT,"84120",801-417-5734,"VA Facility",Government,no,"Not Available",40.709984,-112.02493
-635GB,"Wichita Falls VA Clinic","149 Hart Street","Sheppard Air Force Base",TX,"76311",940-257-0000,"VA Facility",Government,no,"Not Available",0,0
+635GB,"Wichita Falls VA Clinic","149 Hart Street","Sheppard Air Force Base",TX,"76311",940-257-0000,"VA Facility",Government,no,"Not Available",33.976726,-98.517373 
 0509V,"Billings Vet Center","2795 Enterprise Ave., Suite 1",Billings,MT,"59102","406-657-6071 Or 406-657-6071","VA Facility",Government,no,"Not Available",45.75003,-108.58542
 527,"Boulder Vet Center","4999 Pearl East Circle, Suite 106",Boulder,CO,"80301","303-440-7306 Or 877-927-8387","VA Facility",Government,no,"Not Available",40.02116,-105.23718
 0519V,"Casper Vet Center","1030 North Poplar, Suite B",Casper,WY,"82601","307-261-5355 Or 307-261-5355","VA Facility",Government,no,"Not Available",42.860615,-106.33267
@@ -1208,7 +1198,7 @@
 523,"Yakima Vet Center","2119 W. Lincoln Ave",Yakima,WA,"98902","509-457-2736 Or 509-457-2736","VA Facility",Government,no,"Not Available",46.603485,-120.537346
 687,687,"77 Wainwright Drive","Walla Walla",WA,"99362",,"VA Facility",Government,no,"Not Available",46.052536,-118.35569
 523,"Yakima Valley Vet Center","2119 West Lincoln Avenue",Yakima,WA,"98902",509-457-2736,"VA Facility",Government,no,"Not Available",46.603485,-120.53733
-10N21,"VISN 21: Sierra Pacific Network","201 Walnut Avenue","Mare Island",CA,"94592",707-562-8350,"VA Facility",Government,no,"Not Available",0,0
+10N21,"VISN 21: Sierra Pacific Network","201 Walnut Avenue","Mare Island",CA,"94592",707-562-8350,"VA Facility",Government,no,"Not Available", 38.100625,-122.273223 
 662,"San Francisco VA Health Care System","4150 Clement Street","San Francisco",CA,"94121",415-221-4810,"VA Facility",Government,no,"Not Available",37.781143,-122.504105
 570,"Central California VA Health Care System","2615 E. Clinton Avenue",Fresno,CA,"93703","559-225-6100 Or 559-225-6100","VA Facility",Government,no,"Not Available",36.77229,-119.78002
 640,Livermore,"4951 Arroyo Road",Livermore,CA,"94550",925-373-4700,"VA Facility",Government,no,"Not Available",37.637985,-121.763985
@@ -1217,12 +1207,12 @@
 459,"VA Pacific Islands Health Care System","459 Patterson Road",Honolulu,HI,"96819","808-433-0600 Or 800-214-1306","VA Facility",Government,no,"Not Available",21.36117,-157.88878
 640,"VA Palo Alto Health Care System","3801 Miranda Avenue","Palo Alto",CA,"94304",650-493-5000,"VA Facility",Government,no,"Not Available",37.402836,-122.14173
 654,"VA Sierra Nevada Health Care System","975 Kirman Avenue",Reno,NV,"89502","775-786-7200 Or 775-786-7200","VA Facility",Government,no,"Not Available",39.515854,-119.79849
-593,"VA Southern Nevada Healthcare System","6900 North Pecos Road","N. Las Vegas",NV,"89086",702-791-9024,"VA Facility",Government,no,"Not Available",0,0
+593,"VA Southern Nevada Healthcare System","6900 North Pecos Road","N. Las Vegas",NV,"89086",702-791-9024,"VA Facility",Government,no,"Not Available",36.285391,-115.095119 
 640,"Capitola Clinic","1350 41st Avenue, Suite 102",Capitola,CA,"95010",831-464-5519,"VA Facility",Government,no,"Not Available",36.97057,-121.96488
 612,"Chico Outpatient Clinic","280 Cohasset Road",Chico,CA,"95926","530-879-5000 X 9 Or 530-879-5000","VA Facility",Government,no,"Not Available",39.751648,-121.85145
 612,"Fairfield Outpatient Clinic","103 Bodin Circle, Travis Air Force Base",Fairfield,CA,"94535","707-437-1800 Or 707-437-1800","VA Facility",Government,no,"Not Available",38.267887,-121.95876
 5199,"Major General William H. Gourley VA-DoD Outpatient Clinic","201 Ninth Street",Marina,CA,"93933",831-884-1000,"VA Facility",Government,no,"Not Available",36.6799,-121.7897
-96440,"Manila Outpatient Clinic","1501 Roxas Boulevard","Pasay City",PI,"01302",632-550-3888,"VA Facility",Government,no,"Not Available",0,0
+96440,"Manila Outpatient Clinic","1501 Roxas Boulevard","Pasay City",PI,"01302",632-550-3888,"VA Facility",Government,no,"Not Available",14.544023,120.992405 
 612,"Mare Island Outpatient Clinic","201 Walnut Avenue",Vallejo,CA,"94592","707-562-8200 Or 707-562-8200","VA Facility",Government,no,"Not Available",38.1041,-122.2566
 612,"Martinez Outpatient Clinic and Community Living Center","150 Muir Road",Martinez,CA,"94553","925-372-2000 Or 925-372-2000","VA Facility",Government,no,"Not Available",37.994648,-122.11164
 612,"McClellan Dental Clinic - Sacramento","5401 Arnold Avenue",McClellan,CA,"95652",916-333-5500,"VA Facility",Government,no,"Not Available",38.6679,-121.4032
@@ -1256,24 +1246,19 @@
 662BU,"SFVA Downtown Clinic","401 3rd Street","San Francisco",CA,"94107",415-281-5100,"VA Facility",Government,no,"Not Available",37.782543,-122.39735
 570,"Tulare Community-Based Outpatient Clinic","1050 N. Cherry Street",Tulare,CA,"93274",559-684-8703,"VA Facility",Government,no,"Not Available",36.22275,-119.33752
 662GD,"Ukiah VA Outpatient Clinic","630 Kings Court",Ukiah,CA,"95482",707-468-7700,"VA Facility",Government,no,"Not Available",39.14806,-123.1984
-459,"VA American Samoa CBOC","Fiatele Teo Army Reserve Bldg","Pago Pago",AS,"96799",684-699-3730,"VA Facility",Government,no,"Not Available",0,0
 654,"VA Carson Valley Outpatient Clinic","1330 Waterloo Lane, Suite 101",Gardnerville,NV,"89410",775-782-5265,"VA Facility",Government,no,"Not Available",38.925064,-119.74963
 654GD,"VA Diamond View Outpatient Clinic","110 Bella Way",Susanville,CA,"96130","530-251-4550 Or 530-251-4550","VA Facility",Government,no,"Not Available",40.4163,-120.653
-459,"VA Guam Community Based Outpatient Clinic","498 Chalan Palayso","Agana Heights",GU,"96910",671-475-5760,"VA Facility",Government,no,"Not Available",0,0
 459,"VA Hilo Community Based Outpatient Clinic","1285 Waianuenue Avenue, Suite 211",Hilo,HI,"96720",808-935-3781,"VA Facility",Government,no,"Not Available",19.717466,-155.11314
 459,"VA Kauai Community Based Outpatient Clinic","4485 Pahe'e Street, Suite 150",Lihue,HI,"96766",808-246-0497,"VA Facility",Government,no,"Not Available",21.968864,-159.38431
 459,"VA Kona Community Based Outpatient Clinic","35-377 Hualalai Road",Kailua-Kona,HI,"96740",808-329-0774,"VA Facility",Government,no,"Not Available",19.6406,-155.9956
 1396,"VA Leeward Community Based Outpatient Clinic","91-2135 Fort Weaver Road","Ewa Beach",HI,"96706",800-214-1306,"VA Facility",Government,no,"Not Available",21.369507,-158.02618
 459,"VA Maui Community Based Outpatient Clinic","203 Ho'ohana Street, Suite 303",Kahului,HI,"96732",808-871-2454,"VA Facility",Government,no,"Not Available",20.88696,-156.46333
-6307,"VA Saipan Outreach Clinic","Marina Heights Business Park",Saipan,MP,"96950","670-323-9000 Or 670-322-0035","VA Facility",Government,no,"Not Available",0,0
 612,"Yuba City Outpatient Clinic","425 Plumas Street","Yuba City",CA,"95991",530-751-4500,"VA Facility",Government,no,"Not Available",39.130913,-121.614136
-616,"American Samoa Vet Center","Ottoville Road, P.O. Box 982942","Pago Pago",AS,"96799","684-699-3760 Or 877-927-8387","VA Facility",Government,no,"Not Available",0,0
 649,"Chico Vet Center","250 Cohasset Road, Suite 40",Chico,CA,"95926","530-899-6300 Or 530-899-6300","VA Facility",Government,no,"Not Available",39.75176,-121.85193
 610,"Citrus Heights Vet Center","5650 Sunrise Blvd., Suite 150","Citrus Heights",CA,"95610","916-535-0420 Or 916-535-0420","VA Facility",Government,no,"Not Available",38.670345,-121.27155
 602,"Concord Vet Center","1333 Willow Pass Road, Suite 106",Concord,CA,"94520","925-680-4526 Or 925-680-4526","VA Facility",Government,no,"Not Available",37.972385,-122.05445
 644,"Eureka Vet Center","2830 G Street, Suite A",Eureka,CA,"95501","707-444-8271 Or 707-444-8271","VA Facility",Government,no,"Not Available",40.782574,-124.16242
 628,"Fresno Vet Center","1320 E. Shaw Ave, Suite 125",Fresno,CA,"93710","559-487-5660 Or 877-927-8387","VA Facility",Government,no,"Not Available",36.808594,-119.76464
-648,"Guam Vet Center","222 Chalan Santo Papa Street, Suite 201",Hagatna,GU,"96910",671-472-7161,"VA Facility",Government,no,"Not Available",0,0
 534,"Henderson Vet Center","400 North Stephanie, Suite 180",Henderson,NV,"89014","702-791-9100 Or 702-791-9100","VA Facility",Government,no,"Not Available",36.05657,-115.0462
 635,"Hilo Vet Center","70 Lanihuli Street, Suite 102",Hilo,HI,"96720","808-969-3833 Or 887-969-3833","VA Facility",Government,no,"Not Available",19.71111,-155.07872
 609,"Honolulu Vet Center","1680 Kapiolani Blvd. Suite F-3",Honolulu,HI,"96814","808-973-8387 Or 877-927-8387","VA Facility",Government,no,"Not Available",21.291153,-157.83807

--- a/src/main/resources/providers/va_facilities.csv
+++ b/src/main/resources/providers/va_facilities.csv
@@ -1,1499 +1,1501 @@
 ﻿id,name,address,city,state,zip,phone,type,ownership,emergency,quality,LAT,LON
-518,Edith Nourse Rogers Memorial Veterans Hospital (Bedford VA),200 Springs Rd.,Bedford,MA,1730,781-687-2000,VA Facility,Government,no,Not Available,42.503376,-71.272644
-608,Manchester VA Medical Center,718 Smyth Road,Manchester,NH,3104,603-624-4366 Or 603-624-4366,VA Facility,Government,no,Not Available,43.01192,-71.43939
-650,Providence VA Medical Center,830 Chalkstone Avenue,Providence,RI,2908,401-273-7100 Or 401-273-7100,VA Facility,Government,no,Not Available,41.83397,-71.43398
-523A5,"VA Boston Healthcare System, Brockton Campus",940 Belmont Street,Brockton,MA,2301,508-583-4500 Or 508-583-4500,VA Facility,Government,no,Not Available,42.065655,-71.05398
-523,"VA Boston Healthcare System, Jamaica Plain Campus",150 South Huntington Avenue,Jamaica Plain,MA,2130,617-232-9500,VA Facility,Government,no,Not Available,42.32809,-71.11076
-523A4,"VA Boston Healthcare System, West Roxbury Campus",1400 VFW Parkway,West Roxbury,MA,2132,617-323-7700,VA Facility,Government,no,Not Available,0,0
-631,VA Central Western Massachusetts Healthcare System,421 North Main Street,Leeds,MA,1053,413-584-4040,VA Facility,Government,no,Not Available,42.345066,-72.68291
-689A4,"VA Connecticut Healthcare System, Newington Campus",555 Willard Avenue,Newington,CT,6111,860-666-6951,VA Facility,Government,no,Not Available,41.702595,-72.73486
-689,"VA Connecticut Healthcare System, West Haven Campus",950 Campbell Avenue,West Haven,CT,6516,203-932-5711,VA Facility,Government,no,Not Available,41.28468,-72.95741
-402,VA Maine Healthcare System - Togus,1 VA Center,Augusta,ME,4330,207-623-8411 Or 207-623-8411,VA Facility,Government,no,Not Available,0,0
-405,White River Junction VA Medical Center,163 Veterans Drive,White River Junction,VT,5009,802-295-9363 Or 802-295-9363,VA Facility,Government,no,Not Available,43.648075,-72.34463
-523BZ,Causeway OPC,251 Causeway St.,Boston,MA,2114,800-865-3384,VA Facility,Government,no,Not Available,42.3665,-71.05931
-402F,Fort Kent Access Point Clinic,3 Mountain View Drive,Fort Kent,ME,4743,207-834-1572,VA Facility,Government,no,Not Available,0,0
-4730,Houlton Satellite Clinic,Houlton Regional Hospital - 20 Hartford Street,Houlton,ME,4730,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,0,0
-402MMU,Mobile Medical Unit,241 Main Street,Bingham,ME,4920,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,45.053535,-69.88254
-518-vccc,Lowell Veterans Community Care Center,130 Marshall Road,Lowell,MA,1852,978-671-9000,VA Facility,Government,no,Not Available,42.62101,-71.31481
-402GD,Aroostook County (Caribou) Community Based Outpatient Clinic,"163 Van Buren Drive, Ste 6",Caribou,ME,4736,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,0,0
-402HB,Bangor Community Based Outpatient Clinic,35 State Hospital Drive,Bangor,ME,4401,207-561-3600,VA Facility,Government,no,Not Available,44.802254,-68.769394
-405GA,Bennington Outpatient Clinic,186 North Street,Bennington,VT,5201,802-440-3300,VA Facility,Government,no,Not Available,42.879307,-73.1971
-405GC,Brattleboro Community Based Outpatient Clinic,71 GSP Drive,Brattleboro,VT,5301,802-251-2200,VA Facility,Government,no,Not Available,0,0
-405HA,Burlington Outpatient Lakeside Clinic,"128 Lakeside Avenue, Suite 260",Burlington,VT,5401,802-657-7000,VA Facility,Government,no,Not Available,44.46104,-73.22083
-402GB,Calais Outpatient Clinic,50 Union St,Calais,ME,4619,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,45.18957,-67.27797
-608GD,Conway Outpatient Clinic,71 Hobbs Street,Conway,NH,3818,800-892-8384 X 3199,VA Facility,Government,no,Not Available,0,0
-689GE,Danbury Outpatient Clinic,"7 Germantown Road, Ste 2B",Danbury,CT,6810,203-798-8422,VA Facility,Government,no,Not Available,41.40898,-73.43614
-518GG,Fitchburg Outpatient Clinic,881 Main Street,Fitchburg,MA,1420,978-342-9781 Or 978-342-9781,VA Facility,Government,no,Not Available,42.586487,-71.80521
-523GA,Framingham Outpatient Clinic,"61 Lincoln Street, Suite 112",Framingham,MA,1702,800-865-3384,VA Facility,Government,no,Not Available,42.28348,-71.41845
-518GE,Gloucester Community Based Outpatient Clinic (CBOC),199 Main Street,Gloucester,MA,1930,800-838-6331,VA Facility,Government,no,Not Available,42.613102,-70.66085
-631GD,Greenfield Outpatient Clinic,143 Munson Street,Greenfield,MA,1301,413-773-8428 Or 413-773-8428,VA Facility,Government,no,Not Available,42.580627,-72.623634
-518GB,Haverhill Community Based Outpatient Clinic (CBOC),108 Merrimack St.,Haverhill,MA,1830,800-838-6331,VA Facility,Government,no,Not Available,42.77449,-71.07901
-650GB,Hyannis Outpatient Clinic,233 Stevens St,Hyannis,MA,2601,508-771-3190,VA Facility,Government,no,Not Available,41.651745,-70.294235
-689HC,John J. McGuirk (New London) VA Outpatient Clinic,Shaw's Cove Four,New London,CT,6320,860-437-3611,VA Facility,Government,no,Not Available,0,0
-405K,Keene Outpatient Clinic,"640 Marlboro Street, Route 101",Keene,NH,3431,603-358-4900,VA Facility,Government,no,Not Available,42.91539,-72.24931
-402-al,Lewiston/ Auburn Community Based Outpatient Clinic,15 Challenger Drive,Lewiston,ME,4240,207-330-2700 Or 877-421-8263 X 2700,VA Facility,Government,no,Not Available,0,0
-402,Lincoln Community Based Outpatient Clinic,99 River Road,Lincoln,ME,4457,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,0,0
-405HC,Littleton Community Based Outpatient Clinic,264 Cottage Street,Littleton,NH,3561,603-575-6700,VA Facility,Government,no,Not Available,0,0
-523BY,Lowell Outpatient Clinic,130 Marshall Road,Lowell,MA,1852,800-865-3384,VA Facility,Government,no,Not Available,42.62101,-71.31481
-518GA,Lynn Community Based Outpatient Clinic (CBOC),"225 Boston Road, Suite 107",Lynn,MA,1904,800-838-6331,VA Facility,Government,no,Not Available,42.470093,-70.95994
-650GD,Middletown Outpatient Clinic,One Corporate Place,Middletown,RI,2842,401-847-6239,VA Facility,Government,no,Not Available,0,0
-650GA,New Bedford Outpatient Clinic,175 Elm Street,New Bedford,MA,2740,508-994-0217,VA Facility,Government,no,Not Available,41.635937,-70.92991
-405_Newport,Newport Community Based Outpatient Clinic,1734 Crawford Farm Rd.,Newport,VT,5855,802-624-2400,VA Facility,Government,no,Not Available,44.932266,-72.180824
-631GC,Pittsfield Outpatient Clinic,73 Eagle Street,Pittsfield,MA,1201,413-499-2672 Or 413-499-2672,VA Facility,Government,no,Not Available,42.451427,-73.25195
-523GD,Plymouth Outreach Clinic,116 Long Pond Road,Plymouth,MA,2360,800-865-3384,VA Facility,Government,no,Not Available,41.924313,-70.656654
-402-p,Portland Community Based Outpatient Clinic,144 Fore Street,Portland,ME,4101,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,43.65423,-70.26246
-608GA,Portsmouth Outpatient Clinic,Pease International Tradeport 302 Newmarket Street,Portsmouth,NH,3803,603-624-4366 X 3199,VA Facility,Government,no,Not Available,0,0
-523GC,Quincy Outpatient Clinic,110 West Squantum Street,Quincy,MA,2169,800-865-3384,VA Facility,Government,no,Not Available,42.272617,-71.03133
-402GC,Rumford Community Based Outpatient Clinic,431 Franklin St.,Rumford,ME,4726,207-369-3200,VA Facility,Government,no,Not Available,44.551373,-70.55676
-405HF,Rutland Community Based Outpatient Clinic,232 West St.,Rutland,VT,5701,802-772-2300,VA Facility,Government,no,Not Available,43.60715,-72.985634
-402GA,Saco Community Based Outpatient Clinic,655 Main Street,Saco,ME,4072,207-623-8411 X 7490 Or 877-421-8263 X 7490,VA Facility,Government,no,Not Available,43.52166,-70.42791
-608GC,Somersworth Outpatient Clinic,200 Route 108,Somersworth,NH,3878,603-624-4366 X 3199,VA Facility,Government,no,Not Available,43.243023,-70.89857
-631BY,Springfield Outpatient Clinic,25 Bond Street,Springfield,MA,1104,413-731-6000 Or 413-731-6000,VA Facility,Government,no,Not Available,42.110065,-72.60007
-689gb,Stamford Outpatient Clinic,"1275 Summer St, Suite 102",Stamford,CT,6905,203-325-0649,VA Facility,Government,no,Not Available,41.06164,-73.541504
-608HA,Tilton Outpatient Clinic,"630 West Main Street, Suite 400",Tilton,NH,3276,603-624-4366 X 3199,VA Facility,Government,no,Not Available,43.447174,-71.62029
-689GA,Waterbury Outpatient Clinic,95 Scovill Street,Waterbury,CT,6706,203-465-5292,VA Facility,Government,no,Not Available,41.553574,-73.03762
-689GC,Willimantic Outpatient Clinic,1320 Main Street,Willimantic,CT,6226,860-450-7583,VA Facility,Government,no,Not Available,41.715214,-72.22889
-689GD,Winsted Outpatient Clinic,115 Spencer Street,Winsted,CT,6908,860-738-6985,VA Facility,Government,no,Not Available,41.930405,-73.07571
-631GE,Worcester Outpatient Clinic,"605 Lincoln Street,",Worcester,MA,1605,508-856-0104 Or 508-856-0104,VA Facility,Government,no,Not Available,42.297756,-71.766815
-121,Bangor Vet Center,"615 Odlin Road, Suite 3",Bangor,ME,4401,207-947-3391 Or 207-947-3391,VA Facility,Government,no,Not Available,44.78075,-68.82331
-134,Berlin Vet Center,515 Main Street Suite 2,Gorham,NH,3581,603-752-2571,VA Facility,Government,no,Not Available,44.428604,-71.19247
-0101V,Boston Vet Center,"7 Drydock Ave, Suite 2070",Boston,MA,2210,857-203-6461,VA Facility,Government,no,Not Available,42.34461,-71.03728
-104,Brockton Vet Center,1041L Pearl St.,Brockton,MA,2301,508-580-2730 Or 508-580-2730,VA Facility,Government,no,Not Available,42.055134,-71.06661
-136,Cape Cod Vet Center,474 West Main Street,Hyannis,MA,2601,508-778-0124 Or 508-778-0124,VA Facility,Government,no,Not Available,41.650307,-70.313515
-140,Danbury Vet Center,"457 North Main St., 1st Floor",Danbury,CT,6811,203-790-4000 Or 203-790-4000,VA Facility,Government,no,Not Available,41.40501,-73.462845
-117,Hartford Vet Center,"25 Elm Street, Suite A",Rocky Hill,CT,6067,860-563-8800,VA Facility,Government,no,Not Available,41.664818,-72.64043
-1221,Keene Vet Center Outstation,640 Marlboro Rd. (Route 101),Keene,NH,3431,603-358-4950 Or 603-358-4950,VA Facility,Government,no,Not Available,0,0
-129,Lewiston Vet Center,35 Westminster St.,Lewiston,ME,4240,207-783-0068 Or 207-783-0068,VA Facility,Government,no,Not Available,44.075405,-70.17508
-125,Lowell Vet Center,"10 George Street, Gateway Center",Lowell,MA,1852,978-453-1151,VA Facility,Government,no,Not Available,42.642513,-71.3062
-108,Manchester Vet Center,"1461 Hooksett Rd., B6",Hooksett,NH,3106,603-668-7060 Or 603-668-7060,VA Facility,Government,no,Not Available,43.07247,-71.454254
-128,New Bedford Vet Center,"73 Huttleton Ave., Unit 2",Fairhaven,MA,2719,508-999-6920 Or 508-999-6920,VA Facility,Government,no,Not Available,0,0
-116,New Haven Vet Center,291 South Lambert Road,Orange,CT,6477,203-795-0148,VA Facility,Government,no,Not Available,41.262207,-73.00565
-119,Northern Maine Vet Center,456 York Street,Caribou,ME,4736,207-496-3900,VA Facility,Government,no,Not Available,0,0
-127,Norwich Vet Center,2 Cliff St.,Norwich,CT,6360,860-887-1755 Or 860-887-1755,VA Facility,Government,no,Not Available,41.52734,-72.06744
-115,Portland Vet Center,475 Stevens Ave.,Portland,ME,4103,207-780-3584,VA Facility,Government,no,Not Available,43.674862,-70.29505
-113,Providence Vet Center,2038 Warwick Ave,Warwick,RI,2889,401-739-0167,VA Facility,Government,no,Not Available,41.72111,-71.40386
-0100V,"RCS North Atlantic District 1, Zone 1 District Office","15 Dartmouth Drive, Suite 202",Auburn,NH,3032,603-623-4204 Or 603-623-4204,VA Facility,Government,no,Not Available,0,0
-130,Sanford Vet Center,628 Main Street,Springvale,ME,4083,207-490-1513 Or 207-490-1513,VA Facility,Government,no,Not Available,43.455822,-70.79014
-118,South Burlington Vet Center,19 Gregory Drive Suite 201,South Burlington,VT,5403,802-862-1806,VA Facility,Government,no,Not Available,44.455273,-73.13991
-103,Springfield Vet Center,"95 Ashley Avenue, Suite A",West Springfield,MA,1089,413-737-5167 Or 413-737-5167,VA Facility,Government,no,Not Available,42.139397,-72.62382
-122,White River Junction Vet Center,118 Prospect Street Suite 100,White River Junction,VT,5001,802-295-2908 Or 802-295-2908,VA Facility,Government,no,Not Available,0,0
-126,Worcester Vet Center,255 Park Ave Suite # 900,Worcester,MA,1609,508-753-7902,VA Facility,Government,no,Not Available,42.265556,-71.818665
-10N2,VISN 2: New York/New Jersey VA Health Care Network,"130 W. Kingsbridge Road, Building 16",Bronx,NY,10468,718-741-4134,VA Facility,Government,no,Not Available,40.869125,-73.90309
-620,VA Hudson Valley Health Care System,2094 Albany Post Rd.,Montrose,NY,10548,914-737-4400,VA Facility,Government,no,Not Available,41.2446,-73.926155
-561,VA New Jersey Health Care System,385 Tremont Avenue,East Orange,NJ,7018,973-676-1000,VA Facility,Government,no,Not Available,40.753803,-74.23407
-630,VA NY Harbor Healthcare System,423 East 23rd Street,New York,NY,10010,,VA Facility,Government,no,Not Available,40.73663,-73.97797
-528,VA Western New York Healthcare System,3495 Bailey Avenue,Buffalo,NY,14215,716-834-9200 Or 800-532-8387,VA Facility,Government,no,Not Available,42.953728,-78.813774
-528A8,Albany VA Medical Center: Samuel S. Stratton,113 Holland Avenue,Albany,NY,12208,518-626-5000 Or 518-626-5000,VA Facility,Government,no,Not Available,42.649483,-73.77452
-528A6,Bath VA Medical Center,76 Veterans Avenue,Bath,NY,14810,607-664-4000 Or 607-664-4000,VA Facility,Government,no,Not Available,42.343426,-77.34615
-630A4,Brooklyn Campus of the VA NY Harbor Healthcare System,800 Poly Place,Brooklyn,NY,11209,718-836-6600,VA Facility,Government,no,Not Available,40.6099,-74.02558
-528A5,Canandaigua VA Medical Center,400 Fort Hill Avenue,Canandaigua,NY,14424,585-394-2000 Or 585-394-2000,VA Facility,Government,no,Not Available,42.90006,-77.27269
-620A4,Castle Point Campus of the VA Hudson Valley Health Care System,41 Castle Point Road,Wappingers Falls,NY,12590,845-831-2000,VA Facility,Government,no,Not Available,41.539974,-73.95949
-561,East Orange Campus of the VA New Jersey Health Care System,385 Tremont Avenue,East Orange,NJ,7018,973-676-1000,VA Facility,Government,no,Not Available,40.753803,-74.23407
-620,Franklin Delano Roosevelt Campus of the VA Hudson Valley Health Care System (Montrose),2094 Albany Post Rd.,Montrose,NY,10548,914-737-4400,VA Facility,Government,no,Not Available,41.2446,-73.926155
-526,"James J. Peters VA Medical Center (Bronx, NY)",130 West Kingsbridge Road,Bronx,NY,10468,718-584-9000,VA Facility,Government,no,Not Available,40.869102,-73.90305
-561A4,Lyons Campus of the VA New Jersey Health Care System,151 Knollcroft Road,Lyons,NJ,7939,908-647-0180,VA Facility,Government,no,Not Available,0,0
-630,Manhattan Campus of the VA NY Harbor Healthcare System,423 East 23rd Street,New York,NY,10010,212-686-7500,VA Facility,Government,no,Not Available,40.73663,-73.97797
-632,Northport VA Medical Center,79 Middleville Road,Northport,NY,11768,631-261-4400 Or 631-261-4400,VA Facility,Government,no,Not Available,0,0
-528A7,Syracuse VA Medical Center,800 Irving Avenue,Syracuse,NY,13210,315-425-4400 Or 315-425-4400,VA Facility,Government,no,Not Available,43.03934,-76.138054
-528A4,VA Western New York Healthcare System at Batavia,222 Richmond Avenue,Batavia,NY,14020,585-297-1000,VA Facility,Government,no,Not Available,43.009197,-78.198586
-528,VA Western New York Healthcare System at Buffalo,3495 Bailey Avenue,Buffalo,NY,14215,716-834-9200 Or 800-532-8387,VA Facility,Government,no,Not Available,42.953728,-78.813774
-630A5,St. Albans Community Living Center,179-00 Linden Blvd. & 179 Street,Jamaica,NY,11425,718-526-1000,VA Facility,Government,no,Not Available,0,0
-528,Behavioral Health Facility,620 Erie Blvd West,Syracuse,NY,13204,315-425-4400 X 53463,VA Facility,Government,no,Not Available,43.049225,-76.16408
-528G5,Auburn VA Outpatient Clinic,17 Lansing Street,Auburn,NY,13021,315-255-7002,VA Facility,Government,no,Not Available,42.9408,-76.56385
-528G3,Bainbridge VA Outpatient Clinic,109 North Main Street,Bainbridge,NY,13733,607-967-8590,VA Facility,Government,no,Not Available,42.300873,-75.47048
-632HC,Bay Shore Clinic,132 East Main Street,Bay Shore,NY,11706,631-754-7978,VA Facility,Government,no,Not Available,40.723354,-73.24521
-528GN,Binghamton VA Outpatient Clinic,203 Court Street,Binghamton,NY,13901,607-772-9100,VA Facility,Government,no,Not Available,42.100765,-75.90382
-528,CANI,19472 US Route 11,Watertown,NY,13601,315-782-0067,VA Facility,Government,no,Not Available,0,0
-620GB,Carmel Community Clinic/Putnam County,"1875 Route 6, Sterling Bank, (2nd Floor)",Carmel,NY,10512,845-228-5291,VA Facility,Government,no,Not Available,0,0
-528G7,Catskill VA Outpatient Clinic,"Columbia Greene Medical Arts Building, Suite D305, 159 Jefferson Hgts",Catskill,NY,12414,518-626-5240,VA Facility,Government,no,Not Available,0,0
-528GY,Clifton Park VA Outpatient Clinic,963 Route 146,Clifton Park,NY,12065,518-383-8506,VA Facility,Government,no,Not Available,42.868553,-73.80719
-528G4,Coudersport,"24 Maple View Lane, Suite 2",Coudersport,PA,16915,607-664-4670,VA Facility,Government,no,Not Available,41.72552,-78.02134
-528GC,Dunkirk VA Outpatient Clinic,166 East 4th Street,Dunkirk,NY,14048,716-203-6474,VA Facility,Government,no,Not Available,42.483982,-79.32886
-632GA,East Meadow Clinic,"2201 Hempstead Turnpike, Building Q",East Meadow,NY,11554,631-754-7978,VA Facility,Government,no,Not Available,40.725246,-73.55433
-620GH,Eastern Dutchess Pine Plains Community Clinic,"2881 Church St, Rt 199",Pine Plains,NY,12567,518-398-9240,VA Facility,Government,no,Not Available,41.98078,-73.66126
-561GB,Elizabeth CBOC,"654 East Jersey Street, Suite 2A",Elizabeth,NJ,7206,908-994-0120,VA Facility,Government,no,Not Available,40.658993,-74.19809
-528G4,Elmira VA Outpatient Clinic,1316 College Avenue,Elmira,NY,14901,877-845-3247,VA Facility,Government,no,Not Available,42.110176,-76.82008
-528G6,Fonda VA Outpatient Clinic,2623 State Highway 30A,Fonda,NY,12068,518-853-1247,VA Facility,Government,no,Not Available,42.961163,-74.38659
-528GT,Glens Falls VA Outpatient Clinic,84 Broad St.,Glens Falls,NY,12801,518-798-6066,VA Facility,Government,no,Not Available,43.30542,-73.65568
-620GD,Goshen Community Clinic,"30 Hatfield Lane, Suite 204",Goshen,NY,10924,845-294-6927,VA Facility,Government,no,Not Available,41.39409,-74.33894
-561GD,Hackensack CBOC,385 Prospect Avenue,Hackensack,NJ,7601,201-342-4536,VA Facility,Government,no,Not Available,40.895733,-74.05201
-561GA,Hamilton CBOC,3635 Quakerbridge Rd,Hamilton,NJ,8619,609-570-6600,VA Facility,Government,no,Not Available,40.259384,-74.6777
-630GA,Harlem Community Clinic,55 West 125th Street,New York,NY,10027,646-273-8125,VA Facility,Government,no,Not Available,0,0
-561BZ,"James J. Howard Community Clinic (Brick, NJ)",970 Rt. 70,Brick,NJ,8724,732-206-8900,VA Facility,Government,no,Not Available,40.073112,-74.1277
-528GB,Jamestown VA Outpatient Clinic,608 West 3rd Street,Jamestown,NY,14701,716-338-1511,VA Facility,Government,no,Not Available,42.0942,-79.254395
-561GE,Jersey City CBOC,"115 Christopher Columbus Drive, Suite #201",Jersey,NJ,7302,201-435-3055,VA Facility,Government,no,Not Available,40.716923,-74.03316
-528GZ,Kingston VA Outpatient Clinic,324 Plaza Road,Kingston,NY,12401,845-331-8322,VA Facility,Government,no,Not Available,0,0
-528GQ,Lackawanna VA Outpatient Clinic,1234 Abbott Road,Lackawanna,NY,14218,716-821-7815,VA Facility,Government,no,Not Available,42.83065,-78.80516
-528GK,Lockport VA Outpatient Clinic,5883 Snyder Drive,Lockport,NY,14094,716-438-3890,VA Facility,Government,no,Not Available,0,0
-528GL,Massena VA Outpatient Clinic,6100 St. Lawrence Centre,Massena,NY,13662,315-705-6666,VA Facility,Government,no,Not Available,0,0
-620GF,Monticello Community Clinic,55 Sturgis Road,Monticello,NY,12701,845-791-4936,VA Facility,Government,no,Not Available,41.660187,-74.694954
-561GH,Morristown CBOC,540 West Hanover Ave,Morristown,NJ,7960,973-539-9791 Or 973-539-9791,VA Facility,Government,no,Not Available,0,0
-620GA,New City Community Clinic,"345 North Main Street, Upper Level",New City,NY,10956,845-634-8942,VA Facility,Government,no,Not Available,41.167606,-73.98805
-528GD,Niagara Falls VA Outpatient Clinic,2201 Pine Avenue,Niagara Falls,NY,14301,716-862-8580,VA Facility,Government,no,Not Available,43.09509,-79.0356
-528GR,Olean VA Outpatient Clinic,"VA Outpatient Clinic, 465 North Union Street",Olean,NY,14760,716-373-7709,VA Facility,Government,no,Not Available,0,0
-528GP,Oswego VA Outpatient Clinic,437 State Route 104 E,Oswego,NY,13126,315-207-0120,VA Facility,Government,no,Not Available,0,0
-632HD,Patchogue Community Clinic,4 Phyllis Drive,Patchogue,NY,11772,631-754-7978,VA Facility,Government,no,Not Available,40.76871,-72.99638
-561GJ,Paterson CBOC,"11 Getty Avenue, Building #275, St. Joseph's Hospital & Medical Center",Paterson,NJ,7503,973-247-1666,VA Facility,Government,no,Not Available,0,0
-561GF,Piscataway CBOC,"14 WILLS WAY, BUILDING 5",Piscataway,NJ,8854,732-981-8193,VA Facility,Government,no,Not Available,0,0
-528GV,Plattsburgh VA Outpatient Clinic,80 Sharron Avenue,Plattsburgh,NY,12901,518-561-6247,VA Facility,Government,no,Not Available,44.677174,-73.45478
-620GE,Port Jervis Community Clinic,150 Pike St.,Port Jervis,NY,12771,845-856-5396,VA Facility,Government,no,Not Available,41.376755,-74.69058
-620GG,Poughkeepsie Community Clinic,"488 Freedom Plains Rd., Suite 120",Poughkeepsie,NY,12603,845-452-5151,VA Facility,Government,no,Not Available,41.68009,-73.85433
-632HX,Riverhead Clinic,300 Center Drive,Riverhead,NY,11901,631-754-7978,VA Facility,Government,no,Not Available,0,0
-528GE,Rochester VA Outpatient Clinic,465 Westfall Road,Rochester,NY,14620,585-463-2600,VA Facility,Government,no,Not Available,43.114918,-77.60952
-528GM,Rome - Donald J. Mitchell VA Outpatient Clinic,"125 Brookley Road, Building 510",Rome,NY,13441,315-334-7100,VA Facility,Government,no,Not Available,43.21298,-75.418465
-528G2,Saranac Lake,33 Depot St.,Saranac Lake,NY,12983,518-626-5237,VA Facility,Government,no,Not Available,44.330322,-74.13204
-528GW,Schenectady VA Outpatient Clinic,"1346 Gerling Street, Sheridan Plaza",Schenectady,NY,12308,518-346-3334,VA Facility,Government,no,Not Available,42.823162,-73.90894
-528GQ,Springville,15 Commerce Drive,Springville,NY,14141,716-592-2409,VA Facility,Government,no,Not Available,42.504112,-78.682884
-132V,Staten Island Community Clinic,"1150 South Ave, 3rd Floor – Suite 301",Staten Island,NY,10314,718-761-2973,VA Facility,Government,no,Not Available,40.61044,-74.17705
-561GK,Sussex Outpatient Clinic,222 High Street,Newton,NJ,7860,973-756-1504,VA Facility,Government,no,Not Available,41.05696,-74.76037
-526GD,Thomas B. Noonan Community Clinic (Queens),"47-01 Queens Blvd, Room 301",Sunnyside,NY,11104,718-741-4800,VA Facility,Government,no,Not Available,40.743057,-73.91779
-561GI,Tinton Falls Community Based Outpatient Clinic,55 Gilbert St,Tinton Falls,NJ,7701,732-842-4751,VA Facility,Government,no,Not Available,40.3257,-74.07658
-528G9,Tompkins/Cortland County,1451 Dryden Road,Freeville,NY,13068,607-347-4101,VA Facility,Government,no,Not Available,42.4734,-76.395645
-528GX,Troy VA Outpatient Clinic,295 River Street,Troy,NY,12180,518-274-7707,VA Facility,Government,no,Not Available,42.73243,-73.690384
-632HA,Valley Stream Clinic,99 South Central Avenue,Valley Stream,NY,11580,631-754-7978,VA Facility,Government,no,Not Available,40.664974,-73.70841
-528,Watertown VA Outpatient Clinic,144 Eastern Blvd.,Watertown,NY,13601,315-221-7026,VA Facility,Government,no,Not Available,43.968388,-75.88106
-528A5,Wellsboro,1835 Shumway Hill Road,Wellsboro,PA,16901,607-664-4680 Or 877-845-3247 X 44680,VA Facility,Government,no,Not Available,41.737938,-77.26959
-528,Wellsville VA Outpatient Clinic,"3458 Riverside Drive, Route 19",Wellsville,NY,14895,607-664-4660 Or 607-664-4660,VA Facility,Government,no,Not Available,42.148464,-77.97374
-528G2,Westport,7426 NYS Route 9N,Westport,NY,12993,518-626-5236,VA Facility,Government,no,Not Available,0,0
-526GA,White Plains Community Clinic,23 South Broadway,White Plains,NY,10601,914-421-1951 X 4300,VA Facility,Government,no,Not Available,41.032364,-73.76228
-526GB,Yonkers Community Clinic,124 New Main St.,Yonkers,NY,10701,914-375-8055 X 4400,VA Facility,Government,no,Not Available,40.93349,-73.89745
-111,Albany Vet Center,17 Computer Drive West,Albany,NY,12205,518-626-5130,VA Facility,Government,no,Not Available,42.72057,-73.8087
-120,Babylon Vet Center,100 West Main Street,Babylon,NY,11702,631-661-3930 Or 631-661-3930,VA Facility,Government,no,Not Available,40.695957,-73.325325
-137,Binghamton Vet Center,53 Chenango Street,Binghamton,NY,13901,607-722-2393 Or 607-722-2393,VA Facility,Government,no,Not Available,42.100487,-75.91025
-112,Bloomfield Vet Center,2 Broad St. Suite 703,Bloomfield,NJ,7003,973-748-0980 Or 973-748-0980,VA Facility,Government,no,Not Available,40.793514,-74.19776
-110,Bronx Vet Center,"2471 Morris Ave., Suite 1A",Bronx,NY,10468,718-367-3500 Or 718-367-3500,VA Facility,Government,no,Not Available,40.86264,-73.89976
-0105V,Brooklyn Vet Center,25 Chapel St. Suite 604,Brooklyn,NY,11201,718-630-2830 Or 718-630-2830,VA Facility,Government,no,Not Available,40.697277,-73.98651
-0107V,Buffalo Vet Center,2372 Sweet Home Road,Amherst,NY,14228,716-862-7350 Or 716-862-7350,VA Facility,Government,no,Not Available,43.024666,-78.79905
-133,Harlem Vet Center,"2279 - 3rd Avenue, 2nd Floor",New York,NY,10035,646-273-8139 Or 646-273-8139,VA Facility,Government,no,Not Available,0,0
-141,Lakewood Vet Center,1255 NJ-70 Suite 22N,Lakewood,NJ,8701,908-607-6364 Or 908-607-6364,VA Facility,Government,no,Not Available,0,0
-106,Manhattan Vet Center,32 Broadway 2nd Floor - Suite 200,New York,NY,10004,212-951-6866 Or 212-951-6866,VA Facility,Government,no,Not Available,40.70634,-74.01284
-139,Middletown Vet Center,"726 East Main Street, Suite 203",Middletown,NY,10940,845-342-9917 Or 845-342-9917,VA Facility,Government,no,Not Available,41.43988,-74.36706
-0138V,Nassau Vet Center,970 South Broadway,Hicksville,NY,11801,516-348-0088 Or 516-348-0088,VA Facility,Government,no,Not Available,0,0
-109,Queens Vet Center,75-10B 91 Avenue,Woodhaven,NY,11421,718-296-2871,VA Facility,Government,no,Not Available,40.685898,-73.86519
-124,Rochester Vet Center,"2000 S. Winton Road, Bldg 5, Ste. 201",Rochester,NY,14618,585-232-5040,VA Facility,Government,no,Not Available,43.107155,-77.57613
-102,Secaucus Vet Center,"110A Meadowlands Parkway, Suite 102",Secaucus,NJ,7094,201-223-7787 Or 201-223-7787,VA Facility,Government,no,Not Available,40.78257,-74.077415
-132,Staten Island Vet Center,60 Bay Street,Staten Island,NY,10301,718-816-4499 Or 718-816-4499,VA Facility,Government,no,Not Available,40.64047,-74.07568
-131,Syracuse Vet Center,"109 Pine Street, Suite 101",Syracuse,NY,13210,315-478-7127,VA Facility,Government,no,Not Available,43.050083,-76.129715
-114,Trenton Vet Center,934 Parkway Ave. Suite 201,Ewing,NJ,8618,609-882-5744 Or 609-882-5744,VA Facility,Government,no,Not Available,40.255383,-74.79256
-135,Watertown Vet Center,"210 Court Street, Suite 20",Watertown,NY,13601,315-782-5479 Or 315-782-5479,VA Facility,Government,no,Not Available,43.976658,-75.91245
-123,White Plains Vet Center,300 Hamilton Ave. Suite C,White Plains,NY,10601,914-682-6250,VA Facility,Government,no,Not Available,41.03415,-73.767494
-10N4,VISN 4: VA Healthcare - VISN 4,"323 North Shore Drive, Suite 400",Pittsburgh,PA,15212,412-822-3316,VA Facility,Government,no,Not Available,0,0
-646,VA Pittsburgh Healthcare System,University Drive,Pittsburgh,PA,15240,412-822-2222,VA Facility,Government,no,Not Available,0,0
-503,Altoona - James E. Van Zandt VA Medical Center,2907 Pleasant Valley Boulevard,Altoona,PA,16602,814-943-8164 Or 814-943-8164,VA Facility,Government,no,Not Available,40.48913,-78.39827
-542,Coatesville VA Medical Center,1400 Black Horse Hill Road,Coatesville,PA,19320,610-384-7711 Or 610-384-7711,VA Facility,Government,no,Not Available,39.998657,-75.80052
-562,Erie VA Medical Center,135 East 38th Street,Erie,PA,16504,800-274-8387 Or 800-274-8387,VA Facility,Government,no,Not Available,42.10296,-80.064835
-595,Lebanon VA Medical Center,1700 South Lincoln Avenue,Lebanon,PA,17042,717-272-6621 Or 717-272-6621,VA Facility,Government,no,Not Available,40.312363,-76.40701
-642,Philadelphia VA Medical Center,3900 Woodland Avenue,Philadelphia,PA,19104,215-823-5800 Or 215-823-5800,VA Facility,Government,no,Not Available,39.94543,-75.208595
-529,VA Butler Health Care Center,353 North Duffy Road,Butler,PA,16001,800-362-8262,VA Facility,Government,no,Not Available,40.888596,-79.9412
-646A4,"VA Pittsburgh Healthcare System, H.J. Heinz Campus",1010 Delafield Road,Pittsburgh,PA,15215,412-822-2222 Or 866-482-7488,VA Facility,Government,no,Not Available,40.496925,-79.89144
-646,"VA Pittsburgh Healthcare System, University Drive Campus",University Drive,Pittsburgh,PA,15240,412-822-2222 Or 866-482-7488,VA Facility,Government,no,Not Available,0,0
-693,Wilkes-Barre VA Medical Center,1111 East End Blvd.,Wilkes-Barre,PA,18711,570-824-3521 Or 570-824-3521,VA Facility,Government,no,Not Available,41.249058,-75.833755
-460,Wilmington VA Medical Center,1601 Kirkwood Highway,Wilmington,DE,19805,302-994-2511 Or 302-994-2511,VA Facility,Government,no,Not Available,39.73866,-75.606384
-642GF,Camden VA Outpatient Clinic,"300 Broadway, Suite 103",Camden,NJ,8104,877-232-5240,VA Facility,Government,no,Not Available,0,0
-642GE,Philadelphia MultiService Center (Philadelphia County),213-217 North 4th Street,Philadelphia,PA,19106,215-923-1163,VA Facility,Government,no,Not Available,39.954792,-75.14627
-693B4,Allentown VA Outpatient Clinic (693B4),3110 Hamilton Boulevard,Allentown,PA,18103,610-776-4304,VA Facility,Government,no,Not Available,40.58205,-75.51892
-529GC,Armstrong County VA Outpatient Clinic,11 Hilltop Plaza,Kittanning,PA,16201,724-545-8420,VA Facility,Government,no,Not Available,40.81212,-79.54405
-562GB,Ashtabula County VA Clinic,2044 Lambros Lane,Ashtabula,OH,44004,866-463-0912,VA Facility,Government,no,Not Available,0,0
-460HE,Atlantic County CBOC,1909 New Road,Northfield,NJ,8225,800-461-8262 X 2800,VA Facility,Government,no,Not Available,39.36886,-74.56026
-646GC,Beaver County Outpatient Clinic,"300 Brighton Ave., Suite 110",Rochester,PA,15074,724-709-6005,VA Facility,Government,no,Not Available,40.701736,-80.28499
-646GA,Belmont County Outpatient Clinic,103 Plaza Dr. Suite A,St. Clairsville,OH,43950,740-695-9321,VA Facility,Government,no,Not Available,40.07729,-80.91738
-642GA,Burlington County CBOC,3000 Lincoln Drive East,Marlton,NJ,8053,844-441-5499,VA Facility,Government,no,Not Available,39.913647,-74.94009
-595GA,Camp Hill VA Clinic (595GA),25 N. 32nd Street,Camp Hill,PA,17011,717-730-9782,VA Facility,Government,no,Not Available,0,0
-460GD,Cape May County CBOC,1 Monro Avenue,Cape May,NJ,8204,800-461-8262 X 2850,VA Facility,Government,no,Not Available,0,0
-529GD,Clarion County VA Outpatient Clinic,"56 Clarion Plaza, Suite 115",Monroe Township,PA,16214,814-226-3900,VA Facility,Government,no,Not Available,0,0
-693GF,Columbia County Outpatient Clinic,"Alley Medical Center, 301 West Third Street",Berwick,PA,18603,570-759-0351,VA Facility,Government,no,Not Available,0,0
-529GF,Cranberry Township VA Outpatient Clinic,"900 Commonwealth Drive, Suite 900",Cranberry Township,PA,16066,724-742-3500 Or 724-741-3131,VA Facility,Government,no,Not Available,0,0
-562GA,Crawford County Primary Care Clinic,16954 Conneaut Lake Road,Meadville,PA,16335,866-962-3210,VA Facility,Government,no,Not Available,0,0
-460HG,Cumberland County CBOC,79 W. Landis Avenue,Vineland,NJ,8360,800-461-8262 X 6500,VA Facility,Government,no,Not Available,39.48669,-75.03702
-503GB,DuBois (Clearfield County) VA Outpatient Clinic (503GB),5690 Shaffer Road,DuBois,PA,15801,877-626-2500,VA Facility,Government,no,Not Available,0,0
-646GE,Fayette County Outpatient Clinic,635 Pittsburgh Road,Uniontown,PA,15401,724-439-4990,VA Facility,Government,no,Not Available,39.92053,-79.72622
-503GD,Huntingdon County CBOC,13903 William Penn Highway,Mapleton Depot,PA,17052,814-542-2800,VA Facility,Government,no,Not Available,0,0
-503GE,Indiana County CBOC,1570 Oakland Avenue,Indiana,PA,15701,724-349-8900,VA Facility,Government,no,Not Available,40.61499,-79.171394
-503GA,Johnstown VA Outpatient Clinic (Cambria County) (503GA),"598 Galleria Drive, Next to Gander Mountain",Johnstown,PA,15904,877-626-2500,VA Facility,Government,no,Not Available,40.303246,-78.83298
-460GC,Kent County CBOC,"1198 S. Governors Avenue, Suite 201",Dover,DE,19901,800-461-8262 X 2400,VA Facility,Government,no,Not Available,0,0
-595GC,Lancaster VA Clinic (595GC),"1861 Charter Lane, Green Field Corporate Center, Suite 120",Lancaster,PA,17601,717-290-6900,VA Facility,Government,no,Not Available,40.052605,-76.25084
-529GB,Lawrence County VA Outpatient Clinic,"Ridgewood Professional Centre, 1750 New Butler Road",New Castle,PA,16101,724-598-6080,VA Facility,Government,no,Not Available,0,0
-562GC,McKean County Primary Care Clinic,23 Kennedy Street,Bradford,PA,16701,814-368-3019,VA Facility,Government,no,Not Available,41.95659,-78.64741
-529GA,Mercer County VA Outpatient Clinic,"295 N. Kerrwood Drive, Suite 110",Hermitage,PA,16148,724-346-1569,VA Facility,Government,no,Not Available,41.237286,-80.46313
-693GG,Northampton County Outpatient Clinic,Phoebe Slate Belt Nursing Home & Rehab Center 701 Slate Belt Boulevard,Bangor,PA,18013,610-599-0127,VA Facility,Government,no,Not Available,0,0
-595GF,Pottsville VA Clinic (595GF),"1410 Laurel Blvd., Suite 2",Pottsville,PA,17901,570-628-5374,VA Facility,Government,no,Not Available,40.68376,-76.211494
-595GD,Reading VA Clinic (595GD),2762 Century Boulevard,Wyomissing,PA,19610,484-220-2572,VA Facility,Government,no,Not Available,0,0
-693GA,Sayre VA Outpatient Clinic (693GA),1537 Elmira Street,Sayre,PA,18840,570-888-6803,VA Facility,Government,no,Not Available,41.974503,-76.540665
-542GE,Spring City VA Outpatient Clinic (542GE),11 Independence Drive,Spring City,PA,19475,610-383-0239,VA Facility,Government,no,Not Available,40.187653,-75.565445
-542GA,Springfield VA Outpatient Clinic (542GA),"Crozer Keystone Healthplex 194 W. Sproul Road, Suite 105",Springfield,PA,19064,610-383-0239,VA Facility,Government,no,Not Available,0,0
-503GC,State College (Centre County) VA Outpatient Clinic (503GC),2581 Clyde Avenue,State College,PA,16801,877-626-2500,VA Facility,Government,no,Not Available,40.82724,-77.804794
-460GA,Sussex County CBOC,21748 Roth Ave,Georgetown,DE,19947,800-461-8262 X 2300,VA Facility,Government,no,Not Available,0,0
-693GC,Tobyhanna Army Depot (693GC),Building 220,Tobyhanna,PA,18466,570-615-8341,VA Facility,Government,no,Not Available,0,0
-562GD,Venango County VA Clinic,464 Allegheny Boulevard,Franklin,PA,16323,866-962-3260,VA Facility,Government,no,Not Available,41.401962,-79.80932
-642GD,Veterans Health Clinic at Gloucester County (642GD),211 County House Road,Sewell,NJ,8080,877-823-5230 Or 877-823-5230,VA Facility,Government,no,Not Available,39.778458,-75.102425
-642GC,Victor J. Saracini VA Outpatient Clinic (Montgomery County),433 Caredean Dr.,Horsham,PA,19044,215-823-6050,VA Facility,Government,no,Not Available,40.202858,-75.175896
-562GE,Warren CBOC,3 Farm Colony Dr,Warren,PA,16365,866-682-3250,VA Facility,Government,no,Not Available,41.832176,-79.14865
-646GD,Washington County Outpatient Clinic,"1500 West Chestnut St., Room 450",Washington,PA,15301,724-250-7790,VA Facility,Government,no,Not Available,40.164463,-80.274345
-693QA,Wayne County Outpatient Clinic,600 Maple Ave. Suite 2,Honesdale,PA,18431,570-251-6543,VA Facility,Government,no,Not Available,0,0
-646GB,Westmoreland County Outpatient Clinic,"5274 Rt 30 East, Suite 10",Greensburg,PA,15601,724-216-0317,VA Facility,Government,no,Not Available,0,0
-693GB,"Williamsport OPC, Campus of Divine Providence Hospital (693GB)","1705 Warren Avenue, Werner Building - 3rd Floor (Suite 304)",Williamsport,PA,17701,570-322-4791,VA Facility,Government,no,Not Available,41.260082,-76.98141
-595GE,York VA Clinic (595GE),2251 Eastern Blvd.,York,PA,17402,717-840-2730,VA Facility,Government,no,Not Available,39.9719,-76.6848
-238,Bucks County Vet Center,"2 Canal's End Road, Suite 201B",Bristol,PA,19007,215-823-4590 Or 215-823-4590,VA Facility,Government,no,Not Available,0,0
-227,DuBois Vet Center,"100 Meadow Lane, Suite 8",DuBois,PA,15801,814-372-2095,VA Facility,Government,no,Not Available,0,0
-0222V,Erie Vet Center,"240 W. 11th St., Erie Metro Center, Suite 105",Erie,PA,16501,814-453-7955 Or 814-453-7955,VA Facility,Government,no,Not Available,42.12275,-80.0867
-0218V,Harrisburg Vet Center,1500 N. Second Street Suite 2,Harrisburg,PA,17102,717-782-3954 Or 717-782-3954,VA Facility,Government,no,Not Available,40.27054,-76.89296
-242,Lancaster County Vet Center,"1817 Olde Homestead Lane, Suite 207",Lancaster,PA,17601,717-283-0735 Or 717-283-0735,VA Facility,Government,no,Not Available,0,0
-0239V,Norristown Vet Center,"320 E. Johnson Hwy, Suite 201",Norristown,PA,19401,215-823-5245 Or 877-927-8387,VA Facility,Government,no,Not Available,40.128048,-75.32217
-0219V,Northeast Philadelphia Vet Center,101 E. Olney Avenue,Philadelphia,PA,19120,215-924-4670 Or 215-924-4670,VA Facility,Government,no,Not Available,40.035076,-75.11968
-210,Philadelphia Vet Center,801 Arch Street Suite 502,Philadelphia,PA,19107,215-627-0238 Or 215-627-0238,VA Facility,Government,no,Not Available,39.95318,-75.15322
-0211V,Pittsburgh Vet Center,"2500 Baldwick Rd, Suite 15",Pittsburgh,PA,15205,412-920-1765 Or 412-920-1765,VA Facility,Government,no,Not Available,40.426678,-80.05733
-0229V,Scranton Vet Center,1002 Pittston Ave.,Scranton,PA,18505,570-344-2676 Or 570-344-2676,VA Facility,Government,no,Not Available,41.395813,-75.6689
-243V,Sussex County Vet Center,"20653 Dupont Blvd, Suite 1",Georgetown,DE,19947,302-225-9110 Or 302-225-9110,VA Facility,Government,no,Not Available,0,0
-0230V,Ventnor Vet Center,"6601 Ventnor Ave. Suite 105, Ventnor Professional Plaza",Ventnor,NJ,8406,609-487-8387,VA Facility,Government,no,Not Available,39.337135,-74.484406
-0220V,White Oak Vet Center,"2001 Lincoln Way, Suite 21",White Oak,PA,15131,412-678-7704 Or 412-678-7704,VA Facility,Government,no,Not Available,40.337463,-79.80879
-0212V,Williamsport Vet Center,49 E. Fourth Street Suite 104,Williamsport,PA,17701,570-327-5281 Or 570-327-5281,VA Facility,Government,no,Not Available,41.242813,-77.00096
-0215V,Wilmington Vet Center,"2710 Centerville Road, Suite 103",Wilmington,DE,19808,302-994-1660 Or 302-994-1660,VA Facility,Government,no,Not Available,39.75347,-75.62461
-10N5,VISN 5: VA Capitol Health Care Network,"849 International Drive, Suite 275",Linthicum,MD,21090,410-691-1131,VA Facility,Government,no,Not Available,39.206387,-76.674095
-58101,"Homeless Veterans Resource Center (Huntington, WV)",624 9th Street,Huntington,WV,25701,304-529-9142,VA Facility,Government,no,Not Available,38.417686,-82.44307
-512,VA Maryland Health Care System,10 North Greene Street,Baltimore,MD,21201,410-605-7000,VA Facility,Government,no,Not Available,39.28936,-76.623726
-512,Baltimore VA Medical Center - VA Maryland Health Care System,10 North Greene Street,Baltimore,MD,21201,410-605-7000 Or 410-605-7000,VA Facility,Government,no,Not Available,39.28936,-76.623726
-517,Beckley VA Medical Center,200 Veterans Avenue,Beckley,WV,25801,304-255-2121 Or 304-255-2121,VA Facility,Government,no,Not Available,0,0
-540,Clarksburg - Louis A. Johnson VA Medical Center,One Medical Center Drive,Clarksburg,WV,26301,304-623-3461 Or 800-733-0512,VA Facility,Government,no,Not Available,0,0
-581,Huntington VA Medical Center,1540 Spring Valley Drive,Huntington,WV,25704,304-429-6741,VA Facility,Government,no,Not Available,38.384087,-82.51794
-512GB,Loch Raven VA Medical Center - VA Maryland Health Care System,3900 Loch Raven Boulevard,Baltimore,MD,21218,410-605-7000 Or 410-605-7000,VA Facility,Government,no,Not Available,39.33639,-76.59441
-613,Martinsburg VA Medical Center,510 Butler Avenue,Martinsburg,WV,25405,304-263-0811 Or 800-817-3807,VA Facility,Government,no,Not Available,39.4139,-77.9135
-512A5,Perry Point VA Medical Center - VA Maryland Health Care System,VA Medical Center,Perry Point,MD,21902,410-642-2411 Or 410-642-2411,VA Facility,Government,no,Not Available,0,0
-688,Washington DC VA Medical Center,"50 Irving Street, NW",Washington,DC,20422,202-745-8000,VA Facility,Government,no,Not Available,38.931225,-77.012024
-581,Gallipolis VA Clinic,323A Upper River Road,Gallipolis,OH,45631,740-446-3934,VA Facility,Government,no,Not Available,38.83184,-82.15734
-581,Lenore VA Clinic,2867 Route 65,Lenore,WV,25676,304-475-3000,VA Facility,Government,no,Not Available,0,0
-512AX,Baltimore VA Annex,209 West Fayette Street,Baltimore,MD,21201,410-605-7000 Or 800-463-6295,VA Facility,Government,no,Not Available,39.290485,-76.61795
-540GC,Braxton County CBOC (540GC),40 Reston Place,Gassaway,WV,26624,304-364-4500,VA Facility,Government,no,Not Available,0,0
-512GA,Cambridge VA Outpatient Clinic,830 Chesapeake Drive,Cambridge,MD,21613,410-228-6243 Or 877-864-9611,VA Facility,Government,no,Not Available,38.553482,-76.060234
-581GB,Charleston VA Clinic,700 Technology Drive,South Charleston,WV,25309,304-746-5300,VA Facility,Government,no,Not Available,0,0
-688GB,Community Clinic-Southeast,"820 Chesapeake Street, S.E.",Washington,DC,20032,202-745-8685,VA Facility,Government,no,Not Available,38.829216,-76.993225
-688GG,Community Resource and Referral Center (CRRC),"1500 Franklin St., NE",Washington,DC,20018,202-636-7660,VA Facility,Government,no,Not Available,38.925674,-76.98309
-613GA,Cumberland Outpatient Clinic,200 Glenn Street,Cumberland,MD,21502,304-263-0811 X 5130,VA Facility,Government,no,Not Available,39.653942,-78.75825
-512GF,Eastern Baltimore County VA Outpatient Clinic,5253 King Avenue,Rosedale,MD,21237,410-477-1800 Or 410-477-1800,VA Facility,Government,no,Not Available,39.35733,-76.46929
-688,Fort Belvoir Outpatient Clinic,9300 DeWitt Loop Sunrise Pavilion,Fort Belvoir,VA,22060,571-231-2408,VA Facility,Government,no,Not Available,0,0
-613GG,Fort Detrick VA Outpatient Clinic,1433 Porter Street,Frederick,MD,21702,304-263-0811 X 5130,VA Facility,Government,no,Not Available,0,0
-6192,Fort Meade VA Outpatient Clinic,2479 5th Street,Fort Meade,MD,20755,410-305-5300,VA Facility,Government,no,Not Available,0,0
-613GD,Franklin Community Based Outpatient Clinic,91 Pine Street,Franklin,WV,26807,304-263-0811 X 5130,VA Facility,Government,no,Not Available,0,0
-512GC,Glen Burnie VA Outpatient Clinic,"808 Landmark Drive, Suite 128",Glen Burnie,MD,21061,410-590-4140,VA Facility,Government,no,Not Available,39.1484,-76.642006
-517GB,Greenbrier County VA Clinic,228 Shamrock Lane,Ronceverte,WV,24970,304-497-3900,VA Facility,Government,no,Not Available,0,0
-613GB,Hagerstown Outpatient Clinic,"Hub Plaza Bldg, 1101 Opal Ct",Hagerstown,MD,21742,304-263-0811 X 5130,VA Facility,Government,no,Not Available,0,0
-613GF,Harrisonburg Outpatient Clinic,1755 S. High Street,Harrisonburg,VA,22801,304-263-0811 X 5130 Or 800-817-3807 X 5130,VA Facility,Government,no,Not Available,38.432823,-78.90089
-512GD,Loch Raven VA Outpatient Clinic,3901 The Alameda,Baltimore,MD,21218,410-605-7650 Or 410-605-7650,VA Facility,Government,no,Not Available,0,0
-540GD,Monongalia County (540GD),"40 Commerce Drive, Suite 101",Westover,WV,26501,304-292-7535,VA Facility,Government,no,Not Available,0,0
-613GE,Petersburg Community Based Outpatient Clinic,15 Grant St.,Petersburg,WV,26847,304-263-0811 X 5130,VA Facility,Government,no,Not Available,38.99487,-79.11806
-512GE,Pocomoke City VA Outpatient Clinic,"1701 Market Street, Unit 211",Pocomoke,MD,21851,410-957-6718 Or 866-441-0287,VA Facility,Government,no,Not Available,0,0
-581GA,Prestonsburg VA Clinic,5230 KY RT 321,Prestonsburg,KY,41653,606-886-1970,VA Facility,Government,no,Not Available,0,0
-517QA,Princeton VA Clinic,1511 North Walker Street,Princeton,WV,24740,304-255-2121 X 3404,VA Facility,Government,no,Not Available,37.367912,-81.10203
-540,Rural Mobile Unit (540),1 Medical Center Drive,Clarksburg,WV,26301,304-623-3461,VA Facility,Government,no,Not Available,39.269535,-80.36269
-688GD,Southern Maryland VA Outpatient Clinic,29431 Charlotte Hall Road,Charlotte Hall,MD,20622,301-884-7102,VA Facility,Government,no,Not Available,38.47783,-76.77777
-688,Southern PG County Outpatient Clinic,5801 Allentown Road,Camp Springs,MD,20746,301-423-3700,VA Facility,Government,no,Not Available,38.8073,-76.89988
-613GC,Stephens City Outpatient Clinic,170 Prosperity Drive,Winchester,VA,22602,304-263-0811 X 5130,VA Facility,Government,no,Not Available,0,0
-540GA,Tucker County CBOC (540GA),260 Spruce Street,Parsons,WV,26287,304-478-2219,VA Facility,Government,no,Not Available,39.096973,-79.683685
-540GB,Wood County CBOC (540GB),"2311 Ohio Avenue, Suite A",Parkersburg,WV,26101,304-422-5114,VA Facility,Government,no,Not Available,39.282536,-81.549706
-2092,Aberdeen Vet Center Outstation,223 W. Bel Air Avenue,Aberdeen,MD,21001,410-272-6771 Or 877-927-8387,VA Facility,Government,no,Not Available,39.510605,-76.16716
-0228V,Alexandria Vet Center,6940 South Kings Highway #204,Alexandria,VA,22310,703-360-8633 Or 703-360-8633,VA Facility,Government,no,Not Available,38.768433,-77.11709
-0235V,Annapolis Vet Center,100 Annapolis Street,Annapolis,MD,21401,410-605-7826 Or 877-927-8387,VA Facility,Government,no,Not Available,38.990086,-76.50218
-0201V,Baltimore Vet Center,1777 Reisterstown Road Suite 199,Baltimore,MD,21208,410-764-9400 Or 410-764-9400,VA Facility,Government,no,Not Available,39.383865,-76.73311
-0231V,Beckley Vet Center,1000 Johnstown Road,Beckley,WV,25801,304-252-8220 Or 877-927-8387,VA Facility,Government,no,Not Available,37.780453,-81.16978
-0223V,Charleston Vet Center,200 Tracy Way,Charleston,WV,25311,304-343-3825 Or 304-343-3825,VA Facility,Government,no,Not Available,38.35907,-81.59911
-0237V,Clinton Vet Center,"7905 Malcolm Road, Suite 101",Clinton,MD,20735,301-856-7173 Or 301-856-7173,VA Facility,Government,no,Not Available,38.782055,-76.889824
-0236V,Dundalk Vet Center,1553 Merritt Blvd,Dundalk,MD,21222,410-282-6144 Or 877-927-8387,VA Facility,Government,no,Not Available,39.27272,-76.5025
-209,Elkton Vet Center,103 Chesapeake Blvd. Suite A,Elkton,MD,21921,410-392-4485 Or 410-392-4485,VA Facility,Government,no,Not Available,0,0
-0208V,Huntington Vet Center,3135 16th Street Road Suite 11,Huntington,WV,25701,304-523-8387 Or 304-523-8387,VA Facility,Government,no,Not Available,38.39435,-82.40953
-02231V,Logan Vet Center Outstation,21 Veterans Avenue,Henlawson,WV,25624,304-752-4453 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-224,Martinsburg Vet Center,300 Foxcroft Ave. Suite 100A,Martinsburg,WV,25401,304-263-6776 Or 304-263-6776,VA Facility,Government,no,Not Available,39.462715,-77.986916
-0216V,Morgantown Vet Center,"34 Commerce Drive, Suite 101",Morgantown,WV,26501,304-291-4303 Or 304-291-4303,VA Facility,Government,no,Not Available,0,0
-2081,Parkersburg Vet Center Outstation,"2311 Ohio Avenue, Suite D",Pakersburg,WV,26101,304-485-1599 Or 877-927-8387,VA Facility,Government,no,Not Available,39.282536,-81.549706
-0232V,Princeton Vet Center,1511 North Walker Street,Princeton,WV,24740,304-425-8098,VA Facility,Government,no,Not Available,37.367912,-81.10203
-0200V,RCS North Atlantic District 1,"305 W. Chesapeake Ave., Suite 300",Towson,MD,21204,410-828-6619 Or 410-828-6619,VA Facility,Government,no,Not Available,39.40007,-76.60994
-2091,Salisbury Outstation,"926 Snow Hill Road, Building 3",Salisbury,MD,21804,410-912-7263 Or 877-927-8387,VA Facility,Government,no,Not Available,38.34735,-75.58189
-0213V,Silver Spring Vet Center,2900 Linden Lane,Silver Spring,MD,20910,301-589-1073 Or 301-589-1073,VA Facility,Government,no,Not Available,39.014156,-77.05791
-213,Washington DC Vet Center,1296 Upshur St NW,Washington,DC,20011,202-726-5212 Or 202-463-0943,VA Facility,Government,no,Not Available,38.941853,-77.029495
-233,Wheeling Vet Center,1058 Bethlehem Blvd.,Wheeling,WV,26003,304-232-0587 Or 304-232-0587,VA Facility,Government,no,Not Available,40.053024,-80.701645
-10N6,VISN 6: VA Mid-Atlantic Health Care Network,3518 Westgate Drive,Durham,NC,27707,919-956-5541,VA Facility,Government,no,Not Available,35.968067,-78.96135
-637,Asheville VA Medical Center,1100 Tunnel Road,Asheville,NC,28805,828-298-7911,VA Facility,Government,no,Not Available,35.586716,-82.48251
-558,Durham VA Medical Center,508 Fulton Street,Durham,NC,27705,919-286-0411 Or 919-286-0411,VA Facility,Government,no,Not Available,36.008934,-78.937294
-565,Fayetteville VA Medical Center,2300 Ramsey Street,Fayetteville,NC,28301,910-488-2120 Or 910-488-2120,VA Facility,Government,no,Not Available,35.089222,-78.87833
-590,Hampton VA Medical Center,100 Emancipation Drive,Hampton,VA,23667,757-722-9961,VA Facility,Government,no,Not Available,37.0225,-76.330826
-652,Hunter Holmes McGuire VA Medical Center,1201 Broad Rock Boulevard,Richmond,VA,23249,804-675-5000,VA Facility,Government,no,Not Available,0,0
-658,Salem VA Medical Center,1970 Roanoke Boulevard,Salem,VA,24153,540-982-2463 Or 888-982-2463,VA Facility,Government,no,Not Available,37.276184,-80.02463
-659,Salisbury - W.G. (Bill) Hefner VA Medical Center,1601 Brenner Avenue,Salisbury,NC,28144,704-638-9000 Or 704-638-9000,VA Facility,Government,no,Not Available,35.683815,-80.48607
-558,Blind Rehabilitation Outpatient Clinic,8081 Arco Corporate Drive,Raleigh,NC,27617,919-286-5235,VA Facility,Government,no,Not Available,0,0
-558,Brier Creek Dialysis Clinic,"8081 Arco Corporate Drive, Suite 130",Raleigh,NC,27617,919-286-5220,VA Facility,Government,no,Not Available,0,0
-565,Fayetteville Dialysis Clinic,2301 Robeson Street,Fayetteville,NC,28305,910-483-9727,VA Facility,Government,no,Not Available,35.042355,-78.91646
-565GL,Fayetteville Health Care Center,7300 South Raeford Road,Fayetteville,NC,28304,910-488-2120 Or 800-771-6106,VA Facility,Government,no,Not Available,35.033398,-79.03128
-565QD,Fayetteville Rehabilitation Clinic,"4101 Raeford Road, Suite 100-B",Fayetteville,NC,28304,910-908-2222,VA Facility,Government,no,Not Available,35.0437,-78.947235
-558GA,Greenville Health Care Center,401 Moye Blvd,Greenville,NC,27834,252-830-2149,VA Facility,Government,no,Not Available,35.613003,-77.40099
-637GC,Hickory CBOC,2440 Century Place SE,Hickory,NC,28602,828-431-5600,VA Facility,Government,no,Not Available,0,0
-590,Albemarle Primary OPC,1845 W City Dr,Elizabeth City,NC,27909,757-722-9961,VA Facility,Government,no,Not Available,0,0
-565,Brunswick County,18 Doctors Circle (Units 2 & 3),Supply,NC,28462,910-754-6141,VA Facility,Government,no,Not Available,0,0
-659GA,Charlotte CBOC,8601 University East Drive,Charlotte,NC,28213,704-597-3500,VA Facility,Government,no,Not Available,0,0
-659BZ,Charlotte Health Care Center,3506 West Tyvola Road,Charlotte,NC,28208,704-329-1300,VA Facility,Government,no,Not Available,35.20241,-80.91191
-652,Charlottesville CBOC,"590 Peter Jefferson Pkwy, 2nd Floor, Suite 250",Charlottesville,VA,22911,434-293-3890,VA Facility,Government,no,Not Available,38.023098,-78.43744
-590GD,Chesapeake CBOC,1987 S. Military Hwy,Chesapeake,VA,23320,757-722-9961,VA Facility,Government,no,Not Available,36.783978,-76.25732
-658GB,Danville CBOC,705 Piney Forest Rd,Danville,VA,24540,434-710-4210,VA Facility,Government,no,Not Available,36.61081,-79.4059
-558,Durham Clinic,1824 Hillandale Road,Durham,NC,27705,919-383-6107,VA Facility,Government,no,Not Available,36.028954,-78.93582
-652GF,Emporia CBOC,1746 East Atlantic,Emporia,VA,23847,434-348-1055,VA Facility,Government,no,Not Available,36.68982,-77.52629
-637,Franklin CBOC,647 Wayah St,Franklin,NC,28734,828-369-1781,VA Facility,Government,no,Not Available,35.17557,-83.37493
-652gb,Fredericksburg at Southpoint CBOC,"10401 Spotsylvania Ave., Suite 300",Fredericksburg,VA,22408,540-693-3140,VA Facility,Government,no,Not Available,0,0
-652GA,Fredericksburg CBOC,130 Executive Center Parkway,Fredericksburg,VA,22401,540-370-4468,VA Facility,Government,no,Not Available,0,0
-565GF,Goldsboro Community Based Outpatient Clinic,2610 Hospital Road,Goldsboro,NC,27534,919-731-4809,VA Facility,Government,no,Not Available,0,0
-565GD,Hamlet CBOC,100 Jefferson Street,Hamlet,NC,28345,910-582-3536,VA Facility,Government,no,Not Available,34.885742,-79.70201
-558,Hillandale Road Outpatient Clinics 1 & II,1824 Hillandale Road,Durham,NC,27705,919-383-6107,VA Facility,Government,no,Not Available,36.028954,-78.93582
-565GA,Jacksonville CBOC,4006 Henderson Drive,Jacksonville,NC,28546,910-353-6406,VA Facility,Government,no,Not Available,0,0
-659BY,Kernersville Health Care Center,1695 Kernersville Medical Parkway,Kernersville,NC,27284,336-515-5000,VA Facility,Government,no,Not Available,0,0
-658,Lynchburg CBOC,1600 Lakeside Dr,Lynchburg,VA,24501,434-316-5000,VA Facility,Government,no,Not Available,37.40173,-79.18849
-558,Morehead City CBOC,5420 Highway 70,Morehead City,NC,28557,252-240-2349,VA Facility,Government,no,Not Available,0,0
-558,Raleigh CBOC,3305 Sungate Blvd,Raleigh,NC,27610,919-212-0129,VA Facility,Government,no,Not Available,0,0
-558,Raleigh II CBOC,3040 Hammond Business Place Suite 105,Raleigh,NC,27603,919-899-6259,VA Facility,Government,no,Not Available,0,0
-558GG,Raleigh III CBOC,"2600 Atlantic Ave., Suite 200",Raleigh,NC,27604,919-755-2620,VA Facility,Government,no,Not Available,35.82258,-78.60943
-558GG,Raleigh III Clinic,"2600 Atlantic Ave., Ste. 200",Raleigh,NC,27604,919-755-2620,VA Facility,Government,no,Not Available,35.82258,-78.60943
-565 GE,Robeson County CBOC,139 Three Hunts Drive,Pembroke,NC,28372,910-272-3220,VA Facility,Government,no,Not Available,0,0
-637GB,Rutherford County CBOC,374 Charlotte Road,Rutherfordton,NC,28139,828-288-2780,VA Facility,Government,no,Not Available,0,0
-565GG,Sanford CBOC,3112 Tramway Road,Sanford,NC,27332,919-775-6160,VA Facility,Government,no,Not Available,35.43814,-79.2131
-658GD,Staunton CBOC,102 Lacy B. King Way,Staunton,VA,24401,540-886-5777,VA Facility,Government,no,Not Available,0,0
-658GA,Tazewell VA Clinic,388 Ben Bolt Ave,Tazewell,VA,24651,276-988-8860,VA Facility,Government,no,Not Available,0,0
-590,Virginia Beach CBOC,244 Clearfield Ave,Virginia Beach,VA,23462,757-722-9961,VA Facility,Government,no,Not Available,0,0
-565GC,Wilmington HCC,1705 Gardner Road,Wilmington,NC,28405,910-343-5300,VA Facility,Government,no,Not Available,0,0
-658GE,Wytheville CBOC,165 Peppers Ferry Road,Wytheville,VA,24382,276-223-5400,VA Facility,Government,no,Not Available,0,0
-0317V,Charlotte Vet Center,"2114 Ben Craig Dr., Suite 300",Charlotte,NC,28262,704-549-8025 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0315V,Fayetteville Vet Center,2301 Robeson St. Suite 103,Fayetteville,NC,28305,910-488-6252 Or 910-488-6252,VA Facility,Government,no,Not Available,35.042355,-78.91646
-327,Greensboro Vet Center,"3515 W Market St., Suite 120",Greensboro,NC,27406,336-323-2660 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0319V,"Greenville, NC Vet Center","1021 WH Smith Blvd., Suite #100",Greenville,NC,27834,252-355-7920 Or 252-355-7920,VA Facility,Government,no,Not Available,0,0
-0343V,Jacksonville Vet Center,110A Branchwood Dr,Jacksonville,NC,28546,910-577-1100 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0207V,Norfolk Vet Center,"1711 Church Street, Suites A&B",Norfolk,VA,23504,757-623-7584 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0328V,Raleigh Vet Center,"8851 Ellstree Lane, Suite 122",Raleigh,NC,27617,919-361-6419 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0217V,Richmond Vet Center,4902 Fitzhugh Avenue,Richmond,VA,23230,804-353-8958 Or 804-353-8958,VA Facility,Government,no,Not Available,37.579716,-77.495415
-226,Roanoke Vet Center,"350 Albemarle Ave., SW",Roanoke,VA,24016,540-342-9726 Or 877-927-8387,VA Facility,Government,no,Not Available,37.263206,-79.94751
-3271,Rutherford Vet Center Outstation,303 Fairground Road,Spindale,NC,28160,828-288-2757 Or 828-288-2757,VA Facility,Government,no,Not Available,0,0
-0240V,Virginia Beach Vet Center,"324 Southport Circle, Suite 102",Virginia Beach,VA,23452,757-248-3665 Or 757-248-3665,VA Facility,Government,no,Not Available,36.831814,-76.13131
-0315V,Fayetteville (NC) Vet Center,"2301 Robeson St., Suite 103",Fayetteville,NC,28305,910-488-6252 Or 800-771-6106 X 7701,VA Facility,Government,no,Not Available,35.042355,-78.91646
-0343V,Jacksonville Vet Center,110A Branchwood Dr,Jacksonville,NC,28345,910-577-1100 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-10N7,VISN 7: VA Southeast Network,"3700 Crestwood Parkway, NW, Suite 500",Duluth,GA,30096,678-924-5700,VA Facility,Government,no,Not Available,33.94617,-84.13016
-508,Atlanta VA Health Care System,1670 Clairmont Road,Decatur,GA,30033,404-321-6111,VA Facility,Government,no,Not Available,33.8016,-84.30972
-521,Birmingham VA Medical Center,700 S. 19th Street,Birmingham,AL,35233,205-933-8101,VA Facility,Government,no,Not Available,33.511967,-86.89478
-557,Carl Vinson VA Medical Center,1826 Veterans Blvd.,Dublin,GA,31021,478-272-1210,VA Facility,Government,no,Not Available,32.54052,-82.94631
-619A4,Central Alabama Veterans Health Care System East Campus,2400 Hospital Road,Tuskegee,AL,36083,334-727-0550 Or 334-727-0550,VA Facility,Government,no,Not Available,0,0
-619,Central Alabama Veterans Health Care System West Campus,215 Perry Hill Road,Montgomery,AL,36109,334-272-4670 Or 334-272-4670,VA Facility,Government,no,Not Available,32.37902,-86.246376
-509,Charlie Norwood VA Medical Center,1 Freedom Way,Augusta,GA,30904,706-733-0188 Or 706-733-0188,VA Facility,Government,no,Not Available,33.468346,-82.02534
-534,Ralph H. Johnson VA Medical Center,109 Bee Street,Charleston,SC,29401,843-577-5011 Or 843-577-5011,VA Facility,Government,no,Not Available,32.785133,-79.95385
-679,Tuscaloosa VA Medical Center,"3701 Loop Road, East",Tuscaloosa,AL,35404,205-554-2000 Or 205-554-2000,VA Facility,Government,no,Not Available,33.19277,-87.48909
-544,Wm. Jennings Bryan Dorn VA Medical Center,6439 Garners Ferry Road,Columbia,SC,29209,803-776-4000,VA Facility,Government,no,Not Available,33.980034,-80.96186
-509GA,Athens Clinic,9249 Highway 29 North,Athens,GA,30601,706-227-4534,VA Facility,Government,no,Not Available,0,0
-619GB,Dothan Mental Health Clinic,"3753 Ross Clark Cir., Suite 4",Dothan,AL,36303,334-678-1933,VA Facility,Government,no,Not Available,31.252869,-85.415695
-534,Hinesville Clinic,500 East Oglethorpe Highway,Hinesville,GA,31313,912-408-2900,VA Facility,Government,no,Not Available,31.838243,-81.595215
-508,Rome VA Clinic,"30 Chateau Dr, SE",Rome,GA,30161,404-329-2222,VA Facility,Government,no,Not Available,34.220844,-85.15464
-679A1,Selma Outpatient Clinic,206 Vaughan Memorial Drive,Selma,AL,36701,205-554-2000 X 6601 Or 205-554-2000 X 6607,VA Facility,Government,no,Not Available,0,0
-534GF,Trident VA Clinic,9237 University Blvd,North Charleston,SC,29406,843-789-6400,VA Facility,Government,no,Not Available,32.97779,-80.0726
-534QB,Trident VA Clinic – 9229 University Blvd,"9229 University Blvd., Bldg. F, Suite 2A",North Charleston,SC,29406,843-789-6400,VA Facility,Government,no,Not Available,32.977776,-80.07254
-508GK,Trinka Davis Veterans Village Clinic,180 Martin Dr,Carrollton,GA,30117,678-423-4970 X 2155 Or 678-423-4970 X 2156,VA Facility,Government,no,Not Available,33.63418,-85.19058
-534QC,VA Community Resource and Referral Center,2424 City Hall Lane,North Charleston,SC,29405,,VA Facility,Government,no,Not Available,0,0
-509GB,Aiken Community Based Outpatient Clinic,951 Millbrook Avenue,Aiken,SC,29803,803-643-9016,VA Facility,Government,no,Not Available,33.52147,-81.71997
-557GB,Albany Clinic,"814 Radford Blvd., Building 7000",Albany,GA,31701,229-446-9000,VA Facility,Government,no,Not Available,31.55069,-84.063835
-544GD,Anderson County Clinic,3030 North Highway 81,Anderson,SC,29621,864-224-5450,VA Facility,Government,no,Not Available,0,0
-521GE,Anniston/Oxford Clinic,96 Ali Way Creekside South,Oxford,AL,36203,256-832-4141,VA Facility,Government,no,Not Available,0,0
-508QF,Atlanta VA Clinic,250 N. Arcadia Avenue,Decatur,GA,30030,404-329-2222,VA Facility,Government,no,Not Available,33.780342,-84.27822
-508GF,Austell VA CBOC,2041 Mesa Valley Way Suite 185,Austell,GA,30082,404-329-2222,VA Facility,Government,no,Not Available,0,0
-534,Beaufort Clinic,1 Pinckney Blvd,Beaufort,SC,29902,843-770-0444,VA Facility,Government,no,Not Available,0,0
-521GG,Bessemer CBOC,"975 9th Avenue, SW-Suite 400 at UAB West Medical Center West",Bessemer,AL,32055,205-428-3495,VA Facility,Government,no,Not Available,0,0
-521GJ,Birmingham VA Clinic,2415 7th Avenue South,Birmingham,AL,35233,205-933-8101,VA Facility,Government,no,Not Available,33.508595,-86.79411
-508GJ,Blairsville VA CBOC,"1294 Highway 515 East, Suite 100",Blairsville,GA,30512,404-329-2222,VA Facility,Government,no,Not Available,0,0
-557GD,Brunswick,"1111 Glynco Parkway, Bldg. 2, Suite 200",Brunswick,GA,31525,912-261-2355,VA Facility,Government,no,Not Available,0,0
-521GH,Childersburg CBOC,151 9th Ave NW,Childersburg,AL,35044,256-378-9026,VA Facility,Government,no,Not Available,33.27733,-86.35565
-31902,Columbus Clinic,1310 13th AVENUE,Columbus,GA,31901,706-257-7205,VA Facility,Government,no,Not Available,32.47083,-84.97439
-619GB,Dothan,2020 Alexander Drive,Dothan,AL,36301,334-673-4166,VA Facility,Government,no,Not Available,31.21237,-85.36345
-508QB,East Point VA Clinic,"2675 N. Martin St., Building 700 Suite A",East Point,GA,30344,,VA Facility,Government,no,Not Available,33.68299,-84.438034
-544GB,Florence CBOC,1822 Sally Hill Farms Road,Florence,SC,29501,843-292-8383,VA Facility,Government,no,Not Available,34.25562,-79.773415
-508GA,Fort McPherson VA Campus,"1701 Hardee Ave., SW",Atlanta,GA,30310,404-321-6111 X 2222,VA Facility,Government,no,Not Available,0,0
-619QB,Ft. Benning VA Clinic,"6635 Bass Road, Bldg. 9214",Ft. Benning,GA,31905,706-257-7205,VA Facility,Government,no,Not Available,0,0
-508QD,Fulton County VA Clinic,"1513 Cleveland Ave., Building 300",East Point,GA,30344,,VA Facility,Government,no,Not Available,33.679413,-84.43989
-521GD,Gadsden CBOC,206 Rescia Ave,Gadsden,AL,35906,256-413-7154,VA Facility,Government,no,Not Available,33.963287,-86.03298
-534GD,Goose Creek CBOC,2418 NNPTC Circle,Goose Creek,SC,29445,843-577-5011 X 3100,VA Facility,Government,no,Not Available,0,0
-544BZ,Greenville Clinic,41 Park Creek Drive,Greenville,SC,29605,864-299-1600,VA Facility,Government,no,Not Available,34.75783,-82.39619
-619GE,"Guntersville, AL CBOC",101 Judy Smith Drive,Guntersville,AL,35976,256-582-4033,VA Facility,Government,no,Not Available,0,0
-508QE,Gwinnett County VA Clinic,1970 Riverside Parkway,Lawrenceville,GA,30043,404-329-2222,VA Facility,Government,no,Not Available,33.981247,-84.02569
-508QC,Henderson Mill VA Clinic,2296 Henderson Mill Road,Atlanta,GA,30345,,VA Facility,Government,no,Not Available,33.852135,-84.258965
-521GA,Huntsville Clinic,"500 Markaview Drive, NW",Huntsville,AL,35805,256-533-8477,VA Facility,Government,no,Not Available,0,0
-521GF,Jasper Clinic,1454 Jones Dairy Rd,Jasper,AL,35501,205-221-7384,VA Facility,Government,no,Not Available,0,0
-508GH,Lawrenceville VA Clinic,"455 Philip Blvd, Suite 200",Lawrenceville,GA,30046,404-329-2222,VA Facility,Government,no,Not Available,0,0
-557GA,Macon Clinic,5566 Thomaston Road,Macon,GA,31220,478-476-8868,VA Facility,Government,no,Not Available,32.834206,-83.744354
-557GF,Milledgeville Community Based Outpatient Clinic,2249 Vinson Hwy SE,Milledgeville,GA,31061,478-414-4540,VA Facility,Government,no,Not Available,33.047714,-83.212585
-619GF,Montgomery VA Clinic,8105 Veterans Way,Montgomery,AL,36117,800-214-8387,VA Facility,Government,no,Not Available,0,0
-534GB,Myrtle Beach CBOC,3381 Phillis Blvd.,Myrtle Beach,SC,29577,843-477-0177,VA Facility,Government,no,Not Available,33.67208,-78.93672
-534QA,Myrtle Beach VA Clinic – Market Common,1101 Johnson Avenue,Myrtle Beach,SC,29577,843-477-0177,VA Facility,Government,no,Not Available,0,0
-508GI,Newnan VA Clinic,39-A Oak Hill Ct.,Newnan,GA,30265,404-329-2222,VA Facility,Government,no,Not Available,0,0
-508GE,Oakwood VA Clinic,4175 Tanners Creek Drive,Flowery Branch,GA,30542,404-329-2222,VA Facility,Government,no,Not Available,0,0
-544GE,Orangeburg County Clinic,1767 Villagepark Drive,Orangeburg,SC,29118,803-533-1335,VA Facility,Government,no,Not Available,33.5234,-80.85726
-557GC,Perry Outreach Clinic,2370 S. Houston Lake Road,Kathleen,GA,31047,478-224-1309,VA Facility,Government,no,Not Available,32.503242,-83.66276
-544GC,Rock Hill Clinic,2670 Mills Park Drive,Rock Hill,SC,29732,803-366-4848,VA Facility,Government,no,Not Available,34.977192,-81.024704
-534BY,Savannah Clinic,1170 Shawnee St.,Savannah,GA,31419,912-920-0214,VA Facility,Government,no,Not Available,31.986042,-81.173485
-521GC,Shoals Area (Florence) Clinic,422 DD Cox Blvd.,Sheffield,AL,35660,256-381-9055,VA Facility,Government,no,Not Available,0,0
-544,Spartanburg CBOC,279 North Grove Medical Park Drive,Spartanburg,SC,29303,864-582-7025,VA Facility,Government,no,Not Available,0,0
-509GC,Statesboro Clinic,658 Northside Drive East,Statesboro,GA,30458,912-871-8719 Or 706-733-0188 X 1132,VA Facility,Government,no,Not Available,32.43446,-81.75643
-508GG,Stockbridge VA Clinic,175 Medical Blvd.,Stockbridge,GA,30281,404-329-2222,VA Facility,Government,no,Not Available,33.512432,-84.22509
-544,Sumter County Clinic,407 North Salem Avenue,Sumter,SC,29150,803-938-9901,VA Facility,Government,no,Not Available,33.929115,-80.350685
-6426,Tifton VA Clinic,1824 Ridge Avenue North,Tifton,GA,31794,229-391-6080 Or 229-391-6080,VA Facility,Government,no,Not Available,31.441685,-83.51968
-619,VA Outpatient Clinic Monroeville (CBOC),159 Whetstone Street,Monroeville,AL,36400,251-743-5861 Or 251-743-5862,VA Facility,Government,no,Not Available,0,0
-619,Wiregrass CBOC,301 Andrews Avenue,Fort Rucker,AL,36362,800-214-8387 X 7831,VA Facility,Government,no,Not Available,0,0
-0304V,Atlanta Vet Center,"1800 Phoenix Boulevard, Building 400, Suite 404 Box 55",Atlanta,GA,30349,404-417-5414 Or 404-417-5414,VA Facility,Government,no,Not Available,33.614666,-84.442856
-509,Augusta Vet Center,"2050 Walton Way, Suite 100",Augusta,GA,30904,706-729-5762 Or 706-729-5762,VA Facility,Government,no,Not Available,33.475864,-82.00829
-0739V,Birmingham Vet Center,"400 Emery Drive, Suite 200",Hoover,AL,35244,205-212-3122 Or 205-212-3122,VA Facility,Government,no,Not Available,0,0
-0303V,Charleston Vet Center,3625 West Montague Avenue,North Charleston,SC,29418,843-789-7000 Or 843-789-7000,VA Facility,Government,no,Not Available,32.861355,-80.02741
-0324V,Columbia Vet Center,"1710 Richland Street, Suite A",Columbia,SC,29201,803-765-9944 Or 877-927-8387,VA Facility,Government,no,Not Available,34.01316,-81.02945
-0349V,Columbus Vet Center,"2601 Cross Country Drive, Condominium B-2 Suite 900",Columbus,GA,31906,706-596-7170,VA Facility,Government,no,Not Available,0,0
-0316V,"Greenville, SC Vet Center","3 Caledon Court, Suite B",Greenville,SC,29615,864-271-2711 Or 864-271-2711,VA Facility,Government,no,Not Available,34.861446,-82.339714
-738,Huntsville Vet Center,"415 Church Street, Bldg H, Suite 101",Huntsville,AL,35801,256-539-5775 Or 256-539-5775,VA Facility,Government,no,Not Available,34.73529,-86.591606
-0329V,Lawrenceville Vet Center,930 River Centre Place,Lawrenceville,GA,30043,404-728-4195 Or 404-728-4195,VA Facility,Government,no,Not Available,33.973522,-84.03296
-0333V,Macon Vet Center,750 Riverside Drive,Macon,GA,31201,478-477-3813 Or 877-927-8387,VA Facility,Government,no,Not Available,32.841946,-83.62805
-0342V,Marietta Vet Center,"40 Dodd St., Suite 700",Marietta,GA,30060,404-327-4954 Or 404-327-4954,VA Facility,Government,no,Not Available,33.950397,-84.52376
-0740V,Montgomery Vet Center,4405 Atlanta Highway,Montgomery,AL,36109,334-273-7796 Or 877-927-8387,VA Facility,Government,no,Not Available,32.381733,-86.2297
-0347V,Myrtle Beach Vet Center,"2024 Corporate Centre Dr, Suite 103",Myrtle Beach,SC,29577,843-232-2441 Or 843-232-2441,VA Facility,Government,no,Not Available,33.709522,-78.88358
-0323V,Savannah Vet Center,321 Commercial Dr,Savannah,GA,31406,912-961-5800 Or 912-961-5800,VA Facility,Government,no,Not Available,32.006786,-81.10781
-485,VISN 8: VA Sunshine Healthcare Network,"140 Fountain Parkway, Ste. 600",St. Petersburg,FL,33716,727-575-8069,VA Facility,Government,no,Not Available,27.890217,-82.66082
-516,Bay Pines VA Healthcare System,10000 Bay Pines Blvd,Bay Pines,FL,33744,727-398-6661 Or 727-398-6661,VA Facility,Government,no,Not Available,27.8139,-82.770836
-573,North Florida/South Georgia Veterans Health System,1601 S.W. Archer Road,Gainesville,FL,32608,352-376-1611,VA Facility,Government,no,Not Available,29.639143,-82.34345
-672,VA Caribbean Healthcare System,10 Casia Street,San Juan,PR,921,787-641-7582 Or 787-641-7582,VA Facility,Government,no,Not Available,0,0
-673,James A. Haley Veterans' Hospital,13000 Bruce B. Downs,Tampa,FL,33612,813-972-2000,VA Facility,Government,no,Not Available,28.065699,-82.42611
-673QJ,James A. Haley Veterans' Hospital Primary Care Annex,13515 Lake Terrace Lane,Tampa,FL,33637,813-998-8000,VA Facility,Government,no,Not Available,0,0
-573A4,"Lake City VAMC, NF/SGVHS",619 S. Marion Avenue,Lake City,FL,32025,386-755-3016 Or 800-308-8387,VA Facility,Government,no,Not Available,30.183418,-82.63701
-573,"Malcom Randall VAMC, NF/SGVHS",1601 S.W. Archer Road,Gainesville,FL,32608,352-376-1611 Or 800-324-8387,VA Facility,Government,no,Not Available,29.639143,-82.34345
-546,Miami VA Healthcare System,1201 N.W. 16th St.,Miami,FL,33125,305-575-7000 Or 305-575-7000,VA Facility,Government,no,Not Available,25.790472,-80.215126
-675,Orlando VA Medical Center,13800 Veterans Way,Orlando,FL,32827,407-631-1000,VA Facility,Government,no,Not Available,0,0
-548,West Palm Beach VAMC,7305 N. Military Trail,West Palm Beach,FL,33410,561-422-8262 Or 561-422-8262,VA Facility,Government,no,Not Available,26.784203,-80.10725
-548ZZ1,Clewiston Outpatient Clinic,1100 Olympia Street,Clewiston,FL,33440,,VA Facility,Government,no,Not Available,0,0
-573BY,Jacksonville OPC,1536 N Jefferson St,Jacksonville,FL,32209,877-870-5048 Or 904-475-5800,VA Facility,Government,no,Not Available,30.344486,-81.66289
-675GG,Lake Baldwin OPC,5201 Raymond Street,Orlando,FL,32803,407-646-5500,VA Facility,Government,no,Not Available,28.578913,-81.32207
-516BZ,Lee County VA Healthcare Center,2489 Diplomat Parkway East,Cape Coral,FL,33909,239-652-1800,VA Facility,Government,no,Not Available,0,0
-672BZ,Mayaguez OPC,175 Algarrobo Ave.,Mayaguez,PR,682,787-641-7582 X 48501,VA Facility,Government,no,Not Available,0,0
-673BZ,New Port Richey OPC,9912 Little Road,New Port Richey,FL,34654,727-869-4100,VA Facility,Government,no,Not Available,28.294464,-82.67542
-672BO,Ponce OPC,Paseo Del Veterano #1010,Ponce,PR,716,787-641-7582 X 44001 Or 787-641-7582 X 44002,VA Facility,Government,no,Not Available,0,0
-573BY,Southpoint Clinic,6900 Southpoint Dr North,Jacksonville,FL,32209,904-470-6900,VA Facility,Government,no,Not Available,30.255903,-81.5878
-573GF,Tallahassee HCC,2181 East Orange Avenue,Tallahassee,FL,32311,800-541-8387 Or 850-878-0191,VA Facility,Government,no,Not Available,0,0
-573GI,The Villages OPC,8900 SE 165th Mulberry Ln.,The Villages,FL,32162,877-649-0024 Or 352-674-5000,VA Facility,Government,no,Not Available,0,0
-672,Utuado VA Rural Outpatient Clinic,Isaac Gonzalez Street Equina Ledesma,Utuado,PR,641,787-522-2650 Or 787-522-2650,VA Facility,Government,no,Not Available,0,0
-548ZZ2,VA Moore Haven Outpatient Clinic,1021 Health Park Drive,Moore Haven,FL,33471,,VA Facility,Government,no,Not Available,0,0
-675GA,Viera OPC,2900 Veterans Way,Viera,FL,32940,321-637-3788,VA Facility,Government,no,Not Available,28.251802,-80.742805
-675GB,"William V. Chappell, Jr., VA OPC",551 National Health Care Drive,Daytona Beach,FL,32114,386-323-7500,VA Facility,Government,no,Not Available,29.205873,-81.06211
-548,St Lucie County PTSD Clinical Team (PCT) Outpatient Program,126 SW Chamber Court,Port St Lucie,FL,34986,772-878-7876,VA Facility,Government,no,Not Available,0,0
-672GC,Arecibo CBOC,"Road PR-10, Puerto Rico",Arecibo,PR,612,787-641-7582 X 28683 Or 800-449-8729 X 28678,VA Facility,Government,no,Not Available,0,0
-548GD,Boca Raton CBOC,901 Meadows Road,Boca Raton,FL,33433,561-416-8995,VA Facility,Government,no,Not Available,26.358753,-80.10404
-516GD,Bradenton Community-Based Outpatient Clinic,5520 S.R. 64 Suite 101,Bradenton,FL,34208,941-721-0649,VA Facility,Government,no,Not Available,0,0
-673GC,Brooksville CBOC,"14540 Cortez Blvd., Suite 108",Brooksville,FL,34613,352-597-8287,VA Facility,Government,no,Not Available,28.53387,-82.48409
-672GD,Ceiba Community Based Outpatient Clinic,"PR-3, Km. 54.9 Lot#3",Pueblo Ward,PR,735,787-641-7582 X 29001 Or 800-449-8729 X 29001,VA Facility,Government,no,Not Available,0,0
-672GD,Ceiba Community Based Outpatient Clinic,"PR-3, Km. 54.9 Lot#3",Pueblo Ward,PR,735,800-449-8729 X 29001,VA Facility,Government,no,Not Available,0,0
-6298,Ceiba VA Community Based Outpatient Clinic,"PR-3, Km. 54.9, Lot #3",Pueblo Ward,PR,735,800-449-8729 X 29001,VA Facility,Government,no,Not Available,0,0
-5924,Clermont Community Based Outpatient Clinic,805 Oakley Seaver Drive,Clermont,FL,34711,352-536-8200,VA Facility,Government,no,Not Available,0,0
-714,Comerio Rural Outpatient Clinic,15 De Diego Street,Comerio,PR,782,787-522-2660,VA Facility,Government,no,Not Available,0,0
-3333,Crossroads Annex,925 South Semoran Blvd Suite 114,Winter Park,FL,32792,866-998-4365,VA Facility,Government,no,Not Available,28.583382,-81.30698
-546GH,Deerfield Beach VA Community Based Outpatient Clinic,2100 S.W. 10th St.,Deerfield Beach,FL,33442,954-570-5572,VA Facility,Government,no,Not Available,26.30437,-80.13228
-548GB,Delray Beach CBOC,"4800 Linton Blvd., Building E, Suite 300",Delray Beach,FL,33445,561-495-1973,VA Facility,Government,no,Not Available,26.439363,-80.11655
-548GA,Fort Pierce CBOC,"1901 South 25th Street, Suite 103",Ft. Pierce,FL,34947,772-595-5150,VA Facility,Government,no,Not Available,27.467018,-80.34966
-672GE,Guayama CBOC,"FISA Bldg 1st Fl, Paseo Del Pueblo, km 0.3, lote no 6",Guayama,PR,784,787-866-8886,VA Facility,Government,no,Not Available,0,0
-546GA,Healthcare for Homeless Veterans,"1492 W. Flagler St., Suite 101",Miami,FL,33135,305-541-5864,VA Facility,Government,no,Not Available,25.773327,-80.21949
-546,Healthcare for Homeless Veterans,1492 Flagler St,Miami,FL,33135,305-541-5864,VA Facility,Government,no,Not Available,25.773329,-80.21944
-546,Hollywood VA Community Based Outpatient Clinic,"3702 Washington St., Suite 201",Hollywood,FL,33021,954-986-1811,VA Facility,Government,no,Not Available,26.00302,-80.18108
-546GC,Homestead VA Community Based Outpatient Clinic,"950 Krome Ave., Suite 401",Homestead,FL,33030,305-248-0874,VA Facility,Government,no,Not Available,0,0
-673QJ,James A. Haley Veterans' Hospital Primary Care Annex,13515 Lake Terrace Lane,Tampa,FL,33637,813-998-8000,VA Facility,Government,no,Not Available,0,0
-546GE,Key Largo VA Community Based Outpatient Clinic,105662 Overseas Highway,Key Largo,FL,33037,305-451-0164,VA Facility,Government,no,Not Available,25.161482,-80.38247
-546GB,Key West VA Outpatient Clinic,"1300 Douglas Circle, Building L-15",Key West,FL,33040,305-293-4863,VA Facility,Government,no,Not Available,24.568449,-81.75187
-675GC,Kissimmee CBOC,2285 North Central Avenue,Kissimmee,FL,34741,407-518-5004,VA Facility,Government,no,Not Available,28.312544,-81.40857
-673GB,Lakeland CBOC,4237 South Pipkin Rd,Lakeland,FL,33811,863-701-2470,VA Facility,Government,no,Not Available,27.994333,-81.996185
-573GG,Lecanto CBOC,"2804 W. Marc Knighton Ct., Suite A",Lecanto,FL,34461,352-746-8000,VA Facility,Government,no,Not Available,28.905931,-82.48029
-573GK,Marianna CBOC,4970 Highway 90,Marianna,FL,32446,850-718-5620,VA Facility,Government,no,Not Available,30.75043,-85.189995
-516GF,Naples Community-Based Outpatient Clinic,2685 Horseshoe Drive South - Suite 101,Naples,FL,34104,239-659-9188,VA Facility,Government,no,Not Available,26.161837,-81.772446
-573GD,Ocala CBOC,1515 Silver Springs Blvd.,Ocala,FL,34470,352-369-3320,VA Facility,Government,no,Not Available,29.187044,-82.11808
-548GF,Okeechobee CBOC,1201 N. Parrot Avenue,Okeechobee,FL,34972,863-824-3232,VA Facility,Government,no,Not Available,27.25645,-80.82994
-675GD,Orange City CBOC,"2583 South Volusia Ave (17-92), Suite 300",Orange City,FL,32763,386-456-2080,VA Facility,Government,no,Not Available,0,0
-573GL,Palatka CBOC,"400 North State Road 19, Suite 48",Palatka,FL,32177,386-329-8800,VA Facility,Government,no,Not Available,0,0
-516GC,Palm Harbor Community-Based Outpatient Clinic,35209 US Highway 19 North,Palm Harbor,FL,34684,727-734-5276,VA Facility,Government,no,Not Available,0,0
-546GD,Pembroke Pines VA Community Based Outpatient Clinic,"7369 W. Sheridan St., Suite 102",Hollywood,FL,33024,954-894-1668,VA Facility,Government,no,Not Available,26.031391,-80.23594
-573GN,Perry CBOC,1224 N. Peacock Ave.,Perry,FL,32347,850-223-8387,VA Facility,Government,no,Not Available,30.120272,-83.576454
-516GE,Port Charlotte Community-Based Outpatient Clinic,4161 Tamiami Trail Suite 401 & Suite 602 (Annex Bldg),Port Charlotte,FL,33952,941-235-2710,VA Facility,Government,no,Not Available,0,0
-548,Port St Lucie PTSD Clinical Team (PCT) Outpatient Program,128 SW Chamber Court,Port Saint Lucie,FL,34986,772-344-9288,VA Facility,Government,no,Not Available,0,0
-573GE,Saint Augustine CBOC,195 Southpark Blvd.,St. Augustine,FL,32086,866-401-8387 Or 904-829-0814,VA Facility,Government,no,Not Available,29.862272,-81.32687
-672GA,Saint Croix CBOC,"Box 12, RR-02, The Village Mall #113",Kings Hill,VI,850,340-778-5553,VA Facility,Government,no,Not Available,0,0
-672GB,Saint Thomas CBOC,Medical Foundation Building Suite 101,St. Thomas,VI,802,340-776-7072,VA Facility,Government,no,Not Available,0,0
-516GA,Sarasota Community-Based Outpatient Clinic,"5682 Bee Ridge Road, Suite 100",Sarasota,FL,34233,941-371-3349,VA Facility,Government,no,Not Available,27.29881,-82.45636
-516GH,Sebring Community-Based Outpatient Clinic,5901 U.S. Highway 27 South,Sebring,FL,33870,863-471-6227,VA Facility,Government,no,Not Available,0,0
-573,St Marys CBOC,"2603 Osbourne Road, Ste E",St Marys,GA,31558,912-510-3420,VA Facility,Government,no,Not Available,0,0
-516GB,St. Petersburg Community-Based Outpatient Clinic,840 Dr. MLK Jr. Street N,St. Petersburg,FL,33705,727-502-1700,VA Facility,Government,no,Not Available,0,0
-548GC,Stuart CBOC,3501 S E Willoughby Boulevard,Stuart,FL,34997,772-288-0304,VA Facility,Government,no,Not Available,0,0
-675GE,Tavares Community Based Outpatient Clinic,1390 E. Burleigh Blvd.,Tavares,FL,32778,352-253-2900,VA Facility,Government,no,Not Available,0,0
-573GA,Valdosta CBOC,2841 N. Patterson Street,Valdosta,GA,31602,229-293-0132 Or 877-303-8387,VA Facility,Government,no,Not Available,30.868034,-83.29001
-548GE,Vero Beach CBOC,372 17th Street,Vero Beach,FL,32960,772-299-4623,VA Facility,Government,no,Not Available,27.632372,-80.38043
-714,Vieques Rural Outpatient Clinic,Co.Destino Carretera #997,Vieques,PR,765,787-641-7582 X 28601,VA Facility,Government,no,Not Available,0,0
-573GM,Waycross CBOC,515B City Boulevard,Waycross,GA,31501,912-279-4400,VA Facility,Government,no,Not Available,31.231209,-82.34093
-546,William Bill Kling VA Clinic,9800 W. Commercial Blvd.,Sunrise,FL,33351,954-475-5500,VA Facility,Government,no,Not Available,0,0
-673GF,Zephyrhills CBOC,6937 Medical View Ln,Zephyrhills,FL,33541,813-780-2550,VA Facility,Government,no,Not Available,0,0
-0309V,Arecibo Vet Center,50 Gonzalo Marin St,Arecibo,PR,612,787-641-7582 X 28151,VA Facility,Government,no,Not Available,0,0
-0339V,Clearwater Vet Center,29259 US Hwy 19 North,Clearwater,FL,33761,727-549-3600 Or 727-549-3600,VA Facility,Government,no,Not Available,0,0
-675GF,Clermont Vet Center,"1655 East Highway 50, Suite 102",Clermont,FL,34711,352-536-6701 Or 877-927-8387,VA Facility,Government,no,Not Available,28.545898,-81.7555
-0341V,Daytona Beach Vet Center,"1620 Mason Ave., Suite C",Daytona Beach,FL,32117,386-366-6600 Or 386-366-6600,VA Facility,Government,no,Not Available,29.21203,-81.0657
-0311V,Fort Lauderdale Vet Center,3666 W. Oakland Park Blvd.,Lauderdale Lakes,FL,33311,954-714-2381,VA Facility,Government,no,Not Available,26.16532,-80.1985
-0330V,Fort Myers Vet Center,"4110 Center Pointe Drive, Unit 204",Ft. Myers,FL,33916,239-652-1861 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0331V,Gainesville Vet Center,"105 NW 75th Street, Suite #2",Gainesville,FL,32607,352-331-1408 Or 877-927-8387,VA Facility,Government,no,Not Available,29.6545,-82.422386
-0305V,Jacksonville Vet Center,"3728 Phillips Highway, Suite 31",Jacksonville,FL,32207,904-399-8351 Or 904-399-8351,VA Facility,Government,no,Not Available,30.28736,-81.63335
-0337V,Jupiter Vet Center,"6650 W. Indiantown Rd., Suite 120",Jupiter,FL,33458,561-422-1220 Or 561-422-1220,VA Facility,Government,no,Not Available,26.934444,-80.136856
-03101V,Key Largo Vet Center Outstation,105662 Overseas Hwy.,Key Largo,FL,33037,305-451-0164 Or 877-927-8387,VA Facility,Government,no,Not Available,25.161482,-80.38247
-0340V,Lakeland Vet Center,1370 Ariana St.,Lakeland,FL,33803,863-284-0841 Or 863-284-0841,VA Facility,Government,no,Not Available,28.025854,-81.97894
-0332V,Melbourne Vet Center,2098 Sarno Road,Melbourne,FL,32935,321-254-3410 Or 877-927-8387,VA Facility,Government,no,Not Available,28.12169,-80.65558
-0310V,Miami Vet Center,8280 NW 27th St Suite 511,Miami,FL,33122,305-718-3712 Or 305-718-3712,VA Facility,Government,no,Not Available,25.799692,-80.336395
-0348V,Naples Vet Center,"2705 Horseshoe Dr. South, Suite #204",Naples,FL,34104,239-403-2377 Or 877-927-8387,VA Facility,Government,no,Not Available,26.16184,-81.77219
-344,Ocala Vet Center,"3300 SW 34th Avenue, Suite 140",Ocala,FL,34474,352-237-1947 Or 877-927-8387,VA Facility,Government,no,Not Available,29.151766,-82.17551
-0314V,Orlando Vet Center,"5575 S. Semoran Blvd., Suite #30",Orlando,FL,32822,407-857-2800 Or 407-857-2800,VA Facility,Government,no,Not Available,28.48248,-81.310104
-0326V,Palm Beach Vet Center,"4996 10th Ave North, Suite 6",Greenacres,FL,33463,561-422-1201 Or 561-422-1201,VA Facility,Government,no,Not Available,26.631065,-80.122665
-0338V,Pasco County Vet Center,5139 Deer Park Drive,New Port Richey,FL,34653,727-372-1854 Or 727-372-1854,VA Facility,Government,no,Not Available,0,0
-0336V,Pompano Beach Vet Center,"2300 West Sample Road, Suite 102",Pompano,FL,33073,954-984-1669 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0312V,Ponce Vet Center,"35 Mayor Street, Suite 1",Ponce,PR,730,787-841-3260 Or 787-841-3260,VA Facility,Government,no,Not Available,0,0
-0300V,RCS Southeast District 2 District Office,"450 Carillon Parkway, Suite 150",St. Petersburg,FL,33716,727-398-9343 Or 727-398-9343,VA Facility,Government,no,Not Available,27.88889,-82.66944
-0307V,San Juan Vet Center,"Cond. Medical Center Plaza Suite LC 8, 9 & 11, Urb. La Riviera",Rio Piedras,PR,921,787-749-4409 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0320V,Sarasota Vet Center,4801 Swift Rd. Suite A,Sarasota,FL,34231,941-927-8285 Or 877-927-8387,VA Facility,Government,no,Not Available,27.283916,-82.514145
-03121V,St. Croix Vet Center Outstation,"The Village Mall, RR 2 Box 10553 Kingshill",St. Croix,VI,850,340-778-5553 Or 787-641-7582 X 25613,VA Facility,Government,no,Not Available,0,0
-0301V,St. Petersburg Vet Center,"6798 Crosswinds Drive, Bldg A",St. Petersburg,FL,33710,727-549-3633 Or 877-927-8387,VA Facility,Government,no,Not Available,27.79047,-82.7337
-03122V,St. Thomas Vet Center Outstation,"50 Estate Thomas, Medical Foundation Buiding Suite 101",St. Thomas,VI,802,340-774-5017 Or 787-641-7582 X 25507,VA Facility,Government,no,Not Available,0,0
-0325V,Tallahassee Vet Center,2002 Old St. Augustine Road,Tallahassee,FL,32301,850-942-8810,VA Facility,Government,no,Not Available,30.426197,-84.24688
-0318V,Tampa Vet Center,"Fountain Oaks Business Plaza; 3637 W. Waters Ave., Suite 600",Tampa,FL,33614,813-228-2621 Or 813-228-2621,VA Facility,Government,no,Not Available,0,0
-10N9,VISN 9: VA MidSouth Healthcare Network,"1801 West End Ave., Suite 600",Nashville,TN,37203,615-695-2200,VA Facility,Government,no,Not Available,0,0
-596,Lexington VA Medical Center,1101 Veterans Drive,Lexington,KY,40502,859-233-4511,VA Facility,Government,no,Not Available,0,0
-626,Tennessee Valley Healthcare System,1310 24th Avenue South,Nashville,TN,37212,615-327-4751,VA Facility,Government,no,Not Available,36.142414,-86.80479
-596A4,Lexington VAMC: Cooper Division,1101 Veterans Drive,Lexington,KY,40502,859-281-4900 Or 859-233-4511,VA Facility,Government,no,Not Available,0,0
-596,Lexington VAMC: Leestown Division,2250 Leestown Rd,Lexington,KY,40511,859-233-4511 Or 859-281-4900,VA Facility,Government,no,Not Available,38.077587,-84.54163
-614,Memphis VA Medical Center,1030 Jefferson Avenue,Memphis,TN,38104,901-523-8990 Or 901-523-8990,VA Facility,Government,no,Not Available,35.142464,-90.02515
-621,Mountain Home VAMC/Johnson City,Corner of Lamont Street and Veterans Way,Mountain Home,TN,37684,423-926-1171 Or 423-926-1171,VA Facility,Government,no,Not Available,0,0
-603,Robley Rex VA Medical Center,800 Zorn Avenue,Louisville,KY,40206,502-287-4000 Or 502-287-4000,VA Facility,Government,no,Not Available,38.270893,-85.6941
-626A4,Tennessee Valley Healthcare System - Alvin C. York (Murfreesboro) Campus,3400 Lebanon Pike,Murfreesboro,TN,37129,615-867-6000 Or 615-867-6000,VA Facility,Government,no,Not Available,35.908054,-86.38373
-626,Tennessee Valley Healthcare System - Nashville Campus,1310 24th Avenue South,Nashville,TN,37212,615-327-4751 Or 615-327-4751,VA Facility,Government,no,Not Available,36.142414,-86.80479
-621,"Bristol, Virginia OPC",2426 Lee Highway,Bristol,VA,24202,276-645-4520,VA Facility,Government,no,Not Available,36.62954,-82.14808
-626,Charlotte Avenue (Nashville) VA Clinic,1919 Charlotte Avenue,Nashville,TN,37203,615-873-6503,VA Facility,Government,no,Not Available,36.15748,-86.80191
-626GF,Chattanooga VA Clinic,6098 Debra Rd Suite 5200 Bldg 6200,Chattanooga,TN,37411,423-893-6500,VA Facility,Government,no,Not Available,0,0
-626GH,"Cookeville, Tennessee OPC",851 S. Willow Avenue Suite 108,Cookeville,TN,38501,931-284-4060,VA Facility,Government,no,Not Available,36.144985,-85.52289
-626GX,"Hopkinsville, Kentucky OPC",1002 South Virginia Street,Hopkinsville,KY,42240,270-885-2106,VA Facility,Government,no,Not Available,36.86455,-87.48827
-626GN,"McMinnville, Tennessee OPC",1014 S. Chancery Street,McMinnville,TN,37110,931-474-7700,VA Facility,Government,no,Not Available,35.66253,-85.78597
-626GO,Pointe Center Outpatient Clinic (Chattanooga),1208 Pointe Center Drive,Chattanooga,TN,37421,423-893-6500,VA Facility,Government,no,Not Available,0,0
-626,"Women Veterans Healthcare Center (Nashville, TN)","1919 Charlotte Avenue, Suite 300",Nashville,TN,37203,615-327-4751,VA Facility,Government,no,Not Available,0,0
-6301,Athens VA Clinic,1320 Decatur Pike,Athens,TN,37303,423-746-1410,VA Facility,Government,no,Not Available,35.44948,-84.6172
-626GC,Bowling Green VA Clinic,"600 US 31 West Bypass, Suite 12",Bowling Green,KY,42101,270-782-0120,VA Facility,Government,no,Not Available,0,0
-626,Clarksville Dental Clinic,"2291 Dalton Drive, Suite F.",Clarksville,TN,37043,,VA Facility,Government,no,Not Available,0,0
-626GE,Clarksville VA Clinic,782 Weatherly Dr.,Clarksville,TN,37043,931-645-3552,VA Facility,Government,no,Not Available,0,0
-614GE,"Covington, Tennessee (North Memphis), CBOC",3461 Austin Peay Highway,Memphis,TN,38127,901-261-4500,VA Facility,Government,no,Not Available,35.21992,-89.910416
-626GA,"Dover (Stewart County), Tennessee CBOC",1225 Spring Street,Dover,TN,37058,931-232-5138,VA Facility,Government,no,Not Available,36.479477,-87.81392
-614,"Dyersburg, Tennessee CBOC",433 East Parkview Street,Dyersburg,TN,38024,731-287-7289,VA Facility,Government,no,Not Available,36.046345,-89.37962
-626,Harriman Clinic,"2305 North Gateway Ave., Suite 2",Harriman,TN,37748,865-882-2010,VA Facility,Government,no,Not Available,0,0
-614,"Helena, Arkansas CBOC",131 Quarles Lane,Helena,AR,72342,870-228-3644,VA Facility,Government,no,Not Available,34.554462,-90.648125
-614,Holly Springs CBOC,1700 Crescent Meadow Dr,Holly Springs,MS,38635,662-252-2552,VA Facility,Government,no,Not Available,0,0
-626QC,International Plaza CBOC,"2 International Plaza, Suite 300",Nashville,TN,37217,615-367-5928,VA Facility,Government,no,Not Available,36.127193,-86.695755
-614GG,"Jackson, Tennessee CBOC",180 Old Hickory Blvd,Jackson,TN,38305,731-661-2750,VA Facility,Government,no,Not Available,35.65321,-88.83493
-614GB,"Jonesboro, Arkansas CBOC",2908 Caraway Road,Jonesboro,AR,72401,870-277-0778 Or 870-268-6962,VA Facility,Government,no,Not Available,35.80957,-90.67815
-621,Jonesville Rural Outreach Clinic,"32613 Wilderness Road, Suite 101",Jonesville,VA,24263,276-346-2595,VA Facility,Government,no,Not Available,0,0
-621,"Knoxville, Tennessee CBOC",8033 Ray Mears Blvd.,Knoxville,TN,37919,865-545-4592,VA Facility,Government,no,Not Available,35.923336,-84.04693
-621,"LaFollette (Campbell County), Tennessee CBOC",130 Independence Lane,LaFollette,TN,37757,423-563-7666,VA Facility,Government,no,Not Available,0,0
-621,Marion Rural Outreach Clinic,4451 Lee Highway,Marion,VA,24354,276-783-2756,VA Facility,Government,no,Not Available,0,0
-626,Maury County CBOC,833 Nashville Highway,Columbia,TN,38401,931-981-6930,VA Facility,Government,no,Not Available,35.62945,-87.02559
-626,Meharry (Nashville General),1810 Albion Street,Nashville,TN,37208,615-873-6700,VA Facility,Government,no,Not Available,36.16626,-86.80563
-621GE,"Morristown, Tennessee CBOC",925 E. Morris Boulevard,Morristown,TN,37813,423-586-9100,VA Facility,Government,no,Not Available,36.215782,-83.28268
-614GF,Nonconnah Boulevard Primary Care Clinic,1689 Nonconnah Boulevard,Memphis,TN,38132,901-271-4900,VA Facility,Government,no,Not Available,35.071,-90.00735
-621,"Norton, Virginia CBOC",654 Highway 58 East,Norton,VA,24273,276-679-8010,VA Facility,Government,no,Not Available,0,0
-621GA,"Rogersville, Tennessee CBOC",401 Scenic Drive,Rogersville,TN,37857,423-235-1471,VA Facility,Government,no,Not Available,36.40194,-83.01576
-614GD,"Savannah, Tennessee CBOC",765 Florence Rd,Savannah,TN,38372,731-925-2300,VA Facility,Government,no,Not Available,35.21224,-88.2393
-621,Sevierville Clinic,1124 Blanton Dr,Sevierville,TN,37862,865-286-6950,VA Facility,Government,no,Not Available,0,0
-626GG,"Tullahoma, Tennessee CBOC",225 Von Karman Rd,Arnold Air Force Base,TN,37389,931-454-6134,VA Facility,Government,no,Not Available,0,0
-614,Tupelo VA Clinic,1114 Commonwealth Blvd,Tupelo,MS,38804,662-840-6366,VA Facility,Government,no,Not Available,0,0
-596GD,VA Clinic Berea,209 Pauline Drive,Berea,KY,40403,859-986-1259,VA Facility,Government,no,Not Available,0,0
-596,VA Clinic Hazard,210 Black Gold Blvd,Hazard,KY,41701,606-436-2350,VA Facility,Government,no,Not Available,0,0
-596GB,VA Clinic Morehead,333 Beacon Hill Rd,Morehead,KY,40351,606-784-3004,VA Facility,Government,no,Not Available,0,0
-596GA,VA Clinic Somerset,163 Tower Circle,Somerset,KY,42503,606-676-0786,VA Facility,Government,no,Not Available,0,0
-603GH,"VA Healthcare Center, Carrollton",1911 US Highway 227,Carrollton,KY,41008,502-287-6060,VA Facility,Government,no,Not Available,0,0
-603GD,"VA Healthcare Center, Dupont Kentucky CBOC",4010 Dupont Circle,Louisville,KY,40207,502-287-6986,VA Facility,Government,no,Not Available,38.232937,-85.631355
-603GA,"VA Healthcare Center, Ft. Knox Kentucky",851 Ireland Loop,Ft Knox,KY,40121,502-624-9396,VA Facility,Government,no,Not Available,37.90122,-85.94276
-603GF,"VA Healthcare Center, Grayson",619 Elizabethtown Road,Clarkson,KY,42726,866-653-8232,VA Facility,Government,no,Not Available,0,0
-603GB,"VA Healthcare Center, New Albany IN",4347 Security Parkway,New Albany,IN,47150,502-287-4100 Or 502-287-4100,VA Facility,Government,no,Not Available,38.363068,-85.81108
-603GE,"VA Healthcare Center, Newburg Kentucky",3430 Newburg Road,Louisville,KY,40218,502-287-6223,VA Facility,Government,no,Not Available,38.197586,-85.681854
-603GG,"VA Healthcare Center, Scott County",1467 Scott Valley Drive,Scottsburg,IN,47170,877-690-1938 Or 877-690-1938,VA Facility,Government,no,Not Available,0,0
-603GC,"VA Healthcare Center, Shively Kentucky CBOC","3934 North Dixie Highway, Suite 210",Louisville,KY,40216,502-287-6000,VA Facility,Government,no,Not Available,38.194138,-85.806725
-621,Vansant Rural Outreach Clinic,"1941 Lovers Gap Road, Suite A",Vansant,VA,24656,276-597-2106,VA Facility,Government,no,Not Available,0,0
-0722V,Chattanooga Vet Center,951 Eastgate Loop Road Bldg. 5700 - Suite 300,Chattanooga,TN,37411,423-855-6570 Or 423-855-6570,VA Facility,Government,no,Not Available,35.009804,-85.21353
-701,Johnson City Vet Center,"2203 McKinley Road, Suite 254",Johnson City,TN,37604,423-928-8387 Or 423-928-8387,VA Facility,Government,no,Not Available,0,0
-720,Knoxville Vet Center,8033 Ray Mears Blvd,Knoxville,TN,37914,865-633-0000,VA Facility,Government,no,Not Available,35.923336,-84.04693
-203,Lexington Vet Center,1500 Leestown Rd Suite 104,Lexington,KY,40511,859-253-0717 Or 859-253-0717,VA Facility,Government,no,Not Available,38.065773,-84.523636
-202,Louisville Vet Center,1347 S. Third Street,Louisville,KY,40208,502-287-6710 Or 502-287-6710,VA Facility,Government,no,Not Available,38.23077,-85.75937
-0719V,Memphis Vet Center,"1407 Union Ave., Suite 410",Memphis,TN,38104,901-522-3950 Or 901-522-3950,VA Facility,Government,no,Not Available,35.136623,-90.01462
-0724V,Nashville Vet Center,1420 Donelson Pike Suite A-5,Nashville,TN,37217,615-366-1220 Or 615-366-1220,VA Facility,Government,no,Not Available,36.097065,-86.67747
-487,VISN 10: VA Healthcare System,"11500 Northlake Drive, Suite 200",Cincinnati,OH,45249,513-247-4621,VA Facility,Government,no,Not Available,39.276237,-84.34727
-10N11,VISN 11: Veterans In Partnership (Now VISN 10),"24 Frank Lloyd Wright Drive, Lobby L",Ann Arbor,MI,48113,,VA Facility,Government,no,Not Available,42.31775,-83.6821
-6463,"Homeless Team, Veteran Health Indiana",1099 N. Meridian St.,Indianapolis,IN,46204,317-988-5284 Or 317-988-5284,VA Facility,Government,no,Not Available,39.782703,-86.15747
-610,VA Northern Indiana Health Care System,2121 Lake Ave.,Fort Wayne,IN,46805,260-426-5431 Or 260-426-5431,VA Facility,Government,no,Not Available,41.08974,-85.11045
-655,Aleda E. Lutz VA Medical Center,1500 Weiss Street,Saginaw,MI,48602,989-497-2500 Or 800-406-5143,VA Facility,Government,no,Not Available,43.443695,-83.96086
-515,Battle Creek VA Medical Center,5500 Armstrong Road,Battle Creek,MI,49037,269-966-5600,VA Facility,Government,no,Not Available,0,0
-757,Chalmers P. Wylie Ambulatory Care Center,420 N James Road,Columbus,OH,43219,614-257-5200,VA Facility,Government,no,Not Available,39.980396,-82.91203
-538,Chillicothe VA Medical Center,17273 State Route 104,Chillicothe,OH,45601,740-773-1141,VA Facility,Government,no,Not Available,0,0
-539,Cincinnati VA Medical Center,3200 Vine Street,Cincinnati,OH,45220,513-861-3100,VA Facility,Government,no,Not Available,39.13792,-84.509514
-539A4,Cincinnati VA Medical Center-Fort Thomas,1000 S. Ft Thomas Ave,Ft. Thomas,KY,41075,859-572-6202,VA Facility,Government,no,Not Available,39.0889,-84.44801
-552,Dayton VA Medical Center,4100 W. 3rd Street,Dayton,OH,45428,937-268-6511 Or 937-268-6511,VA Facility,Government,no,Not Available,39.749374,-84.253174
-553,John D. Dingell VA Medical Center,4646 John R,Detroit,MI,48201,313-576-1000 Or 313-576-1000,VA Facility,Government,no,Not Available,42.355137,-83.06039
-541,Louis Stokes Cleveland VA Medical Center,10701 East Boulevard,Cleveland,OH,44106,216-791-3800,VA Facility,Government,no,Not Available,0,0
-583,Richard L. Roudebush VA Medical Center (Indianapolis VA Medical Center),1481 W. 10th Street,Indianapolis,IN,46202,317-554-0000 Or 317-554-0000,VA Facility,Government,no,Not Available,39.779716,-86.18758
-506,VA Ann Arbor Healthcare System,2215 Fuller Road,Ann Arbor,MI,48105,734-769-7100 Or 734-769-7100,VA Facility,Government,no,Not Available,42.28566,-83.71592
-610,VA Northern Indiana Health Care System - Marion Campus,1700 East 38th Street,Marion,IN,46953,765-674-3321 Or 765-674-3321,VA Facility,Government,no,Not Available,40.523746,-85.63726
-610A4,VA Northern Indiana Health Care System-Fort Wayne Campus,2121 Lake Ave.,Fort Wayne,IN,46805,260-426-5431 Or 260-426-5431,VA Facility,Government,no,Not Available,41.08974,-85.11045
-583QA,Bloomington Mental Health Outpatient Clinic,1332 West Arch Haven Avenue,Bloomington,IN,47403,812-349-4406,VA Facility,Government,no,Not Available,39.161076,-86.55194
-541BY,Canton Outpatient Clinic,733 Market Avenue South,Canton,OH,44702,330-489-4600,VA Facility,Government,no,Not Available,40.79339,-81.37653
-583QC,Terre Haute Mental Health Outpatient Clinic,70W Honey Creek Pkwy,Terre Haute,IN,47802,812-232-8325,VA Facility,Government,no,Not Available,39.42494,-87.41705
-506QB,VA Ann Arbor - Green Road Outpatient Clinic,2500 Green Road,Ann Arbor,MI,48105,734-769-7100,VA Facility,Government,no,Not Available,42.30916,-83.69277
-506QA,VA Ann Arbor - Packard Road Outpatient Clinic,3800 Packard Road,Ann Arbor,MI,48108,734-769-7100,VA Facility,Government,no,Not Available,42.24532,-83.687454
-506GA,VA Ann Arbor - Toledo Annex,2595 Arlington Avenue,Toledo,OH,43614,,VA Facility,Government,no,Not Available,41.623123,-83.60686
-583GF,Wakeman VA Clinic,Building 1010,Edinburgh,IN,46124,812-348-0300,VA Facility,Government,no,Not Available,0,0
-541BZ,Youngstown Outpatient Clinic,2031 Belmont Avenue,Youngstown,OH,44505,330-740-9200,VA Facility,Government,no,Not Available,41.126682,-80.66435
-541GG,Akron Community Based Outpatient Clinic,55 W. Waterloo,Akron,OH,44319,330-724-7715,VA Facility,Government,no,Not Available,41.02876,-81.52917
-538GA,Athens Community Based Outpatient Clinic,510 West Union Street,Athens,OH,45701,740-593-7314,VA Facility,Government,no,Not Available,39.331062,-82.12392
-655GF,Bad Axe Community Based Outpatient Clinic,"1142 S. Van Dyke RD, Suite 100",Bad Axe,MI,48413,989-269-7445,VA Facility,Government,no,Not Available,43.800236,-83.04325
-539GA,Bellevue Community Based Outpatient Clinic,"103 Landmark Drive, Suite 300",Bellevue,KY,41073,859-392-3840,VA Facility,Government,no,Not Available,39.10029,-84.48472
-515GC,Benton Harbor VA Outpatient Clinic,115 West Main Street,Benton Harbor,MI,49022,269-934-9123,VA Facility,Government,no,Not Available,42.11607,-86.455154
-583GB,Bloomington VA Clinic,455 South Landmark Avenue,Bloomington,IN,47403,812-336-5723,VA Facility,Government,no,Not Available,39.16402,-86.55629
-655GG,Cadillac Community Based Outpatient Clinic,1909 North Mitchell St,Cadillac,MI,49601,231-775-4401,VA Facility,Government,no,Not Available,44.278004,-85.406685
-538,Cambridge Community Based Outpatient Clinic,2146 Southgate Pkwy,Cambridge,OH,43725,740-432-1963,VA Facility,Government,no,Not Available,40.00885,-81.57982
-655GH,Cheboygan County Community Based Outpatient Clinic,14540 Mackinaw Hwy,Mackinaw City,MI,49701,231-436-5176,VA Facility,Government,no,Not Available,45.76145,-84.73206
-655GE,Clare Community Outpatient Clinic,11775 N Isabella Rd,Clare,MI,48617,989-386-8113,VA Facility,Government,no,Not Available,43.811226,-84.74836
-655GD,Clement C. Van Wagoner Outpatient Clinic,180 North State Avenue,Alpena,MI,49707,989-356-8720,VA Facility,Government,no,Not Available,45.061,-83.430756
-539GB,Clermont County Community Based Outpatient Clinic,4600 Beechwood Road,Cincinnati,OH,45244,513-943-3680,VA Facility,Government,no,Not Available,39.11444,-84.30561
-541GH,East Liverpool/Calcutta Community Based Outpatient Clinic,"15655 St Rt. 170, Suite A",Calcutta,OH,43920,330-386-4303,VA Facility,Government,no,Not Available,40.673294,-80.57691
-539,Florence Community Based Outpatient Clinic,7310 Turfway Rd.,Florence,KY,41042,859-282-4480,VA Facility,Government,no,Not Available,0,0
-655GA,Gaylord VA Outpatient Clinic,806 South Otsego,Gaylord,MI,49735,989-732-7525,VA Facility,Government,no,Not Available,0,0
-539GF,Georgetown Community Based Outpatient Clinic,474 Home Street,Georgetown,OH,45121,937-378-3413,VA Facility,Government,no,Not Available,38.856293,-83.898125
-610A4,Goshen VA Outpatient Clinic,2606 Peddlers Village Road Suite 210,Goshen,IN,46526,574-534-6108 Or 877-292-0968,VA Facility,Government,no,Not Available,0,0
-655QB,Grand Traverse VA Clinic,880 Munson Avenue,Traverse City,MI,49686,231-932-9720 Or 800-406-5143 X 11412,VA Facility,Government,no,Not Available,0,0
-655GI,Grayling Community Based Outpatient Clinic,1680 Hartwick Pines Road,Grayling,MI,49738,989-344-2002,VA Facility,Government,no,Not Available,44.70946,-84.71005
-757GB,Grove City Community Based Outpatient Clinic,1955 Ohio Drive,Grove City,OH,43123,614-257-5800 Or 888-615-9448 X 5800,VA Facility,Government,no,Not Available,39.880787,-83.05464
-539GE,Hamilton Community Based Outpatient Clinic,1750 South Erie Highway,Hamilton,OH,45011,513-870-9444,VA Facility,Government,no,Not Available,39.37911,-84.54975
-6464,Indy West VA Clinic,3850 Shore Dr. Suite 203,Indianapolis,IN,46254,317-988-1772 Or 317-988-1772,VA Facility,Government,no,Not Available,39.82476,-86.28068
-538GD,Lancaster Community Based Outpatient Clinic,1703 North Memorial Drive,Lancaster,OH,43130,740-653-6145,VA Facility,Government,no,Not Available,39.73196,-82.617905
-515GB,Lansing VA Outpatient Clinic,2025 South Washington Avenue,Lansing,MI,48910,517-267-3925,VA Facility,Government,no,Not Available,42.71088,-84.55337
-539GC,Lawrenceburg (Dearborn) Community Based Outpatient Clinic,1600 Flossie Drive,Greendale,IN,47025,812-539-2313,VA Facility,Government,no,Not Available,0,0
-552GB,Lima Community Based Outpatient Clinic,1303 Bellefontaine Ave,Lima,OH,45804,419-222-5788,VA Facility,Government,no,Not Available,40.731922,-84.081825
-6108,Lorain Community Based Outpatient Clinic,5255 N. Abbe Rd.,Sheffield Village,OH,44035,440-934-9158,VA Facility,Government,no,Not Available,41.426277,-82.07694
-541GD,Mansfield Community Based Outpatient Clinic,1025 South Trimble Rd.,Mansfield,OH,44906,419-529-4602,VA Facility,Government,no,Not Available,40.738087,-82.55166
-538GC,Marietta Community Based Outpatient Clinic,27843 State Route 7,Marietta,OH,45750,740-568-0412,VA Facility,Government,no,Not Available,0,0
-757,Marion Community Based Outpatient Clinic,"1203 Delaware Avenue, Corporate Center #2",Marion,OH,43302,740-223-8809 Or 888-615-9448 X 5920,VA Facility,Government,no,Not Available,40.569786,-83.12243
-583GC,Martinsville VA Outpatient Clinic,2200 John R. Wooden Drive,Martinsville,IN,46151,317-988-0120 Or 317-554-0000 X 80120,VA Facility,Government,no,Not Available,39.427006,-86.40602
-541GE,McCafferty Community Based Outpatient Clinic,4242 Lorain Avenue,Cleveland,OH,44113,216-939-0699,VA Facility,Government,no,Not Available,41.479897,-81.71472
-552GA,Middletown Community Based Outpatient Clinic,4337 N. Union Road,Middletown,OH,45005,513-423-8387,VA Facility,Government,no,Not Available,39.509254,-84.31619
-610,Muncie/Anderson VA Outpatient Clinic,2600 W White River Blvd,Muncie,IN,47303,765-254-5602,VA Facility,Government,no,Not Available,40.186367,-85.41668
-515GA,Muskegon VA Outpatient Clinic,5000 Hakes Dr.,Muskegon,MI,49441,231-798-4445,VA Facility,Government,no,Not Available,43.164448,-86.2334
-541,New Philadelphia Community Based Outpatient Clinic,"1260 Monroe Ave, Suite 1A",New Philadelphia,OH,44663,330-602-5339,VA Facility,Government,no,Not Available,0,0
-757-N,Newark Community Based Outpatient Clinic,1855 W. Main Street,Newark,OH,43055,740-788-8329 Or 888-615-9448 X 5900,VA Facility,Government,no,Not Available,40.041317,-82.4684
-655GC,Oscoda VA Outpatient Clinic,"5671 Skeel Avenue, Suite 4",Oscoda,MI,48750,989-747-0026,VA Facility,Government,no,Not Available,44.451687,-83.351974
-541GF,Painesville Community Based Outpatient Clinic,7 West Jackson Street,Painesville,OH,44077,440-357-6740,VA Facility,Government,no,Not Available,41.725227,-81.2485
-541GL,Parma Community Based Outpatient Clinic,8787 Brookpark Road,Parma,OH,44129,216-739-7000,VA Facility,Government,no,Not Available,0,0
-610GD,Peru Community Based Outpatient Clinic,750 N Broadway,Peru,IN,46970,765-472-8907,VA Facility,Government,no,Not Available,40.76819,-86.078384
-553,Pontiac VA Outpatient Clinic,"44200 Woodward Avenue, Suite 208",Pontiac,MI,48341,248-332-4540,VA Facility,Government,no,Not Available,0,0
-538GB,Portsmouth Community Based Outpatient Clinic,840 Gallia Street,Portsmouth,OH,45662,740-353-3236,VA Facility,Government,no,Not Available,38.734104,-82.99568
-541,Ravenna Community Based Outpatient Clinic,6751 N Chestnut St,Ravenna,OH,44266,330-296-3641,VA Facility,Government,no,Not Available,41.174595,-81.24526
-552GC,Richmond Community Based Outpatient Clinic,1010 N. J Street,Richmond,IN,47374,765-973-6915,VA Facility,Government,no,Not Available,39.84063,-84.888824
-655AA,Saginaw VA Healthcare Annex,4241 Barnard Road,Saginaw,MI,48603,800-406-5143 X 11230,VA Facility,Government,no,Not Available,43.468258,-83.96569
-541GC,Sandusky Community Based Outpatient Clinic,3416 Columbus Avenue,Sandusky,OH,44870,419-625-7350,VA Facility,Government,no,Not Available,41.41938,-82.69002
-610A4,South Bend VA Outpatient Clinic,333 W. Western Ave,South Bend,IN,46601,866-436-1291 Or 866-436-1291,VA Facility,Government,no,Not Available,41.67231,-86.25395
-552GD,Springfield Community Based Outpatient Clinic,512 South Burnett Road,Springfield,OH,45505,937-328-3385,VA Facility,Government,no,Not Available,39.915005,-83.77042
-610BY,St. Joseph County VA Clinic,1540 Trinity Place,Mishawaka,IN,46545,574-272-9000,VA Facility,Government,no,Not Available,0,0
-583GA,Terre Haute VA Clinic,110 W Honeycreek Pkwy,Terre Haute,IN,47802,812-232-2890,VA Facility,Government,no,Not Available,39.424934,-87.41767
-655GB,Traverse City VA Outpatient Clinic,3271 RACQUET CLUB DRIVE,Traverse City,MI,49684,231-932-9720 Or 800-406-5143 X 11412,VA Facility,Government,no,Not Available,0,0
-506GB,VA Ann Arbor - Flint Community Based Outpatient Clinic,2360 South Linden Road,Flint,MI,48532,810-720-2913,VA Facility,Government,no,Not Available,42.991943,-83.77245
-506GC,VA Ann Arbor - Jackson Community Based Outpatient Clinic,4328 Page Avenue,Michigan Center,MI,49254,517-764-3609,VA Facility,Government,no,Not Available,42.235546,-84.33686
-506GA,VA Ann Arbor - Toledo Community Based Outpatient Clinic,1200 South Detroit Avenue,Toledo,OH,43614,419-259-2000,VA Facility,Government,no,Not Available,0,0
-541GI,Warren Community Based Outpatient Clinic,1460 Tod Ave (NW),Warren,OH,44485,330-392-0311,VA Facility,Government,no,Not Available,41.246456,-80.83477
-583GE,West Lafayette VA Clinic,3851 N. River Road,Lafayette,IN,47906,,VA Facility,Government,no,Not Available,40.412487,-86.97694
-538GF,Wilmington Community-Based Outpatient Clinic,448 West Main Street,Wilmington,OH,45177,937-382-3949,VA Facility,Government,no,Not Available,39.44553,-83.8363
-515BY,Wyoming Health Care Center,5838 Metro Way,Wyoming,MI,49519,616-249-5300,VA Facility,Government,no,Not Available,0,0
-553GA,Yale VA Outpatient Clinic,7470 Brockway Road,Yale,MI,48097,810-387-3211,VA Facility,Government,no,Not Available,43.138046,-82.79886
-757GA,Zanesville Community Based Outpatient Clinic,2800 Maple Avenue,Zanesville,OH,43701,740-453-7725 Or 888-615-9448 X 5751,VA Facility,Government,no,Not Available,39.974194,-82.01204
-204,Cincinnati Vet Center,801B W. 8th St. Suite 126,Cincinnati,OH,45203,513-763-3500 Or 513-763-3500,VA Facility,Government,no,Not Available,39.103344,-84.52966
-0205V,Cleveland Vet Center,5310 1/2 Warrensville Center Rd,Maple Heights,OH,44137,216-707-7901 Or 216-707-7901,VA Facility,Government,no,Not Available,41.41617,-81.53732
-0221V,Columbus Vet Center,30 Spruce Street,Columbus,OH,43215,614-257-5550,VA Facility,Government,no,Not Available,39.97233,-83.00369
-0225V,Dayton Vet Center,"627 Edwin C. Moses Blvd.,6th Floor, East Medical Plaza",Dayton,OH,45417,937-461-9150 Or 937-461-9150,VA Facility,Government,no,Not Available,39.74863,-84.19844
-0401V,Dearborn Vet Center,"19855 Outer Drive, Suite 105 W",Dearborn,MI,48124,313-277-1428 Or 313-277-1428,VA Facility,Government,no,Not Available,42.303585,-83.26335
-402,Detroit Vet Center,11214 East Jefferson Avenue,Detroit,MI,48214,313-822-1141,VA Facility,Government,no,Not Available,42.36637,-82.97188
-0409V,Fort Wayne Vet Center,"5800 Fairfield Ave., Suite 265",Fort Wayne,IN,46807,260-460-1456 Or 260-460-1456,VA Facility,Government,no,Not Available,41.03154,-85.14336
-403,Grand Rapids Vet Center,2050 Breton Rd SE,Grand Rapids,MI,49546,616-285-5795,VA Facility,Government,no,Not Available,42.926167,-85.60905
-0413V,Indianapolis Vet Center,"8330 Naab Road, Suite 103",Indianapolis,IN,46260,317-988-1600 Or 317-988-1600,VA Facility,Government,no,Not Available,39.911648,-86.198395
-0437V,Macomb County Vet Center,42621 Garfield Rd. Suite 105,Clinton Township,MI,48038,586-412-0107 Or 586-412-0107,VA Facility,Government,no,Not Available,42.610115,-82.95288
-02061V,McCafferty Vet Center Outstation,4242 Lorain Avenue Suite 203,Cleveland,OH,44113,216-939-0784 Or 877-927-8387,VA Facility,Government,no,Not Available,41.479897,-81.71472
-0206V,Parma Vet Center,5700 Pearl Road Suite 102,Parma,OH,44129,440-845-5023 Or 440-845-5023,VA Facility,Government,no,Not Available,41.406796,-81.74186
-0417V,Peoria Vet Center,"8305 N. Allen Road, Suite 1",Peoria,IL,61615,309-689-9708 Or 309-689-9708,VA Facility,Government,no,Not Available,40.788372,-89.63111
-0438V,Pontiac Vet Center,"44200 Woodward Avenue, Suite 108",Pontiac,MI,48341,248-874-1015 Or 248-874-1015,VA Facility,Government,no,Not Available,0,0
-433,Saginaw Vet Center,5360 Hampton Place,Saginaw,MI,48604,989-321-4650 Or 989-321-4650,VA Facility,Government,no,Not Available,0,0
-0421V,"Springfield, IL Vet Center",2980 Baker Drive,Springfield,IL,62703,217-492-4955 Or 217-492-4955,VA Facility,Government,no,Not Available,39.762154,-89.64444
-0241V,Stark County Vet Center,"601 Cleveland Ave N, Suite C",Canton,OH,44702,330-454-3120 Or 330-454-3120,VA Facility,Government,no,Not Available,40.79531,-81.37779
-0234V,Toledo Vet Center,"1565 S. Byrne Road, Suite 104",Toledo,OH,43614,419-213-7533 Or 877-927-8387,VA Facility,Government,no,Not Available,41.6112,-83.625755
-445,Traverse City Vet Center,3766 N US 31 South,Traverse City,MI,49684,231-935-0051 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-506,VA Ann Arbor - North Campus Research Complex,2800 Plymouth Road,Ann Arbor,MI,48105,734-769-7100,VA Facility,Government,no,Not Available,42.30256,-83.705765
-506,VA Ann Arbor - Offsite Warehouse,844 Highland Drive,Ann Arbor,MI,48105,734-769-7100,VA Facility,Government,no,Not Available,42.22654,-83.72491
-506,VA Ann Arbor Business Office,2200 Commonwealth Blvd,Ann Arbor,MI,48105,734-769-7100,VA Facility,Government,no,Not Available,42.307255,-83.69625
-506,VA Ann Arbor Finance & Payroll Office,3001 Earhart Road,Ann Arbor,MI,48105,734-769-7100,VA Facility,Government,no,Not Available,42.325016,-83.68348
-10N12,VISN 12: VA Great Lakes Health Care System,"11301 W. Cermak Road, Suite 810",Westchester,IL,60154,708-492-3900,VA Facility,Government,no,Not Available,41.84804,-87.90505
-556,Captain James A. Lovell Federal Health Care Center,3001 Green Bay Road,North Chicago,IL,60064,847-688-1900 Or 847-688-1900,VA Facility,Government,no,Not Available,42.30826,-87.86246
-695,Clement J. Zablocki Veterans Affairs Medical Center,5000 West National Avenue,Milwaukee,WI,53295,414-384-2000,VA Facility,Government,no,Not Available,43.020367,-87.97142
-578,Edward Hines Jr. VA Hospital,5000 South 5th Ave,Hines,IL,60141,708-202-8387,VA Facility,Government,no,Not Available,0,0
-537,Jesse Brown VA Medical Center,820 South Damen Avenue,Chicago,IL,60612,312-569-8387 Or 312-569-8387,VA Facility,Government,no,Not Available,41.8712,-87.67639
-585,Oscar G. Johnson VA Medical Center,325 East H Street,Iron Mountain,MI,49801,906-774-3300,VA Facility,Government,no,Not Available,45.81145,-88.06337
-676,Tomah VA Medical Center,500 E. Veterans Street,Tomah,WI,54660,608-372-3971,VA Facility,Government,no,Not Available,44.00095,-90.50921
-550,VA Illiana Health Care System,1900 East Main Street,Danville,IL,61832,217-554-3000 Or 217-554-3000,VA Facility,Government,no,Not Available,0,0
-607,William S. Middleton Memorial Veterans Hospital,2500 Overlook Terrace,Madison,WI,53705,608-256-1901 Or 888-478-8321,VA Facility,Government,no,Not Available,43.073982,-89.429085
-1007,1007 USS Tranquillity,3420 Illinois Street,Great Lakes,IL,60088,847-688-6755,VA Facility,Government,no,Not Available,42.30789,-87.85014
-1523,1523 USS Red Rover,3350 Illinois Street,Great Lakes,IL,60088,847-688-5568,VA Facility,Government,no,Not Available,42.30791,-87.85014
-537BY,"Adam Benjamin, Jr. OPC",9301 Madison Street,Crown Point,IN,46307,219-662-5000,VA Facility,Government,no,Not Available,0,0
-695BY,Appleton Clinic (John H. Bradley),10 Tri-Park Way,Appleton,WI,54914,920-831-0070,VA Facility,Government,no,Not Available,44.281895,-88.453674
-537HA,Auburn Gresham (Chicago) Clinic,7731 S Halsted St,Chicago,IL,60620,773-962-3700,VA Facility,Government,no,Not Available,41.75367,-87.644104
-578GD,Aurora Clinic,161 South Lincolnway,North Aurora,IL,60542,630-859-2504,VA Facility,Government,no,Not Available,41.80079,-88.32549
-607GD,Baraboo Clinic,1670 South Blvd,Baraboo,WI,53913,608-356-9318,VA Facility,Government,no,Not Available,0,0
-607GE,Beaver Dam Clinic,"215 Corporate Drive, Suite D",Beaver Dam,WI,53916,920-356-9415,VA Facility,Government,no,Not Available,0,0
-537GA,Chicago Heights Clinic,30 E. 15th Street (Suite 314),Chicago Heights,IL,60411,708-754-8880,VA Facility,Government,no,Not Available,41.504265,-87.64218
-676GE,Clark County Outpatient Clinic,8 Johnson Street,Owen,WI,54460,715-229-4701,VA Facility,Government,no,Not Available,0,0
-695GC,Cleveland Clinic,1205 North Avenue,Cleveland,WI,53015,920-693-5600 Or 920-693-5600,VA Facility,Government,no,Not Available,43.92128,-87.75155
-556GA,Evanston Clinic,1942 Dempster Street,Evanston,IL,60202,847-869-6315,VA Facility,Government,no,Not Available,42.041096,-87.69995
-556,"Fisher Clinic, Bldg. 237",2470 Sampson Street,Great Lakes,IL,60088,847-688-2469,VA Facility,Government,no,Not Available,42.312874,-87.83964
-607GF,Freeport Clinic,"750 Kiwanis Drive, Suite 250",Freeport,IL,61032,815-235-4881,VA Facility,Government,no,Not Available,42.29079,-89.67082
-695GD,Green Bay Clinic (Milo C. Huempfner),2851 University Avenue,Green Bay,WI,54311,920-431-2500 Or 877-204-7970,VA Facility,Government,no,Not Available,44.5213,-87.94072
-585GA,Hancock Clinic,787 Market Street,Hancock,MI,49930,906-482-7762,VA Facility,Government,no,Not Available,0,0
-1231,Hoffman Estates,4885 Hoffman Blvd,Hoffman Estates,IL,60192,847-645-1443,VA Facility,Government,no,Not Available,0,0
-585GD,Ironwood Clinic,629 W. Cloverland Dr. Suite 1,Ironwood,MI,49938,906-932-0032,VA Facility,Government,no,Not Available,46.46337,-90.183044
-607GC,Janesville Clinic,2419 Morse Street,Janesville,WI,53545,608-758-9300,VA Facility,Government,no,Not Available,42.72222,-88.99433
-578GA,Joliet Clinic,1201 Eagle St,Joliet,IL,60432,815-740-8100,VA Facility,Government,no,Not Available,41.535557,-88.05301
-1111,Kankakee Clinic,"581 William Latham Drive, Suite 301",Bourbonnais,IL,60914,815-932-3823,VA Facility,Government,no,Not Available,41.162605,-87.8785
-556GD,Kenosha Clinic,8207 22nd Avenue,Kenosha,WI,53140,262-653-9286 Or 262-653-9286,VA Facility,Government,no,Not Available,42.555126,-87.83505
-537a,Lakeside Clinic,"211 E. Ontario St., 12th Floor",Chicago,IL,60611,312-469-4850,VA Facility,Government,no,Not Available,41.89342,-87.61852
-2970,LaSalle Clinic,4461 N Progress Blvd,Peru,IL,61354,815-223-9678,VA Facility,Government,no,Not Available,0,0
-585,Manistique Outreach Clinic,813 East Lakeshore Drive,Manistique,MI,49854,906-341-3420,VA Facility,Government,no,Not Available,45.948757,-86.23988
-585HA,Marquette Clinic,1414 W. Fair Ave Suite 285,Marquette,MI,49855,906-226-4618,VA Facility,Government,no,Not Available,46.5568,-87.416
-556GC,McHenry Clinic,3715 Municipal Drive,McHenry,IL,60050,815-759-2306,VA Facility,Government,no,Not Available,0,0
-585GC,Menominee Clinic,"1110 10th Avenue, Suite 101",Menominee,MI,49858,906-863-1286,VA Facility,Government,no,Not Available,45.10786,-87.616394
-578GG,Oak Lawn Clinic,10201 S. Cicero,Oak Lawn,IL,60453,708-499-3675,VA Facility,Government,no,Not Available,41.707726,-87.74034
-237,OHMD Occupational Health Medicine Department,2410 Sampson Street,Great Lakes,IL,60088,847-688-6712,VA Facility,Government,no,Not Available,42.312893,-87.83964
-585GB,Rhinelander Clinic,639 West Kemp Street,Rhinelander,WI,54501,715-362-4080,VA Facility,Government,no,Not Available,0,0
-676GC,River Valley Clinic,2600 State Road,La Crosse,WI,54601,608-784-3886,VA Facility,Government,no,Not Available,43.81284,-91.21725
-607HA,Rockford Clinic,816 Featherstone Road,Rockford,IL,61107,815-227-0081,VA Facility,Government,no,Not Available,42.27791,-88.9972
-585HB,Sault Ste. Marie Clinic,509 Osborn Blvd. Suite 306,Sault Ste. Marie,MI,49783,906-253-9383,VA Facility,Government,no,Not Available,46.498116,-84.34945
-695GA,Union Grove Clinic,21425 Spring Street,Union Grove,WI,53182,262-878-7000,VA Facility,Government,no,Not Available,42.698612,-88.08003
-556GE,USS Osborne Dental Clinic,3440 Ohio Street,Great Lakes,IL,60088,847-688-2100,VA Facility,Government,no,Not Available,0,0
-676GA,Wausau Clinic,515 South 32nd Avenue,Wausau,WI,54401,715-842-2834,VA Facility,Government,no,Not Available,44.958927,-89.67598
-676GD,Wisconsin Rapids Clinic,555 West Grand Ave.,Wisconsin Rapids,WI,54495,715-424-4682,VA Facility,Government,no,Not Available,44.394993,-89.830055
-695,Community Resource and Referral Center - Milwaukee,1818 Martin Luther King Jr. Drive,Milwaukee,WI,53212,414-263-7673,VA Facility,Government,no,Not Available,43.054127,-87.91425
-550BY,Bob Michel VA Outpatient Clinic,7717 N. Orange Prairie Road,Peoria,IL,61615,309-589-6800,VA Facility,Government,no,Not Available,0,0
-550GA,Decatur VA Outpatient Clinic,3035 East Mound Road,Decatur,IL,62526,217-875-2670,VA Facility,Government,no,Not Available,39.892822,-88.914024
-607AA,Madison Central Clinic,2500 Overlook Terrace,Madison,WI,53705,888-856-9039 X 17059,VA Facility,Government,no,Not Available,43.073982,-89.429085
-607AB,Madison West Annex Clinic,1 Science Court,Madison,WI,53711,608-280-7059,VA Facility,Government,no,Not Available,43.059372,-89.468864
-550GF,Mattoon Community Based Outpatient Clinic,501 Lakeland Blvd.,Mattoon,IL,61938,217-258-3370,VA Facility,Government,no,Not Available,39.478317,-88.37655
-550GD,Springfield VA Outpatient Clinic,"5850 South 6th Street, Suite A",Springfield,IL,62703,217-529-5046,VA Facility,Government,no,Not Available,0,0
-676,VA River Valley Integrated Health Center,1525 Losey Blvd South,LaCrosse,WI,54601,608-787-6411,VA Facility,Government,no,Not Available,43.79642,-91.21983
-0436V,Aurora Vet Center,"750 Shoreline Drive, Suite 150",Aurora,IL,60504,630-585-1853 Or 630-585-1853,VA Facility,Government,no,Not Available,41.74383,-88.22525
-0407V,Chicago Heights Vet Center,"1010 Dixie Hwy, 2nd Floor",Chicago Heights,IL,60411,708-754-8885 Or 708-754-8885,VA Facility,Government,no,Not Available,41.513294,-87.64522
-0410V,Chicago Vet Center,"3348 W. 87th Street, Suite 2",Chicago,IL,60652,773-962-3740 Or 773-962-3740,VA Facility,Government,no,Not Available,41.735046,-87.71181
-0434V,Escanaba Vet Center,"3500 Ludington Street, Suite # 110",Escanaba,MI,49829,906-233-0244 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0420V,Evanston Vet Center,1901 Howard St,Evanston,IL,60202,847-332-1019 Or 847-332-1019,VA Facility,Government,no,Not Available,42.01934,-87.69962
-0412V,Gary Area Vet Center,107 E. 93rd Ave,Crown Point,IN,46307,219-736-5633 Or 877-927-8387,VA Facility,Government,no,Not Available,41.449306,-87.33577
-0441V,Green Bay Vet Center,1600 S. Ashland Ave,Green Bay,WI,54304,920-435-5650 Or 920-435-5650,VA Facility,Government,no,Not Available,44.500378,-88.038445
-0442V,La Crosse Vet Center,20 Copeland Ave.,La Crosse,WI,54603,608-782-4403 Or 877-927-8387,VA Facility,Government,no,Not Available,43.821068,-91.24907
-0419V,Madison Vet Center,1291 N. Sherman Ave,Madison,WI,53704,608-264-5342 Or 608-264-5342,VA Facility,Government,no,Not Available,43.11412,-89.36377
-0415V,Milwaukee Vet Center,"7910 N. 76th Street, Suite 100",Milwaukee,WI,53223,414-902-5561,VA Facility,Government,no,Not Available,0,0
-0411V,Oak Park Vet Center,1515 South Harlem,Forest Park,IL,60130,708-457-8805,VA Facility,Government,no,Not Available,0,0
-0435V,Orland Park Vet Center,"8651 W.159th Street, Suite 1",Orland Park,IL,60462,708-444-0561,VA Facility,Government,no,Not Available,41.60169,-87.83271
-0447V,Rockford Vet Center,"7015 Rote Road, Suite 105",Rockford,IL,61107,815-395-1276 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-444,South Bend Vet Center,4727 Miami Street,South Bend,IN,46614,574-231-8480 Or 877-927-8387,VA Facility,Government,no,Not Available,41.627018,-86.234795
-4421,Wausau Vet Center,"605 S 24th Ave, Suite 24",Wausau,WI,54401,715-842-1724 Or 877-927-8387,VA Facility,Government,no,Not Available,44.957066,-89.66565
-10N15,VISN 15: VA Heartland Network,"1201 Walnut St, Suite 800",Kansas City,MO,64106,816-701-3000,VA Facility,Government,no,Not Available,39.099815,-94.582054
-657,VA St. Louis Health Care System,1 Jefferson Barracks Drive,Saint Louis,MO,63125,314-652-4100,VA Facility,Government,no,Not Available,38.509212,-90.28942
-657,VA St. Louis Health Care System - John Cochran Division,915 North Grand Blvd.,Saint Louis,MO,63106,314-652-4100,VA Facility,Government,no,Not Available,38.641426,-90.22986
-589A4,Harry S. Truman Memorial,800 Hospital Drive,Columbia,MO,65201,573-814-6000 Or 573-814-6000,VA Facility,Government,no,Not Available,38.937588,-92.32859
-657A4,John J. Pershing VA Medical Center,1500 N. Westwood Blvd.,Poplar Bluff,MO,63901,573-686-4151 Or 573-686-4151,VA Facility,Government,no,Not Available,36.7715,-90.418
-589,Kansas City VA Medical Center,4801 Linwood Boulevard,Kansas City,MO,64128,816-861-4700,VA Facility,Government,no,Not Available,39.067238,-94.52744
-657A5,Marion VA Medical Center,2401 West Main Street,Marion,IL,62959,618-997-5311 Or 618-997-5311,VA Facility,Government,no,Not Available,37.729828,-88.95548
-589A7,Robert J. Dole VA Medical Center,5500 E. Kellogg,Wichita,KS,67218,316-685-2221 Or 316-685-2221,VA Facility,Government,no,Not Available,0,0
-589A5,VA Eastern Kansas Health Care System - Colmery-O'Neil VA Medical Center,2200 SW Gage Boulevard,Topeka,KS,66622,785-350-3111 Or 785-350-3111,VA Facility,Government,no,Not Available,39.027374,-95.72494
-589A6,VA Eastern Kansas Health Care System - Dwight D. Eisenhower VA Medical Center,4101 S. 4th Street,Leavenworth,KS,66048,913-682-2000 Or 913-682-2000,VA Facility,Government,no,Not Available,39.279087,-94.9005
-657A0,VA St. Louis Health Care System - Jefferson Barracks Division,1 Jefferson Barracks Drive,Saint Louis,MO,63125,314-652-4100,VA Facility,Government,no,Not Available,38.509212,-90.28942
-657A5,Enterprise Way VA Clinic,1301 Enterprise Way Suite 68,Marion,IL,62959,618-993-1008,VA Facility,Government,no,Not Available,37.74047,-88.93996
-657J,Evansville Health Care Center,6211 E. Waterford Blvd.,Evansville,IN,47715,812-465-6202,VA Facility,Government,no,Not Available,0,0
-657A5,Heartland Street VA Clinic,3404 Heartland Street,Marion,IL,62959,,VA Facility,Government,no,Not Available,0,0
-589,Johnson County/Radiation Oncology VA Clinic,10500 Mastin St,Overland Park,KS,66212,816-922-2750,VA Facility,Government,no,Not Available,38.941135,-94.701965
-589JE,Platte City,2303 Higgins Suite F,Platte City,MO,64079,800-952-8387 X 59141,VA Facility,Government,no,Not Available,0,0
-657GA,Belleville Clinic,6500 W Main St,Belleville,IL,62223,314-286-6988,VA Facility,Government,no,Not Available,38.554073,-90.0401
-5240,Belton CBOC,209 Cunningham Industrial Parkway,Belton,MO,64012,816-922-2161,VA Facility,Government,no,Not Available,38.809227,-94.504654
-589GZ,Cameron Clinic,1111 Euclid Dr,Cameron,MO,64429,816-922-2500 X 54251,VA Facility,Government,no,Not Available,0,0
-657A4,Cape Girardeau Community-Based Outpatient Clinic,3051 William St.,Cape Girardeau,MO,63703,573-339-0909,VA Facility,Government,no,Not Available,37.30073,-89.568634
-657GT,Carbondale Community Based Outpatient Clinic,1130 East Walnut Street,Carbondale,IL,62901,618-351-1031,VA Facility,Government,no,Not Available,37.726982,-89.19631
-589GM,Chanute - Neosho Memorial Medical Center,629 South Plummer,Chanute,KS,66720,800-574-8387 X 54453,VA Facility,Government,no,Not Available,37.675755,-95.47092
-589G2,"Dodge City, Kansas CBOC",2201 Summerlon Circle,Dodge City,KS,67843,888-878-6881 X 57450,VA Facility,Government,no,Not Available,0,0
-657GM,Effingham Community Based Outpatient Clinic,1011 Ford Avenue,Effingham,IL,62401,217-347-7600,VA Facility,Government,no,Not Available,0,0
-589GN,Emporia CBOC,"919 W. 12th Avenue, Suite D",Emporia,KS,66801,800-574-8387 X 54451,VA Facility,Government,no,Not Available,38.412285,-96.19184
-589JB,Excelsior Springs MO CBOC,197 McCleary Rd,Excelsior Springs,MO,64024,816-922-2970 Or 816-861-4700 X 52970,VA Facility,Government,no,Not Available,39.341568,-94.26308
-657GI,Farmington CBOC,1580 W. Columbia St,Farmington,MO,63640,573-760-1365,VA Facility,Government,no,Not Available,37.77193,-90.444756
-589gf,Fort Leonard Wood CBOC,700 GW Lane Street,Waynesville,MO,65583,573-774-2285,VA Facility,Government,no,Not Available,0,0
-589GV,Ft Scott CBOC,902 Horton Street,Ft. Scott,KS,66701,800-574-8387 X 54750,VA Facility,Government,no,Not Available,37.830357,-94.713615
-589GP,Garnett - Anderson County Hospital,421 South Maple,Garnett,KS,66032,800-574-8387 X 54453,VA Facility,Government,no,Not Available,0,0
-657GO,Hanson Community Based Outpatient Clinic,926 Veterans Drive,Hanson,KY,42413,270-322-8019,VA Facility,Government,no,Not Available,0,0
-657GU,Harrisburg Community Based Outpatient Clinic,608 Rollie Moore Drive,Harrisburg,IL,62946,618-252-6150,VA Facility,Government,no,Not Available,0,0
-589A7,"Hays, Kansas CBOC",207-B E. 7th,Hays,KS,67601,888-878-6881 X 41000,VA Facility,Government,no,Not Available,38.86904,-99.33027
-589ZZ,Honor Annex,4251 Northern Avenue,Kansas City,MO,64133,816-861-4700,VA Facility,Government,no,Not Available,39.04498,-94.45213
-657,Hope Recovery Center VA St. Louis Health Care System,515 North Jefferson Avenue,St. Louis,MO,63103,314-652-4100 X 55500 Or 800-228-5459 X 55500,VA Facility,Government,no,Not Available,38.634754,-90.21337
-589,"Hutchinson, Kansas CBOC",1625 E 30th Ave,Hutchinson,KS,67502,888-878-6881 X 41100,VA Facility,Government,no,Not Available,38.08652,-97.89665
-589G8,Jefferson City VA CBOC,2707 W Edgewood Dr,Jefferson City,MO,65109,573-635-0233,VA Facility,Government,no,Not Available,38.570843,-92.21489
-589GR,Junction City,1169 Southwind Drive,Junction City,KS,66441,800-574-8387 X 54670,VA Facility,Government,no,Not Available,0,0
-589a4,Kirksville VA CBOC/North East Missouri Health Council,1510 North Crown Drive,Kirksville,MO,63501,660-627-8387,VA Facility,Government,no,Not Available,40.20692,-92.57394
-589GH,Lake of the Ozarks CBOC,940 Executive Drive,Osage Beach,MO,65065,573-302-7890,VA Facility,Government,no,Not Available,0,0
-589GU,Lawrence,2200 Harvard Road,Lawrence,KS,66049,800-574-8387 X 54650,VA Facility,Government,no,Not Available,38.9643,-95.26153
-589G3,"Liberal, Kansas CBOC","2 Rock Island Road, Suite 200",Liberal,KS,67901,888-878-6881 X 57400,VA Facility,Government,no,Not Available,37.038788,-100.92228
-5236,Louisburg-Paola Clinic,501 South Hospital Drive,Paola,KS,66071,816-922-2160,VA Facility,Government,no,Not Available,38.569992,-94.863716
-589JD,Marshfield VA Clinic,1240 Banning Street,Marshfield,MO,65706,417-468-1963,VA Facility,Government,no,Not Available,37.344913,-92.92716
-657GR,Mayfield Community Based Outpatient Clinic,1253 Paris Road Suite A,Mayfield,KY,42066,270-247-2455,VA Facility,Government,no,Not Available,36.72426,-88.62816
-589GX,Mexico VA CBOC,3460 South Clark Street,Mexico,MO,65265,573-581-9630,VA Facility,Government,no,Not Available,0,0
-589ZX,Mobile Medical Unit,4801 Linwood Blvd,Kansas City,MO,64128,816-861-4700 X 52977 Or 800-525-1483 X 52977,VA Facility,Government,no,Not Available,39.067238,-94.52744
-657GK,Mt. Vernon Community Based Outpatient Clinic,4105 N. Water Tower Place,Mt. Vernon,IL,62864,618-246-2910,VA Facility,Government,no,Not Available,38.307262,-88.941864
-589GD,Nevada Clinic,322 South Prewitt,Nevada,MO,64772,816-861-4700 X 54235,VA Facility,Government,no,Not Available,37.83659,-94.37613
-657GP,Owensboro Community Based Outpatient Clinic,3400 New Hartford Road,Owensboro,KY,42303,270-684-5034,VA Facility,Government,no,Not Available,37.7375,-87.09166
-657GL,Paducah Community Based Outpatient Clinic,2620 Perkins Creek Dr.,Paducah,KY,42001,270-444-8465,VA Facility,Government,no,Not Available,0,0
-657GG,Paragould Community-Based Outpatient Clinic,2420 Linwood Drive - Suite 3,Paragould,AR,72450,870-236-9756,VA Facility,Government,no,Not Available,0,0
-589G5,"Parsons, Kansas CBOC",1907 Harding Dr.,Parsons,KS,67357,888-878-6881 X 41060,VA Facility,Government,no,Not Available,0,0
-657GW,Pocahontas Community-Based Outpatient Clinic,300 Camp Rd,Pocahontas,AR,72455,870-248-0571,VA Facility,Government,no,Not Available,0,0
-657GN,Salem (MO) Community-Based Outpatient Clinic,35629 MO-Hwy 72,Salem,MO,65560,573-729-6626,VA Facility,Government,no,Not Available,0,0
-589GW,"Salina, Kansas CBOC","1410 E. Iron, Suite 1",Salina,KS,67401,888-878-6881 X 41020,VA Facility,Government,no,Not Available,38.840443,-97.589294
-589JA,Sedalia VA Clinic,3320 West 10th Street,Sedalia,MO,65301,660-826-3800,VA Facility,Government,no,Not Available,38.704,-93.27141
-589JC,Shawnee VA Clinic,6830 Anderson St,Shawnee,KS,66226,816-922-2750,VA Facility,Government,no,Not Available,0,0
-657GV,Sikeston CBOC,903 South Kingshighway,Sikeston,MO,63801,573-472-2139,VA Facility,Government,no,Not Available,36.886517,-89.5912
-657GD,St. Charles Clinic,844 Waterbury Falls Drive,O'Fallon,MO,63368,314-286-6988,VA Facility,Government,no,Not Available,0,0
-589GY,St. James VA Clinic,207 Matlock Drive,St. James,MO,65559,573-265-0448,VA Facility,Government,no,Not Available,0,0
-589GI,St. Joseph Clinic,3302 S. Belt Hwy Suite P,ST.JOSEPH,MO,64503,800-952-8387 X 56925,VA Facility,Government,no,Not Available,39.737244,-94.80113
-657DY,St. Louis CBOC,6854 Parker Road,Florissant,MO,63033,314-286-6988,VA Facility,Government,no,Not Available,38.796257,-90.23481
-657,VA St. Louis Health Care System Primary Care Team 1 Annex,4974 Manchester Avenue,St. Louis,MO,63110,314-289-6566,VA Facility,Government,no,Not Available,38.625465,-90.26762
-657,VA St. Louis Health Care System Primary Care Team 2 Annex,2727 Washington Avenue,St. Louis,MO,63103,314-289-7659,VA Facility,Government,no,Not Available,38.635654,-90.21635
-657GQ,Vincennes Community Based Outpatient Clinic,1813 Willow Street Suite 6A,Vincennes,IN,47591,812-882-0894,VA Facility,Government,no,Not Available,38.657276,-87.53027
-589G1,Warrensburg Clinic,702 E. Young St.,Warrensburg,MO,64093,816-922-2500 X 54281,VA Facility,Government,no,Not Available,38.77199,-93.720215
-657GS,Washington MO CBOC,1627 A Roy Drive,Washington,MO,63090,314-289-7950 Or 800-228-5459 X 57950,VA Facility,Government,no,Not Available,0,0
-657A4,West Plains CBOC,1801 E. State Route K,West Plains,MO,65775,417-257-2454,VA Facility,Government,no,Not Available,36.726402,-91.88993
-589GJ,Wyandotte CBOC,"21 N 12th Street, Bethany Medical Building, Suite 110",Kansas City,KS,66102,800-952-8387 X 56990,VA Facility,Government,no,Not Available,39.104305,-94.640076
-0443V,Columbia Vet Center,"4040 Rangeline Street, Suite 105",Columbia,MO,65202,573-814-6206 Or 573-814-6206,VA Facility,Government,no,Not Available,38.991932,-92.32376
-0422V,East St. Louis Vet Center,1265 N. 89th Street Suite 5,East St. Louis,IL,62203,618-397-6602 Or 877-927-8387,VA Facility,Government,no,Not Available,38.596157,-90.05323
-0418V,Evansville Vet Center,1100 N. Burkhardt Rd,Evansville,IN,47715,812-473-5993 Or 812-473-5993,VA Facility,Government,no,Not Available,37.986885,-87.474
-0408V,Kansas City Vet Center,"4800 Main Street, Suite 107",Kansas City,MO,64112,816-753-1866 Or 816-753-1866,VA Facility,Government,no,Not Available,39.03929,-94.587105
-0432V,Manhattan Vet Center,"205 South 4th Street, Suite B",Manhattan,KS,66502,785-350-4920 Or 785-350-4920,VA Facility,Government,no,Not Available,39.178177,-96.56182
-0400V,RCS Midwest District 3 District Office,"2122 Kratky Rd., Suite 130",St. Louis,MO,63114,314-894-6190,VA Facility,Government,no,Not Available,38.697098,-90.406784
-0414V,St. Louis Vet Center,2901 Olive,St. Louis,MO,63103,314-531-5355,VA Facility,Government,no,Not Available,38.634422,-90.22021
-0426V,Wichita Vet Center,251 N. Water St.,Wichita,KS,67202,316-265-0889 Or 877-927-8397,VA Facility,Government,no,Not Available,37.68888,-97.339554
-10N16,VISN 16: South Central VA Health Care Network,715 S. Pear Orchard Road,Ridgeland,MS,39157,601-206-6900,VA Facility,Government,no,Not Available,32.403606,-90.123535
-502,Alexandria VA Health Care System,2495 Shreveport Hwy 71 N,Pineville,LA,71360,318-473-0010,VA Facility,Government,no,Not Available,31.353516,-92.43374
-598,Central Arkansas Veterans Healthcare System Eugene J. Towbin Healthcare Center,2200 Fort Roots Drive,North Little Rock,AR,72114,501-257-1000,VA Facility,Government,no,Not Available,34.773396,-92.289375
-598,Central Arkansas Veterans Healthcare System John L. McClellan Memorial Veterans Hospital,4300 West 7th Street,Little Rock,AR,72205,501-257-1000,VA Facility,Government,no,Not Available,34.744892,-92.32114
-586,G.V. (Sonny) Montgomery VA Medical Center,1500 E. Woodrow Wilson Drive,Jackson,MS,39216,601-362-4471,VA Facility,Government,no,Not Available,32.32652,-90.165695
-520,Gulf Coast Veterans Health Care System,400 Veterans Avenue,Biloxi,MS,39531,228-523-5000,VA Facility,Government,no,Not Available,30.414478,-88.94722
-580,Michael E. DeBakey VA Medical Center,2002 Holcombe Blvd.,Houston,TX,77030,713-791-1414 Or 713-791-1414,VA Facility,Government,no,Not Available,29.705933,-95.39014
-667,Overton Brooks VA Medical Center,510 E. Stoner Ave.,Shreveport,LA,71101,318-221-8411 Or 318-221-8411,VA Facility,Government,no,Not Available,32.49999,-93.73993
-667,Shreveport,510 E Stoner Ave,Shreveport,LA,71101,,VA Facility,Government,no,Not Available,32.49999,-93.73993
-629,Southeast Louisiana Veterans Health Care System,2400 Canal Street,New Orleans,LA,70119,800-935-8387 Or 800-935-8387,VA Facility,Government,no,Not Available,29.963257,-90.08411
-564,Veterans Health Care System of the Ozarks,1100 N. College Avenue,Fayetteville,AR,72703,479-443-4301 Or 479-443-4301,VA Facility,Government,no,Not Available,36.077305,-94.157074
-580,Katy VA Outpatient Clinic,750 Westgreen Blvd,Katy,TX,77450,281-578-4600,VA Facility,Government,no,Not Available,29.778257,-95.73581
-629BY,Baton Rouge Outpatient Clinic,7968 Essen Park Ave.,Baton Rouge,LA,70809,225-761-3400,VA Facility,Government,no,Not Available,30.403616,-91.099525
-77701,Beaumont VA Outpatient Clinic,3420 Veterans Circle,Beaumont,TX,77707,409-981-8550 Or 800-833-7734,VA Facility,Government,no,Not Available,0,0
-629,Bogalusa VA Outpatient Clinic,521 Ontario Avenue,Bogalusa,LA,70427,985-735-9029,VA Facility,Government,no,Not Available,30.791603,-89.86743
-564,Branson OPC,5571 North Gretna Rd,Branson,MO,65616,417-243-2300 Or 417-243-2300,VA Facility,Government,no,Not Available,36.645756,-93.27286
-580BZ,Charles Wilson VA Outpatient Clinic,2206 North John Redditt Drive,Lufkin,TX,75904,936-671-4300 Or 800-209-3120,VA Facility,Government,no,Not Available,31.356213,-94.76453
-586GF,Columbus Clinic,824 Alabama St,Columbus,MS,39702,662-244-0391,VA Facility,Government,no,Not Available,33.493317,-88.36798
-580,Conroe VA Outpatient Clinic,"690 South Loop 336 West, 3rd & 4th Floors",Conroe,TX,77304,936-522-4000 Or 800-553-2278 X 10900,VA Facility,Government,no,Not Available,0,0
-598GG,Conway CBOC,1520 East Dave Ward Drive,Conway,AR,72032,501-548-0500,VA Facility,Government,no,Not Available,0,0
-520-GC,Eglin CBOC,100 Veterans Way,Eglin AFB,FL,32542,866-520-7359,VA Facility,Government,no,Not Available,0,0
-598GB,El Dorado CBOC,1702 North West Ave.,El Dorado,AR,71730,870-875-5900,VA Facility,Government,no,Not Available,33.228554,-92.665634
-502GF,Fort Polk CBOC,3353 University Parkway,Leesville,LA,71446,337-392-3800,VA Facility,Government,no,Not Available,0,0
-629,Franklin VA Outpatient Clinic,603 Haifleigh Street,Franklin,LA,70538,337-828-9092,VA Facility,Government,no,Not Available,29.805956,-91.49894
-564GB,Ft Smith OPC,1500 Dodson Ave Sparks Medical Plaza,Ft Smith,AR,72917,479-441-2600,VA Facility,Government,no,Not Available,0,0
-500GC,Galveston VA Outpatient Clinic,3828 Avenue N,Galveston,TX,77550,409-761-3200 Or 800-553-2278 X 11000,VA Facility,Government,no,Not Available,29.291033,-94.80806
-564BY,Gene Taylor CBOC,600 N Main,Mt Vernon,MO,65712,417-466-4000 Or 417-466-4000,VA Facility,Government,no,Not Available,37.108696,-93.818886
-586GC,Greenville CBOC,1502 S Colorado St,Greenville,MS,38703,662-332-9872,VA Facility,Government,no,Not Available,33.385975,-91.0301
-629,Hammond VA Outpatient Clinic,1131 South Morrison Boulevard,Hammond,LA,70403,985-902-5100,VA Facility,Government,no,Not Available,30.488743,-90.48272
-564GA,Harrison OPC,707 N Main St,Harrison,AR,72601,870-741-3592,VA Facility,Government,no,Not Available,36.236847,-93.10711
-586GD,Hattiesburg CBOC,"5003 Hardy Street, Tower B, Suite 402",Hattiesburg,MS,39402,601-296-3530,VA Facility,Government,no,Not Available,0,0
-598GC,Hot Springs CBOC,177 Sawtooth Oak St,Hot Springs,AR,71901,501-520-6250 Or 501-520-6250,VA Facility,Government,no,Not Available,0,0
-502GD,Houma CBOC,6433 West Park Avenue,Houma,LA,70364,985-851-0188 Or 800-935-8387 X 0,VA Facility,Government,no,Not Available,29.621208,-90.748245
-564GE,Jay CBOC,1569 N. Main St.,Jay,OK,74346,918-253-1900 Or 918-253-1900,VA Facility,Government,no,Not Available,36.43826,-94.78232
-502GA,Jennings Clinic,1907 Johnson St.,Jennings,LA,70546,337-824-1000,VA Facility,Government,no,Not Available,30.239265,-92.66137
-520BZ,Joint Ambulatory Care Center,790 Veterans Way,Pensacola,FL,32507,850-912-2000,VA Facility,Government,no,Not Available,30.397266,-87.29239
-667,Knight Street Clinic,3000 Knight Street Building 5,Shreveport,LA,71105,318-221-8411 X 7411,VA Facility,Government,no,Not Available,0,0
-586GA,Kosciusko CBOC,405 West Adams,Kosciusko,MS,39090,662-289-2880,VA Facility,Government,no,Not Available,0,0
-502GB,Lafayette CBOC Campus A—Specialty and Primary Care,3149 Ambassador Caffery Parkway,Lafayette,LA,70501,337-706-3415,VA Facility,Government,no,Not Available,30.18702,-92.075
-502GB,Lafayette CBOC Campus B—Mental Health,309 St. Julien Avenue,Lafayette,LA,70506,337-706-3415,VA Facility,Government,no,Not Available,30.213179,-92.02821
-502GL,Lake Charles CBOC,"3601 Gerstner Memorial Drive, Hwy14",Lake Charles,LA,70607,337-475-9500,VA Facility,Government,no,Not Available,30.158312,-93.15324
-580GF,Lake Jackson VA Outpatient Clinic,208 Oak Drive South,Lake Jackson,TX,77566,979-230-4852,VA Facility,Government,no,Not Available,29.031244,-95.45573
-667GC,Longview CBOC,1005 N. Eastman Rd.,Longview,TX,75601,903-247-8262 Or 800-957-8262,VA Facility,Government,no,Not Available,32.513065,-94.71108
-586GG,McComb,1308 Harrison Ave,McComb,MS,39648,601-250-0965,VA Facility,Government,no,Not Available,31.249437,-90.469894
-598GD,Mena CBOC,300 S. Morrow Road,Mena,AR,71953,501-609-2700 Or 855-838-2369,VA Facility,Government,no,Not Available,0,0
-586GB,Meridian CBOC,2103 13th St,Meridian,MS,39301,601-482-3275,VA Facility,Government,no,Not Available,32.36986,-88.699455
-520GA,Mobile Outpatient Clinic,1504 Springhill Ave.,Mobile,AL,36604,251-219-3900 Or 251-219-3900,VA Facility,Government,no,Not Available,30.692453,-88.07212
-667GB,Monroe CBOC,1691 Bienville Dr,Monroe,LA,71203,318-343-6100 Or 800-832-3525,VA Facility,Government,no,Not Available,0,0
-598GA,Mountain Home CBOC,759 Hwy 62 East,Mountain Home,AR,72653,870-594-8387 Or 877-338-8003,VA Facility,Government,no,Not Available,36.345554,-92.37713
-586GE,Natchez CBOC,"105 Northgate Drive, Suite 2",Natchez,MS,39120,601-442-7141,VA Facility,Government,no,Not Available,0,0
-502GG,Natchitoches CBOC,740 Keyser Avenue,Natchitoches,LA,71457,318-357-3300,VA Facility,Government,no,Not Available,31.753004,-93.07155
-629,New Orleans VA Outpatient Clinic,2400 Canal Street,New Orleans,LA,70119,,VA Facility,Government,no,Not Available,29.963257,-90.08411
-564,"Ozark, Arkansas OPC",2713 West Commercial,Ozark,AR,72949,479-508-1000 Or 479-508-1000,VA Facility,Government,no,Not Available,35.49001,-93.855194
-520GB,Panama City Outpatient Clinic,2600 Veterans Way(along Magnolia Beach Road),Panama City Beach,FL,32408,850-636-7000 Or 888-231-5047 X 7331,VA Facility,Government,no,Not Available,0,0
-598,Pine Bluff CBOC,4747 Dusty Lake Drive Suite 203,Pine Bluff,AR,71603,870-541-9300,VA Facility,Government,no,Not Available,0,0
-580,Richmond VA Outpatient Clinic,"22001 Southwest Freeway, Suite 200",Richmond,TX,77469,832-595-7700 Or 800-553-2278 X 10000,VA Facility,Government,no,Not Available,0,0
-598GH,Russellville CBOC,3106 West 2nd CT,Russellville,AR,72801,479-880-5100,VA Facility,Government,no,Not Available,35.28474,-93.16528
-598,Searcy CBOC,1120 S Main St,Searcy,AR,72143,501-207-4700,VA Facility,Government,no,Not Available,35.25888,-91.73588
-629E,Slidell VA Outpatient Clinic,60491 Doss Dr Ste B,Slidell,LA,70460,985-690-2626 Or 985-690-2626,VA Facility,Government,no,Not Available,0,0
-629,St. John VA Outpatient Clinic,4004 West Airline Hwy.,Reserve,LA,70084,504-565-4705,VA Facility,Government,no,Not Available,0,0
-667GA,Texarkana CBOC,910 Realtor Ave,Texarkana,AR,71854,870-216-2242 Or 800-571-8387,VA Facility,Government,no,Not Available,33.4701,-94.03299
-580,Texas City VA Outpatient Clinic,"9300 Emmett F. Lowry Expressway, Suite 206",Texas City,TX,77591,409-986-2900 Or 800-553-2278 X 10500,VA Facility,Government,no,Not Available,29.401304,-95.01783
-580GH,Tomball VA Outpatient Clinic,1200 W. Main Street,Tomball,TX,77375,281-516-1505,VA Facility,Government,no,Not Available,30.091705,-95.62763
-0734V,Alexandria Vet Center,"5803 Coliseum Blvd., Sute D",Alexandria,LA,71303,318-466-4327 Or 877-927-8387,VA Facility,Government,no,Not Available,31.295115,-92.49501
-0725V,Baton Rouge Vet Center,"7850 Anselmo Lane, Suite B",Baton Rouge,LA,70810,225-761-3140 Or 225-761-3140,VA Facility,Government,no,Not Available,30.392668,-91.100845
-0744v,Bay County Vet Center,"3109 Minnesota Ave, Suite 101",Panama City,FL,32405,850-522-6102 Or 850-522-6102,VA Facility,Government,no,Not Available,30.208765,-85.6455
-735,Beaumont Vet Center,"990 IH10 North, Suite 180",Beaumont,TX,77702,409-347-0124 Or 409-347-0124,VA Facility,Government,no,Not Available,0,0
-0737V,Biloxi Vet Center,288 Veterans Ave,Biloxi,MS,39531,228-388-9938 Or 228-388-9938,VA Facility,Government,no,Not Available,30.40239,-88.94716
-0727V,Fayetteville Vet Center,1416 N. College Ave.,Fayetteville,AR,72703,479-582-7152 Or 479-582-7152,VA Facility,Government,no,Not Available,36.08108,-94.156654
-0710V,Houston Southwest Vet Center,"10103 Fondren Road, Suite 470",Houston,TX,77096,713-523-0884,VA Facility,Government,no,Not Available,29.67084,-95.50856
-0731V,Houston Vet Center,"14300 Cornerstone Village Dr., Suite 110",Houston,TX,77014,281-537-7812 Or 281-537-7812,VA Facility,Government,no,Not Available,29.988022,-95.48308
-0711V,Houston West Vet Center,701 N. Post Oak Road Suite 102,Houston,TX,77024,713-682-2288 Or 713-682-2288,VA Facility,Government,no,Not Available,29.77968,-95.45675
-0709V,Jackson Vet Center,1755 Lelia Dr. Suite 104,Jackson,MS,39216,601-985-2560 Or 601-985-2560,VA Facility,Government,no,Not Available,32.33308,-90.144554
-0713V,Little Rock Vet Center,201 W. Broadway St. Suite A,North Little Rock,AR,72114,501-324-6395 Or 501-324-6395,VA Facility,Government,no,Not Available,34.756107,-92.26903
-0741V,Mobile Vet Center,"3221 Springhill Ave Bldg 2, Suite C",Mobile,AL,36607,251-478-5906 Or 251-478-5906,VA Facility,Government,no,Not Available,0,0
-0717V,New Orleans Vet Center,"1250 Poydras Street, 4th Floor, Suite 400",New Orleans,LA,70113,504-507-4977,VA Facility,Government,no,Not Available,0,0
-0743V,Okaloosa County Vet Center,"6 11th Avenue, Suite G 1",Shalimar,FL,32579,850-651-1000 Or 850-651-1000,VA Facility,Government,no,Not Available,30.447157,-86.57846
-0742V,Pensacola Vet Center,4504 Twin Oaks Drive,Pensacola,FL,32506,850-456-6113 Or 850-456-5886,VA Facility,Government,no,Not Available,30.409218,-87.27792
-0704V,Shreveport Vet Center,"2800 Youree Dr. Bldg. 1, Suite 105",Shreveport,LA,71104,318-861-1776 Or 318-861-1776,VA Facility,Government,no,Not Available,0,0
-0736V,"Springfield, MO Vet Center",3616 S. Campbell,Springfield,MO,65807,417-881-4197 Or 417-881-4197,VA Facility,Government,no,Not Available,37.14929,-93.29583
-10N17,VISN 17: VA Heart of Texas Health Care Network,"2301 East Lamar Blvd., Suite 650",Arlington,TX,76006,817-652-1111,VA Facility,Government,no,Not Available,32.761486,-97.07099
-504,Amarillo VA Health Care System,"6010 Amarillo Boulevard, West",Amarillo,TX,79106,806-355-9703 Or 806-355-9703,VA Facility,Government,no,Not Available,0,0
-674,Central Texas Veterans Health Care System,1901 Veterans Memorial Drive,Temple,TX,76504,254-778-4811 Or 254-778-4811,VA Facility,Government,no,Not Available,31.079578,-97.34862
-756,El Paso VA Health Care System,5001 North Piedras Street,El Paso,TX,79930,915-564-6100,VA Facility,Government,no,Not Available,31.820763,-106.46147
-671,South Texas Veterans Health Care System,7400 Merton Minter Blvd.,San Antonio,TX,78229,210-617-5300 Or 210-617-5300,VA Facility,Government,no,Not Available,0,0
-549,VA North Texas Health Care System,4500 South Lancaster Road,Dallas,TX,75216,800-849-3597 Or 214-742-8387,VA Facility,Government,no,Not Available,32.69437,-96.79336
-740,VA Texas Valley Coastal Bend Health Care System,2601 Veterans Drive,Harlingen,TX,78550,956-291-9000 Or 855-864-0516,VA Facility,Government,no,Not Available,0,0
-519,West Texas VA Health Care System,300 Veterans Blvd.,Big Spring,TX,79720,432-263-7361 Or 432-263-7361,VA Facility,Government,no,Not Available,32.23064,-101.47079
-549,Dallas VA Medical Center,4500 S. Lancaster Rd.,Dallas,TX,75216,800-849-3597 Or 800-849-3597,VA Facility,Government,no,Not Available,32.694347,-96.79335
-674A4,Doris Miller Department of Veterans Affairs Medical Center,4800 Memorial Drive,Waco,TX,76711,254-752-6581 Or 254-752-6581,VA Facility,Government,no,Not Available,31.513947,-97.16254
-671A4,Kerrville VA Hospital,3600 Memorial Blvd,Kerrville,TX,78028,866-487-1653,VA Facility,Government,no,Not Available,30.015045,-99.118126
-549A4,Sam Rayburn Memorial Veterans Center,1201 E. 9th St.,Bonham,TX,75418,800-924-8387 Or 800-924-8387,VA Facility,Government,no,Not Available,33.58155,-96.16723
-674BY,Austin Outpatient Clinic,7901 Metropolis Drive,Austin,TX,78744,512-823-4000 Or 800-423-2111,VA Facility,Government,no,Not Available,0,0
-671,Balcones Heights Outpatient Clinic,"4522 Fredericksburg Road, Suites A-10 and A-88",San Antonio,TX,78201,210-732-1802,VA Facility,Government,no,Not Available,29.492617,-98.55369
-740GC,Corpus Christi OPC,"5283 Old Brownsville Road,",Corpus Christi,TX,78405,361-806-5600,VA Facility,Government,no,Not Available,27.75859,-97.456085
-740,Corpus Christi PACT Annex,"5227 Old Brownsville Road, Suite 11",Corpus Christi,TX,78405,361-806-5600,VA Facility,Government,no,Not Available,27.759275,-97.45505
-740,Corpus Christi VA Speciality Outpatient Clinic,205 S. Enterprize Parkway,Corpus Christi,TX,78405,361-939-6510,VA Facility,Government,no,Not Available,0,0
-549,Fort Worth Outpatient Clinic,2201 SE Loop 820,Fort Worth,TX,76119,800-443-9672 Or 817-730-0000,VA Facility,Government,no,Not Available,32.66894,-97.29961
-671,Frank M. Tejeda VA Outpatient Clinic,5788 Eckhert Road,San Antonio,TX,78240,210-699-2100,VA Facility,Government,no,Not Available,29.517317,-98.59535
-740GD,Laredo Outpatient Clinic,4602 N. Bartlett,Laredo,TX,78041,956-523-7850,VA Facility,Government,no,Not Available,0,0
-504BY,Lubbock Clinic,6104 Avenue Q South Drive,Lubbock,TX,79412,806-472-3400,VA Facility,Government,no,Not Available,33.537964,-101.85425
-740GB,McAllen Outpatient Clinic,901 E. Hackberry Ave.,McAllen,TX,78503,956-618-7100,VA Facility,Government,no,Not Available,26.208422,-98.2105
-671,North Central Federal OPC,17440 Henderson Pass,San Antonio,TX,78232,210-483-2900,VA Facility,Government,no,Not Available,0,0
-549,Polk Street VA Clinic,4243 S. Polk Street,Dallas,TX,75224,214-372-8100,VA Facility,Government,no,Not Available,32.69242,-96.83995
-671,San Antonio Dental Clinic,8410 Data Point,San Antonio,TX,78229,210-949-8900,VA Facility,Government,no,Not Available,29.517626,-98.56916
-671,Shavano Park Outpatient Clinic,"4350 Lockhill-Selma Road, Suite 200",San Antonio,TX,78249,210-949-3773,VA Facility,Government,no,Not Available,0,0
-674,Temple VA Clinic Annex,"4501 South General Bruce Drive, Suite 75",Temple,TX,76502,254-743-1624 Or 254-743-1627,VA Facility,Government,no,Not Available,31.086763,-97.39863
-549GA,Tyler VA Primary Care Clinic,7916 S. Broadway Ave.,Tyler,TX,75703,855-375-6930 Or 903-266-5900,VA Facility,Government,no,Not Available,32.262688,-95.30751
-671,Victoria OPC,"1908 North Laurent Street, Suite 150",Victoria,TX,77901,361-582-7700,VA Facility,Government,no,Not Available,28.810976,-96.991264
-519HC,Abilene CBOC,3850 Ridgemont,Abilene,TX,79606,325-695-3252,VA Facility,Government,no,Not Available,32.404293,-99.76582
-671GH,Beeville CBOC,302 South Hillside Dr,Beeville,TX,78102,361-358-9912,VA Facility,Government,no,Not Available,28.406782,-97.73223
-549GE,Bridgeport CBOC,1713 South FM 51,Decatur,TX,76234,940-627-7001,VA Facility,Government,no,Not Available,0,0
-674GB,Brownwood CBOC,2600 Memorial Park Drive,Brownwood,TX,76801,325-641-0568,VA Facility,Government,no,Not Available,0,0
-674GC,Bryan/College Station CBOC,"1651 Rock Prairie Road, Ste. 100",College Station,TX,77845,979-680-0361,VA Facility,Government,no,Not Available,30.582659,-96.29087
-674GD,Cedar Park CBOC,600 N. Bell Boulevard,Cedar Park,TX,78613,512-219-2340,VA Facility,Government,no,Not Available,30.51541,-97.82645
-504GB,Childress Clinic,1001 Highway 83 North,Childress,TX,79201,940-937-8528,VA Facility,Government,no,Not Available,0,0
-504BZ,Clovis CBOC,921 East Llano Estacado,Clovis,NM,88101,575-763-4335,VA Facility,Government,no,Not Available,34.433884,-103.194916
-504HB,Dalhart VA Community Based Outpatient Clinic,325 Denver Ave,Dalhart,TX,79022,806-249-0673,VA Facility,Government,no,Not Available,36.06303,-102.5219
-549GD,Denton CBOC,2223 Colorado Blvd.,Denton,TX,76205,940-891-6350,VA Facility,Government,no,Not Available,0,0
-756GB,Eastside El Paso CBOC,"2400 Trawood Drive, Suite 200",El Paso,TX,79936,915-217-2428,VA Facility,Government,no,Not Available,31.76511,-106.315895
-519HB,Fort Stockton Clinic,2071 North Main,Fort Stockton,TX,79735,432-685-2110,VA Facility,Government,no,Not Available,0,0
-549GF,Granbury CBOC,601 Fall Creek Hwy.,Granbury,TX,76049,817-326-3902,VA Facility,Government,no,Not Available,32.469315,-97.69639
-549GH,Greenville CBOC,"4006 Wellington Rd., Suite 100A",Greenville,TX,75401,903-450-1143,VA Facility,Government,no,Not Available,33.129063,-96.12283
-519GB,Hobbs CBOC,1601 N Turner (4th Floor),Hobbs,NM,88240,575-391-0354,VA Facility,Government,no,Not Available,0,0
-674HB,LaGrange Rural OutReach Clinic,890 E Travis St,LaGrange,TX,78945,979-968-5878,VA Facility,Government,no,Not Available,29.90971,-96.868614
-756GA,Las Cruces CBOC,1635 Don Roser,Las Cruces,NM,88001,575-522-1241,VA Facility,Government,no,Not Available,0,0
-671GL,New Braunfels CBOC,"705 Landa Street, Suite C",New Braunfels,TX,78130,830-643-0717,VA Facility,Government,no,Not Available,29.705301,-98.13165
-671,NorthEast 410 /San Antonio Clinic,2391 NE Loop 410 Ste 101,San Antonio,TX,78217,210-590-0247,VA Facility,Government,no,Not Available,29.516327,-98.42043
-671,Northwest 410/San Antonio Clinic,4318 Woodcock Ste 120,San Antonio,TX,78228,210-736-4051,VA Facility,Government,no,Not Available,29.485802,-98.56912
-674GA,Palestine CBOC,"2000 So. Loop 256, Suite 124",Palestine,TX,75801,903-723-9006,VA Facility,Government,no,Not Available,0,0
-671,Pecan Valley CBOC,"4243 E. Southcross, Ste 204",San Antonio,TX,78222,210-337-4316,VA Facility,Government,no,Not Available,29.374807,-98.41205
-519GA,Permian Basin Community Based Outpatient Clinic,8050 E. Hwy 191,Odessa,TX,79762,432-685-2110,VA Facility,Government,no,Not Available,0,0
-6427,Plano CBOC,3804 W 15th Street,Plano,TX,75075,972-801-4200,VA Facility,Government,no,Not Available,0,0
-519HF,San Angelo Clinic,2018 Pulliam,San Angelo,TX,76905,325-658-6138,VA Facility,Government,no,Not Available,31.470688,-100.40485
-671,Seguin CBOC,526 E. Court Street,Seguin,TX,78155,830-372-1697,VA Facility,Government,no,Not Available,29.56896,-97.9608
-549GC,Sherman CBOC,3811 US 75 N,Sherman,TX,75090,903-487-0477,VA Facility,Government,no,Not Available,0,0
-671,South Bexar/San Antonio Clinic,4610 E Southcross Blvd Ste 100,San Antonio,TX,78222,210-648-1491,VA Facility,Government,no,Not Available,29.374544,-98.402145
-519AB,Stamford Clinic,1601 N Columbia,Stamford,TX,79553,325-695-3252,VA Facility,Government,no,Not Available,0,0
-671,SW Military CBOC,"1714 SW Military Dr., Suite 101",San Antonio,TX,78221,210-923-0777,VA Facility,Government,no,Not Available,29.35664,-98.51999
-733,Abilene Vet Center,3564 N. 6th St.,Abilene,TX,79603,325-232-7925 Or 325-232-7925,VA Facility,Government,no,Not Available,32.455303,-99.76634
-0702V,Amarillo Vet Center,3414 Olsen Blvd. Suite E,Amarillo,TX,79109,806-354-9779 Or 806-354-9779,VA Facility,Government,no,Not Available,35.185078,-101.88002
-0732V,Arlington Vet Center,3337 West Pioneer Parkway,Pantego,TX,76013,817-274-0981 Or 817-274-0981,VA Facility,Government,no,Not Available,32.711346,-97.16024
-0703V,Austin Vet Center,"2015 S. I.H. 35, Southcliff Bldg., Suite 101",Austin,TX,78741,512-416-1314 Or 512-416-1314,VA Facility,Government,no,Not Available,0,0
-0705V,Corpus Christi Vet Center,4646 Corona Suite 250,Corpus Christi,TX,78411,361-854-9961 Or 361-854-9961,VA Facility,Government,no,Not Available,27.713821,-97.38916
-5461,Dallas Vet Center,"8610 Greenville Ave., Suite 125",Dallas,TX,75243,214-361-5896 Or 214-361-5896,VA Facility,Government,no,Not Available,32.894432,-96.75287
-0707V,El Paso Vet Center,1155 Westmoreland Suite 121,El Paso,TX,79925,915-772-0013 Or 915-772-0013,VA Facility,Government,no,Not Available,31.778967,-106.38721
-0708V,Fort Worth Vet Center,6620 Hawk Creek Avenue,Westworth Village,TX,76114,817-921-9095 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0726V,Killeen Vet Center,"302 Millers Crossing, Suite #4",Harker Heights,TX,76548,254-953-7100 Or 877-927-8387,VA Facility,Government,no,Not Available,31.06693,-97.6638
-0712V,Laredo Vet Center,6999 McPherson Road Suite 102,Laredo,TX,78041,956-723-4680 Or 956-723-4680,VA Facility,Government,no,Not Available,27.572512,-99.47259
-0714V,Lubbock Vet Center,3106 50th st sute 400,Lubbock,TX,79413,806-792-9782 Or 877-927-8387,VA Facility,Government,no,Not Available,33.54874,-101.881485
-0715V,McAllen Vet Center,"2108 S M Street, MedPoint Plaza, Unit 2",McAllen,TX,78503,956-631-2147 Or 956-631-2147,VA Facility,Government,no,Not Available,0,0
-0730V,Mesquite Vet Center,"502 West Kearney, Suite 300",Mesquite,TX,75149,972-288-8030 Or 972-288-8030,VA Facility,Government,no,Not Available,32.770718,-96.602806
-716,Midland Vet Center,"4400 N. Midland Drive, Suite 540",Midland,TX,79707,432-697-8222 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0700V,"RCS Continental District 4, Zone 2 District Office",4500 S. Lancaster Rd. Building 69,Dallas,TX,75216,214-857-1254 Or 214-857-1254,VA Facility,Government,no,Not Available,32.694347,-96.79335
-0721V,San Antonio Northeast Vet Center,"9504 IH 35 N, Suite 214",San Antonio,TX,78233,210-650-0422 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0729V,San Antonio Northwest Vet Center,"9910 W Loop 1604 N, Suite 126",San Antonio,TX,78254,210-688-0606 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-10N19,VISN 19: Rocky Mountain Network,"4100 E. Mississippi Ave., 11th floor",Glendale,CO,80246,303-202-8165,VA Facility,Government,no,Not Available,39.696564,-104.939606
-623,Eastern Oklahoma VA Health Care System (Jack C. Montgomery VAMC),1011 Honor Heights Drive,Muskogee,OK,74401,918-577-3000 Or 918-577-3000,VA Facility,Government,no,Not Available,0,0
-635,Oklahoma City VA Health Care System,921 N.E. 13th Street,Oklahoma City,OK,73104,405-456-1000 Or 405-456-1000,VA Facility,Government,no,Not Available,35.48231,-97.49622
-554,VA Eastern Colorado Health Care System(ECHCS),1055 Clermont Street,Denver,CO,80220,303-399-8020,VA Facility,Government,no,Not Available,39.73255,-104.93508
-436,VA Montana Health Care System,3687 Veterans Drive,Fort Harrison,MT,59636,406-442-6410,VA Facility,Government,no,Not Available,0,0
-660,VA Salt Lake City Health Care System,500 Foothill Drive,Salt Lake City,UT,84148,801-582-1565,VA Facility,Government,no,Not Available,40.758488,-111.84073
-442,Cheyenne VA Medical,2360 E. Pershing Blvd.,Cheyenne,WY,82001,307-778-7550 Or 307-778-7550,VA Facility,Government,no,Not Available,41.145813,-104.7888
-575,Grand Junction VA Medical Center,2121 North Avenue,Grand Junction,CO,81501,970-242-0731 Or 970-242-0731,VA Facility,Government,no,Not Available,39.077374,-108.54048
-666,Sheridan VA Medical Center,1898 Fort Road,Sheridan,WY,82801,307-672-3473 Or 307-672-3473,VA Facility,Government,no,Not Available,44.826782,-106.98457
-666,Afton Outreach Clinic,125 South Washington,Afton,WY,83110,307-886-5266,VA Facility,Government,no,Not Available,0,0
-554GI,Burlington Telehealth Clinic,1177 Rose Avenue,Burlington,CO,80807,719-346-5239,VA Facility,Government,no,Not Available,39.300983,-102.265015
-6402,Ernest Childers VA Outpatient Clinic / Tulsa,9322 E. 41st St.,Tulsa,OK,74145,918-628-2518,VA Facility,Government,no,Not Available,36.104477,-95.87215
-666,Evanston Primary Care Telehealth Outreach Clinic,1565 South Highway 150 #E,Evanston,WY,82930,877-733-6128,VA Facility,Government,no,Not Available,0,0
-575,Glenwood Springs VA Telehealth Clinic,"2425 S Grand Ave., Suite 101",Glenwood Springs,CO,81601,970-945-1007,VA Facility,Government,no,Not Available,39.528496,-107.32537
-436,Hamilton Primary Care Telehealth Outreach Clinic,299 Fairgrounds Suite A,Hamilton,MT,59840,406-363-3352,VA Facility,Government,no,Not Available,46.25502,-114.15041
-436QC,Helena VA Sleep Clinic,2271 Deerfield Lane,Helena,MT,59601,406-447-7443,VA Facility,Government,no,Not Available,46.57023,-111.97614
-554,Jewell Clinic,14400 E Jewell Ave,Aurora,CO,80012,303-283-5400,VA Facility,Government,no,Not Available,39.682083,-104.82089
-442,Laramie Mobile Telehealth Clinic,2901 Armory Road,Laramie,WY,82702,888-483-9127 X 3816,VA Facility,Government,no,Not Available,0,0
-575,Moab VA Telehealth Clinic,702 South Main Street,Moab,UT,84532,435-719-4144,VA Facility,Government,no,Not Available,0,0
-436,Plentywood Primary Care Telehealth Outreach Clinic,440 West Laurel Ave.,Plentywood,MT,59254,406-765-3718,VA Facility,Government,no,Not Available,48.778694,-104.56304
-442,Rawlins PCTOC,1809 East Daley Street,Rawlins,WY,82301,307-324-5578,VA Facility,Government,no,Not Available,41.796143,-107.21673
-554,Salida Telehealth Clinic,920 Rush Drive,Salida,CO,81201,719-539-8666,VA Facility,Government,no,Not Available,0,0
-6422,South Oklahoma City VA Clinic,7919 Mid America Blvd.,Oklahoma City,OK,73135,405-855-6000,VA Facility,Government,no,Not Available,35.388805,-97.41268
-442,Sterling Mobile Telehealth Clinic,100 College Dr.,Sterling,CO,80751,888-483-9127 X 3816,VA Facility,Government,no,Not Available,40.637978,-103.19676
-442,Torrington Mobile Telehealth Clinic,908 West 25th Ave.,Torrington,WY,82240,888-483-9127 X 3816,VA Facility,Government,no,Not Available,42.068966,-104.19548
-623BY01,Tulsa Behavioral Medicine Clinic,10159 E 11th Street,Tulsa,OK,74128,918-610-2000 Or 918-610-2000,VA Facility,Government,no,Not Available,36.148,-95.86382
-436HC,"VA Montana Health Care System, Havre CBOC","130 13th Street, Suite 1",Havre,MT,59501,406-265-4304,VA Facility,Government,no,Not Available,48.53932,-109.6853
-442,Wheatland Mobile Telehealth Clinic,759 East Cole Street,Wheatland,WY,82201,888-483-9127 X 3816,VA Facility,Government,no,Not Available,42.045074,-104.95171
-666,Worland Primary Care Telehealth Outreach Clinic,"510 South 15th., Suite D",Worland,WY,82401,877-483-0370,VA Facility,Government,no,Not Available,44.01252,-107.94842
-635,Ada CBOC,717 Better Now Plaza,Ada,OK,74820,580-436-2262,VA Facility,Government,no,Not Available,0,0
-567GC,Alamosa /San Luis Valley Clinic/Sierra Blanca Clinic,622 Del Sol Drive,Alamosa,CO,81101,719-587-6800,VA Facility,Government,no,Not Available,0,0
-635GF,Altus VA Clinic,"1604 N. Main, Highway 283",Altus,OK,73521,580-482-0721,VA Facility,Government,no,Not Available,34.65482,-99.33396
-436GA,Anaconda VA Community Based Outpatient Clinic,"118 East 7th St., Suite 2A",Anaconda,MT,59711,406-496-3000,VA Facility,Government,no,Not Available,46.124325,-112.95442
-635HB,Ardmore VA Clinic,"2002 12th Ave NW, Suite E",Ardmore,OK,73401,580-222-0400,VA Facility,Government,no,Not Available,34.187466,-97.153885
-554GB,Aurora Outpatient Clinic,13701 E Mississippi Ave Gateway Medical Bldg #200,Aurora,CO,80012,303-398-6340,VA Facility,Government,no,Not Available,0,0
-436GH,Billings VA Community Based Outpatient Clinic with Specialty Clinic,Outpatient: 1775 Spring Creek Lane; Specialty Clinic: 1766 Majestic Lane,Billings,MT,59102,406-373-3500,VA Facility,Government,no,Not Available,0,0
-635GC,Blackwell VA Clinic,1009 W. Ferguson Ave.,Blackwell,OK,74631,580-363-0052,VA Facility,Government,no,Not Available,36.796967,-97.29587
-436GD,Bozeman VA Community Based Outpatient Clinic,"300 N. Willson, Suite 703G",Bozeman,MT,59715,406-582-5300,VA Facility,Government,no,Not Available,45.68204,-111.03872
-666GB,Casper Outpatient Clinic,4140 S. Poplar Str.,Casper,WY,82601,866-338-5168,VA Facility,Government,no,Not Available,42.81012,-106.343544
-666GD,Cody Outpatient Clinic,1432 Rumsey Avenue,Cody,WY,82421,307-587-4015,VA Facility,Government,no,Not Available,44.527145,-109.05949
-575GB,Craig Telehealth Clinic,785 Russell Street - Suite 400,Craig,CO,81625,970-824-6721,VA Facility,Government,no,Not Available,40.519424,-107.54609
-436,Cut Bank VA Community Based Outpatient Clinic,#8 2nd Ave SE,Cut Bank,MT,59427,406-873-9047,VA Facility,Government,no,Not Available,48.634796,-112.330124
-501GJ,Durango CCBOC,"1970 East Third Avenue, Suite 102",Durango,CO,81301,970-247-2214,VA Facility,Government,no,Not Available,37.2841,-107.874466
-660GK,Elko Outreach Clinic,2719 Argent Ave. #9,Elko,NV,89801,775-738-0188,VA Facility,Government,no,Not Available,40.841846,-115.78992
-5901,Enid VA Clinic,"915 E Owen K. Garriott, Suite G",Enid,OK,73701,580-977-1855,VA Facility,Government,no,Not Available,36.390648,-97.86482
-442GC,Fort Collins Outpatient Clinic,2509 Research Blvd.,Fort Collins,CO,80526,970-224-1550 Or 970-224-1550,VA Facility,Government,no,Not Available,40.555664,-105.08729
-666GB,Gillette Outpatient Clinic,604 express Drive,Gillette,WY,82718,866-621-1887,VA Facility,Government,no,Not Available,0,0
-436GI,Glasgow VA Community Based Outpatient Clinic,"630 Second Ave. South, Suite A",Glasgow,MT,59230,406-228-4101,VA Facility,Government,no,Not Available,48.1947,-106.63871
-436GK,Glendive VA Community Based Outpatient Clinic,2000 Montana Ave.,Glendive,MT,59330,406-377-4755,VA Facility,Government,no,Not Available,47.127228,-104.68935
-554/GC,Golden Outpatient Clinic,1020 Johnson Road,Golden,CO,80401,303-914-2680,VA Facility,Government,no,Not Available,39.74029,-105.20192
-436GB,Great Falls VA Community Based Outpatient Clinic,"1417 9th Street South, Suite 200 and 300",Great Falls,MT,59405,406-791-3200,VA Facility,Government,no,Not Available,47.48997,-111.29218
-623GA,Hartshorne VA Outpatient Clinic,1429 Pennsylvania Ave.,Hartshorne,OK,74547,888-878-1598,VA Facility,Government,no,Not Available,34.842693,-95.54845
-660,Idaho Falls Outreach Clinic,3544 East 17th Street,Idaho Falls,ID,83406,208-522-2922,VA Facility,Government,no,Not Available,43.48186,-111.961975
-6421,Jack C. Montgomery East,2414 E. Shawnee Bypass,Muskogee,OK,74403,918-577-3699,VA Facility,Government,no,Not Available,35.770924,-95.3399
-436GF,Kalispell VA Community Based Outpatient Clinic,"31 Three Mile Dr., Suite 102",Kalispell,MT,59901,406-758-2700,VA Facility,Government,no,Not Available,48.21142,-114.33203
-554GG,La Junta Outpatient Clinic,"1100 Carson Ave., Suite 104",La Junta,CO,81050,719-383-5195,VA Facility,Government,no,Not Available,37.978893,-103.54871
-554GH,Lamar Outpatient Clinic,"1401 South Main Street, Suite 2",Lamar,CO,81052,719-336-0315,VA Facility,Government,no,Not Available,38.07654,-102.618164
-635GA,Lawton/Ft. Sill VA Clinic,"4303 Pittman and Thomas, Building 4303",Fort Sill,OK,73503,580-585-5600,VA Facility,Government,no,Not Available,0,0
-436,Lewistown VA Community Based Outpatient Clinic,"629 NE Main St., Suite 1",Lewistown,MT,59457,406-535-4790,VA Facility,Government,no,Not Available,47.070553,-109.415794
-442,Loveland Community Clinic,5200 Hahns Peak Drive,Loveland,CO,80538,970-962-4900,VA Facility,Government,no,Not Available,40.412712,-105.00748
-623GC,McCurtain County Community Based Outpatient Clinic,903 SE Washington St.,Idabel,OK,74745,580-920-7200,VA Facility,Government,no,Not Available,33.895565,-94.81764
-436GJ,Miles City VA Community Based Outreach Clinic/ Nursing Home,210 S. Winchester,Miles City,MT,59301,406-874-5600,VA Facility,Government,no,Not Available,46.406296,-105.83044
-436GC,Missoula VA Community Based Outpatient Clinic,"2687 Palmer St., Suite C",Missoula,MT,59808,406-493-3700,VA Facility,Government,no,Not Available,46.887005,-114.03008
-575GA,Montrose Outpatient Clinic,154 Colorado Avenue,Montrose,CO,81401,970-249-7791,VA Facility,Government,no,Not Available,38.470642,-107.871895
-635,North May Oklahoma City VA Clinic,2915 Pine Ridge Road,Oklahoma City,OK,73120,405-752-6500,VA Facility,Government,no,Not Available,35.59251,-97.56757
-660GB,Ogden CBOC,982 Chambers Street,South Ogden,UT,84403,801-479-4105,VA Facility,Government,no,Not Available,41.166492,-111.95761
-660GE,Orem CBOC,"1443 West 800 North, Suite #302",Orem,UT,84057,801-235-0953,VA Facility,Government,no,Not Available,0,0
-554GE,PFC Floyd K. Lindstrom Clinic at Colorado Springs,3141 Centennial Boulevard,Colorado Springs,CO,80907,719-327-5660,VA Facility,Government,no,Not Available,0,0
-660GA,Pocatello CBOC,500 S 11th Ave,Pocatello,ID,83201,208-232-6214,VA Facility,Government,no,Not Available,42.86736,-112.43386
-660,Price CBOC,"189 South 600 West, Suite B",Price,UT,84501,435-613-0342,VA Facility,Government,no,Not Available,39.59684,-110.79974
-554GD,Pueblo Outpatient Clinic,4776 Eagleridge Circle,Pueblo,CO,81008,719-553-1000,VA Facility,Government,no,Not Available,0,0
-666GC,Riverton Outpatient Clinic,2300 Rose Lane,Riverton,WY,82501,866-338-2609,VA Facility,Government,no,Not Available,43.03563,-108.42055
-666GF,Rock Springs Outpatient Clinic,1401 Gateway,Rock Springs,WY,82901,866-381-2830,VA Facility,Government,no,Not Available,0,0
-660GD,Roosevelt CBOC,245 West 200 North,Roosevelt,UT,84066,435-725-1050,VA Facility,Government,no,Not Available,40.302086,-109.995995
-442GB,Sidney VA Outpatient Clinic,1116 10th Ave,Sidney,NE,69162,308-254-6085,VA Facility,Government,no,Not Available,41.140823,-102.976555
-660GG,St. George CBOC,"230 North 1680 East, Building N",St. George,UT,84790,435-634-7608,VA Facility,Government,no,Not Available,0,0
-635GE,Stillwater VA Clinic,320 N. Perkins Avenue,Stillwater,OK,74074,405-707-8100,VA Facility,Government,no,Not Available,0,0
-623,Vinita Outpatient Clinic,269 S 7th St,Vinita,OK,74301,918-713-5400,VA Facility,Government,no,Not Available,36.63692,-95.14327
-660GJ,Western Salt Lake CBOC,2750 South 5600 West,West Valley City,UT,84120,801-417-5734,VA Facility,Government,no,Not Available,40.709984,-112.02493
-635GB,Wichita Falls VA Clinic,149 Hart Street,Sheppard Air Force Base,TX,76311,940-257-0000,VA Facility,Government,no,Not Available,0,0
-0509V,Billings Vet Center,"2795 Enterprise Ave., Suite 1",Billings,MT,59102,406-657-6071 Or 406-657-6071,VA Facility,Government,no,Not Available,45.75003,-108.58542
-527,Boulder Vet Center,"4999 Pearl East Circle, Suite 106",Boulder,CO,80301,303-440-7306 Or 877-927-8387,VA Facility,Government,no,Not Available,40.02116,-105.23718
-0519V,Casper Vet Center,"1030 North Poplar, Suite B",Casper,WY,82601,307-261-5355 Or 307-261-5355,VA Facility,Government,no,Not Available,42.860615,-106.33267
-0501V,Cheyenne Vet Center,3219 E Pershing Blvd,Cheyenne,WY,82001,307-778-7370 Or 307-778-7370,VA Facility,Government,no,Not Available,41.145607,-104.77146
-525,Colorado Springs Vet Center,602 South Nevada Avenue,Colorado Springs,CO,80903,719-471-9992 Or 719-471-9992,VA Facility,Government,no,Not Available,38.82535,-104.822044
-0504V,Denver Vet Center,7465 East First Avenue Suite B,Denver,CO,80230,303-326-0645,VA Facility,Government,no,Not Available,39.718548,-104.90127
-0543V,Fort Collins Vet Center,702 W Drake Builing C,Fort Collins,CO,80526,970-221-5176 Or 970-221-5176,VA Facility,Government,no,Not Available,40.552666,-105.087814
-526,Grand Junction Vet Center,2472 Patterson Road Unit 16,Grand Junction,CO,81505,970-245-4156 Or 970-245-4156,VA Facility,Government,no,Not Available,39.091896,-108.59437
-538,Great Falls Vet Center,615 2nd Avenue North,Great Falls,MT,59401,406-452-9048 Or 406-452-9048,VA Facility,Government,no,Not Available,47.507515,-111.29696
-5281,Helena Outstation,1301 Elm Street Suite C,Helena,MT,59601,406-457-8060,VA Facility,Government,no,Not Available,46.607727,-112.01875
-539,Kalispell Vet Center,"690 North Meridian Road, Suite 101",Kalispell,MT,59901,406-257-7308,VA Facility,Government,no,Not Available,48.189045,-114.330666
-0728V,Lawton Vet Center,"1016 SW C Avenue, Suite B",Lawton,OK,73501,580-585-5880,VA Facility,Government,no,Not Available,34.605194,-98.40351
-528,Missoula Vet Center,910 Brooks St.,Missoula,MT,59801,406-721-4918,VA Facility,Government,no,Not Available,46.855923,-114.007286
-5141,Ogden Outstation,2357 N 400 E Washington Blvd,North Ogden,UT,84414,801-737-9737,VA Facility,Government,no,Not Available,41.30123,-111.968796
-0718V,Oklahoma City Vet Center,6804 N. Robinson Avenue,Oklahoma City,OK,73116,405-456-5184 Or 877-927-8387,VA Facility,Government,no,Not Available,35.540695,-97.51643
-531,Pocatello Vet Center,"1800 Garrett Way, Suite 47",Pocatello,ID,83201,208-232-0316 Or 208-232-0316,VA Facility,Government,no,Not Available,42.87654,-112.458466
-532,Provo Vet Center,360 S. State Street Bldg C Suite 103,Orem,UT,84058,801-377-1117,VA Facility,Government,no,Not Available,40.29056,-111.69216
-542,Pueblo Vet Center,"1515 Fortino Blvd., Suite 130",Pueblo,CO,81008,719-583-4058,VA Facility,Government,no,Not Available,38.312466,-104.62828
-0500V,RCS Continental District 4 District Office,"789 Sherman Street, Suite 570",Denver,CO,80203,303-577-5205 Or 303-577-5207,VA Facility,Government,no,Not Available,39.728817,-104.98489
-0540v,Saint George Vet Center,"1664 South Dixie Drive, Suite C-102",St. George,UT,84770,435-673-4494 Or 435-673-4494,VA Facility,Government,no,Not Available,0,0
-514,Salt Lake Vet Center,22 West Fireclay Avenue,Murray,UT,84107,801-266-1499 Or 877-927-8387,VA Facility,Government,no,Not Available,40.677994,-111.89191
-0723V,Tulsa Vet Center,14002 E. 21st Street,Tulsa,OK,74134,918-628-2760 Or 918-628-2760,VA Facility,Government,no,Not Available,36.13344,-95.82066
-10N20,VISN 20: Northwest Network,"1601 4th Plain Blvd Building 17, 4th Floor, Suite 403",Vancouver,WA,98661,360-619-5925,VA Facility,Government,no,Not Available,0,0
-463,Alaska VA Healthcare System,1201 North Muldoon Road,Anchorage,AK,99504,907-257-4700 Or 907-257-4700,VA Facility,Government,no,Not Available,61.23116,-149.74269
-648,Portland VA Medical Center,3710 SW U.S. Veterans Hospital Road,Portland,OR,97239,503-220-8262 Or 503-220-8262,VA Facility,Government,no,Not Available,45.49641,-122.68452
-663,VA Puget Sound Health Care System,1660 S. Columbian Way,Seattle,WA,98108,206-762-1010 Or 206-762-1010,VA Facility,Government,no,Not Available,47.56228,-122.311424
-663A4,VA Puget Sound Health Care System - American Lake Division,9600 Veterans Dr,Lakewood,WA,98493,253-582-8440 Or 253-582-8440,VA Facility,Government,no,Not Available,0,0
-663,VA Puget Sound Health Care System - Seattle Division,1660 S. Columbian Way,Seattle,WA,98108,206-762-1010 Or 206-762-1010,VA Facility,Government,no,Not Available,47.56228,-122.311424
-531,Boise VA Medical Center,500 West Fort Street,Boise,ID,83702,208-422-1000,VA Facility,Government,no,Not Available,43.61825,-116.194214
-687,Jonathan M. Wainwright Memorial VA Medical Center,77 Wainwright Drive,Walla Walla,WA,99362,888-687-8863 Or 509-525-5200,VA Facility,Government,no,Not Available,46.052536,-118.35569
-668,Mann-Grandstaff VA Medical Center,4815 N. Assembly Street,Spokane,WA,99205,509-434-7000,VA Facility,Government,no,Not Available,47.701454,-117.47557
-653,Roseburg VA Health Care System,913 NW Garden Valley Blvd.,Roseburg,OR,97471,541-440-1000,VA Facility,Government,no,Not Available,43.228924,-123.36807
-648A4,VA Portland Health Care System - Vancouver Campus,1601 E. Fourth Plain Blvd,Vancouver,WA,98661,360-696-4061,VA Facility,Government,no,Not Available,45.639336,-122.65486
-692,White City or VA Southern Oregon Rehabilitation Center,8495 Crater Lake Hwy.,White City,OR,97503,541-826-2111,VA Facility,Government,no,Not Available,42.440937,-122.834885
-531,Burns Oregon Outpatient Clinic,271 N Egan Ave,Burns,OR,97720,541-573-3339,VA Facility,Government,no,Not Available,43.588093,-119.059525
-463,Juneau VA Outreach Clinic,"709 West 9th Street, Suite 150",Juneau,AK,99801,907-796-4300 Or 907-796-4300,VA Facility,Government,no,Not Available,58.301617,-134.4209
-668,Libby RHC,211 E. Second St.,Libby,MT,59923,406-293-8711,VA Facility,Government,no,Not Available,48.393345,-115.548874
-531,Mountain Home Idaho Outpatient Clinic,815 North 6th East,Mountain Home,ID,83647,208-580-2001,VA Facility,Government,no,Not Available,43.137764,-115.69252
-648,Newport Outreach Clinic,1010 SW Coast Highway,Newport,OR,97365,541-265-4182,VA Facility,Government,no,Not Available,44.62718,-124.06144
-531,Salmon Idaho Outpatient Clinic,705 Lena Street,Salmon,ID,83467,208-756-8515,VA Facility,Government,no,Not Available,45.173313,-113.89316
-668,Sandpoint RHC,420 N. 2nd Ave. Suite-200,Sandpoint,ID,83864,208-263-0450,VA Facility,Government,no,Not Available,48.276367,-116.54873
-648GE,The Dalles Outreach Clinic,704 Veterans Drive,The Dalles,OR,97058,541-296-3937,VA Facility,Government,no,Not Available,45.600388,-121.12573
-648,West Linn CBOC,1750 SW Blankenship Rd Ste 300,West Linn,OR,97068,503-210-4900,VA Facility,Government,no,Not Available,0,0
-0523V,Yakima Valley Vet Center,2119 W. Lincoln,Yakima,WA,98902,509-457-2736,VA Facility,Government,no,Not Available,46.603485,-120.537346
-648GA,Bend CBOC,2650 NE Courtney Drive,Bend,OR,97701,541-647-5200 Or 855-213-8002,VA Facility,Government,no,Not Available,44.071987,-121.26456
-653BY,BHRRS - Behavioral Health Recovery & Reintegration Services,211 E 7th Ave Suite 118,Eugene,OR,97401,541-440-1000,VA Facility,Government,no,Not Available,44.052135,-123.089455
-663GB,Bremerton CBOC,925 Adele Avenue,Bremerton,WA,98312,360-473-0340,VA Facility,Government,no,Not Available,47.56878,-122.662964
-653GB,Brookings VA Clinic,840 Railroad St,Brookings,OR,97415,541-412-1152,VA Facility,Government,no,Not Available,42.05251,-124.28958
-531GG,Caldwell Idaho Outpatient Clinic,4521 Thomas Jefferson Drive,Caldwell,ID,83605,208-454-4820,VA Facility,Government,no,Not Available,0,0
-648ZZ,Community Resource and Referral Center (CRRC),308 SW 1st Ave,Portland,OR,97204,503-808-1256 Or 800-949-1004 X 51256,VA Facility,Government,no,Not Available,45.520313,-122.67219
-653BY,Eugene Health Care Center,3355 Chad Dr.,Eugene,OR,97408,541-607-0897,VA Facility,Government,no,Not Available,44.087612,-123.05653
-463GA,Fairbanks VA Community Based Outpatient Clinic,"Bldg 4076, Neeley Road, Room 1J-101",Fort Wainwright,AK,99703,907-361-6370 Or 907-361-6370,VA Facility,Government,no,Not Available,0,0
-648GE,Fairview Clinic,1800 NE Market Drive,Fairview,OR,97024,503-660-0600,VA Facility,Government,no,Not Available,0,0
-687,Grangeville (ID) VA Outpatient Clinic,711 West North Street,Grangeville,ID,83850,208-983-4671,VA Facility,Government,no,Not Available,45.927563,-116.12766
-692SS,Grants Pass West VA CBOC,1877 Williams Hwy,Grants Pass,OR,97527,541-955-5551,VA Facility,Government,no,Not Available,42.417038,-123.33931
-648GF,Hillsboro CBOC,"1925 NE Stucki Ave., Suite #300",Hillsboro,OR,97006,503-906-5000,VA Facility,Government,no,Not Available,0,0
-463GB,Kenai VA Community Based Outpatient Clinic,"11312 Kenai Spur Highway, Suite 39",Kenai,AK,99611,907-395-4100 Or 877-797-8924,VA Facility,Government,no,Not Available,60.55464,-151.25703
-692GA,Klamath Falls CBOC,2225 North El Dorado Blvd.,Klamath Falls,OR,97601,541-273-6206,VA Facility,Government,no,Not Available,42.24797,-121.7848
-687GC,La Grande (OR) Community Based Outpatient Clinic,202 12th Street,La Grande,OR,97850,541-963-0627,VA Facility,Government,no,Not Available,45.313206,-118.08635
-687GB,Lewiston (ID) Community Based Outpatient Clinic,"1630 23rd Avenue, Bldg. 2",Lewiston,ID,83501,208-746-7784,VA Facility,Government,no,Not Available,46.397305,-117.00901
-648GB,Lincoln City Clinic,"4422 NE Devils Lake Road, Suite 2",Lincoln City,OR,97367,541-265-0547,VA Facility,Government,no,Not Available,0,0
-463GC,Mat-Su VA Community Based Outpatient Clinic,"865 N. Seward Meridian Parkway, Suite 105",Wasilla,AK,99654,907-631-3100 Or 800-323-8648,VA Facility,Government,no,Not Available,61.5738,-149.35968
-687TH,Morrow County VA Telehealth Clinic (Boardman OR),"2 Marine Drive, Suite 103 ~ P.O. Box 1059",Boardman,OR,97818,541-481-2255,VA Facility,Government,no,Not Available,0,0
-663,Mount Vernon CBOC,"307 S. 13th St., Suite 200",Mount Vernon,WA,98274,360-848-8500,VA Facility,Government,no,Not Available,48.41875,-122.32529
-653GA,North Bend VA Clinic,2191 Marion Street,North Bend,OR,97459,541-756-8002,VA Facility,Government,no,Not Available,43.40408,-124.23651
-648GD,North Coast CBOC,"91400 N. Neacoxie Street, building 7315",Warrenton,OR,97146,503-220-8262 X 52593,VA Facility,Government,no,Not Available,0,0
-668GB (North Idaho),North Idaho CBOC,915 W. Emma Avenue,Coeur d 'Alene,ID,83814,208-665-1700,VA Facility,Government,no,Not Available,47.69261,-116.79611
-663GB,North Olympic Peninsula,1114 Georgiana St,Port Angeles,WA,98362,360-565-7420,VA Facility,Government,no,Not Available,48.11315,-123.41334
-687GA,Richland (WA) Community Based Outpatient Clinic,"825 Jadwin Ave., Ste. 250, Federal Bldg., 2nd Floor",Richland,WA,99352,509-946-1020,VA Facility,Government,no,Not Available,46.277122,-119.27524
-648GB,Salem CBOC,"1750 McGilchrist St. SE, Suite 130",Salem,OR,97302,971-304-2200,VA Facility,Government,no,Not Available,44.916733,-123.023155
-663GD,South Sound CBOC,151 NE Hampe Way,Chehalis,WA,98532,360-748-3049,VA Facility,Government,no,Not Available,0,0
-531GE,Twin Falls Idaho Outpatient Clinic,260 2nd Avenue East,Twin Falls,ID,83301,208-732-0959,VA Facility,Government,no,Not Available,42.5551,-114.46718
-663GA,Valor CBOC Bellevue,13033 Bel-Red Road Suite 210,Bellevue,WA,98005,425-214-1055 Or 425-214-1055,VA Facility,Government,no,Not Available,47.621864,-122.165504
-663GA,Valor CBOC Federal Way,34617 11th Place South Suite 301,Federal Way,WA,98003,253-336-4142,VA Facility,Government,no,Not Available,47.291386,-122.32083
-663GA,Valor CBOC North Seattle,"12360 Lake City Way NE, Suite 200",Seattle,WA,98125,206-384-4382,VA Facility,Government,no,Not Available,47.71814,-122.29588
-687TH,Wallowa County VA Telehealth Clinic (Enterprise OR),401 NE 1st Street,Enterprise,OR,97828,541-426-0219,VA Facility,Government,no,Not Available,45.428265,-117.27629
-668,Wenatchee CBOC,2530 Chester-Kimm Road,Wenatchee,WA,98801,509-663-7615 Or 509-663-7615,VA Facility,Government,no,Not Available,47.46406,-120.334
-687HA,Yakima (WA) Community Based Outpatient Clinic,717 Fruitvale Blvd.,Yakima,WA,98902,509-966-0199,VA Facility,Government,no,Not Available,46.612583,-120.5218
-0502V,Anchorage Vet Center,"4400 Business Park Blvd, Suite B-34",Anchorage,AK,99503,907-563-6966 Or 877-927-8387,VA Facility,Government,no,Not Available,61.180626,-149.88925
-0522V,Bellingham Vet Center,3800 Byron Ave Suite 124,Bellingham,WA,98229,360-733-9226 Or 877-927-8387,VA Facility,Government,no,Not Available,48.73362,-122.46637
-0503V,Boise Vet Center,"2424 Bank DrivE, Suite 100",Boise,ID,83705,208-342-3612 Or 877-927-8387,VA Facility,Government,no,Not Available,43.59107,-116.211555
-0622V,Central Oregon Vet Center,1645 NE Forbes Rd. Suite 105,Bend,OR,97701,541-749-2112 Or 541-749-2112,VA Facility,Government,no,Not Available,0,0
-626,Eugene Vet Center,190 East 11th Avenue,Eugene,OR,97401,541-465-6918 Or 877-927-8387,VA Facility,Government,no,Not Available,44.0477,-123.08984
-529,Everett Vet Center,3311 Wetmore Avenue,Everett,WA,98201,425-252-9701,VA Facility,Government,no,Not Available,47.97373,-122.20698
-0511V,Fairbanks Vet Center,"540 4th Ave., Suite 100",Fairbanks,AK,99701,907-456-4238 Or 877-927-8387,VA Facility,Government,no,Not Available,64.842415,-147.71849
-0535V,Federal Way Vet Center,32020 32nd Ave South Suite 110,Federal Way,WA,98001,253-838-3090 Or 253-838-3090,VA Facility,Government,no,Not Available,0,0
-645,Grants Pass Vet Center,211 S.E. 10th St.,Grants Pass,OR,97526,541-479-6912 Or 877-927-8387,VA Facility,Government,no,Not Available,42.43722,-123.322266
-05021V,Kenai Vet Center Outstation,43299 Kalifornsky Beach Rd. Ste 4,Soldotna,AK,99669,907-260-7640 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0617V,Portland Vet Center,1505 NE 122nd Ave.,Portland,OR,97230,503-688-5361 Or 877-927-8387 X 7,VA Facility,Government,no,Not Available,45.53367,-122.53765
-640,Salem Vet Center,"2645 Portland Road NE, Suite 250",Salem,OR,97301,503-362-9911 Or 877-927-8387,VA Facility,Government,no,Not Available,44.961227,-123.014565
-0507V,Seattle Vet Center,"4735 E Marginal Way S, Room 1102",Seattle,WA,98134,206-658-4225 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0510V,Spokane Vet Center,13109 E Mirabeau Parkway,Spokane,WA,99216,509-444-8387 Or 509-444-8387,VA Facility,Government,no,Not Available,0,0
-508,Tacoma Vet Center,4916 Center St. Suite E,Tacoma,WA,98409,253-565-7038 Or 253-565-7038,VA Facility,Government,no,Not Available,47.234417,-122.50397
-0541V,Walla Walla County Vet Center,1104 West Poplar,Walla Walla,WA,99362,509-526-8387 Or 509-526-8387,VA Facility,Government,no,Not Available,46.059216,-118.35254
-0512V,Wasilla Vet Center,851 E. West Point Drive Suite 102,Wasilla,AK,99654,907-376-4318 Or 907-376-4318,VA Facility,Government,no,Not Available,61.58227,-149.42818
-523,Yakima Vet Center,2119 W. Lincoln Ave,Yakima,WA,98902,509-457-2736 Or 509-457-2736,VA Facility,Government,no,Not Available,46.603485,-120.537346
-687,687,77 Wainwright Drive,Walla Walla,WA,99362,,VA Facility,Government,no,Not Available,46.052536,-118.35569
-523,Yakima Valley Vet Center,2119 West Lincoln Avenue,Yakima,WA,98902,509-457-2736,VA Facility,Government,no,Not Available,46.603485,-120.53733
-10N21,VISN 21: Sierra Pacific Network,201 Walnut Avenue,Mare Island,CA,94592,707-562-8350,VA Facility,Government,no,Not Available,0,0
-662,San Francisco VA Health Care System,4150 Clement Street,San Francisco,CA,94121,415-221-4810,VA Facility,Government,no,Not Available,37.781143,-122.504105
-570,Central California VA Health Care System,2615 E. Clinton Avenue,Fresno,CA,93703,559-225-6100 Or 559-225-6100,VA Facility,Government,no,Not Available,36.77229,-119.78002
-640,Livermore,4951 Arroyo Road,Livermore,CA,94550,925-373-4700,VA Facility,Government,no,Not Available,37.637985,-121.763985
-640,Menlo Park,795 Willow Road,Menlo Park,CA,94025,650-614-9997,VA Facility,Government,no,Not Available,37.46356,-122.15805
-612,VA Northern California Health Care System,10535 Hospital Way,Mather,CA,95655,800-382-8387 Or 916-843-7000,VA Facility,Government,no,Not Available,38.571793,-121.297386
-459,VA Pacific Islands Health Care System,459 Patterson Road,Honolulu,HI,96819,808-433-0600 Or 800-214-1306,VA Facility,Government,no,Not Available,21.36117,-157.88878
-640,VA Palo Alto Health Care System,3801 Miranda Avenue,Palo Alto,CA,94304,650-493-5000,VA Facility,Government,no,Not Available,37.402836,-122.14173
-654,VA Sierra Nevada Health Care System,975 Kirman Avenue,Reno,NV,89502,775-786-7200 Or 775-786-7200,VA Facility,Government,no,Not Available,39.515854,-119.79849
-593,VA Southern Nevada Healthcare System,6900 North Pecos Road,N. Las Vegas,NV,89086,702-791-9024,VA Facility,Government,no,Not Available,0,0
-640,Capitola Clinic,"1350 41st Avenue, Suite 102",Capitola,CA,95010,831-464-5519,VA Facility,Government,no,Not Available,36.97057,-121.96488
-612,Chico Outpatient Clinic,280 Cohasset Road,Chico,CA,95926,530-879-5000 X 9 Or 530-879-5000,VA Facility,Government,no,Not Available,39.751648,-121.85145
-612,Fairfield Outpatient Clinic,"103 Bodin Circle, Travis Air Force Base",Fairfield,CA,94535,707-437-1800 Or 707-437-1800,VA Facility,Government,no,Not Available,38.267887,-121.95876
-5199,Major General William H. Gourley VA-DoD Outpatient Clinic,201 Ninth Street,Marina,CA,93933,831-884-1000,VA Facility,Government,no,Not Available,0,0
-96440,Manila Outpatient Clinic,1501 Roxas Boulevard,Pasay City,PI,1302,632-550-3888,VA Facility,Government,no,Not Available,0,0
-612,Mare Island Outpatient Clinic,201 Walnut Avenue,Vallejo,CA,94592,707-562-8200 Or 707-562-8200,VA Facility,Government,no,Not Available,0,0
-612,Martinez Outpatient Clinic and Community Living Center,150 Muir Road,Martinez,CA,94553,925-372-2000 Or 925-372-2000,VA Facility,Government,no,Not Available,37.994648,-122.11164
-612,McClellan Dental Clinic - Sacramento,5401 Arnold Avenue,McClellan,CA,95652,916-333-5500,VA Facility,Government,no,Not Available,0,0
-612,McClellan Outpatient Clinic - Sacramento,5342 Dudley Blvd.,McClellan,CA,95652,916-561-7400 Or 916-561-7400,VA Facility,Government,no,Not Available,0,0
-640,Modesto Clinic,1225 Oakdale Road,Modesto,CA,95355,209-557-6200,VA Facility,Government,no,Not Available,37.662674,-120.95753
-459,National Center for PTSD - Pacific Islands Division,"3375 Koapaka Street, Suite I-560",Honolulu,HI,96819,808-566-1546,VA Facility,Government,no,Not Available,21.33633,-157.91733
-593GG,Northeast Primary Care Clinic,4461 E Charleston Blvd,Las Vegas,NV,89104,702-791-9050,VA Facility,Government,no,Not Available,36.158955,-115.07734
-593GD,Northwest Primary Care Clinic,3968 N Rancho Dr,Las Vegas,NV,89130,702-791-9020,VA Facility,Government,no,Not Available,36.230484,-115.22426
-612,Oakland Behavioral Health Clinic,525 21st Street,Oakland,CA,94612,510-587-3400 Or 510-587-3400,VA Facility,Government,no,Not Available,37.810413,-122.270035
-612,Oakland Outpatient Clinic,2221 Martin Luther King Jr. Way,Oakland,CA,94612,510-267-7800 Or 510-267-7800,VA Facility,Government,no,Not Available,37.812134,-122.27288
-612,Redding Outpatient Clinic,351 Hartnell Avenue,Redding,CA,96002,530-226-7555 Or 530-226-7555,VA Facility,Government,no,Not Available,40.56456,-122.367836
-612,Sacramento Mental Health Clinic at Mather,10535 Hospital Way,Mather,CA,95655,916-366-5420 Or 916-366-5420,VA Facility,Government,no,Not Available,38.571793,-121.297386
-640BY,San Jose Clinic,80 Great Oaks Boulevard,San Jose,CA,95119,408-363-3000,VA Facility,Government,no,Not Available,37.233974,-121.778854
-654GA,Sierra Foothills Outpatient Clinic,11985 Heritage Oak Place,Auburn,CA,95603,530-889-0872,VA Facility,Government,no,Not Available,38.940647,-121.099236
-640GB,Sonora Clinic,13663 Mono Way,Sonora,CA,95370,209-588-2600,VA Facility,Government,no,Not Available,0,0
-593GE,Southeast Primary Care Clinic,1020 S Boulder,Henderson,NV,89015,702-791-9030,VA Facility,Government,no,Not Available,36.029716,-114.97094
-593GF,Southwest Primary Care Clinic,7235 South Buffalo Drive,Las Vegas,NV,89113,702-791-9040,VA Facility,Government,no,Not Available,36.056946,-115.261024
-640,Stockton Clinic,7777 South Freedom Rd,French Camp,CA,95231,209-946-3400,VA Facility,Government,no,Not Available,0,0
-4201,VA Lanai Outreach Clinic,628-B Seventh Street,Lanai City,HI,96783,808-565-6423,VA Facility,Government,no,Not Available,20.826756,-156.91786
-4202,VA Molokai Outreach Clinic,280 Home Olu Place,Kaunakakai,HI,96748,808-553-3191,VA Facility,Government,no,Not Available,0,0
-612A,Yreka,101 E Oberlin Rd,Yreka,CA,96097,530-841-8500,VA Facility,Government,no,Not Available,41.716076,-122.63874
-662GG,Clearlake VA Outpatient Clinic,15145 Lakeshore Drive,Clearlake,CA,95422,707-995-7200,VA Facility,Government,no,Not Available,38.949894,-122.63026
-662GC,Eureka VA Outpatient Clinic,930 W. Harris,Eureka,CA,95503,707-269-7500,VA Facility,Government,no,Not Available,40.780552,-124.18108
-640GC,Fremont Clinic,"39199 Liberty Street, Building B",Fremont,CA,94538,510-791-4000,VA Facility,Government,no,Not Available,37.550194,-121.9808
-654,Lahontan Valley VA Clinic,"1020 New River Parkway, Suite 304",Fallon,NV,89406,775-326-2659,VA Facility,Government,no,Not Available,0,0
-570GA,Merced Community-Based Outpatient Clinic,340 E Yosemite Ave,Merced,CA,95340,209-381-0105,VA Facility,Government,no,Not Available,37.33211,-120.46582
-570GC,Oakhurst Community-Based Outpatient Clinic,40597 Westlake Drive,Oakhurst,CA,93644,559-683-5300,VA Facility,Government,no,Not Available,37.338547,-119.66928
-5119,Pahrump Community Based Outpatient Clinic,220 South Lola Lane,Pahrump,NV,89048,775-727-7535,VA Facility,Government,no,Not Available,0,0
-662GE,San Bruno VA Outpatient Clinic,"1001 Sneath Lane, Suite 300, Third Floor",San Bruno,CA,94066,650-615-6000,VA Facility,Government,no,Not Available,37.63524,-122.42477
-662GA,Santa Rosa VA Outpatient Clinic,3841 Brickway Blvd,Santa Rosa,CA,95403,707-569-2300,VA Facility,Government,no,Not Available,38.51461,-122.79337
-662BU,SFVA Downtown Clinic,401 3rd Street,San Francisco,CA,94107,415-281-5100,VA Facility,Government,no,Not Available,37.782543,-122.39735
-570,Tulare Community-Based Outpatient Clinic,1050 N. Cherry Street,Tulare,CA,93274,559-684-8703,VA Facility,Government,no,Not Available,36.22275,-119.33752
-662GD,Ukiah VA Outpatient Clinic,630 Kings Court,Ukiah,CA,95482,707-468-7700,VA Facility,Government,no,Not Available,39.14806,-123.1984
-459,VA American Samoa CBOC,Fiatele Teo Army Reserve Bldg,Pago Pago,AS,96799,684-699-3730,VA Facility,Government,no,Not Available,0,0
-654,VA Carson Valley Outpatient Clinic,"1330 Waterloo Lane, Suite 101",Gardnerville,NV,89410,775-782-5265,VA Facility,Government,no,Not Available,38.925064,-119.74963
-654GD,VA Diamond View Outpatient Clinic,110 Bella Way,Susanville,CA,96130,530-251-4550 Or 530-251-4550,VA Facility,Government,no,Not Available,0,0
-459,VA Guam Community Based Outpatient Clinic,498 Chalan Palayso,Agana Heights,GU,96910,671-475-5760,VA Facility,Government,no,Not Available,0,0
-459,VA Hilo Community Based Outpatient Clinic,"1285 Waianuenue Avenue, Suite 211",Hilo,HI,96720,808-935-3781,VA Facility,Government,no,Not Available,19.717466,-155.11314
-459,VA Kauai Community Based Outpatient Clinic,"4485 Pahe'e Street, Suite 150",Lihue,HI,96766,808-246-0497,VA Facility,Government,no,Not Available,21.968864,-159.38431
-459,VA Kona Community Based Outpatient Clinic,35-377 Hualalai Road,Kailua-Kona,HI,96740,808-329-0774,VA Facility,Government,no,Not Available,0,0
-1396,VA Leeward Community Based Outpatient Clinic,91-2135 Fort Weaver Road,Ewa Beach,HI,96706,800-214-1306,VA Facility,Government,no,Not Available,21.369507,-158.02618
-459,VA Maui Community Based Outpatient Clinic,"203 Ho'ohana Street, Suite 303",Kahului,HI,96732,808-871-2454,VA Facility,Government,no,Not Available,20.88696,-156.46333
-6307,VA Saipan Outreach Clinic,Marina Heights Business Park,Saipan,MP,96950,670-323-9000 Or 670-322-0035,VA Facility,Government,no,Not Available,0,0
-612,Yuba City Outpatient Clinic,425 Plumas Street,Yuba City,CA,95991,530-751-4500,VA Facility,Government,no,Not Available,39.130913,-121.614136
-616,American Samoa Vet Center,"Ottoville Road, P.O. Box 982942",Pago Pago,AS,96799,684-699-3760 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-649,Chico Vet Center,"250 Cohasset Road, Suite 40",Chico,CA,95926,530-899-6300 Or 530-899-6300,VA Facility,Government,no,Not Available,39.75176,-121.85193
-610,Citrus Heights Vet Center,"5650 Sunrise Blvd., Suite 150",Citrus Heights,CA,95610,916-535-0420 Or 916-535-0420,VA Facility,Government,no,Not Available,38.670345,-121.27155
-602,Concord Vet Center,"1333 Willow Pass Road, Suite 106",Concord,CA,94520,925-680-4526 Or 925-680-4526,VA Facility,Government,no,Not Available,37.972385,-122.05445
-644,Eureka Vet Center,"2830 G Street, Suite A",Eureka,CA,95501,707-444-8271 Or 707-444-8271,VA Facility,Government,no,Not Available,40.782574,-124.16242
-628,Fresno Vet Center,"1320 E. Shaw Ave, Suite 125",Fresno,CA,93710,559-487-5660 Or 877-927-8387,VA Facility,Government,no,Not Available,36.808594,-119.76464
-648,Guam Vet Center,"222 Chalan Santo Papa Street, Suite 201",Hagatna,GU,96910,671-472-7161,VA Facility,Government,no,Not Available,0,0
-534,Henderson Vet Center,"400 North Stephanie, Suite 180",Henderson,NV,89014,702-791-9100 Or 702-791-9100,VA Facility,Government,no,Not Available,36.05657,-115.0462
-635,Hilo Vet Center,"70 Lanihuli Street, Suite 102",Hilo,HI,96720,808-969-3833 Or 887-969-3833,VA Facility,Government,no,Not Available,19.71111,-155.07872
-609,Honolulu Vet Center,1680 Kapiolani Blvd. Suite F-3,Honolulu,HI,96814,808-973-8387 Or 877-927-8387,VA Facility,Government,no,Not Available,21.291153,-157.83807
-0636V,Kailua-Kona Vet Center,73-4976 Kamanu St,Kailua-Kona,HI,96740,808-329-0574,VA Facility,Government,no,Not Available,19.687277,-156.01602
-633,Kauai Vet Center,"4485 Pahe'e St., Suite 101",Lihue,HI,96766,808-246-1163 Or 877-927-8387,VA Facility,Government,no,Not Available,21.968864,-159.38431
-0505V,Las Vegas Vet Center,"7455 W. Washington Ave, Suite 240",Las Vegas,NV,89128,702-791-9170,VA Facility,Government,no,Not Available,36.181328,-115.2531
-634,Maui Vet Center,157 Ma'a Street,KAHULUI,HI,96732,808-242-8557,VA Facility,Government,no,Not Available,0,0
-650,Modesto Vet Center,"1219 N. Carpenter Rd., Suite 11-12",Modesto,CA,95351,209-569-0713 Or 877-927-8387,VA Facility,Government,no,Not Available,37.652004,-121.031006
-646,North Bay Vet Center,"6010 Commerce Blvd., Ste. 145",Rohnert Park,CA,94928,707-586-3295,VA Facility,Government,no,Not Available,38.352222,-122.71077
-612,Oakland Vet Center,"7700 Edgewater Drive, Suite 125",Oakland,CA,94621,510-562-7906 Or 510-562-7906,VA Facility,Government,no,Not Available,37.743034,-122.20435
-647,Peninsula Vet Center,"345 Middlefield Road, Building 1",Menlo Park,CA,94025,650-617-4300 Or 877-927-8387,VA Facility,Government,no,Not Available,37.456406,-122.16773
-0600V,RCS Pacific District 5 District Office,420 Executive Court North Suite A,Fairfield,CA,94534,707-646-2988 Or 707-646-2988,VA Facility,Government,no,Not Available,38.230152,-122.12159
-0506V,Reno Vet Center,5580 Mill St. Suite 600,Reno,NV,89502,775-323-1294 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-638,Sacramento Vet Center,1111 Howe Avenue Suite #390,Sacramento,CA,95825,916-566-7430 Or 877-927-8387,VA Facility,Government,no,Not Available,38.584957,-121.41534
-620,San Francisco Vet Center,505 Polk Street,San Francisco,CA,94102,415-441-5051 Or 877-927-8387,VA Facility,Government,no,Not Available,37.78154,-122.418884
-615,San Jose Vet Center,80 Great Oaks Blvd.,San Jose,CA,95119,408-993-0729 Or 408-993-0729,VA Facility,Government,no,Not Available,37.233974,-121.778854
-639,Santa Cruz County Vet Center,"1350 41st Ave, Suite 104",Capitola,CA,95010,831-464-4575 Or 877-927-8387,VA Facility,Government,no,Not Available,36.97057,-121.96488
-0621V,Western Oahu Vet Center,"885 Kamokila Boulevard, Suite 105",Kapolei,HI,96707,808-674-2414 Or 877-927-8387,VA Facility,Government,no,Not Available,21.330032,-158.08583
-593GH,Laughlin Rural Outreach Clinic,"3650 South Point Circle, Building D, 2nd Floor, Suite 200",Laughlin,NV,89029,702-298-1100,VA Facility,Government,no,Not Available,0,0
-10N22,VISN 22: Desert Pacific Healthcare Network,"300 Oceangate, Suite 700",Long Beach,CA,90802,562-826-5963,VA Facility,Government,no,Not Available,33.766495,-118.1987
-501,New Mexico VA Health Care System,"1501 San Pedro Drive, SE",Albuquerque,NM,87108,505-265-1711 Or 505-265-1711,VA Facility,Government,no,Not Available,35.056324,-106.577675
-649,Northern Arizona VA Health Care System,500 North Highway 89,Prescott,AZ,86313,928-445-4860 Or 928-445-4860,VA Facility,Government,no,Not Available,0,0
-644,Phoenix VA Health Care System,650 E. Indian School Road,Phoenix,AZ,85012,602-277-5551 Or 602-277-5551,VA Facility,Government,no,Not Available,33.494797,-112.0668
-678,Southern Arizona VA Health Care System,3601 South 6th Avenue,Tucson,AZ,85723,520-792-1450 Or 520-792-1450,VA Facility,Government,no,Not Available,32.18126,-110.96826
-691,VA Greater Los Angeles Healthcare System (GLA),11301 Wilshire Boulevard,Los Angeles,CA,90073,310-478-3711,VA Facility,Government,no,Not Available,0,0
-605,VA Loma Linda Healthcare System,11201 Benton Street,Loma Linda,CA,92357,909-825-7084 Or 909-825-7084,VA Facility,Government,no,Not Available,34.051037,-117.25238
-600,VA Long Beach Healthcare System,5901 E. 7th Street,Long Beach,CA,90822,562-826-8000 Or 562-826-8000,VA Facility,Government,no,Not Available,33.775333,-118.11876
-664,VA San Diego Healthcare System,3350 La Jolla Village Drive,San Diego,CA,92161,858-552-8585,VA Facility,Government,no,Not Available,0,0
-664,ASPIRE Center,2121 San Diego Avenue,San Diego,CA,92110,855-297-8397,VA Facility,Government,no,Not Available,32.746605,-117.18952
-605,Blythe Rural Health Clinic,1273 West Hobson Way,Blythe,CA,92225,760-921-1224,VA Facility,Government,no,Not Available,33.61016,-114.60913
-649,Chinle Comprehensive Care Facility (Indian Health Services),Hwy 191 and Hospital Drive,Chinle,AZ,86503,928-674-7675,VA Facility,Government,no,Not Available,0,0
-649GF,Holbrook VA Clinic,33 W. Vista Dr.,Holbrook,AZ,86025,928-524-1050,VA Facility,Government,no,Not Available,0,0
-691GA,Los Angeles Ambulatory Care Center,351 East Temple Street,Los Angeles,CA,90012,213-253-2677,VA Facility,Government,no,Not Available,34.05251,-118.239746
-649,Page VA Clinic,801 N Navajo Dr. Ste-B,Page,AZ,86040,928-645-4966,VA Facility,Government,no,Not Available,36.91684,-111.4514
-6381,Polacca VA Clinic,Highway 264 Mile Post 388,Polacca,AZ,86042,928-283-4465,VA Facility,Government,no,Not Available,0,0
-664,Rio Clinic,"8989 Rio San Diego, Suite 360",San Diego,CA,92108,619-228-8000,VA Facility,Government,no,Not Available,32.77582,-117.13689
-691A4,Sepulveda OPC and Nursing Home,16111 Plummer Street,North Hills,CA,91343,818-891-7711 Or 818-891-7711,VA Facility,Government,no,Not Available,34.24288,-118.48041
-649,Tuba City VA Clinic,167 N Main St P.O. Box 600,Tuba City,AZ,86045,928-283-4465,VA Facility,Government,no,Not Available,36.142876,-111.23962
-605BZ,VA Loma Linda Ambulatory Care Center,26001 Redlands Blvd.,Redlands,CA,92373,909-825-7084,VA Facility,Government,no,Not Available,34.063038,-117.23747
-691,VA West Los Angeles Healthcare Center,11301 Wilshire Blvd,Los Angeles,CA,90073,310-478-3711,VA Facility,Government,no,Not Available,0,0
-501GI,Alamogordo CCBOC,"3199 N. White Sands Blvd., Suite D10",Alamogordo,NM,88310,575-437-9195,VA Facility,Government,no,Not Available,32.933743,-105.96381
-600GA,Anaheim,2569 W Woodland Dr,Anaheim,CA,92801,714-763-5300,VA Facility,Government,no,Not Available,33.849346,-117.97515
-649GE,Anthem CBOC,"41810 North Venture Dr., Bldg. B",Anthem,AZ,85086,623-249-2300 Or 800-949-1005 X 2300,VA Facility,Government,no,Not Available,0,0
-501GA,Artesia Clinic,"2410 W. Main St.,",Artesia,NM,88210,575-746-3531,VA Facility,Government,no,Not Available,32.842644,-104.42751
-691GD,Bakersfield Community Based Outpatient Clinic,1801 Westwind Drive,Bakersfield,CA,93301,661-632-1800,VA Facility,Government,no,Not Available,35.376835,-119.04256
-678GC,Casa Grande CBOC,"1876 E. Sabin Drive, Building A Ste 15",Casa Grande,AZ,85122,520-836-2536,VA Facility,Government,no,Not Available,0,0
-664GC,Chula Vista Clinic,865 3rd Avenue,Chula Vista,CA,91910,619-409-1600,VA Facility,Government,no,Not Available,32.62196,-117.07232
-605GD,Corona,"2045 Compton Avenue, Bldg. 7, Suite 101",Corona,CA,92881,951-817-8820,VA Facility,Government,no,Not Available,33.853207,-117.536194
-649GE,Cottonwood CBOC,501 S. Willard,Cottonwood,AZ,86326,928-649-1523,VA Facility,Government,no,Not Available,34.73068,-112.02738
-691GF,East Los Angeles Community Based Outpatient Clinic,5426 E. Olympic Boulevard,City of Commerce,CA,90040,323-725-7372,VA Facility,Government,no,Not Available,34.015556,-118.155075
-664GD,Escondido,815 East Pennsylvania Avenue,Escondido,CA,92025,760-466-7020,VA Facility,Government,no,Not Available,33.127407,-117.072014
-501GE,Espanola CCBOC,105 S. Coronado Ave.,Espanola,NM,87532,505-367-4213,VA Facility,Government,no,Not Available,35.99053,-106.08518
-501GB,Farmington CBOC,3605 English Road,Farmington,NM,87402,505-326-4383,VA Facility,Government,no,Not Available,36.761497,-108.14833
-649GB,Flagstaff CBOC,1300 W. University Ave. Suite 200,Flagstaff,AZ,86001,928-226-1056 Or 800-949-1005 X 5650,VA Facility,Government,no,Not Available,35.184116,-111.670784
-501GD,Gallup CBOC,2075 NM Hwy 602,Gallup,NM,87301,505-722-7234,VA Facility,Government,no,Not Available,0,0
-691,Gardena Community Based Outpatient Clinic,1149 West 190th Street,Gardena,CA,90248,310-851-4705,VA Facility,Government,no,Not Available,33.858334,-118.29599
-644,Globe-Miami VA Health Care Clinic,"5860 S. Hospital Drive, Suite 111",Globe,AZ,85501,928-425-0027,VA Facility,Government,no,Not Available,33.40677,-110.82588
-678GE,Green Valley CBOC,380 W. Vista Hermosa Drive #140,Green Valley,AZ,85614,520-399-2291,VA Facility,Government,no,Not Available,31.854649,-110.99739
-664GA,Imperial Valley,1115 South 4th Street,El Centro,CA,92243,760-352-1506,VA Facility,Government,no,Not Available,32.78269,-115.55243
-6425,Kayenta VA Clinic,394.3 Highway 160,Kayenta,AZ,86033,928-445-4860 X 3392 Or 800-949-1005 X 3392,VA Facility,Government,no,Not Available,0,0
-649GA,Kingman CBOC,2668 Hualapai Mountain Road,Kingman,AZ,86401,928-718-7300,VA Facility,Government,no,Not Available,0,0
-600GE,Laguna Hills,25292 McIntyre Road,Laguna Hills,CA,92653,949-587-3700,VA Facility,Government,no,Not Available,33.596123,-117.67979
-649GC,Lake Havasu City CBOC,"2035 Mesquite, Suite D",Lake Havasu City,AZ,86403,928-505-7100 Or 800-949-1005 X 7100,VA Facility,Government,no,Not Available,34.47788,-114.33046
-691,Lancaster Community Based Outpatient Clinic,340 E Avenue I Suite 108,Lancaster,CA,93535,661-729-8655,VA Facility,Government,no,Not Available,34.70404,-118.12551
-501G2,Las Vegas CCBOC,"624 University Ave.,",Las Vegas,NM,87701,505-425-1910,VA Facility,Government,no,Not Available,35.595673,-105.21634
-644GH,Midtown VA Clinic,5040 N 15th Ave,Phoenix,AZ,85015,602-234-7080,VA Facility,Government,no,Not Available,33.51061,-112.09123
-664,Mission Valley Clinic,8810 Rio San Diego Drive,San Diego,CA,92108,619-400-5000,VA Facility,Government,no,Not Available,32.775913,-117.14002
-605GB,Murrieta,"28078 Baxter Rd., Suite 540",Murrieta,CA,92563,951-290-6500,VA Facility,Government,no,Not Available,0,0
-644GG,Northeast CBOC (Phoenix),11390 E. Via Linda Rd. Ste.105,Scottsdale,AZ,85259,480-579-2200,VA Facility,Government,no,Not Available,33.589054,-111.83652
-501GM,Northwest Metro,1760 Grande Blvd SE,Rio Rancho,NM,87124,505-896-7200,VA Facility,Government,no,Not Available,35.22997,-106.66115
-644GA,Northwest VA Health Care Clinic,"13985 W. Grand Avenue, Suite 101",Surprise,AZ,85374,623-251-2884,VA Facility,Government,no,Not Available,0,0
-664GB,Oceanside Clinic,1300 Rancho del Oro Drive,Oceanside,CA,92056,760-643-2000,VA Facility,Government,no,Not Available,0,0
-691gm,Oxnard Community Based Outpatient Clinic,1690 Universe Circle,Oxnard,CA,93033,805-204-9135,VA Facility,Government,no,Not Available,34.18277,-119.16113
-605GC,Palm Desert,"41-990 Cook St, Bldg F Ste 1004",Palm Desert,CA,92211,760-341-5570,VA Facility,Government,no,Not Available,0,0
-644GD,Payson VA Health Care Clinic,903 E Highway 260,Payson,AZ,85541,928-468-2100 Or 928-468-2100,VA Facility,Government,no,Not Available,34.251347,-111.32259
-605GE,Rancho Cucamonga,"8599 Haven Ave., Suite 102",Rancho Cucamonga,CA,91730,909-946-5348,VA Facility,Government,no,Not Available,34.095577,-117.57578
-501HB,Raton CBOC,1493 Whittier Street,Raton,NM,87440,575-445-2391,VA Facility,Government,no,Not Available,0,0
-678GD,Safford Clinic,355 N. 8th Avenue,Safford,AZ,85546,928-428-8010,VA Facility,Government,no,Not Available,32.835648,-109.71604
-691GK,San Luis Obispo Community Based Outpatient Clinic,"1288 Morro Street, Ste.200",San Luis Obispo,CA,93401,805-543-1233,VA Facility,Government,no,Not Available,35.279198,-120.660416
-600GB,Santa Ana,1506 Brookhollow Dr,Santa Ana,CA,92705,714-434-4600,VA Facility,Government,no,Not Available,33.71314,-117.84916
-691GB,Santa Barbara Community Based Outpatient Clinic,"4440 Calle Real,",Santa Barbara,CA,93110,805-683-1491,VA Facility,Government,no,Not Available,34.442417,-119.77877
-501GK,Santa Fe CBOC,5152 Beckner Road,Santa Fe,NM,87507,505-986-8645,VA Facility,Government,no,Not Available,0,0
-691,Santa Maria Community Based Outpatient Clinic,1550 East Main Street,Santa Maria,CA,93454,805-354-6000,VA Facility,Government,no,Not Available,34.96743,-120.42733
-644GB,Show Low VA Health Care Clinic,"5171 Cub Lake Road, Suite C380",Show Low,AZ,85901,928-532-1069,VA Facility,Government,no,Not Available,34.202072,-110.02095
-678GA,Sierra Vista Clinic,101 N. Coronado Drive Suite A,Sierra Vista,AZ,85635,520-459-1529,VA Facility,Government,no,Not Available,31.553316,-110.27763
-501GC,Silver City Clinic,2950 Leslie Road,Silver City,NM,88061,575-538-2921,VA Facility,Government,no,Not Available,32.79467,-108.26302
-664GE,Sorrento Valley Clinic,10455 Sorrento Valley Road,San Diego,CA,92121,858-552-7475,VA Facility,Government,no,Not Available,32.89261,-117.21451
-644BY,Southeast VA Health Care Clinic,3285 S. Val Vista Dr.,Gilbert,AZ,85297,480-397-2800,VA Facility,Government,no,Not Available,0,0
-644GC,Southwest Community Based Outpatient Clinic,9250 W. Thomas Rd.,Phoenix,AZ,85037,623-772-4000,VA Facility,Government,no,Not Available,33.47967,-112.25856
-501,Taos CCBOC,1353 Paseo Del Pueblo Sur,Taos,NM,87571,575-751-0328,VA Facility,Government,no,Not Available,36.37114,-105.595764
-644GE,Thunderbird VA Health Care Clinic,9424 N. 25th Ave.,Phoenix,AZ,85021,602-633-6900,VA Facility,Government,no,Not Available,33.571198,-112.11228
-501GH,Truth or Consequences CCBOC,1960 North Date Street,Truth or Consequences,NM,87901,575-894-7662,VA Facility,Government,no,Not Available,33.150505,-107.24602
-678GF,VA Northwest Tucson Clinic,2945 W. Ina Road,Tucson,AZ,85741,520-219-2418,VA Facility,Government,no,Not Available,32.33738,-111.03047
-678GG,VA Southeast Tucson Clinic,7395 S. Houghton Road Ste 129,Tucson,AZ,85747,520-664-1831,VA Facility,Government,no,Not Available,32.117203,-110.772675
-605GA,Victorville,"12138 Industrial Boulevard, Suite 120",Victorville,CA,92395,760-951-2599,VA Facility,Government,no,Not Available,34.472652,-117.2829
-600GC,Villages At Cabrillo,"2001 River Ave, Bldg 28",Long Beach,CA,90806,562-388-8000,VA Facility,Government,no,Not Available,0,0
-600gd,Whittier/Santa Fe Springs Clinic,10330 Pioneer Blvd Suite 180,Santa Fe Springs,CA,90670,562-347-2200,VA Facility,Government,no,Not Available,0,0
-470-8262,Yuma Clinic,3111 S. 4th Avenue,Yuma,AZ,85364,928-317-9973,VA Facility,Government,no,Not Available,32.672523,-114.62432
-0515V,Albuquerque Vet Center,2001 Mountain Road NW,Albuquerque,NM,87104,505-346-6562 Or 505-346-6562,VA Facility,Government,no,Not Available,35.098385,-106.66792
-603,Antelope Valley Vet Center,"38925 Trade Center Drive, Suites I/J",Palmdale,CA,93551,661-267-1026 Or 661-267-1026,VA Facility,Government,no,Not Available,0,0
-601,Bakersfield Vet Center,1110 Golden State Ave.,Bakersfield,CA,93301,661-323-8387 Or 661-323-8387,VA Facility,Government,no,Not Available,0,0
-605,Chatsworth Vet Center,"20946 Devonshire St, Suite 101",Chatsworth,CA,91311,818-576-0201,VA Facility,Government,no,Not Available,34.25723,-118.5896
-05161V,Chinle Vet Center Outstation,"Navajo Route 7, Old BIA Complex-B59",Chinle,AZ,86503,844-286-7270,VA Facility,Government,no,Not Available,0,0
-614,Chula Vista Vet Center,"180 Otay Lakes Road, Suite 108",Bonita,CA,91902,877-618-6534 Or 877-618-6534,VA Facility,Government,no,Not Available,32.659225,-117.03042
-611,Corona Vet Center,800 Magnolia Avenue Suite 110,Corona,CA,92879,951-734-0525 Or 951-734-0525,VA Facility,Government,no,Not Available,33.85894,-117.55446
-607,Culver City Vet Center,5730 Uplander Way Suite 100,Culver City,CA,90230,310-641-0326 Or 310-641-0326,VA Facility,Government,no,Not Available,33.986443,-118.38459
-623,East Los Angeles Vet Center,5400 E. Olympic Blvd. Suite 140,Commerce,CA,90022,323-728-9966 Or 323-728-9966,VA Facility,Government,no,Not Available,34.015686,-118.1557
-0516V,Farmington Vet Center,4251 E. Main Suite A,Farmington,NM,87402,505-327-9684 Or 505-327-9684,VA Facility,Government,no,Not Available,36.759556,-108.15592
-613,High Desert Vet Center,"15095 Amargosa Rd, Suite 107",Victorville,CA,92394,760-261-5925 Or 760-261-5925,VA Facility,Government,no,Not Available,34.524727,-117.33031
-5162,Hopi Vet Center Outstation,"P.O. Box 929, 1 Main St.",Hotevilla,AZ,86030,928-734-5166 Or 928-734-5166,VA Facility,Government,no,Not Available,0,0
-536,Lake Havasu Vet Center,"1720 Mesquite, Suite 101",Lake Havasu,AZ,86403,928-505-0394 Or 928-505-0394,VA Facility,Government,no,Not Available,34.478374,-114.34081
-530,Las Cruces Vet Center,"1120 Commerce Street, Suite B",Las Cruces,NM,88001,575-523-9826 Or 575-523-9826,VA Facility,Government,no,Not Available,0,0
-0606V,Los Angeles Vet Center,1045 W. Redondo Beach Blvd. Suite 150,Gardena,CA,90247,310-767-1221 Or 877-927-8387,VA Facility,Government,no,Not Available,33.89245,-118.29319
-524,Mesa Vet Center,"1303 South Longmore, Suite 5",Mesa,AZ,85202,480-610-6727 Or 480-610-6727,VA Facility,Government,no,Not Available,33.391068,-111.863785
-624,North Orange County Vet Center,12453 Lewis St. Suite 101,Garden Grove,CA,92840,714-776-0161 Or 877-927-8387,VA Facility,Government,no,Not Available,33.78244,-117.897484
-0517V,Phoenix Vet Center,4020 N. 20th St. #110,Phoenix,AZ,85016,602-640-2981 Or 602-640-2981,VA Facility,Government,no,Not Available,33.4934,-112.038925
-0518V,Prescott Vet Center (Dr. Cameron K. McKinley Vet Center),"3180 Stillwater Drive, Suite A",Prescott,AZ,86305,928-778-3469 Or 877-927-8387,VA Facility,Government,no,Not Available,34.59808,-112.46729
-637,San Bernardino Vet Center,"1325 E. Cooley Drive, Suite 101",Colton,CA,92324,909-801-5762 Or 877-927-8387,VA Facility,Government,no,Not Available,34.054634,-117.30536
-618,San Diego Vet Center,"2790 Truxtun Road, Suite 130",San Diego,CA,92106,858-642-1500 Or 858-642-1500,VA Facility,Government,no,Not Available,32.740627,-117.21285
-0619v,San Luis Obispo Vet Center,1070 Southwood Drive,San Luis Obispo,CA,93401,805-782-9101 Or 877-927-8387,VA Facility,Government,no,Not Available,35.265366,-120.64087
-642,San Marcos Vet Center,"One Civic Center Dr., Suite 150",San Marcos,CA,92069,855-898-6050 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-0520V,Santa Fe Vet Center,2209 Brothers Road Suite 110,Santa Fe,NM,87505,505-988-6562 Or 505-988-6562,VA Facility,Government,no,Not Available,35.65078,-105.95243
-5921,South Orange County Vet Center,"26431 Crown Valley Parkway, Suite 100",Mission Viejo,CA,92691,949-348-6700 Or 877-927-8387,VA Facility,Government,no,Not Available,0,0
-608,Temecula Vet Center,"40935 County Center Drive, Suite A/B",Temecula,CA,92591,951-302-4849 Or 951-302-4849,VA Facility,Government,no,Not Available,33.528206,-117.16034
-0521V,Tucson Vet Center,2525 E. Broadway Blvd Suite 100,Tucson,AZ,85716,520-882-0333,VA Facility,Government,no,Not Available,32.221508,-110.93447
-643,Ventura Vet Center,790 E. Santa Clara St. Suite 100,Ventura,CA,93001,805-585-1860 Or 805-585-1860,VA Facility,Government,no,Not Available,34.279526,-119.28866
-0533V,West Valley Vet Center,14050 N. 83rd Avenue Suite 170,Peoria,AZ,85381,623-398-8854 Or 623-398-8854,VA Facility,Government,no,Not Available,33.612053,-112.23756
-0537V,Yuma Vet Center,"1450 E. 16th St, Suite 103",Yuma,AZ,85365,928-271-8700 Or 928-271-8700,VA Facility,Government,no,Not Available,32.69857,-114.60357
-678CG,Casa Grande Rural Health Care Coordination Center,"1179 E. Cottonwood Lane, Suite 1",Casa Grande,AZ,85122,520-629-4801 Or 520-629-4801,VA Facility,Government,no,Not Available,32.894085,-111.735535
-600QA,Community Resource and Referral Center,888 W. Santa Ana Blvd. Suite 150,Santa Ana,CA,92701,844-838-8300 Or 844-838-8300,VA Facility,Government,no,Not Available,33.75201,-117.85871
-678SV,Sierra Vista Rural Health Care Coordination Center,"157 North Coronado Drive, Suite B",Sierra Vista,AZ,85635,520-629-4802 Or 520-629-4802,VA Facility,Government,no,Not Available,31.552668,-110.27763
-10N23,VISN 23: VA Midwest Health Care Network,"2805 Dodd Road, Suite 250",Eagan,MN,55121,651-405-5600,VA Facility,Government,no,Not Available,44.855087,-93.12877
-437,Fargo VA Health Care System,2101 Elm Street N.,Fargo,ND,58102,701-232-3241 Or 701-232-3241,VA Facility,Government,no,Not Available,46.90639,-96.776855
-636A8,Iowa City VA Health Care System,601 Highway 6 West,Iowa City,IA,52246,319-338-0581,VA Facility,Government,no,Not Available,0,0
-618,Minneapolis VA Health Care System,One Veterans Drive,Minneapolis,MN,55417,612-725-2000,VA Facility,Government,no,Not Available,0,0
-636,Omaha VA Medical Center--VA Nebraska-Western Iowa HCS,4101 Woolworth Avenue,Omaha,NE,68105,402-346-8800 Or 800-451-5796,VA Facility,Government,no,Not Available,41.245132,-95.97476
-656,St. Cloud VA Health Care System,4801 Veterans Drive,St. Cloud,MN,56303,320-252-1670 Or 320-252-1670,VA Facility,Government,no,Not Available,0,0
-568A4,VA Black Hills Health Care System - Hot Springs Campus,500 North 5th Street,Hot Springs,SD,57747,605-745-2000 Or 605-745-2000,VA Facility,Government,no,Not Available,43.435852,-103.47448
-568,VA Black Hills Health Care System - Fort Meade Campus,113 Comanche Road,Fort Meade,SD,57741,605-347-2511 Or 605-347-2511,VA Facility,Government,no,Not Available,44.412003,-103.46777
-636A6,VA Central Iowa Health Care System,3600 30th Street,Des Moines,IA,50310,515-699-5999 Or 515-699-5999,VA Facility,Government,no,Not Available,41.628147,-93.65877
-636A4,Grand Island VA Medical Center,2201 No. Broadwell Avenue,Grand Island,NE,68803,308-382-3660 Or 866-580-1810,VA Facility,Government,no,Not Available,40.942425,-98.35887
-438,Royal C. Johnson Veterans Memorial Medical Center,"2501 W. 22nd Street, PO Box 5046",Sioux Falls,SD,57117,605-336-3230,VA Facility,Government,no,Not Available,43.53304,-96.75647
-636A8,Coralville OPC,520 10 Ave Ste 200,Coralville,IA,52441,319-358-2406 Or 319-688-3365,VA Facility,Government,no,Not Available,0,0
-636A5,Lincoln VA Clinic,600 South 70th Street,Lincoln,NE,68510,402-489-3802 Or 866-851-6052,VA Facility,Government,no,Not Available,40.807457,-96.62502
-636QC,Community Resource and Referral Center - Cedar Rapids,1535 First Ave SE,Cedar Rapids,IA,52403,319-365-0898,VA Facility,Government,no,Not Available,41.988605,-91.651436
-636A6,Community Resource and Referral Center - Des Moines,1223 Center Street,Des Moines,IA,50309,515-699-5637,VA Facility,Government,no,Not Available,41.59168,-93.63398
-636QI,Community Resource and Referral Center - Quad Cities,415 North Perry Street,Davenport,IA,52801,563-328-5800,VA Facility,Government,no,Not Available,41.52367,-90.57259
-438GD,Aberdeen VA Clinic,"2301 8th Ave. NE, Suite 225",Aberdeen,SD,57401,605-229-3500,VA Facility,Government,no,Not Available,45.473736,-98.455605
-618GK,Albert Lea VA Clinic,1665 West Main St.,Albert Lea,MN,56007,507-377-6051,VA Facility,Government,no,Not Available,43.64646,-93.38959
-656,Alexandria Community Based Outpatient Clinic,515 22nd Avenue East,Alexandria,MN,56308,320-759-2640,VA Facility,Government,no,Not Available,45.867462,-95.37343
-636,Bellevue VA Clinic,"2206 Longo Drive, Suite 102",Bellevue,NE,68005,402-591-4500,VA Facility,Government,no,Not Available,41.15577,-95.92394
-437GE,Bemidji VA Community Based Outpatient Clinic,"1217 Anne St., Bemidji, MN 56601",Bemidji,MN,56601,218-755-6360,VA Facility,Government,no,Not Available,0,0
-636GF,Bettendorf VA Clinic,2979 Victoria Street,Bettendorf,IA,52722,563-332-8528,VA Facility,Government,no,Not Available,41.553448,-90.4971
-437GB,Bismarck VA Community Based Outpatient Clinic,"Gateway Mall, 2700 State Street, Suite F",Bismarck,ND,58503,701-221-9152,VA Facility,Government,no,Not Available,0,0
-656GA,Brainerd VA Clinic,722 NW 7th Street,Brainerd,MN,56401,218-855-1115,VA Facility,Government,no,Not Available,46.35942,-94.22238
-0405V,Carroll CBOC,"311 S Clark St, Suite 275",Carroll,IA,51401,712-794-6780 Or 855-794-6780,VA Facility,Government,no,Not Available,42.05701,-94.86798
-638A8,Cedar Rapids CBOC,2230 Wiley Blvd SW,Cedar Rapids,IA,52404,319-369-4340,VA Facility,Government,no,Not Available,41.95747,-91.72585
-618GE,Chippewa Valley VA Clinic,475 Chippewa Mall Drive Suite 418,Chippewa Falls,WI,54729,715-720-3780,VA Facility,Government,no,Not Available,44.92612,-91.38237
-636GU,Decorah VA Clinic,915 Short St.,Decorah,IA,52101,563-387-5840,VA Facility,Government,no,Not Available,43.291492,-91.797
-437GL,Devils Lake VA Community Based Outpatient Clinic,1031 7th St. NE,Devils Lake,ND,58301,701-662-5801,VA Facility,Government,no,Not Available,48.1148,-98.850716
-437,Dickinson VA Community Based Outpatient Clinic,528 - 21st St. W. Suite F,Dickinson,ND,58601,701-483-1850,VA Facility,Government,no,Not Available,46.905,-102.79279
-636GJ,Dubuque VA Clinic,"200 Mercy Dr, Ste 106",Dubuque,IA,52001,563-588-5520,VA Facility,Government,no,Not Available,42.492767,-90.673805
-618GB,Ely VA Clinic,720 Miners Drive East,Ely,MN,55731,218-365-0001,VA Facility,Government,no,Not Available,0,0
-437GC,Fergus Falls VA Community Based Outpatient Clinic,1839 N Park St,Fergus Falls,MN,56537,218-739-1400,VA Facility,Government,no,Not Available,46.302166,-96.07622
-636GK,Fort Dodge CBOC,2419 2nd Avenue N,Fort Dodge,IA,50501,515-576-2235 Or 877-578-8846,VA Facility,Government,no,Not Available,0,0
-636GI,Galesburg VA Clinic,310 Home Boulevard,Galesburg,IL,61401,309-343-0311 Or 309-343-0311,VA Facility,Government,no,Not Available,0,0
-568HB,Gordon VA Clinic,300 East 8th Street,Gordon,NE,69343,308-282-1442,VA Facility,Government,no,Not Available,42.811832,-102.200356
-437GA,Grafton VA Community Based Outpatient Clinic,1319 11th St. West,Grafton,ND,58237,701-352-4059,VA Facility,Government,no,Not Available,0,0
-437GI,Grand Forks VA Community Based Outpatient Clinic,"3221 32nd Avenue South, Suite 700",Grand Forks,ND,58201,701-335-4380,VA Facility,Government,no,Not Available,47.88944,-97.07383
-618GH,Hayward VA Clinic,15954 River's Edge Drive Suite 103,Hayward,WI,54843,715-934-5454,VA Facility,Government,no,Not Available,46.004047,-91.489845
-618GB,Hibbing VA Clinic,990 West 41st Street Suite 5,Hibbing,MN,55746,218-263-1400,VA Facility,Government,no,Not Available,47.4001,-92.961655
-636,Holdrege VA Clinic,1118 Burlington St,Holdrege,NE,68949,308-995-3760,VA Facility,Government,no,Not Available,40.44539,-99.37966
-437,Jamestown VA Community Based Outpatient,2422 20th St SW,Jamestown,ND,58401,701-952-4787,VA Facility,Government,no,Not Available,0,0
-636A7,Knoxville CBOC,1607 N. Lincoln Street,Knoxville,IA,50138,641-828-5019 Or 800-816-8878,VA Facility,Government,no,Not Available,0,0
-618GJ,Lyle C. Pearson VA Clinic,1961 Premier Dr Suite 330,Mankato,MN,56001,507-387-2939,VA Facility,Government,no,Not Available,44.179867,-93.94533
-618GD,Maplewood VA Clinic,"1725 Legacy Parkway, Suite 100",Maplewood,MN,55109,651-225-5420,VA Facility,Government,no,Not Available,0,0
-636GD,Marshalltown CBOC,101 Iowa Ave W,Marshalltown,IA,50158,641-754-6700 Or 877-424-4404,VA Facility,Government,no,Not Available,42.006947,-92.91202
-636GC,Mason City CBOC,"520 S. Pierce, Suite 150",Mason City,IA,50401,641-494-5000 Or 800-351-4671,VA Facility,Government,no,Not Available,43.147163,-93.22106
-568HK,McLaughlin VA Clinic,"Veterans Industries, Sales Barn Rd, P.O. Box 519",McLaughlin,SD,57642,605-823-4574,VA Facility,Government,no,Not Available,0,0
-437GD,Minot VA Community Based Outpatient Clinic,"5th Medical Group, 10 Missile Avenue",Minot,ND,58705,701-727-9800,VA Facility,Government,no,Not Available,0,0
-568HS,Mission CBOC,"Horizon Health Care, Inc. 153 Main Street",Mission,SD,57555,605-856-2295,VA Facility,Government,no,Not Available,0,0
-656GB,Montevideo VA Clinic,1025 North 13th Street,Montevideo,MN,56265,320-269-2222,VA Facility,Government,no,Not Available,44.95535,-95.71118
-568HA,Newcastle VA Clinic,1124 Washington Blvd.,Newcastle,WY,57555,307-746-4491,VA Facility,Government,no,Not Available,43.848816,-104.188515
-636GA,Norfolk VA Clinic,"710 S 13th, Suite 1200",Norfolk,NE,68701,402-370-4570,VA Facility,Government,no,Not Available,42.02499,-97.42654
-636GB,North Platte VA Clinic,"600 East Francis, Suite 3",North Platte,NE,69101,308-532-6906,VA Facility,Government,no,Not Available,41.122543,-100.75789
-618GI,Northwest Metro VA Clinic,7545 Veterans Drive,Ramsey,MN,55303,612-467-1100,VA Facility,Government,no,Not Available,0,0
-636PP,O'Neill Community-Based Outreach Clinic,555 E. John Street,O'Neill,NE,68763,402-336-2982,VA Facility,Government,no,Not Available,42.462406,-98.64539
-636GS,Ottumwa VA Clinic,1009 E Pennsylvania Ave,Ottumwa,IA,52501,641-683-4300,VA Facility,Government,no,Not Available,41.027508,-92.389656
-568HH,Panhandle of Nebraska CBOC,601 S 5th Ave,Scottsbluff,NE,69361,308-225-5330,VA Facility,Government,no,Not Available,41.85344,-103.65583
-568GB,Pierre VA Clinic,"Linn Medical Clinic, 1601 North Harrison, Suite 6",Pierre,SD,57501,605-945-1710,VA Facility,Government,no,Not Available,0,0
-568HF,Pine Ridge VA Clinic,Next to Dialysis Building across from IHS Hospital,Pine Ridge,SD,57770,605-867-2393 X 4033,VA Facility,Government,no,Not Available,0,0
-636GG,Quincy VA Clinic,721 Broadway Street,Quincy,IL,62301,217-224-3366,VA Facility,Government,no,Not Available,39.935753,-91.4044
-568GA,Rapid City VA Clinic,3625 5th Street,Rapid City,SD,57701,605-718-1095,VA Facility,Government,no,Not Available,44.05007,-103.22412
-618GH,Rice Lake VA Clinic,2700A College Drive,Rice Lake,WI,54868,715-236-3355,VA Facility,Government,no,Not Available,45.481583,-91.744316
-618GG,Rochester VA Clinic,3900 Fairway Place NW,Rochester,MN,55901,507-252-0885,VA Facility,Government,no,Not Available,0,0
-618GJ,Shakopee VA Clinic,1111 Shakopee Town Square,Shakopee,MN,55379,952-445-4070,VA Facility,Government,no,Not Available,0,0
-636,Shenandoah VA Clinic,512 S Fremont,Shenandoah,IA,51601,712-246-0092,VA Facility,Government,no,Not Available,40.758163,-95.37214
-438GC,Sioux City VA Clinic,"1551 Indian Hills Drive, Suite 206",Sioux City,IA,51104,712-258-4700,VA Facility,Government,no,Not Available,42.532574,-96.3904
-618GA,South Central VA Clinic,1212 Heckman Court,St. James,MN,56081,507-375-9670,VA Facility,Government,no,Not Available,43.970703,-94.618034
-438GA,Spirit Lake VA Clinic,1310 Lake Street,Spirit Lake,IA,51360,712-336-6400,VA Facility,Government,no,Not Available,0,0
-636GT,Sterling VA Outpatient Clinic,406 Avenue C,Sterling,IL,61081,815-632-6200,VA Facility,Government,no,Not Available,41.789516,-89.700195
-618BY,Twin Ports VA Clinic,3520 Tower Avenue,Superior,WI,54880,715-398-2400,VA Facility,Government,no,Not Available,0,0
-636GH,Waterloo VA Clinic,945 Tower Park Drive,Waterloo,IA,50701,319-235-1230,VA Facility,Government,no,Not Available,0,0
-438GF,Watertown CBOC,917 – 29th Street SE,Watertown,SD,57201,605-884-2420,VA Facility,Government,no,Not Available,0,0
-437GF,Williston VA Community Based Outpatient Clinic,205 Main Street,Williston,ND,58802,701-572-2470,VA Facility,Government,no,Not Available,48.1456,-103.62167
-568HP,Winner VA Clinic,660 West 2nd Street,Winner,SD,57580,605-842-2443,VA Facility,Government,no,Not Available,43.376553,-99.86538
-0446V,Bismarck Vet Center,"619 Riverwood Drive, Suite 105",Bismarck,ND,58504,701-224-9751 Or 701-224-9751,VA Facility,Government,no,Not Available,46.794674,-100.80184
-0439V,Brooklyn Park Vet Center,"7001 78th Avenue North, Suite 300",Brooklyn Park,MN,55445,763-503-2220 Or 877-927-8387,VA Facility,Government,no,Not Available,45.09529,-93.370834
-0431V,Cedar Rapids Vet Center,"4250 River Center Court NE, Suite D",Cedar Rapids,IA,52402,319-378-0016 Or 319-378-0016,VA Facility,Government,no,Not Available,42.019444,-91.70087
-0405V,Des Moines Vet Center,1821 22nd Street #115,Des Moines,IA,50266,515-284-4929 Or 515-284-4929,VA Facility,Government,no,Not Available,41.599247,-93.73604
-0429V,Duluth Vet Center,4402 Haines Road,Duluth,MN,55811,218-722-8654 Or 877-927-8387,VA Facility,Government,no,Not Available,46.829487,-92.174805
-0406V,Fargo Vet Center,3310 Fiechtner Drive. Suite 100,Fargo,ND,58103,701-237-0942 Or 701-237-0942,VA Facility,Government,no,Not Available,46.86399,-96.83272
-589GE,Grand Forks Vet Center,3001 32nd Ave. S. Suite 6A,Grand Forks,ND,58201,701-620-1448 Or 877-927-8387,VA Facility,Government,no,Not Available,47.88944,-97.07062
-0427V,Lincoln Vet Center,"3119 O Street, Suite A",Lincoln,NE,68510,402-476-9736 Or 402-476-9736,VA Facility,Government,no,Not Available,40.813408,-96.67602
-4231,Martin Outstation,P.O. Box 910 105 E. Hwy 18,Martin,SD,57747,605-685-1300 Or 605-685-1300,VA Facility,Government,no,Not Available,0,0
-0404V,Minot Vet Center,1400 20th Avenue SW Ste 2,Minot,ND,58701,701-852-0177 Or 877-927-8387,VA Facility,Government,no,Not Available,48.210842,-101.31301
-0424V,Omaha Vet Center,3047 S 72nd Street,Omaha,NE,68124,402-346-6735,VA Facility,Government,no,Not Available,41.23105,-96.02388
-0430V,Quad Cities Vet Center,"465 Avenue of the Cities, Suite #140",East Moline,IL,61244,309-755-3260 Or 309-755-3260,VA Facility,Government,no,Not Available,0,0
-0423V,Rapid City Vet Center,"621 6th St, Suite 101",Rapid City,SD,57701,605-348-0077 Or 877-927-8387,VA Facility,Government,no,Not Available,44.079773,-103.227394
-0428V,Sioux City Vet Center,1551 Indian Hills Drive Suite 214,Sioux City,IA,51104,712-255-3808 Or 712-255-3808,VA Facility,Government,no,Not Available,42.532574,-96.3904
-0425V,Sioux Falls Vet Center,3200 W 49th Street,Sioux Falls,SD,57106,605-330-4552 Or 605-330-4552,VA Facility,Government,no,Not Available,43.50762,-96.765205
-0416V,St. Paul Vet Center,"550 County Road D West, Suite 10",New Brighton,MN,55112,651-644-4022 Or 651-644-4022,VA Facility,Government,no,Not Available,0,0
-438GE,Wagner Outreach Clinic,400 West Hwy 46,Wagner,SD,57380,605-384-2340,VA Facility,Government,no,Not Available,0,0
+518,"Edith Nourse Rogers Memorial Veterans Hospital (Bedford VA)","200 Springs Rd.",Bedford,MA,"01730",781-687-2000,"VA Facility",Government,no,"Not Available",42.503376,-71.272644
+608,"Manchester VA Medical Center","718 Smyth Road",Manchester,NH,"03104","603-624-4366 Or 603-624-4366","VA Facility",Government,no,"Not Available",43.01192,-71.43939
+650,"Providence VA Medical Center","830 Chalkstone Avenue",Providence,RI,"02908","401-273-7100 Or 401-273-7100","VA Facility",Government,no,"Not Available",41.83397,-71.43398
+523A5,"VA Boston Healthcare System, Brockton Campus","940 Belmont Street",Brockton,MA,"02301","508-583-4500 Or 508-583-4500","VA Facility",Government,no,"Not Available",42.065655,-71.05398
+523,"VA Boston Healthcare System, Jamaica Plain Campus","150 South Huntington Avenue","Jamaica Plain",MA,"02130",617-232-9500,"VA Facility",Government,no,"Not Available",42.32809,-71.11076
+523A4,"VA Boston Healthcare System, West Roxbury Campus","1400 VFW Parkway","West Roxbury",MA,"02132",617-323-7700,"VA Facility",Government,no,"Not Available",42.2793,-71.1657
+631,"VA Central Western Massachusetts Healthcare System","421 North Main Street",Leeds,MA,"01053",413-584-4040,"VA Facility",Government,no,"Not Available",42.345066,-72.68291
+689A4,"VA Connecticut Healthcare System, Newington Campus","555 Willard Avenue",Newington,CT,"06111",860-666-6951,"VA Facility",Government,no,"Not Available",41.702595,-72.73486
+689,"VA Connecticut Healthcare System, West Haven Campus","950 Campbell Avenue","West Haven",CT,"06516",203-932-5711,"VA Facility",Government,no,"Not Available",41.28468,-72.95741
+402,"VA Maine Healthcare System - Togus","1 VA Center",Augusta,ME,"04330","207-623-8411 Or 207-623-8411","VA Facility",Government,no,"Not Available",39.2954,-78.6378
+405,"White River Junction VA Medical Center","163 Veterans Drive","White River Junction",VT,"05009","802-295-9363 Or 802-295-9363","VA Facility",Government,no,"Not Available",43.648075,-72.34463
+523BZ,"Causeway OPC","251 Causeway St.",Boston,MA,"02114",800-865-3384,"VA Facility",Government,no,"Not Available",42.3665,-71.05931
+402F,"Fort Kent Access Point Clinic","3 Mountain View Drive","Fort Kent",ME,"04743",207-834-1572,"VA Facility",Government,no,"Not Available",47.2587,-68.5895
+4730,"Houlton Satellite Clinic","Houlton Regional Hospital - 20 Hartford Street",Houlton,ME,"04730","207-623-8411 X 7490 Or 877-421-8263 X 7490","VA Facility",Government,no,"Not Available",45.0743,-92.7505
+402MMU,"Mobile Medical Unit","241 Main Street",Bingham,ME,"04920","207-623-8411 X 7490 Or 877-421-8263 X 7490","VA Facility",Government,no,"Not Available",45.053535,-69.88254
+518-vccc,"Lowell Veterans Community Care Center","130 Marshall Road",Lowell,MA,"01852",978-671-9000,"VA Facility",Government,no,"Not Available",42.62101,-71.31481
+402GD,"Aroostook County (Caribou) Community Based Outpatient Clinic","163 Van Buren Drive, Ste 6",Caribou,ME,"04736","207-623-8411 X 7490 Or 877-421-8263 X 7490","VA Facility",Government,no,"Not Available",46.9121,-68.0431
+402HB,"Bangor Community Based Outpatient Clinic","35 State Hospital Drive",Bangor,ME,"04401",207-561-3600,"VA Facility",Government,no,"Not Available",44.802254,-68.769394
+405GA,"Bennington Outpatient Clinic","186 North Street",Bennington,VT,"05201",802-440-3300,"VA Facility",Government,no,"Not Available",42.879307,-73.1971
+405GC,"Brattleboro Community Based Outpatient Clinic","71 GSP Drive",Brattleboro,VT,"05301",802-251-2200,"VA Facility",Government,no,"Not Available",42.8509,-72.5579
+405HA,"Burlington Outpatient Lakeside Clinic","128 Lakeside Avenue, Suite 260",Burlington,VT,"05401",802-657-7000,"VA Facility",Government,no,"Not Available",44.46104,-73.22083
+402GB,"Calais Outpatient Clinic","50 Union St",Calais,ME,"04619","207-623-8411 X 7490 Or 877-421-8263 X 7490","VA Facility",Government,no,"Not Available",45.18957,-67.27797
+608GD,"Conway Outpatient Clinic","71 Hobbs Street",Conway,NH,"03818","800-892-8384 X 3199","VA Facility",Government,no,"Not Available",36.4235,-77.2729
+689GE,"Danbury Outpatient Clinic","7 Germantown Road, Ste 2B",Danbury,CT,"06810",203-798-8422,"VA Facility",Government,no,"Not Available",41.40898,-73.43614
+518GG,"Fitchburg Outpatient Clinic","881 Main Street",Fitchburg,MA,"01420","978-342-9781 Or 978-342-9781","VA Facility",Government,no,"Not Available",42.586487,-71.80521
+523GA,"Framingham Outpatient Clinic","61 Lincoln Street, Suite 112",Framingham,MA,"01702",800-865-3384,"VA Facility",Government,no,"Not Available",42.28348,-71.41845
+518GE,"Gloucester Community Based Outpatient Clinic (CBOC)","199 Main Street",Gloucester,MA,"01930",800-838-6331,"VA Facility",Government,no,"Not Available",42.613102,-70.66085
+631GD,"Greenfield Outpatient Clinic","143 Munson Street",Greenfield,MA,"01301","413-773-8428 Or 413-773-8428","VA Facility",Government,no,"Not Available",42.580627,-72.623634
+518GB,"Haverhill Community Based Outpatient Clinic (CBOC)","108 Merrimack St.",Haverhill,MA,"01830",800-838-6331,"VA Facility",Government,no,"Not Available",42.77449,-71.07901
+650GB,"Hyannis Outpatient Clinic","233 Stevens St",Hyannis,MA,"02601",508-771-3190,"VA Facility",Government,no,"Not Available",41.651745,-70.294235
+689HC,"John J. McGuirk (New London) VA Outpatient Clinic","Shaw's Cove Four","New London",CT,"06320",860-437-3611,"VA Facility",Government,no,"Not Available",43.414,-71.9851
+405K,"Keene Outpatient Clinic","640 Marlboro Street, Route 101",Keene,NH,"03431",603-358-4900,"VA Facility",Government,no,"Not Available",42.91539,-72.24931
+402-al,"Lewiston/ Auburn Community Based Outpatient Clinic","15 Challenger Drive",Lewiston,ME,"04240","207-330-2700 Or 877-421-8263 X 2700","VA Facility",Government,no,"Not Available",46.4166,-117.0177
+402,"Lincoln Community Based Outpatient Clinic","99 River Road",Lincoln,ME,"04457","207-623-8411 X 7490 Or 877-421-8263 X 7490","VA Facility",Government,no,"Not Available",38.8916,-121.293
+405HC,"Littleton Community Based Outpatient Clinic","264 Cottage Street",Littleton,NH,"03561",603-575-6700,"VA Facility",Government,no,"Not Available",39.6133,-105.0166
+523BY,"Lowell Outpatient Clinic","130 Marshall Road",Lowell,MA,"01852",800-865-3384,"VA Facility",Government,no,"Not Available",42.62101,-71.31481
+518GA,"Lynn Community Based Outpatient Clinic (CBOC)","225 Boston Road, Suite 107",Lynn,MA,"01904",800-838-6331,"VA Facility",Government,no,"Not Available",42.470093,-70.95994
+650GD,"Middletown Outpatient Clinic","One Corporate Place",Middletown,RI,"02842",401-847-6239,"VA Facility",Government,no,"Not Available",41.4459,-74.4229
+650GA,"New Bedford Outpatient Clinic","175 Elm Street","New Bedford",MA,"02740",508-994-0217,"VA Facility",Government,no,"Not Available",41.635937,-70.92991
+405_Newport,"Newport Community Based Outpatient Clinic","1734 Crawford Farm Rd.",Newport,VT,"05855",802-624-2400,"VA Facility",Government,no,"Not Available",44.932266,-72.180824
+631GC,"Pittsfield Outpatient Clinic","73 Eagle Street",Pittsfield,MA,"01201","413-499-2672 Or 413-499-2672","VA Facility",Government,no,"Not Available",42.451427,-73.25195
+523GD,"Plymouth Outreach Clinic","116 Long Pond Road",Plymouth,MA,"02360",800-865-3384,"VA Facility",Government,no,"Not Available",41.924313,-70.656654
+402-p,"Portland Community Based Outpatient Clinic","144 Fore Street",Portland,ME,"04101","207-623-8411 X 7490 Or 877-421-8263 X 7490","VA Facility",Government,no,"Not Available",43.65423,-70.26246
+608GA,"Portsmouth Outpatient Clinic","Pease International Tradeport 302 Newmarket Street",Portsmouth,NH,"03803","603-624-4366 X 3199","VA Facility",Government,no,"Not Available",43.0718,-70.7626
+523GC,"Quincy Outpatient Clinic","110 West Squantum Street",Quincy,MA,"02169",800-865-3384,"VA Facility",Government,no,"Not Available",42.272617,-71.03133
+402GC,"Rumford Community Based Outpatient Clinic","431 Franklin St.",Rumford,ME,"04726",207-369-3200,"VA Facility",Government,no,"Not Available",44.551373,-70.55676
+405HF,"Rutland Community Based Outpatient Clinic","232 West St.",Rutland,VT,"05701",802-772-2300,"VA Facility",Government,no,"Not Available",43.60715,-72.985634
+402GA,"Saco Community Based Outpatient Clinic","655 Main Street",Saco,ME,"04072","207-623-8411 X 7490 Or 877-421-8263 X 7490","VA Facility",Government,no,"Not Available",43.52166,-70.42791
+608GC,"Somersworth Outpatient Clinic","200 Route 108",Somersworth,NH,"03878","603-624-4366 X 3199","VA Facility",Government,no,"Not Available",43.243023,-70.89857
+631BY,"Springfield Outpatient Clinic","25 Bond Street",Springfield,MA,"01104","413-731-6000 Or 413-731-6000","VA Facility",Government,no,"Not Available",42.110065,-72.60007
+689gb,"Stamford Outpatient Clinic","1275 Summer St, Suite 102",Stamford,CT,"06905",203-325-0649,"VA Facility",Government,no,"Not Available",41.06164,-73.541504
+608HA,"Tilton Outpatient Clinic","630 West Main Street, Suite 400",Tilton,NH,"03276","603-624-4366 X 3199","VA Facility",Government,no,"Not Available",43.447174,-71.62029
+689GA,"Waterbury Outpatient Clinic","95 Scovill Street",Waterbury,CT,"06706",203-465-5292,"VA Facility",Government,no,"Not Available",41.553574,-73.03762
+689GC,"Willimantic Outpatient Clinic","1320 Main Street",Willimantic,CT,"06226",860-450-7583,"VA Facility",Government,no,"Not Available",41.715214,-72.22889
+689GD,"Winsted Outpatient Clinic","115 Spencer Street",Winsted,CT,"06908",860-738-6985,"VA Facility",Government,no,"Not Available",41.930405,-73.07571
+631GE,"Worcester Outpatient Clinic","605 Lincoln Street,",Worcester,MA,"01605","508-856-0104 Or 508-856-0104","VA Facility",Government,no,"Not Available",42.297756,-71.766815
+121,"Bangor Vet Center","615 Odlin Road, Suite 3",Bangor,ME,"04401","207-947-3391 Or 207-947-3391","VA Facility",Government,no,"Not Available",44.78075,-68.82331
+134,"Berlin Vet Center","515 Main Street Suite 2",Gorham,NH,"03581",603-752-2571,"VA Facility",Government,no,"Not Available",44.428604,-71.19247
+0101V,"Boston Vet Center","7 Drydock Ave, Suite 2070",Boston,MA,"02210",857-203-6461,"VA Facility",Government,no,"Not Available",42.34461,-71.03728
+104,"Brockton Vet Center","1041L Pearl St.",Brockton,MA,"02301","508-580-2730 Or 508-580-2730","VA Facility",Government,no,"Not Available",42.055134,-71.06661
+136,"Cape Cod Vet Center","474 West Main Street",Hyannis,MA,"02601","508-778-0124 Or 508-778-0124","VA Facility",Government,no,"Not Available",41.650307,-70.313515
+140,"Danbury Vet Center","457 North Main St., 1st Floor",Danbury,CT,"06811","203-790-4000 Or 203-790-4000","VA Facility",Government,no,"Not Available",41.40501,-73.462845
+117,"Hartford Vet Center","25 Elm Street, Suite A","Rocky Hill",CT,"06067",860-563-8800,"VA Facility",Government,no,"Not Available",41.664818,-72.64043
+1221,"Keene Vet Center Outstation","640 Marlboro Rd. (Route 101)",Keene,NH,"03431","603-358-4950 Or 603-358-4950","VA Facility",Government,no,"Not Available",40.3451,-81.8682
+129,"Lewiston Vet Center","35 Westminster St.",Lewiston,ME,"04240","207-783-0068 Or 207-783-0068","VA Facility",Government,no,"Not Available",44.075405,-70.17508
+125,"Lowell Vet Center","10 George Street, Gateway Center",Lowell,MA,"01852",978-453-1151,"VA Facility",Government,no,"Not Available",42.642513,-71.3062
+108,"Manchester Vet Center","1461 Hooksett Rd., B6",Hooksett,NH,"03106","603-668-7060 Or 603-668-7060","VA Facility",Government,no,"Not Available",43.07247,-71.454254
+128,"New Bedford Vet Center","73 Huttleton Ave., Unit 2",Fairhaven,MA,"02719","508-999-6920 Or 508-999-6920","VA Facility",Government,no,"Not Available",41.6318,-70.8801
+116,"New Haven Vet Center","291 South Lambert Road",Orange,CT,"06477",203-795-0148,"VA Facility",Government,no,"Not Available",41.262207,-73.00565
+119,"Northern Maine Vet Center","456 York Street",Caribou,ME,"04736",207-496-3900,"VA Facility",Government,no,"Not Available",46.9121,-68.0431
+127,"Norwich Vet Center","2 Cliff St.",Norwich,CT,"06360","860-887-1755 Or 860-887-1755","VA Facility",Government,no,"Not Available",41.52734,-72.06744
+115,"Portland Vet Center","475 Stevens Ave.",Portland,ME,"04103",207-780-3584,"VA Facility",Government,no,"Not Available",43.674862,-70.29505
+113,"Providence Vet Center","2038 Warwick Ave",Warwick,RI,"02889",401-739-0167,"VA Facility",Government,no,"Not Available",41.72111,-71.40386
+0100V,"RCS North Atlantic District 1, Zone 1 District Office","15 Dartmouth Drive, Suite 202",Auburn,NH,"03032","603-623-4204 Or 603-623-4204","VA Facility",Government,no,"Not Available",42.2514,-94.8778
+130,"Sanford Vet Center","628 Main Street",Springvale,ME,"04083","207-490-1513 Or 207-490-1513","VA Facility",Government,no,"Not Available",43.455822,-70.79014
+118,"South Burlington Vet Center","19 Gregory Drive Suite 201","South Burlington",VT,"05403",802-862-1806,"VA Facility",Government,no,"Not Available",44.455273,-73.13991
+103,"Springfield Vet Center","95 Ashley Avenue, Suite A","West Springfield",MA,"01089","413-737-5167 Or 413-737-5167","VA Facility",Government,no,"Not Available",42.139397,-72.62382
+122,"White River Junction Vet Center","118 Prospect Street Suite 100","White River Junction",VT,"05001","802-295-2908 Or 802-295-2908","VA Facility",Government,no,"Not Available",43.649,-72.3193
+126,"Worcester Vet Center","255 Park Ave Suite # 900",Worcester,MA,"01609",508-753-7902,"VA Facility",Government,no,"Not Available",42.265556,-71.818665
+10N2,"VISN 2: New York/New Jersey VA Health Care Network","130 W. Kingsbridge Road, Building 16",Bronx,NY,"10468",718-741-4134,"VA Facility",Government,no,"Not Available",40.869125,-73.90309
+620,"VA Hudson Valley Health Care System","2094 Albany Post Rd.",Montrose,NY,"10548",914-737-4400,"VA Facility",Government,no,"Not Available",41.2446,-73.926155
+561,"VA New Jersey Health Care System","385 Tremont Avenue","East Orange",NJ,"07018",973-676-1000,"VA Facility",Government,no,"Not Available",40.753803,-74.23407
+630,"VA NY Harbor Healthcare System","423 East 23rd Street","New York",NY,"10010",,"VA Facility",Government,no,"Not Available",40.73663,-73.97797
+528,"VA Western New York Healthcare System","3495 Bailey Avenue",Buffalo,NY,"14215","716-834-9200 Or 800-532-8387","VA Facility",Government,no,"Not Available",42.953728,-78.813774
+528A8,"Albany VA Medical Center: Samuel S. Stratton","113 Holland Avenue",Albany,NY,"12208","518-626-5000 Or 518-626-5000","VA Facility",Government,no,"Not Available",42.649483,-73.77452
+528A6,"Bath VA Medical Center","76 Veterans Avenue",Bath,NY,"14810","607-664-4000 Or 607-664-4000","VA Facility",Government,no,"Not Available",42.343426,-77.34615
+630A4,"Brooklyn Campus of the VA NY Harbor Healthcare System","800 Poly Place",Brooklyn,NY,"11209",718-836-6600,"VA Facility",Government,no,"Not Available",40.6099,-74.02558
+528A5,"Canandaigua VA Medical Center","400 Fort Hill Avenue",Canandaigua,NY,"14424","585-394-2000 Or 585-394-2000","VA Facility",Government,no,"Not Available",42.90006,-77.27269
+620A4,"Castle Point Campus of the VA Hudson Valley Health Care System","41 Castle Point Road","Wappingers Falls",NY,"12590",845-831-2000,"VA Facility",Government,no,"Not Available",41.539974,-73.95949
+561,"East Orange Campus of the VA New Jersey Health Care System","385 Tremont Avenue","East Orange",NJ,"07018",973-676-1000,"VA Facility",Government,no,"Not Available",40.753803,-74.23407
+620,"Franklin Delano Roosevelt Campus of the VA Hudson Valley Health Care System (Montrose)","2094 Albany Post Rd.",Montrose,NY,"10548",914-737-4400,"VA Facility",Government,no,"Not Available",41.2446,-73.926155
+526,"James J. Peters VA Medical Center (Bronx, NY)","130 West Kingsbridge Road",Bronx,NY,"10468",718-584-9000,"VA Facility",Government,no,"Not Available",40.869102,-73.90305
+561A4,"Lyons Campus of the VA New Jersey Health Care System","151 Knollcroft Road",Lyons,NJ,"07939",908-647-0180,"VA Facility",Government,no,"Not Available",38.9678,-87.0943
+630,"Manhattan Campus of the VA NY Harbor Healthcare System","423 East 23rd Street","New York",NY,"10010",212-686-7500,"VA Facility",Government,no,"Not Available",40.73663,-73.97797
+632,"Northport VA Medical Center","79 Middleville Road",Northport,NY,"11768","631-261-4400 Or 631-261-4400","VA Facility",Government,no,"Not Available",33.229,-87.5772
+528A7,"Syracuse VA Medical Center","800 Irving Avenue",Syracuse,NY,"13210","315-425-4400 Or 315-425-4400","VA Facility",Government,no,"Not Available",43.03934,-76.138054
+528A4,"VA Western New York Healthcare System at Batavia","222 Richmond Avenue",Batavia,NY,"14020",585-297-1000,"VA Facility",Government,no,"Not Available",43.009197,-78.198586
+528,"VA Western New York Healthcare System at Buffalo","3495 Bailey Avenue",Buffalo,NY,"14215","716-834-9200 Or 800-532-8387","VA Facility",Government,no,"Not Available",42.953728,-78.813774
+630A5,"St. Albans Community Living Center","179-00 Linden Blvd. & 179 Street",Jamaica,NY,"11425",718-526-1000,"VA Facility",Government,no,"Not Available",40.6915,-73.8057
+528,"Behavioral Health Facility","620 Erie Blvd West",Syracuse,NY,"13204","315-425-4400 X 53463","VA Facility",Government,no,"Not Available",43.049225,-76.16408
+528G5,"Auburn VA Outpatient Clinic","17 Lansing Street",Auburn,NY,"13021",315-255-7002,"VA Facility",Government,no,"Not Available",42.9408,-76.56385
+528G3,"Bainbridge VA Outpatient Clinic","109 North Main Street",Bainbridge,NY,"13733",607-967-8590,"VA Facility",Government,no,"Not Available",42.300873,-75.47048
+632HC,"Bay Shore Clinic","132 East Main Street","Bay Shore",NY,"11706",631-754-7978,"VA Facility",Government,no,"Not Available",40.723354,-73.24521
+528GN,"Binghamton VA Outpatient Clinic","203 Court Street",Binghamton,NY,"13901",607-772-9100,"VA Facility",Government,no,"Not Available",42.100765,-75.90382
+528,CANI,"19472 US Route 11",Watertown,NY,"13601",315-782-0067,"VA Facility",Government,no,"Not Available",42.3709,-71.1828
+620GB,"Carmel Community Clinic/Putnam County","1875 Route 6, Sterling Bank, (2nd Floor)",Carmel,NY,"10512",845-228-5291,"VA Facility",Government,no,"Not Available",36.5552,-121.9233
+528G7,"Catskill VA Outpatient Clinic","Columbia Greene Medical Arts Building, Suite D305, 159 Jefferson Hgts",Catskill,NY,"12414",518-626-5240,"VA Facility",Government,no,"Not Available",42.2041,-73.9432
+528GY,"Clifton Park VA Outpatient Clinic","963 Route 146","Clifton Park",NY,"12065",518-383-8506,"VA Facility",Government,no,"Not Available",42.868553,-73.80719
+528G4,Coudersport,"24 Maple View Lane, Suite 2",Coudersport,PA,"16915",607-664-4670,"VA Facility",Government,no,"Not Available",41.72552,-78.02134
+528GC,"Dunkirk VA Outpatient Clinic","166 East 4th Street",Dunkirk,NY,"14048",716-203-6474,"VA Facility",Government,no,"Not Available",42.483982,-79.32886
+632GA,"East Meadow Clinic","2201 Hempstead Turnpike, Building Q","East Meadow",NY,"11554",631-754-7978,"VA Facility",Government,no,"Not Available",40.725246,-73.55433
+620GH,"Eastern Dutchess Pine Plains Community Clinic","2881 Church St, Rt 199","Pine Plains",NY,"12567",518-398-9240,"VA Facility",Government,no,"Not Available",41.98078,-73.66126
+561GB,"Elizabeth CBOC","654 East Jersey Street, Suite 2A",Elizabeth,NJ,"07206",908-994-0120,"VA Facility",Government,no,"Not Available",40.658993,-74.19809
+528G4,"Elmira VA Outpatient Clinic","1316 College Avenue",Elmira,NY,"14901",877-845-3247,"VA Facility",Government,no,"Not Available",42.110176,-76.82008
+528G6,"Fonda VA Outpatient Clinic","2623 State Highway 30A",Fonda,NY,"12068",518-853-1247,"VA Facility",Government,no,"Not Available",42.961163,-74.38659
+528GT,"Glens Falls VA Outpatient Clinic","84 Broad St.","Glens Falls",NY,"12801",518-798-6066,"VA Facility",Government,no,"Not Available",43.30542,-73.65568
+620GD,"Goshen Community Clinic","30 Hatfield Lane, Suite 204",Goshen,NY,"10924",845-294-6927,"VA Facility",Government,no,"Not Available",41.39409,-74.33894
+561GD,"Hackensack CBOC","385 Prospect Avenue",Hackensack,NJ,"07601",201-342-4536,"VA Facility",Government,no,"Not Available",40.895733,-74.05201
+561GA,"Hamilton CBOC","3635 Quakerbridge Rd",Hamilton,NJ,"08619",609-570-6600,"VA Facility",Government,no,"Not Available",40.259384,-74.6777
+630GA,"Harlem Community Clinic","55 West 125th Street","New York",NY,"10027",646-273-8125,"VA Facility",Government,no,"Not Available",40.7143,-74.006
+561BZ,"James J. Howard Community Clinic (Brick, NJ)","970 Rt. 70",Brick,NJ,"08724",732-206-8900,"VA Facility",Government,no,"Not Available",40.073112,-74.1277
+528GB,"Jamestown VA Outpatient Clinic","608 West 3rd Street",Jamestown,NY,"14701",716-338-1511,"VA Facility",Government,no,"Not Available",42.0942,-79.254395
+561GE,"Jersey City CBOC","115 Christopher Columbus Drive, Suite #201",Jersey,NJ,"07302",201-435-3055,"VA Facility",Government,no,"Not Available",40.716923,-74.03316
+528GZ,"Kingston VA Outpatient Clinic","324 Plaza Road",Kingston,NY,"12401",845-331-8322,"VA Facility",Government,no,"Not Available",41.927,-73.9974
+528GQ,"Lackawanna VA Outpatient Clinic","1234 Abbott Road",Lackawanna,NY,"14218",716-821-7815,"VA Facility",Government,no,"Not Available",42.83065,-78.80516
+528GK,"Lockport VA Outpatient Clinic","5883 Snyder Drive",Lockport,NY,"14094",716-438-3890,"VA Facility",Government,no,"Not Available",29.616,-90.472
+528GL,"Massena VA Outpatient Clinic","6100 St. Lawrence Centre",Massena,NY,"13662",315-705-6666,"VA Facility",Government,no,"Not Available",44.9281,-74.8919
+620GF,"Monticello Community Clinic","55 Sturgis Road",Monticello,NY,"12701",845-791-4936,"VA Facility",Government,no,"Not Available",41.660187,-74.694954
+561GH,"Morristown CBOC","540 West Hanover Ave",Morristown,NJ,"07960","973-539-9791 Or 973-539-9791","VA Facility",Government,no,"Not Available",40.0631,-81.0743
+620GA,"New City Community Clinic","345 North Main Street, Upper Level","New City",NY,"10956",845-634-8942,"VA Facility",Government,no,"Not Available",41.167606,-73.98805
+528GD,"Niagara Falls VA Outpatient Clinic","2201 Pine Avenue","Niagara Falls",NY,"14301",716-862-8580,"VA Facility",Government,no,"Not Available",43.09509,-79.0356
+528GR,"Olean VA Outpatient Clinic","VA Outpatient Clinic, 465 North Union Street",Olean,NY,"14760",716-373-7709,"VA Facility",Government,no,"Not Available",38.3996,-92.477
+528GP,"Oswego VA Outpatient Clinic","437 State Route 104 E",Oswego,NY,"13126",315-207-0120,"VA Facility",Government,no,"Not Available",43.4554,-76.5105
+632HD,"Patchogue Community Clinic","4 Phyllis Drive",Patchogue,NY,"11772",631-754-7978,"VA Facility",Government,no,"Not Available",40.76871,-72.99638
+561GJ,"Paterson CBOC","11 Getty Avenue, Building #275, St. Joseph's Hospital & Medical Center",Paterson,NJ,"07503",973-247-1666,"VA Facility",Government,no,"Not Available",45.9371,-119.6028
+561GF,"Piscataway CBOC","14 WILLS WAY, BUILDING 5",Piscataway,NJ,"08854",732-981-8193,"VA Facility",Government,no,"Not Available",40.4993,-74.399
+528GV,"Plattsburgh VA Outpatient Clinic","80 Sharron Avenue",Plattsburgh,NY,"12901",518-561-6247,"VA Facility",Government,no,"Not Available",44.677174,-73.45478
+620GE,"Port Jervis Community Clinic","150 Pike St.","Port Jervis",NY,"12771",845-856-5396,"VA Facility",Government,no,"Not Available",41.376755,-74.69058
+620GG,"Poughkeepsie Community Clinic","488 Freedom Plains Rd., Suite 120",Poughkeepsie,NY,"12603",845-452-5151,"VA Facility",Government,no,"Not Available",41.68009,-73.85433
+632HX,"Riverhead Clinic","300 Center Drive",Riverhead,NY,"11901",631-754-7978,"VA Facility",Government,no,"Not Available",40.9539,-72.6465
+528GE,"Rochester VA Outpatient Clinic","465 Westfall Road",Rochester,NY,"14620",585-463-2600,"VA Facility",Government,no,"Not Available",43.114918,-77.60952
+528GM,"Rome - Donald J. Mitchell VA Outpatient Clinic","125 Brookley Road, Building 510",Rome,NY,"13441",315-334-7100,"VA Facility",Government,no,"Not Available",43.21298,-75.418465
+528G2,"Saranac Lake","33 Depot St.","Saranac Lake",NY,"12983",518-626-5237,"VA Facility",Government,no,"Not Available",44.330322,-74.13204
+528GW,"Schenectady VA Outpatient Clinic","1346 Gerling Street, Sheridan Plaza",Schenectady,NY,"12308",518-346-3334,"VA Facility",Government,no,"Not Available",42.823162,-73.90894
+528GQ,Springville,"15 Commerce Drive",Springville,NY,"14141",716-592-2409,"VA Facility",Government,no,"Not Available",42.504112,-78.682884
+132V,"Staten Island Community Clinic","1150 South Ave, 3rd Floor – Suite 301","Staten Island",NY,"10314",718-761-2973,"VA Facility",Government,no,"Not Available",40.61044,-74.17705
+561GK,"Sussex Outpatient Clinic","222 High Street",Newton,NJ,"07860",973-756-1504,"VA Facility",Government,no,"Not Available",41.05696,-74.76037
+526GD,"Thomas B. Noonan Community Clinic (Queens)","47-01 Queens Blvd, Room 301",Sunnyside,NY,"11104",718-741-4800,"VA Facility",Government,no,"Not Available",40.743057,-73.91779
+561GI,"Tinton Falls Community Based Outpatient Clinic","55 Gilbert St","Tinton Falls",NJ,"07701",732-842-4751,"VA Facility",Government,no,"Not Available",40.3257,-74.07658
+528G9,"Tompkins/Cortland County","1451 Dryden Road",Freeville,NY,"13068",607-347-4101,"VA Facility",Government,no,"Not Available",42.4734,-76.395645
+528GX,"Troy VA Outpatient Clinic","295 River Street",Troy,NY,"12180",518-274-7707,"VA Facility",Government,no,"Not Available",42.73243,-73.690384
+632HA,"Valley Stream Clinic","99 South Central Avenue","Valley Stream",NY,"11580",631-754-7978,"VA Facility",Government,no,"Not Available",40.664974,-73.70841
+528,"Watertown VA Outpatient Clinic","144 Eastern Blvd.",Watertown,NY,"13601",315-221-7026,"VA Facility",Government,no,"Not Available",43.968388,-75.88106
+528A5,Wellsboro,"1835 Shumway Hill Road",Wellsboro,PA,"16901","607-664-4680 Or 877-845-3247 X 44680","VA Facility",Government,no,"Not Available",41.737938,-77.26959
+528,"Wellsville VA Outpatient Clinic","3458 Riverside Drive, Route 19",Wellsville,NY,"14895","607-664-4660 Or 607-664-4660","VA Facility",Government,no,"Not Available",42.148464,-77.97374
+528G2,Westport,"7426 NYS Route 9N",Westport,NY,"12993",518-626-5236,"VA Facility",Government,no,"Not Available",41.3089,-73.3637
+526GA,"White Plains Community Clinic","23 South Broadway","White Plains",NY,"10601","914-421-1951 X 4300","VA Facility",Government,no,"Not Available",41.032364,-73.76228
+526GB,"Yonkers Community Clinic","124 New Main St.",Yonkers,NY,"10701","914-375-8055 X 4400","VA Facility",Government,no,"Not Available",40.93349,-73.89745
+111,"Albany Vet Center","17 Computer Drive West",Albany,NY,"12205",518-626-5130,"VA Facility",Government,no,"Not Available",42.72057,-73.8087
+120,"Babylon Vet Center","100 West Main Street",Babylon,NY,"11702","631-661-3930 Or 631-661-3930","VA Facility",Government,no,"Not Available",40.695957,-73.325325
+137,"Binghamton Vet Center","53 Chenango Street",Binghamton,NY,"13901","607-722-2393 Or 607-722-2393","VA Facility",Government,no,"Not Available",42.100487,-75.91025
+112,"Bloomfield Vet Center","2 Broad St. Suite 703",Bloomfield,NJ,"07003","973-748-0980 Or 973-748-0980","VA Facility",Government,no,"Not Available",40.793514,-74.19776
+110,"Bronx Vet Center","2471 Morris Ave., Suite 1A",Bronx,NY,"10468","718-367-3500 Or 718-367-3500","VA Facility",Government,no,"Not Available",40.86264,-73.89976
+0105V,"Brooklyn Vet Center","25 Chapel St. Suite 604",Brooklyn,NY,"11201","718-630-2830 Or 718-630-2830","VA Facility",Government,no,"Not Available",40.697277,-73.98651
+0107V,"Buffalo Vet Center","2372 Sweet Home Road",Amherst,NY,"14228","716-862-7350 Or 716-862-7350","VA Facility",Government,no,"Not Available",43.024666,-78.79905
+133,"Harlem Vet Center","2279 - 3rd Avenue, 2nd Floor","New York",NY,"10035","646-273-8139 Or 646-273-8139","VA Facility",Government,no,"Not Available",40.7143,-74.006
+141,"Lakewood Vet Center","1255 NJ-70 Suite 22N",Lakewood,NJ,"08701","908-607-6364 Or 908-607-6364","VA Facility",Government,no,"Not Available",40.0979,-74.2176
+106,"Manhattan Vet Center","32 Broadway 2nd Floor - Suite 200","New York",NY,"10004","212-951-6866 Or 212-951-6866","VA Facility",Government,no,"Not Available",40.70634,-74.01284
+139,"Middletown Vet Center","726 East Main Street, Suite 203",Middletown,NY,"10940","845-342-9917 Or 845-342-9917","VA Facility",Government,no,"Not Available",41.43988,-74.36706
+0138V,"Nassau Vet Center","970 South Broadway",Hicksville,NY,"11801","516-348-0088 Or 516-348-0088","VA Facility",Government,no,"Not Available",40.7548,-73.6018
+109,"Queens Vet Center","75-10B 91 Avenue",Woodhaven,NY,"11421",718-296-2871,"VA Facility",Government,no,"Not Available",40.685898,-73.86519
+124,"Rochester Vet Center","2000 S. Winton Road, Bldg 5, Ste. 201",Rochester,NY,"14618",585-232-5040,"VA Facility",Government,no,"Not Available",43.107155,-77.57613
+102,"Secaucus Vet Center","110A Meadowlands Parkway, Suite 102",Secaucus,NJ,"07094","201-223-7787 Or 201-223-7787","VA Facility",Government,no,"Not Available",40.78257,-74.077415
+132,"Staten Island Vet Center","60 Bay Street","Staten Island",NY,"10301","718-816-4499 Or 718-816-4499","VA Facility",Government,no,"Not Available",40.64047,-74.07568
+131,"Syracuse Vet Center","109 Pine Street, Suite 101",Syracuse,NY,"13210",315-478-7127,"VA Facility",Government,no,"Not Available",43.050083,-76.129715
+114,"Trenton Vet Center","934 Parkway Ave. Suite 201",Ewing,NJ,"08618","609-882-5744 Or 609-882-5744","VA Facility",Government,no,"Not Available",40.255383,-74.79256
+135,"Watertown Vet Center","210 Court Street, Suite 20",Watertown,NY,"13601","315-782-5479 Or 315-782-5479","VA Facility",Government,no,"Not Available",43.976658,-75.91245
+123,"White Plains Vet Center","300 Hamilton Ave. Suite C","White Plains",NY,"10601",914-682-6250,"VA Facility",Government,no,"Not Available",41.03415,-73.767494
+10N4,"VISN 4: VA Healthcare - VISN 4","323 North Shore Drive, Suite 400",Pittsburgh,PA,"15212",412-822-3316,"VA Facility",Government,no,"Not Available",40.4344,-80.0248
+646,"VA Pittsburgh Healthcare System","University Drive",Pittsburgh,PA,"15240",412-822-2222,"VA Facility",Government,no,"Not Available",40.4344,-80.0248
+503,"Altoona - James E. Van Zandt VA Medical Center","2907 Pleasant Valley Boulevard",Altoona,PA,"16602","814-943-8164 Or 814-943-8164","VA Facility",Government,no,"Not Available",40.48913,-78.39827
+542,"Coatesville VA Medical Center","1400 Black Horse Hill Road",Coatesville,PA,"19320","610-384-7711 Or 610-384-7711","VA Facility",Government,no,"Not Available",39.998657,-75.80052
+562,"Erie VA Medical Center","135 East 38th Street",Erie,PA,"16504","800-274-8387 Or 800-274-8387","VA Facility",Government,no,"Not Available",42.10296,-80.064835
+595,"Lebanon VA Medical Center","1700 South Lincoln Avenue",Lebanon,PA,"17042","717-272-6621 Or 717-272-6621","VA Facility",Government,no,"Not Available",40.312363,-76.40701
+642,"Philadelphia VA Medical Center","3900 Woodland Avenue",Philadelphia,PA,"19104","215-823-5800 Or 215-823-5800","VA Facility",Government,no,"Not Available",39.94543,-75.208595
+529,"VA Butler Health Care Center","353 North Duffy Road",Butler,PA,"16001",800-362-8262,"VA Facility",Government,no,"Not Available",40.888596,-79.9412
+646A4,"VA Pittsburgh Healthcare System, H.J. Heinz Campus","1010 Delafield Road",Pittsburgh,PA,"15215","412-822-2222 Or 866-482-7488","VA Facility",Government,no,"Not Available",40.496925,-79.89144
+646,"VA Pittsburgh Healthcare System, University Drive Campus","University Drive",Pittsburgh,PA,"15240","412-822-2222 Or 866-482-7488","VA Facility",Government,no,"Not Available",40.4344,-80.0248
+693,"Wilkes-Barre VA Medical Center","1111 East End Blvd.",Wilkes-Barre,PA,"18711","570-824-3521 Or 570-824-3521","VA Facility",Government,no,"Not Available",41.249058,-75.833755
+460,"Wilmington VA Medical Center","1601 Kirkwood Highway",Wilmington,DE,"19805","302-994-2511 Or 302-994-2511","VA Facility",Government,no,"Not Available",39.73866,-75.606384
+642GF,"Camden VA Outpatient Clinic","300 Broadway, Suite 103",Camden,NJ,"08104",877-232-5240,"VA Facility",Government,no,"Not Available",44.2098,-69.0648
+642GE,"Philadelphia MultiService Center (Philadelphia County)","213-217 North 4th Street",Philadelphia,PA,"19106",215-923-1163,"VA Facility",Government,no,"Not Available",39.954792,-75.14627
+693B4,"Allentown VA Outpatient Clinic (693B4)","3110 Hamilton Boulevard",Allentown,PA,"18103",610-776-4304,"VA Facility",Government,no,"Not Available",40.58205,-75.51892
+529GC,"Armstrong County VA Outpatient Clinic","11 Hilltop Plaza",Kittanning,PA,"16201",724-545-8420,"VA Facility",Government,no,"Not Available",40.81212,-79.54405
+562GB,"Ashtabula County VA Clinic","2044 Lambros Lane",Ashtabula,OH,"44004",866-463-0912,"VA Facility",Government,no,"Not Available",41.865,-80.7898
+460HE,"Atlantic County CBOC","1909 New Road",Northfield,NJ,"08225","800-461-8262 X 2800","VA Facility",Government,no,"Not Available",39.36886,-74.56026
+646GC,"Beaver County Outpatient Clinic","300 Brighton Ave., Suite 110",Rochester,PA,"15074",724-709-6005,"VA Facility",Government,no,"Not Available",40.701736,-80.28499
+646GA,"Belmont County Outpatient Clinic","103 Plaza Dr. Suite A","St. Clairsville",OH,"43950",740-695-9321,"VA Facility",Government,no,"Not Available",40.07729,-80.91738
+642GA,"Burlington County CBOC","3000 Lincoln Drive East",Marlton,NJ,"08053",844-441-5499,"VA Facility",Government,no,"Not Available",39.913647,-74.94009
+595GA,"Camp Hill VA Clinic (595GA)","25 N. 32nd Street","Camp Hill",PA,"17011",717-730-9782,"VA Facility",Government,no,"Not Available",40.1367,-77.2428
+460GD,"Cape May County CBOC","1 Monro Avenue","Cape May",NJ,"08204","800-461-8262 X 2850","VA Facility",Government,no,"Not Available",38.9351,-74.906
+529GD,"Clarion County VA Outpatient Clinic","56 Clarion Plaza, Suite 115","Monroe Township",PA,"16214",814-226-3900,"VA Facility",Government,no,"Not Available",40.3192,-74.4285
+693GF,"Columbia County Outpatient Clinic","Alley Medical Center, 301 West Third Street",Berwick,PA,"18603",570-759-0351,"VA Facility",Government,no,"Not Available",40.7796,-90.5437
+529GF,"Cranberry Township VA Outpatient Clinic","900 Commonwealth Drive, Suite 900","Cranberry Township",PA,"16066","724-742-3500 Or 724-741-3131","VA Facility",Government,no,"Not Available",0,0
+562GA,"Crawford County Primary Care Clinic","16954 Conneaut Lake Road",Meadville,PA,"16335",866-962-3210,"VA Facility",Government,no,"Not Available",39.7925,-93.2925
+460HG,"Cumberland County CBOC","79 W. Landis Avenue",Vineland,NJ,"08360","800-461-8262 X 6500","VA Facility",Government,no,"Not Available",39.48669,-75.03702
+503GB,"DuBois (Clearfield County) VA Outpatient Clinic (503GB)","5690 Shaffer Road",DuBois,PA,"15801",877-626-2500,"VA Facility",Government,no,"Not Available",43.493,-109.6436
+646GE,"Fayette County Outpatient Clinic","635 Pittsburgh Road",Uniontown,PA,"15401",724-439-4990,"VA Facility",Government,no,"Not Available",39.92053,-79.72622
+503GD,"Huntingdon County CBOC","13903 William Penn Highway","Mapleton Depot",PA,"17052",814-542-2800,"VA Facility",Government,no,"Not Available",40.3198,-77.9785
+503GE,"Indiana County CBOC","1570 Oakland Avenue",Indiana,PA,"15701",724-349-8900,"VA Facility",Government,no,"Not Available",40.61499,-79.171394
+503GA,"Johnstown VA Outpatient Clinic (Cambria County) (503GA)","598 Galleria Drive, Next to Gander Mountain",Johnstown,PA,"15904",877-626-2500,"VA Facility",Government,no,"Not Available",40.303246,-78.83298
+460GC,"Kent County CBOC","1198 S. Governors Avenue, Suite 201",Dover,DE,"19901","800-461-8262 X 2400","VA Facility",Government,no,"Not Available",32.5771,-81.7151
+595GC,"Lancaster VA Clinic (595GC)","1861 Charter Lane, Green Field Corporate Center, Suite 120",Lancaster,PA,"17601",717-290-6900,"VA Facility",Government,no,"Not Available",40.052605,-76.25084
+529GB,"Lawrence County VA Outpatient Clinic","Ridgewood Professional Centre, 1750 New Butler Road","New Castle",PA,"16101",724-598-6080,"VA Facility",Government,no,"Not Available",39.6621,-75.5663
+562GC,"McKean County Primary Care Clinic","23 Kennedy Street",Bradford,PA,"16701",814-368-3019,"VA Facility",Government,no,"Not Available",41.95659,-78.64741
+529GA,"Mercer County VA Outpatient Clinic","295 N. Kerrwood Drive, Suite 110",Hermitage,PA,"16148",724-346-1569,"VA Facility",Government,no,"Not Available",41.237286,-80.46313
+693GG,"Northampton County Outpatient Clinic","Phoebe Slate Belt Nursing Home & Rehab Center 701 Slate Belt Boulevard",Bangor,PA,"18013",610-599-0127,"VA Facility",Government,no,"Not Available",40.8657,-75.2066
+595GF,"Pottsville VA Clinic (595GF)","1410 Laurel Blvd., Suite 2",Pottsville,PA,"17901",570-628-5374,"VA Facility",Government,no,"Not Available",40.68376,-76.211494
+595GD,"Reading VA Clinic (595GD)","2762 Century Boulevard",Wyomissing,PA,"19610",484-220-2572,"VA Facility",Government,no,"Not Available",0,0
+693GA,"Sayre VA Outpatient Clinic (693GA)","1537 Elmira Street",Sayre,PA,"18840",570-888-6803,"VA Facility",Government,no,"Not Available",41.974503,-76.540665
+542GE,"Spring City VA Outpatient Clinic (542GE)","11 Independence Drive","Spring City",PA,"19475",610-383-0239,"VA Facility",Government,no,"Not Available",40.187653,-75.565445
+542GA,"Springfield VA Outpatient Clinic (542GA)","Crozer Keystone Healthplex 194 W. Sproul Road, Suite 105",Springfield,PA,"19064",610-383-0239,"VA Facility",Government,no,"Not Available",39.7495,-89.606
+503GC,"State College (Centre County) VA Outpatient Clinic (503GC)","2581 Clyde Avenue","State College",PA,"16801",877-626-2500,"VA Facility",Government,no,"Not Available",40.82724,-77.804794
+460GA,"Sussex County CBOC","21748 Roth Ave",Georgetown,DE,"19947","800-461-8262 X 2300","VA Facility",Government,no,"Not Available",39.9376,-76.0833
+693GC,"Tobyhanna Army Depot (693GC)","Building 220",Tobyhanna,PA,"18466",570-615-8341,"VA Facility",Government,no,"Not Available",41.188,-75.3804
+562GD,"Venango County VA Clinic","464 Allegheny Boulevard",Franklin,PA,"16323",866-962-3260,"VA Facility",Government,no,"Not Available",41.401962,-79.80932
+642GD,"Veterans Health Clinic at Gloucester County (642GD)","211 County House Road",Sewell,NJ,"08080","877-823-5230 Or 877-823-5230","VA Facility",Government,no,"Not Available",39.778458,-75.102425
+642GC,"Victor J. Saracini VA Outpatient Clinic (Montgomery County)","433 Caredean Dr.",Horsham,PA,"19044",215-823-6050,"VA Facility",Government,no,"Not Available",40.202858,-75.175896
+562GE,"Warren CBOC","3 Farm Colony Dr",Warren,PA,"16365",866-682-3250,"VA Facility",Government,no,"Not Available",41.832176,-79.14865
+646GD,"Washington County Outpatient Clinic","1500 West Chestnut St., Room 450",Washington,PA,"15301",724-250-7790,"VA Facility",Government,no,"Not Available",40.164463,-80.274345
+693QA,"Wayne County Outpatient Clinic","600 Maple Ave. Suite 2",Honesdale,PA,"18431",570-251-6543,"VA Facility",Government,no,"Not Available",41.6294,-75.2424
+646GB,"Westmoreland County Outpatient Clinic","5274 Rt 30 East, Suite 10",Greensburg,PA,"15601",724-216-0317,"VA Facility",Government,no,"Not Available",40.3015,-79.5389
+693GB,"Williamsport OPC, Campus of Divine Providence Hospital (693GB)","1705 Warren Avenue, Werner Building - 3rd Floor (Suite 304)",Williamsport,PA,"17701",570-322-4791,"VA Facility",Government,no,"Not Available",41.260082,-76.98141
+595GE,"York VA Clinic (595GE)","2251 Eastern Blvd.",York,PA,"17402",717-840-2730,"VA Facility",Government,no,"Not Available",39.9719,-76.6848
+238,"Bucks County Vet Center","2 Canal's End Road, Suite 201B",Bristol,PA,"19007","215-823-4590 Or 215-823-4590","VA Facility",Government,no,"Not Available",39.2879,-80.524
+227,"DuBois Vet Center","100 Meadow Lane, Suite 8",DuBois,PA,"15801",814-372-2095,"VA Facility",Government,no,"Not Available",43.493,-109.6436
+0222V,"Erie Vet Center","240 W. 11th St., Erie Metro Center, Suite 105",Erie,PA,"16501","814-453-7955 Or 814-453-7955","VA Facility",Government,no,"Not Available",42.12275,-80.0867
+0218V,"Harrisburg Vet Center","1500 N. Second Street Suite 2",Harrisburg,PA,"17102","717-782-3954 Or 717-782-3954","VA Facility",Government,no,"Not Available",40.27054,-76.89296
+242,"Lancaster County Vet Center","1817 Olde Homestead Lane, Suite 207",Lancaster,PA,"17601","717-283-0735 Or 717-283-0735","VA Facility",Government,no,"Not Available",38.5478,-87.8653
+0239V,"Norristown Vet Center","320 E. Johnson Hwy, Suite 201",Norristown,PA,"19401","215-823-5245 Or 877-927-8387","VA Facility",Government,no,"Not Available",40.128048,-75.32217
+0219V,"Northeast Philadelphia Vet Center","101 E. Olney Avenue",Philadelphia,PA,"19120","215-924-4670 Or 215-924-4670","VA Facility",Government,no,"Not Available",40.035076,-75.11968
+210,"Philadelphia Vet Center","801 Arch Street Suite 502",Philadelphia,PA,"19107","215-627-0238 Or 215-627-0238","VA Facility",Government,no,"Not Available",39.95318,-75.15322
+0211V,"Pittsburgh Vet Center","2500 Baldwick Rd, Suite 15",Pittsburgh,PA,"15205","412-920-1765 Or 412-920-1765","VA Facility",Government,no,"Not Available",40.426678,-80.05733
+0229V,"Scranton Vet Center","1002 Pittston Ave.",Scranton,PA,"18505","570-344-2676 Or 570-344-2676","VA Facility",Government,no,"Not Available",41.395813,-75.6689
+243V,"Sussex County Vet Center","20653 Dupont Blvd, Suite 1",Georgetown,DE,"19947","302-225-9110 Or 302-225-9110","VA Facility",Government,no,"Not Available",39.9376,-76.0833
+0230V,"Ventnor Vet Center","6601 Ventnor Ave. Suite 105, Ventnor Professional Plaza",Ventnor,NJ,"08406",609-487-8387,"VA Facility",Government,no,"Not Available",39.337135,-74.484406
+0220V,"White Oak Vet Center","2001 Lincoln Way, Suite 21","White Oak",PA,"15131","412-678-7704 Or 412-678-7704","VA Facility",Government,no,"Not Available",40.337463,-79.80879
+0212V,"Williamsport Vet Center","49 E. Fourth Street Suite 104",Williamsport,PA,"17701","570-327-5281 Or 570-327-5281","VA Facility",Government,no,"Not Available",41.242813,-77.00096
+0215V,"Wilmington Vet Center","2710 Centerville Road, Suite 103",Wilmington,DE,"19808","302-994-1660 Or 302-994-1660","VA Facility",Government,no,"Not Available",39.75347,-75.62461
+10N5,"VISN 5: VA Capitol Health Care Network","849 International Drive, Suite 275",Linthicum,MD,"21090",410-691-1131,"VA Facility",Government,no,"Not Available",39.206387,-76.674095
+58101,"Homeless Veterans Resource Center (Huntington, WV)","624 9th Street",Huntington,WV,"25701",304-529-9142,"VA Facility",Government,no,"Not Available",38.417686,-82.44307
+512,"VA Maryland Health Care System","10 North Greene Street",Baltimore,MD,"21201",410-605-7000,"VA Facility",Government,no,"Not Available",39.28936,-76.623726
+512,"Baltimore VA Medical Center - VA Maryland Health Care System","10 North Greene Street",Baltimore,MD,"21201","410-605-7000 Or 410-605-7000","VA Facility",Government,no,"Not Available",39.28936,-76.623726
+517,"Beckley VA Medical Center","200 Veterans Avenue",Beckley,WV,"25801","304-255-2121 Or 304-255-2121","VA Facility",Government,no,"Not Available",37.7782,-81.1882
+540,"Clarksburg - Louis A. Johnson VA Medical Center","One Medical Center Drive",Clarksburg,WV,"26301","304-623-3461 Or 800-733-0512","VA Facility",Government,no,"Not Available",40.1887,-74.4407
+581,"Huntington VA Medical Center","1540 Spring Valley Drive",Huntington,WV,"25704",304-429-6741,"VA Facility",Government,no,"Not Available",38.384087,-82.51794
+512GB,"Loch Raven VA Medical Center - VA Maryland Health Care System","3900 Loch Raven Boulevard",Baltimore,MD,"21218","410-605-7000 Or 410-605-7000","VA Facility",Government,no,"Not Available",39.33639,-76.59441
+613,"Martinsburg VA Medical Center","510 Butler Avenue",Martinsburg,WV,"25405","304-263-0811 Or 800-817-3807","VA Facility",Government,no,"Not Available",39.4139,-77.9135
+512A5,"Perry Point VA Medical Center - VA Maryland Health Care System","VA Medical Center","Perry Point",MD,"21902","410-642-2411 Or 410-642-2411","VA Facility",Government,no,"Not Available",39.5543,-76.0719
+688,"Washington DC VA Medical Center","50 Irving Street, NW",Washington,DC,"20422",202-745-8000,"VA Facility",Government,no,"Not Available",38.931225,-77.012024
+581,"Gallipolis VA Clinic","323A Upper River Road",Gallipolis,OH,"45631",740-446-3934,"VA Facility",Government,no,"Not Available",38.83184,-82.15734
+581,"Lenore VA Clinic","2867 Route 65",Lenore,WV,"25676",304-475-3000,"VA Facility",Government,no,"Not Available",37.799,-82.2868
+512AX,"Baltimore VA Annex","209 West Fayette Street",Baltimore,MD,"21201","410-605-7000 Or 800-463-6295","VA Facility",Government,no,"Not Available",39.290485,-76.61795
+540GC,"Braxton County CBOC (540GC)","40 Reston Place",Gassaway,WV,"26624",304-364-4500,"VA Facility",Government,no,"Not Available",38.7257,-80.8036
+512GA,"Cambridge VA Outpatient Clinic","830 Chesapeake Drive",Cambridge,MD,"21613","410-228-6243 Or 877-864-9611","VA Facility",Government,no,"Not Available",38.553482,-76.060234
+581GB,"Charleston VA Clinic","700 Technology Drive","South Charleston",WV,"25309",304-746-5300,"VA Facility",Government,no,"Not Available",39.837,-83.6654
+688GB,"Community Clinic-Southeast","820 Chesapeake Street, S.E.",Washington,DC,"20032",202-745-8685,"VA Facility",Government,no,"Not Available",38.829216,-76.993225
+688GG,"Community Resource and Referral Center (CRRC)","1500 Franklin St., NE",Washington,DC,"20018",202-636-7660,"VA Facility",Government,no,"Not Available",38.925674,-76.98309
+613GA,"Cumberland Outpatient Clinic","200 Glenn Street",Cumberland,MD,"21502","304-263-0811 X 5130","VA Facility",Government,no,"Not Available",39.653942,-78.75825
+512GF,"Eastern Baltimore County VA Outpatient Clinic","5253 King Avenue",Rosedale,MD,"21237","410-477-1800 Or 410-477-1800","VA Facility",Government,no,"Not Available",39.35733,-76.46929
+688,"Fort Belvoir Outpatient Clinic","9300 DeWitt Loop Sunrise Pavilion","Fort Belvoir",VA,"22060",571-231-2408,"VA Facility",Government,no,"Not Available",38.711,-77.1621
+613GG,"Fort Detrick VA Outpatient Clinic","1433 Porter Street",Frederick,MD,"21702","304-263-0811 X 5130","VA Facility",Government,no,"Not Available",40.0701,-90.429
+6192,"Fort Meade VA Outpatient Clinic","2479 5th Street","Fort Meade",MD,"20755",410-305-5300,"VA Facility",Government,no,"Not Available",44.4096,-103.475
+613GD,"Franklin Community Based Outpatient Clinic","91 Pine Street",Franklin,WV,"26807","304-263-0811 X 5130","VA Facility",Government,no,"Not Available",39.559,-84.3041
+512GC,"Glen Burnie VA Outpatient Clinic","808 Landmark Drive, Suite 128","Glen Burnie",MD,"21061",410-590-4140,"VA Facility",Government,no,"Not Available",39.1484,-76.642006
+517GB,"Greenbrier County VA Clinic","228 Shamrock Lane",Ronceverte,WV,"24970",304-497-3900,"VA Facility",Government,no,"Not Available",37.7329,-80.4649
+613GB,"Hagerstown Outpatient Clinic","Hub Plaza Bldg, 1101 Opal Ct",Hagerstown,MD,"21742","304-263-0811 X 5130","VA Facility",Government,no,"Not Available",39.6418,-77.72
+613GF,"Harrisonburg Outpatient Clinic","1755 S. High Street",Harrisonburg,VA,"22801","304-263-0811 X 5130 Or 800-817-3807 X 5130","VA Facility",Government,no,"Not Available",38.432823,-78.90089
+512GD,"Loch Raven VA Outpatient Clinic","3901 The Alameda",Baltimore,MD,"21218","410-605-7650 Or 410-605-7650","VA Facility",Government,no,"Not Available",39.2904,-76.6122
+540GD,"Monongalia County (540GD)","40 Commerce Drive, Suite 101",Westover,WV,"26501",304-292-7535,"VA Facility",Government,no,"Not Available",39.6001,-75.9369
+613GE,"Petersburg Community Based Outpatient Clinic","15 Grant St.",Petersburg,WV,"26847","304-263-0811 X 5130","VA Facility",Government,no,"Not Available",38.99487,-79.11806
+512GE,"Pocomoke City VA Outpatient Clinic","1701 Market Street, Unit 211",Pocomoke,MD,"21851","410-957-6718 Or 866-441-0287","VA Facility",Government,no,"Not Available",0,0
+581GA,"Prestonsburg VA Clinic","5230 KY RT 321",Prestonsburg,KY,"41653",606-886-1970,"VA Facility",Government,no,"Not Available",37.6656,-82.7716
+517QA,"Princeton VA Clinic","1511 North Walker Street",Princeton,WV,"24740","304-255-2121 X 3404","VA Facility",Government,no,"Not Available",37.367912,-81.10203
+540,"Rural Mobile Unit (540)","1 Medical Center Drive",Clarksburg,WV,"26301",304-623-3461,"VA Facility",Government,no,"Not Available",39.269535,-80.36269
+688GD,"Southern Maryland VA Outpatient Clinic","29431 Charlotte Hall Road","Charlotte Hall",MD,"20622",301-884-7102,"VA Facility",Government,no,"Not Available",38.47783,-76.77777
+688,"Southern PG County Outpatient Clinic","5801 Allentown Road","Camp Springs",MD,"20746",301-423-3700,"VA Facility",Government,no,"Not Available",38.8073,-76.89988
+613GC,"Stephens City Outpatient Clinic","170 Prosperity Drive",Winchester,VA,"22602","304-263-0811 X 5130","VA Facility",Government,no,"Not Available",42.7734,-72.3831
+540GA,"Tucker County CBOC (540GA)","260 Spruce Street",Parsons,WV,"26287",304-478-2219,"VA Facility",Government,no,"Not Available",39.096973,-79.683685
+540GB,"Wood County CBOC (540GB)","2311 Ohio Avenue, Suite A",Parkersburg,WV,"26101",304-422-5114,"VA Facility",Government,no,"Not Available",39.282536,-81.549706
+2092,"Aberdeen Vet Center Outstation","223 W. Bel Air Avenue",Aberdeen,MD,"21001","410-272-6771 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.510605,-76.16716
+0228V,"Alexandria Vet Center","6940 South Kings Highway #204",Alexandria,VA,"22310","703-360-8633 Or 703-360-8633","VA Facility",Government,no,"Not Available",38.768433,-77.11709
+0235V,"Annapolis Vet Center","100 Annapolis Street",Annapolis,MD,"21401","410-605-7826 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.990086,-76.50218
+0201V,"Baltimore Vet Center","1777 Reisterstown Road Suite 199",Baltimore,MD,"21208","410-764-9400 Or 410-764-9400","VA Facility",Government,no,"Not Available",39.383865,-76.73311
+0231V,"Beckley Vet Center","1000 Johnstown Road",Beckley,WV,"25801","304-252-8220 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.780453,-81.16978
+0223V,"Charleston Vet Center","200 Tracy Way",Charleston,WV,"25311","304-343-3825 Or 304-343-3825","VA Facility",Government,no,"Not Available",38.35907,-81.59911
+0237V,"Clinton Vet Center","7905 Malcolm Road, Suite 101",Clinton,MD,"20735","301-856-7173 Or 301-856-7173","VA Facility",Government,no,"Not Available",38.782055,-76.889824
+0236V,"Dundalk Vet Center","1553 Merritt Blvd",Dundalk,MD,"21222","410-282-6144 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.27272,-76.5025
+209,"Elkton Vet Center","103 Chesapeake Blvd. Suite A",Elkton,MD,"21921","410-392-4485 Or 410-392-4485","VA Facility",Government,no,"Not Available",36.81,-87.1542
+0208V,"Huntington Vet Center","3135 16th Street Road Suite 11",Huntington,WV,"25701","304-523-8387 Or 304-523-8387","VA Facility",Government,no,"Not Available",38.39435,-82.40953
+02231V,"Logan Vet Center Outstation","21 Veterans Avenue",Henlawson,WV,"25624","304-752-4453 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.9023,-81.9882
+224,"Martinsburg Vet Center","300 Foxcroft Ave. Suite 100A",Martinsburg,WV,"25401","304-263-6776 Or 304-263-6776","VA Facility",Government,no,"Not Available",39.462715,-77.986916
+0216V,"Morgantown Vet Center","34 Commerce Drive, Suite 101",Morgantown,WV,"26501","304-291-4303 Or 304-291-4303","VA Facility",Government,no,"Not Available",39.6295,-79.9559
+2081,"Parkersburg Vet Center Outstation","2311 Ohio Avenue, Suite D",Pakersburg,WV,"26101","304-485-1599 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.282536,-81.549706
+0232V,"Princeton Vet Center","1511 North Walker Street",Princeton,WV,"24740",304-425-8098,"VA Facility",Government,no,"Not Available",37.367912,-81.10203
+0200V,"RCS North Atlantic District 1","305 W. Chesapeake Ave., Suite 300",Towson,MD,"21204","410-828-6619 Or 410-828-6619","VA Facility",Government,no,"Not Available",39.40007,-76.60994
+2091,"Salisbury Outstation","926 Snow Hill Road, Building 3",Salisbury,MD,"21804","410-912-7263 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.34735,-75.58189
+0213V,"Silver Spring Vet Center","2900 Linden Lane","Silver Spring",MD,"20910","301-589-1073 Or 301-589-1073","VA Facility",Government,no,"Not Available",39.014156,-77.05791
+213,"Washington DC Vet Center","1296 Upshur St NW",Washington,DC,"20011","202-726-5212 Or 202-463-0943","VA Facility",Government,no,"Not Available",38.941853,-77.029495
+233,"Wheeling Vet Center","1058 Bethlehem Blvd.",Wheeling,WV,"26003","304-232-0587 Or 304-232-0587","VA Facility",Government,no,"Not Available",40.053024,-80.701645
+10N6,"VISN 6: VA Mid-Atlantic Health Care Network","3518 Westgate Drive",Durham,NC,"27707",919-956-5541,"VA Facility",Government,no,"Not Available",35.968067,-78.96135
+637,"Asheville VA Medical Center","1100 Tunnel Road",Asheville,NC,"28805",828-298-7911,"VA Facility",Government,no,"Not Available",35.586716,-82.48251
+558,"Durham VA Medical Center","508 Fulton Street",Durham,NC,"27705","919-286-0411 Or 919-286-0411","VA Facility",Government,no,"Not Available",36.008934,-78.937294
+565,"Fayetteville VA Medical Center","2300 Ramsey Street",Fayetteville,NC,"28301","910-488-2120 Or 910-488-2120","VA Facility",Government,no,"Not Available",35.089222,-78.87833
+590,"Hampton VA Medical Center","100 Emancipation Drive",Hampton,VA,"23667",757-722-9961,"VA Facility",Government,no,"Not Available",37.0225,-76.330826
+652,"Hunter Holmes McGuire VA Medical Center","1201 Broad Rock Boulevard",Richmond,VA,"23249",804-675-5000,"VA Facility",Government,no,"Not Available",37.5538,-77.4603
+658,"Salem VA Medical Center","1970 Roanoke Boulevard",Salem,VA,"24153","540-982-2463 Or 888-982-2463","VA Facility",Government,no,"Not Available",37.276184,-80.02463
+659,"Salisbury - W.G. (Bill) Hefner VA Medical Center","1601 Brenner Avenue",Salisbury,NC,"28144","704-638-9000 Or 704-638-9000","VA Facility",Government,no,"Not Available",35.683815,-80.48607
+558,"Blind Rehabilitation Outpatient Clinic","8081 Arco Corporate Drive",Raleigh,NC,"27617",919-286-5235,"VA Facility",Government,no,"Not Available",35.7721,-78.6386
+558,"Brier Creek Dialysis Clinic","8081 Arco Corporate Drive, Suite 130",Raleigh,NC,"27617",919-286-5220,"VA Facility",Government,no,"Not Available",35.7721,-78.6386
+565,"Fayetteville Dialysis Clinic","2301 Robeson Street",Fayetteville,NC,"28305",910-483-9727,"VA Facility",Government,no,"Not Available",35.042355,-78.91646
+565GL,"Fayetteville Health Care Center","7300 South Raeford Road",Fayetteville,NC,"28304","910-488-2120 Or 800-771-6106","VA Facility",Government,no,"Not Available",35.033398,-79.03128
+565QD,"Fayetteville Rehabilitation Clinic","4101 Raeford Road, Suite 100-B",Fayetteville,NC,"28304",910-908-2222,"VA Facility",Government,no,"Not Available",35.0437,-78.947235
+558GA,"Greenville Health Care Center","401 Moye Blvd",Greenville,NC,"27834",252-830-2149,"VA Facility",Government,no,"Not Available",35.613003,-77.40099
+637GC,"Hickory CBOC","2440 Century Place SE",Hickory,NC,"28602",828-431-5600,"VA Facility",Government,no,"Not Available",35.7332,-81.3412
+590,"Albemarle Primary OPC","1845 W City Dr","Elizabeth City",NC,"27909",757-722-9961,"VA Facility",Government,no,"Not Available",36.2946,-76.2511
+565,"Brunswick County","18 Doctors Circle (Units 2 & 3)",Supply,NC,"28462",910-754-6141,"VA Facility",Government,no,"Not Available",34.0245,-78.2942
+659GA,"Charlotte CBOC","8601 University East Drive",Charlotte,NC,"28213",704-597-3500,"VA Facility",Government,no,"Not Available",35.2271,-80.8431
+659BZ,"Charlotte Health Care Center","3506 West Tyvola Road",Charlotte,NC,"28208",704-329-1300,"VA Facility",Government,no,"Not Available",35.20241,-80.91191
+652,"Charlottesville CBOC","590 Peter Jefferson Pkwy, 2nd Floor, Suite 250",Charlottesville,VA,"22911",434-293-3890,"VA Facility",Government,no,"Not Available",38.023098,-78.43744
+590GD,"Chesapeake CBOC","1987 S. Military Hwy",Chesapeake,VA,"23320",757-722-9961,"VA Facility",Government,no,"Not Available",36.783978,-76.25732
+658GB,"Danville CBOC","705 Piney Forest Rd",Danville,VA,"24540",434-710-4210,"VA Facility",Government,no,"Not Available",36.61081,-79.4059
+558,"Durham Clinic","1824 Hillandale Road",Durham,NC,"27705",919-383-6107,"VA Facility",Government,no,"Not Available",36.028954,-78.93582
+652GF,"Emporia CBOC","1746 East Atlantic",Emporia,VA,"23847",434-348-1055,"VA Facility",Government,no,"Not Available",36.68982,-77.52629
+637,"Franklin CBOC","647 Wayah St",Franklin,NC,"28734",828-369-1781,"VA Facility",Government,no,"Not Available",35.17557,-83.37493
+652gb,"Fredericksburg at Southpoint CBOC","10401 Spotsylvania Ave., Suite 300",Fredericksburg,VA,"22408",540-693-3140,"VA Facility",Government,no,"Not Available",38.3032,-77.4605
+652GA,"Fredericksburg CBOC","130 Executive Center Parkway",Fredericksburg,VA,"22401",540-370-4468,"VA Facility",Government,no,"Not Available",38.3032,-77.4605
+565GF,"Goldsboro Community Based Outpatient Clinic","2610 Hospital Road",Goldsboro,NC,"27534",919-731-4809,"VA Facility",Government,no,"Not Available",32.0443,-99.6843
+565GD,"Hamlet CBOC","100 Jefferson Street",Hamlet,NC,"28345",910-582-3536,"VA Facility",Government,no,"Not Available",34.885742,-79.70201
+558,"Hillandale Road Outpatient Clinics 1 & II","1824 Hillandale Road",Durham,NC,"27705",919-383-6107,"VA Facility",Government,no,"Not Available",36.028954,-78.93582
+565GA,"Jacksonville CBOC","4006 Henderson Drive",Jacksonville,NC,"28546",910-353-6406,"VA Facility",Government,no,"Not Available",33.8137,-85.7613
+659BY,"Kernersville Health Care Center","1695 Kernersville Medical Parkway",Kernersville,NC,"27284",336-515-5000,"VA Facility",Government,no,"Not Available",36.1199,-80.0737
+658,"Lynchburg CBOC","1600 Lakeside Dr",Lynchburg,VA,"24501",434-316-5000,"VA Facility",Government,no,"Not Available",37.40173,-79.18849
+558,"Morehead City CBOC","5420 Highway 70","Morehead City",NC,"28557",252-240-2349,"VA Facility",Government,no,"Not Available",34.7386,-76.7677
+558,"Raleigh CBOC","3305 Sungate Blvd",Raleigh,NC,"27610",919-212-0129,"VA Facility",Government,no,"Not Available",35.7721,-78.6386
+558,"Raleigh II CBOC","3040 Hammond Business Place Suite 105",Raleigh,NC,"27603",919-899-6259,"VA Facility",Government,no,"Not Available",35.7721,-78.6386
+558GG,"Raleigh III CBOC","2600 Atlantic Ave., Suite 200",Raleigh,NC,"27604",919-755-2620,"VA Facility",Government,no,"Not Available",35.82258,-78.60943
+558GG,"Raleigh III Clinic","2600 Atlantic Ave., Ste. 200",Raleigh,NC,"27604",919-755-2620,"VA Facility",Government,no,"Not Available",35.82258,-78.60943
+"565 GE","Robeson County CBOC","139 Three Hunts Drive",Pembroke,NC,"28372",910-272-3220,"VA Facility",Government,no,"Not Available",32.1363,-81.6235
+637GB,"Rutherford County CBOC","374 Charlotte Road",Rutherfordton,NC,"28139",828-288-2780,"VA Facility",Government,no,"Not Available",35.3404,-82.0261
+565GG,"Sanford CBOC","3112 Tramway Road",Sanford,NC,"27332",919-775-6160,"VA Facility",Government,no,"Not Available",35.43814,-79.2131
+658GD,"Staunton CBOC","102 Lacy B. King Way",Staunton,VA,"24401",540-886-5777,"VA Facility",Government,no,"Not Available",39.4875,-87.1889
+658GA,"Tazewell VA Clinic","388 Ben Bolt Ave",Tazewell,VA,"24651",276-988-8860,"VA Facility",Government,no,"Not Available",37.0595,-81.522
+590,"Virginia Beach CBOC","244 Clearfield Ave","Virginia Beach",VA,"23462",757-722-9961,"VA Facility",Government,no,"Not Available",36.8439,-76.1424
+565GC,"Wilmington HCC","1705 Gardner Road",Wilmington,NC,"28405",910-343-5300,"VA Facility",Government,no,"Not Available",39.4453,-83.8285
+658GE,"Wytheville CBOC","165 Peppers Ferry Road",Wytheville,VA,"24382",276-223-5400,"VA Facility",Government,no,"Not Available",36.9498,-81.1289
+0317V,"Charlotte Vet Center","2114 Ben Craig Dr., Suite 300",Charlotte,NC,"28262","704-549-8025 Or 877-927-8387","VA Facility",Government,no,"Not Available",35.2271,-80.8431
+0315V,"Fayetteville Vet Center","2301 Robeson St. Suite 103",Fayetteville,NC,"28305","910-488-6252 Or 910-488-6252","VA Facility",Government,no,"Not Available",35.042355,-78.91646
+327,"Greensboro Vet Center","3515 W Market St., Suite 120",Greensboro,NC,"27406","336-323-2660 Or 877-927-8387","VA Facility",Government,no,"Not Available",36.0726,-79.792
+0319V,"Greenville, NC Vet Center","1021 WH Smith Blvd., Suite #100",Greenville,NC,"27834","252-355-7920 Or 252-355-7920","VA Facility",Government,no,"Not Available",34.8526,-82.394
+0343V,"Jacksonville Vet Center","110A Branchwood Dr",Jacksonville,NC,"28546","910-577-1100 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.8137,-85.7613
+0207V,"Norfolk Vet Center","1711 Church Street, Suites A&B",Norfolk,VA,"23504","757-623-7584 Or 877-927-8387","VA Facility",Government,no,"Not Available",36.8468,-76.2852
+0328V,"Raleigh Vet Center","8851 Ellstree Lane, Suite 122",Raleigh,NC,"27617","919-361-6419 Or 877-927-8387","VA Facility",Government,no,"Not Available",35.7721,-78.6386
+0217V,"Richmond Vet Center","4902 Fitzhugh Avenue",Richmond,VA,"23230","804-353-8958 Or 804-353-8958","VA Facility",Government,no,"Not Available",37.579716,-77.495415
+226,"Roanoke Vet Center","350 Albemarle Ave., SW",Roanoke,VA,"24016","540-342-9726 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.263206,-79.94751
+3271,"Rutherford Vet Center Outstation","303 Fairground Road",Spindale,NC,"28160","828-288-2757 Or 828-288-2757","VA Facility",Government,no,"Not Available",35.3586,-81.9238
+0240V,"Virginia Beach Vet Center","324 Southport Circle, Suite 102","Virginia Beach",VA,"23452","757-248-3665 Or 757-248-3665","VA Facility",Government,no,"Not Available",36.831814,-76.13131
+0315V,"Fayetteville (NC) Vet Center","2301 Robeson St., Suite 103",Fayetteville,NC,"28305","910-488-6252 Or 800-771-6106 X 7701","VA Facility",Government,no,"Not Available",35.042355,-78.91646
+0343V,"Jacksonville Vet Center","110A Branchwood Dr",Jacksonville,NC,"28345","910-577-1100 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.8137,-85.7613
+10N7,"VISN 7: VA Southeast Network","3700 Crestwood Parkway, NW, Suite 500",Duluth,GA,"30096",678-924-5700,"VA Facility",Government,no,"Not Available",33.94617,-84.13016
+508,"Atlanta VA Health Care System","1670 Clairmont Road",Decatur,GA,"30033",404-321-6111,"VA Facility",Government,no,"Not Available",33.8016,-84.30972
+521,"Birmingham VA Medical Center","700 S. 19th Street",Birmingham,AL,"35233",205-933-8101,"VA Facility",Government,no,"Not Available",33.511967,-86.89478
+557,"Carl Vinson VA Medical Center","1826 Veterans Blvd.",Dublin,GA,"31021",478-272-1210,"VA Facility",Government,no,"Not Available",32.54052,-82.94631
+619A4,"Central Alabama Veterans Health Care System East Campus","2400 Hospital Road",Tuskegee,AL,"36083","334-727-0550 Or 334-727-0550","VA Facility",Government,no,"Not Available",32.3807,-85.6808
+619,"Central Alabama Veterans Health Care System West Campus","215 Perry Hill Road",Montgomery,AL,"36109","334-272-4670 Or 334-272-4670","VA Facility",Government,no,"Not Available",32.37902,-86.246376
+509,"Charlie Norwood VA Medical Center","1 Freedom Way",Augusta,GA,"30904","706-733-0188 Or 706-733-0188","VA Facility",Government,no,"Not Available",33.468346,-82.02534
+534,"Ralph H. Johnson VA Medical Center","109 Bee Street",Charleston,SC,"29401","843-577-5011 Or 843-577-5011","VA Facility",Government,no,"Not Available",32.785133,-79.95385
+679,"Tuscaloosa VA Medical Center","3701 Loop Road, East",Tuscaloosa,AL,"35404","205-554-2000 Or 205-554-2000","VA Facility",Government,no,"Not Available",33.19277,-87.48909
+544,"Wm. Jennings Bryan Dorn VA Medical Center","6439 Garners Ferry Road",Columbia,SC,"29209",803-776-4000,"VA Facility",Government,no,"Not Available",33.980034,-80.96186
+509GA,"Athens Clinic","9249 Highway 29 North",Athens,GA,"30601",706-227-4534,"VA Facility",Government,no,"Not Available",33.9609,-83.3779
+619GB,"Dothan Mental Health Clinic","3753 Ross Clark Cir., Suite 4",Dothan,AL,"36303",334-678-1933,"VA Facility",Government,no,"Not Available",31.252869,-85.415695
+534,"Hinesville Clinic","500 East Oglethorpe Highway",Hinesville,GA,"31313",912-408-2900,"VA Facility",Government,no,"Not Available",31.838243,-81.595215
+508,"Rome VA Clinic","30 Chateau Dr, SE",Rome,GA,"30161",404-329-2222,"VA Facility",Government,no,"Not Available",34.220844,-85.15464
+679A1,"Selma Outpatient Clinic","206 Vaughan Memorial Drive",Selma,AL,"36701","205-554-2000 X 6601 Or 205-554-2000 X 6607","VA Facility",Government,no,"Not Available",32.4833,-86.9982
+534GF,"Trident VA Clinic","9237 University Blvd","North Charleston",SC,"29406",843-789-6400,"VA Facility",Government,no,"Not Available",32.97779,-80.0726
+534QB,"Trident VA Clinic – 9229 University Blvd","9229 University Blvd., Bldg. F, Suite 2A","North Charleston",SC,"29406",843-789-6400,"VA Facility",Government,no,"Not Available",32.977776,-80.07254
+508GK,"Trinka Davis Veterans Village Clinic","180 Martin Dr",Carrollton,GA,"30117","678-423-4970 X 2155 Or 678-423-4970 X 2156","VA Facility",Government,no,"Not Available",33.63418,-85.19058
+534QC,"VA Community Resource and Referral Center","2424 City Hall Lane","North Charleston",SC,"29405",,"VA Facility",Government,no,"Not Available",32.8546,-79.9748
+509GB,"Aiken Community Based Outpatient Clinic","951 Millbrook Avenue",Aiken,SC,"29803",803-643-9016,"VA Facility",Government,no,"Not Available",33.52147,-81.71997
+557GB,"Albany Clinic","814 Radford Blvd., Building 7000",Albany,GA,"31701",229-446-9000,"VA Facility",Government,no,"Not Available",31.55069,-84.063835
+544GD,"Anderson County Clinic","3030 North Highway 81",Anderson,SC,"29621",864-224-5450,"VA Facility",Government,no,"Not Available",34.5034,-82.6501
+521GE,"Anniston/Oxford Clinic","96 Ali Way Creekside South",Oxford,AL,"36203",256-832-4141,"VA Facility",Government,no,"Not Available",34.3402,-89.4833
+508QF,"Atlanta VA Clinic","250 N. Arcadia Avenue",Decatur,GA,"30030",404-329-2222,"VA Facility",Government,no,"Not Available",33.780342,-84.27822
+508GF,"Austell VA CBOC","2041 Mesa Valley Way Suite 185",Austell,GA,"30082",404-329-2222,"VA Facility",Government,no,"Not Available",33.8126,-84.6344
+534,"Beaufort Clinic","1 Pinckney Blvd",Beaufort,SC,"29902",843-770-0444,"VA Facility",Government,no,"Not Available",32.4316,-80.6698
+521GG,"Bessemer CBOC","975 9th Avenue, SW-Suite 400 at UAB West Medical Center West",Bessemer,AL,"32055",205-428-3495,"VA Facility",Government,no,"Not Available",33.4056,-86.9977
+521GJ,"Birmingham VA Clinic","2415 7th Avenue South",Birmingham,AL,"35233",205-933-8101,"VA Facility",Government,no,"Not Available",33.508595,-86.79411
+508GJ,"Blairsville VA CBOC","1294 Highway 515 East, Suite 100",Blairsville,GA,"30512",404-329-2222,"VA Facility",Government,no,"Not Available",34.8762,-83.9582
+557GD,Brunswick,"1111 Glynco Parkway, Bldg. 2, Suite 200",Brunswick,GA,"31525",912-261-2355,"VA Facility",Government,no,"Not Available",35.2673,-89.7687
+521GH,"Childersburg CBOC","151 9th Ave NW",Childersburg,AL,"35044",256-378-9026,"VA Facility",Government,no,"Not Available",33.27733,-86.35565
+31902,"Columbus Clinic","1310 13th AVENUE",Columbus,GA,"31901",706-257-7205,"VA Facility",Government,no,"Not Available",32.47083,-84.97439
+619GB,Dothan,"2020 Alexander Drive",Dothan,AL,"36301",334-673-4166,"VA Facility",Government,no,"Not Available",31.21237,-85.36345
+508QB,"East Point VA Clinic","2675 N. Martin St., Building 700 Suite A","East Point",GA,"30344",,"VA Facility",Government,no,"Not Available",33.68299,-84.438034
+544GB,"Florence CBOC","1822 Sally Hill Farms Road",Florence,SC,"29501",843-292-8383,"VA Facility",Government,no,"Not Available",34.25562,-79.773415
+508GA,"Fort McPherson VA Campus","1701 Hardee Ave., SW",Atlanta,GA,"30310","404-321-6111 X 2222","VA Facility",Government,no,"Not Available",33.749,-84.388
+619QB,"Ft. Benning VA Clinic","6635 Bass Road, Bldg. 9214","Ft. Benning",GA,"31905",706-257-7205,"VA Facility",Government,no,"Not Available",32.3524,-84.9688
+508QD,"Fulton County VA Clinic","1513 Cleveland Ave., Building 300","East Point",GA,"30344",,"VA Facility",Government,no,"Not Available",33.679413,-84.43989
+521GD,"Gadsden CBOC","206 Rescia Ave",Gadsden,AL,"35906",256-413-7154,"VA Facility",Government,no,"Not Available",33.963287,-86.03298
+534GD,"Goose Creek CBOC","2418 NNPTC Circle","Goose Creek",SC,"29445","843-577-5011 X 3100","VA Facility",Government,no,"Not Available",32.9878,-80.0057
+544BZ,"Greenville Clinic","41 Park Creek Drive",Greenville,SC,"29605",864-299-1600,"VA Facility",Government,no,"Not Available",34.75783,-82.39619
+619GE,"Guntersville, AL CBOC","101 Judy Smith Drive",Guntersville,AL,"35976",256-582-4033,"VA Facility",Government,no,"Not Available",34.3196,-86.2735
+508QE,"Gwinnett County VA Clinic","1970 Riverside Parkway",Lawrenceville,GA,"30043",404-329-2222,"VA Facility",Government,no,"Not Available",33.981247,-84.02569
+508QC,"Henderson Mill VA Clinic","2296 Henderson Mill Road",Atlanta,GA,"30345",,"VA Facility",Government,no,"Not Available",33.852135,-84.258965
+521GA,"Huntsville Clinic","500 Markaview Drive, NW",Huntsville,AL,"35805",256-533-8477,"VA Facility",Government,no,"Not Available",30.7235,-95.5508
+521GF,"Jasper Clinic","1454 Jones Dairy Rd",Jasper,AL,"35501",205-221-7384,"VA Facility",Government,no,"Not Available",43.8492,-96.3464
+508GH,"Lawrenceville VA Clinic","455 Philip Blvd, Suite 200",Lawrenceville,GA,"30046",404-329-2222,"VA Facility",Government,no,"Not Available",33.9562,-83.988
+557GA,"Macon Clinic","5566 Thomaston Road",Macon,GA,"31220",478-476-8868,"VA Facility",Government,no,"Not Available",32.834206,-83.744354
+557GF,"Milledgeville Community Based Outpatient Clinic","2249 Vinson Hwy SE",Milledgeville,GA,"31061",478-414-4540,"VA Facility",Government,no,"Not Available",33.047714,-83.212585
+619GF,"Montgomery VA Clinic","8105 Veterans Way",Montgomery,AL,"36117",800-214-8387,"VA Facility",Government,no,"Not Available",44.9025,-72.6382
+534GB,"Myrtle Beach CBOC","3381 Phillis Blvd.","Myrtle Beach",SC,"29577",843-477-0177,"VA Facility",Government,no,"Not Available",33.67208,-78.93672
+534QA,"Myrtle Beach VA Clinic – Market Common","1101 Johnson Avenue","Myrtle Beach",SC,"29577",843-477-0177,"VA Facility",Government,no,"Not Available",33.6891,-78.8867
+508GI,"Newnan VA Clinic","39-A Oak Hill Ct.",Newnan,GA,"30265",404-329-2222,"VA Facility",Government,no,"Not Available",33.3807,-84.7997
+508GE,"Oakwood VA Clinic","4175 Tanners Creek Drive","Flowery Branch",GA,"30542",404-329-2222,"VA Facility",Government,no,"Not Available",34.1675,-83.912
+544GE,"Orangeburg County Clinic","1767 Villagepark Drive",Orangeburg,SC,"29118",803-533-1335,"VA Facility",Government,no,"Not Available",33.5234,-80.85726
+557GC,"Perry Outreach Clinic","2370 S. Houston Lake Road",Kathleen,GA,"31047",478-224-1309,"VA Facility",Government,no,"Not Available",32.503242,-83.66276
+544GC,"Rock Hill Clinic","2670 Mills Park Drive","Rock Hill",SC,"29732",803-366-4848,"VA Facility",Government,no,"Not Available",34.977192,-81.024704
+534BY,"Savannah Clinic","1170 Shawnee St.",Savannah,GA,"31419",912-920-0214,"VA Facility",Government,no,"Not Available",31.986042,-81.173485
+521GC,"Shoals Area (Florence) Clinic","422 DD Cox Blvd.",Sheffield,AL,"35660",256-381-9055,"VA Facility",Government,no,"Not Available",30.6957,-101.9818
+544,"Spartanburg CBOC","279 North Grove Medical Park Drive",Spartanburg,SC,"29303",864-582-7025,"VA Facility",Government,no,"Not Available",34.9496,-81.9321
+509GC,"Statesboro Clinic","658 Northside Drive East",Statesboro,GA,"30458","912-871-8719 Or 706-733-0188 X 1132","VA Facility",Government,no,"Not Available",32.43446,-81.75643
+508GG,"Stockbridge VA Clinic","175 Medical Blvd.",Stockbridge,GA,"30281",404-329-2222,"VA Facility",Government,no,"Not Available",33.512432,-84.22509
+544,"Sumter County Clinic","407 North Salem Avenue",Sumter,SC,"29150",803-938-9901,"VA Facility",Government,no,"Not Available",33.929115,-80.350685
+6426,"Tifton VA Clinic","1824 Ridge Avenue North",Tifton,GA,"31794","229-391-6080 Or 229-391-6080","VA Facility",Government,no,"Not Available",31.441685,-83.51968
+619,"VA Outpatient Clinic Monroeville (CBOC)","159 Whetstone Street",Monroeville,AL,"36400","251-743-5861 Or 251-743-5862","VA Facility",Government,no,"Not Available",40.4212,-79.7881
+619,"Wiregrass CBOC","301 Andrews Avenue","Fort Rucker",AL,"36362","800-214-8387 X 7831","VA Facility",Government,no,"Not Available",31.3497,-85.6846
+0304V,"Atlanta Vet Center","1800 Phoenix Boulevard, Building 400, Suite 404 Box 55",Atlanta,GA,"30349","404-417-5414 Or 404-417-5414","VA Facility",Government,no,"Not Available",33.614666,-84.442856
+509,"Augusta Vet Center","2050 Walton Way, Suite 100",Augusta,GA,"30904","706-729-5762 Or 706-729-5762","VA Facility",Government,no,"Not Available",33.475864,-82.00829
+0739V,"Birmingham Vet Center","400 Emery Drive, Suite 200",Hoover,AL,"35244","205-212-3122 Or 205-212-3122","VA Facility",Government,no,"Not Available",33.4054,-86.8114
+0303V,"Charleston Vet Center","3625 West Montague Avenue","North Charleston",SC,"29418","843-789-7000 Or 843-789-7000","VA Facility",Government,no,"Not Available",32.861355,-80.02741
+0324V,"Columbia Vet Center","1710 Richland Street, Suite A",Columbia,SC,"29201","803-765-9944 Or 877-927-8387","VA Facility",Government,no,"Not Available",34.01316,-81.02945
+0349V,"Columbus Vet Center","2601 Cross Country Drive, Condominium B-2 Suite 900",Columbus,GA,"31906",706-596-7170,"VA Facility",Government,no,"Not Available",32.461,-84.9877
+0316V,"Greenville, SC Vet Center","3 Caledon Court, Suite B",Greenville,SC,"29615","864-271-2711 Or 864-271-2711","VA Facility",Government,no,"Not Available",34.861446,-82.339714
+738,"Huntsville Vet Center","415 Church Street, Bldg H, Suite 101",Huntsville,AL,"35801","256-539-5775 Or 256-539-5775","VA Facility",Government,no,"Not Available",34.73529,-86.591606
+0329V,"Lawrenceville Vet Center","930 River Centre Place",Lawrenceville,GA,"30043","404-728-4195 Or 404-728-4195","VA Facility",Government,no,"Not Available",33.973522,-84.03296
+0333V,"Macon Vet Center","750 Riverside Drive",Macon,GA,"31201","478-477-3813 Or 877-927-8387","VA Facility",Government,no,"Not Available",32.841946,-83.62805
+0342V,"Marietta Vet Center","40 Dodd St., Suite 700",Marietta,GA,"30060","404-327-4954 Or 404-327-4954","VA Facility",Government,no,"Not Available",33.950397,-84.52376
+0740V,"Montgomery Vet Center","4405 Atlanta Highway",Montgomery,AL,"36109","334-273-7796 Or 877-927-8387","VA Facility",Government,no,"Not Available",32.381733,-86.2297
+0347V,"Myrtle Beach Vet Center","2024 Corporate Centre Dr, Suite 103","Myrtle Beach",SC,"29577","843-232-2441 Or 843-232-2441","VA Facility",Government,no,"Not Available",33.709522,-78.88358
+0323V,"Savannah Vet Center","321 Commercial Dr",Savannah,GA,"31406","912-961-5800 Or 912-961-5800","VA Facility",Government,no,"Not Available",32.006786,-81.10781
+485,"VISN 8: VA Sunshine Healthcare Network","140 Fountain Parkway, Ste. 600","St. Petersburg",FL,"33716",727-575-8069,"VA Facility",Government,no,"Not Available",27.890217,-82.66082
+516,"Bay Pines VA Healthcare System","10000 Bay Pines Blvd","Bay Pines",FL,"33744","727-398-6661 Or 727-398-6661","VA Facility",Government,no,"Not Available",27.8139,-82.770836
+573,"North Florida/South Georgia Veterans Health System","1601 S.W. Archer Road",Gainesville,FL,"32608",352-376-1611,"VA Facility",Government,no,"Not Available",29.639143,-82.34345
+672,"VA Caribbean Healthcare System","10 Casia Street","San Juan",PR,"00921","787-641-7582 Or 787-641-7582","VA Facility",Government,no,"Not Available",18.3765,-66.1627
+673,"James A. Haley Veterans' Hospital","13000 Bruce B. Downs",Tampa,FL,"33612",813-972-2000,"VA Facility",Government,no,"Not Available",28.065699,-82.42611
+673QJ,"James A. Haley Veterans' Hospital Primary Care Annex","13515 Lake Terrace Lane",Tampa,FL,"33637",813-998-8000,"VA Facility",Government,no,"Not Available",27.872,-82.4388
+573A4,"Lake City VAMC, NF/SGVHS","619 S. Marion Avenue","Lake City",FL,"32025","386-755-3016 Or 800-308-8387","VA Facility",Government,no,"Not Available",30.183418,-82.63701
+573,"Malcom Randall VAMC, NF/SGVHS","1601 S.W. Archer Road",Gainesville,FL,"32608","352-376-1611 Or 800-324-8387","VA Facility",Government,no,"Not Available",29.639143,-82.34345
+546,"Miami VA Healthcare System","1201 N.W. 16th St.",Miami,FL,"33125","305-575-7000 Or 305-575-7000","VA Facility",Government,no,"Not Available",25.790472,-80.215126
+675,"Orlando VA Medical Center","13800 Veterans Way",Orlando,FL,"32827",407-631-1000,"VA Facility",Government,no,"Not Available",28.5383,-81.3792
+548,"West Palm Beach VAMC","7305 N. Military Trail","West Palm Beach",FL,"33410","561-422-8262 Or 561-422-8262","VA Facility",Government,no,"Not Available",26.784203,-80.10725
+548ZZ1,"Clewiston Outpatient Clinic","1100 Olympia Street",Clewiston,FL,"33440",,"VA Facility",Government,no,"Not Available",26.5378,-81.0113
+573BY,"Jacksonville OPC","1536 N Jefferson St",Jacksonville,FL,"32209","877-870-5048 Or 904-475-5800","VA Facility",Government,no,"Not Available",30.344486,-81.66289
+675GG,"Lake Baldwin OPC","5201 Raymond Street",Orlando,FL,"32803",407-646-5500,"VA Facility",Government,no,"Not Available",28.578913,-81.32207
+516BZ,"Lee County VA Healthcare Center","2489 Diplomat Parkway East","Cape Coral",FL,"33909",239-652-1800,"VA Facility",Government,no,"Not Available",26.5629,-81.9495
+672BZ,"Mayaguez OPC","175 Algarrobo Ave.",Mayaguez,PR,"00682","787-641-7582 X 48501","VA Facility",Government,no,"Not Available",0,0
+673BZ,"New Port Richey OPC","9912 Little Road","New Port Richey",FL,"34654",727-869-4100,"VA Facility",Government,no,"Not Available",28.294464,-82.67542
+672BO,"Ponce OPC","Paseo Del Veterano #1010",Ponce,PR,"00716","787-641-7582 X 44001 Or 787-641-7582 X 44002","VA Facility",Government,no,"Not Available",0,0
+573BY,"Southpoint Clinic","6900 Southpoint Dr North",Jacksonville,FL,"32209",904-470-6900,"VA Facility",Government,no,"Not Available",30.255903,-81.5878
+573GF,"Tallahassee HCC","2181 East Orange Avenue",Tallahassee,FL,"32311","800-541-8387 Or 850-878-0191","VA Facility",Government,no,"Not Available",30.4383,-84.2807
+573GI,"The Villages OPC","8900 SE 165th Mulberry Ln.","The Villages",FL,"32162","877-649-0024 Or 352-674-5000","VA Facility",Government,no,"Not Available",28.9341,-81.9599
+672,"Utuado VA Rural Outpatient Clinic","Isaac Gonzalez Street Equina Ledesma",Utuado,PR,"00641","787-522-2650 Or 787-522-2650","VA Facility",Government,no,"Not Available",0,0
+548ZZ2,"VA Moore Haven Outpatient Clinic","1021 Health Park Drive","Moore Haven",FL,"33471",,"VA Facility",Government,no,"Not Available",26.8331,-81.0931
+675GA,"Viera OPC","2900 Veterans Way",Viera,FL,"32940",321-637-3788,"VA Facility",Government,no,"Not Available",28.251802,-80.742805
+675GB,"William V. Chappell, Jr., VA OPC","551 National Health Care Drive","Daytona Beach",FL,"32114",386-323-7500,"VA Facility",Government,no,"Not Available",29.205873,-81.06211
+548,"St Lucie County PTSD Clinical Team (PCT) Outpatient Program","126 SW Chamber Court","Port St Lucie",FL,"34986",772-878-7876,"VA Facility",Government,no,"Not Available",27.2939,-80.3503
+672GC,"Arecibo CBOC","Road PR-10, Puerto Rico",Arecibo,PR,"00612","787-641-7582 X 28683 Or 800-449-8729 X 28678","VA Facility",Government,no,"Not Available",0,0
+548GD,"Boca Raton CBOC","901 Meadows Road","Boca Raton",FL,"33433",561-416-8995,"VA Facility",Government,no,"Not Available",26.358753,-80.10404
+516GD,"Bradenton Community-Based Outpatient Clinic","5520 S.R. 64 Suite 101",Bradenton,FL,"34208",941-721-0649,"VA Facility",Government,no,"Not Available",27.4989,-82.5748
+673GC,"Brooksville CBOC","14540 Cortez Blvd., Suite 108",Brooksville,FL,"34613",352-597-8287,"VA Facility",Government,no,"Not Available",28.53387,-82.48409
+672GD,"Ceiba Community Based Outpatient Clinic","PR-3, Km. 54.9 Lot#3","Pueblo Ward",PR,"00735","787-641-7582 X 29001 Or 800-449-8729 X 29001","VA Facility",Government,no,"Not Available",0,0
+672GD,"Ceiba Community Based Outpatient Clinic","PR-3, Km. 54.9 Lot#3","Pueblo Ward",PR,"00735","800-449-8729 X 29001","VA Facility",Government,no,"Not Available",0,0
+6298,"Ceiba VA Community Based Outpatient Clinic","PR-3, Km. 54.9, Lot #3","Pueblo Ward",PR,"00735","800-449-8729 X 29001","VA Facility",Government,no,"Not Available",0,0
+5924,"Clermont Community Based Outpatient Clinic","805 Oakley Seaver Drive",Clermont,FL,"34711",352-536-8200,"VA Facility",Government,no,"Not Available",28.5494,-81.7729
+714,"Comerio Rural Outpatient Clinic","15 De Diego Street",Comerio,PR,"00782",787-522-2660,"VA Facility",Government,no,"Not Available",0,0
+3333,"Crossroads Annex","925 South Semoran Blvd Suite 114","Winter Park",FL,"32792",866-998-4365,"VA Facility",Government,no,"Not Available",28.583382,-81.30698
+546GH,"Deerfield Beach VA Community Based Outpatient Clinic","2100 S.W. 10th St.","Deerfield Beach",FL,"33442",954-570-5572,"VA Facility",Government,no,"Not Available",26.30437,-80.13228
+548GB,"Delray Beach CBOC","4800 Linton Blvd., Building E, Suite 300","Delray Beach",FL,"33445",561-495-1973,"VA Facility",Government,no,"Not Available",26.439363,-80.11655
+548GA,"Fort Pierce CBOC","1901 South 25th Street, Suite 103","Ft. Pierce",FL,"34947",772-595-5150,"VA Facility",Government,no,"Not Available",27.467018,-80.34966
+672GE,"Guayama CBOC","FISA Bldg 1st Fl, Paseo Del Pueblo, km 0.3, lote no 6",Guayama,PR,"00784",787-866-8886,"VA Facility",Government,no,"Not Available",0,0
+546GA,"Healthcare for Homeless Veterans","1492 W. Flagler St., Suite 101",Miami,FL,"33135",305-541-5864,"VA Facility",Government,no,"Not Available",25.773327,-80.21949
+546,"Healthcare for Homeless Veterans","1492 Flagler St",Miami,FL,"33135",305-541-5864,"VA Facility",Government,no,"Not Available",25.773329,-80.21944
+546,"Hollywood VA Community Based Outpatient Clinic","3702 Washington St., Suite 201",Hollywood,FL,"33021",954-986-1811,"VA Facility",Government,no,"Not Available",26.00302,-80.18108
+546GC,"Homestead VA Community Based Outpatient Clinic","950 Krome Ave., Suite 401",Homestead,FL,"33030",305-248-0874,"VA Facility",Government,no,"Not Available",25.4865,-80.5028
+673QJ,"James A. Haley Veterans' Hospital Primary Care Annex","13515 Lake Terrace Lane",Tampa,FL,"33637",813-998-8000,"VA Facility",Government,no,"Not Available",27.872,-82.4388
+546GE,"Key Largo VA Community Based Outpatient Clinic","105662 Overseas Highway","Key Largo",FL,"33037",305-451-0164,"VA Facility",Government,no,"Not Available",25.161482,-80.38247
+546GB,"Key West VA Outpatient Clinic","1300 Douglas Circle, Building L-15","Key West",FL,"33040",305-293-4863,"VA Facility",Government,no,"Not Available",24.568449,-81.75187
+675GC,"Kissimmee CBOC","2285 North Central Avenue",Kissimmee,FL,"34741",407-518-5004,"VA Facility",Government,no,"Not Available",28.312544,-81.40857
+673GB,"Lakeland CBOC","4237 South Pipkin Rd",Lakeland,FL,"33811",863-701-2470,"VA Facility",Government,no,"Not Available",27.994333,-81.996185
+573GG,"Lecanto CBOC","2804 W. Marc Knighton Ct., Suite A",Lecanto,FL,"34461",352-746-8000,"VA Facility",Government,no,"Not Available",28.905931,-82.48029
+573GK,"Marianna CBOC","4970 Highway 90",Marianna,FL,"32446",850-718-5620,"VA Facility",Government,no,"Not Available",30.75043,-85.189995
+516GF,"Naples Community-Based Outpatient Clinic","2685 Horseshoe Drive South - Suite 101",Naples,FL,"34104",239-659-9188,"VA Facility",Government,no,"Not Available",26.161837,-81.772446
+573GD,"Ocala CBOC","1515 Silver Springs Blvd.",Ocala,FL,"34470",352-369-3320,"VA Facility",Government,no,"Not Available",29.187044,-82.11808
+548GF,"Okeechobee CBOC","1201 N. Parrot Avenue",Okeechobee,FL,"34972",863-824-3232,"VA Facility",Government,no,"Not Available",27.25645,-80.82994
+675GD,"Orange City CBOC","2583 South Volusia Ave (17-92), Suite 300","Orange City",FL,"32763",386-456-2080,"VA Facility",Government,no,"Not Available",28.9489,-81.2987
+573GL,"Palatka CBOC","400 North State Road 19, Suite 48",Palatka,FL,"32177",386-329-8800,"VA Facility",Government,no,"Not Available",29.6486,-81.6376
+516GC,"Palm Harbor Community-Based Outpatient Clinic","35209 US Highway 19 North","Palm Harbor",FL,"34684",727-734-5276,"VA Facility",Government,no,"Not Available",28.0781,-82.7637
+546GD,"Pembroke Pines VA Community Based Outpatient Clinic","7369 W. Sheridan St., Suite 102",Hollywood,FL,"33024",954-894-1668,"VA Facility",Government,no,"Not Available",26.031391,-80.23594
+573GN,"Perry CBOC","1224 N. Peacock Ave.",Perry,FL,"32347",850-223-8387,"VA Facility",Government,no,"Not Available",30.120272,-83.576454
+516GE,"Port Charlotte Community-Based Outpatient Clinic","4161 Tamiami Trail Suite 401 & Suite 602 (Annex Bldg)","Port Charlotte",FL,"33952",941-235-2710,"VA Facility",Government,no,"Not Available",26.9762,-82.0906
+548,"Port St Lucie PTSD Clinical Team (PCT) Outpatient Program","128 SW Chamber Court","Port Saint Lucie",FL,"34986",772-344-9288,"VA Facility",Government,no,"Not Available",27.2939,-80.3503
+573GE,"Saint Augustine CBOC","195 Southpark Blvd.","St. Augustine",FL,"32086","866-401-8387 Or 904-829-0814","VA Facility",Government,no,"Not Available",29.862272,-81.32687
+672GA,"Saint Croix CBOC","Box 12, RR-02, The Village Mall #113","Kings Hill",VI,"00850",340-778-5553,"VA Facility",Government,no,"Not Available",0,0
+672GB,"Saint Thomas CBOC","Medical Foundation Building Suite 101","St. Thomas",VI,"00802",340-776-7072,"VA Facility",Government,no,"Not Available",48.6306,-97.4713
+516GA,"Sarasota Community-Based Outpatient Clinic","5682 Bee Ridge Road, Suite 100",Sarasota,FL,"34233",941-371-3349,"VA Facility",Government,no,"Not Available",27.29881,-82.45636
+516GH,"Sebring Community-Based Outpatient Clinic","5901 U.S. Highway 27 South",Sebring,FL,"33870",863-471-6227,"VA Facility",Government,no,"Not Available",27.4273,-81.3405
+573,"St Marys CBOC","2603 Osbourne Road, Ste E","St Marys",GA,"31558",912-510-3420,"VA Facility",Government,no,"Not Available",41.3081,-93.7297
+516GB,"St. Petersburg Community-Based Outpatient Clinic","840 Dr. MLK Jr. Street N","St. Petersburg",FL,"33705",727-502-1700,"VA Facility",Government,no,"Not Available",27.7788,-82.6823
+548GC,"Stuart CBOC","3501 S E Willoughby Boulevard",Stuart,FL,"34997",772-288-0304,"VA Facility",Government,no,"Not Available",27.1975,-80.2528
+675GE,"Tavares Community Based Outpatient Clinic","1390 E. Burleigh Blvd.",Tavares,FL,"32778",352-253-2900,"VA Facility",Government,no,"Not Available",28.776,-81.7152
+573GA,"Valdosta CBOC","2841 N. Patterson Street",Valdosta,GA,"31602","229-293-0132 Or 877-303-8387","VA Facility",Government,no,"Not Available",30.868034,-83.29001
+548GE,"Vero Beach CBOC","372 17th Street","Vero Beach",FL,"32960",772-299-4623,"VA Facility",Government,no,"Not Available",27.632372,-80.38043
+714,"Vieques Rural Outpatient Clinic","Co.Destino Carretera #997",Vieques,PR,"00765","787-641-7582 X 28601","VA Facility",Government,no,"Not Available",0,0
+573GM,"Waycross CBOC","515B City Boulevard",Waycross,GA,"31501",912-279-4400,"VA Facility",Government,no,"Not Available",31.231209,-82.34093
+546,"William Bill Kling VA Clinic","9800 W. Commercial Blvd.",Sunrise,FL,"33351",954-475-5500,"VA Facility",Government,no,"Not Available",26.134,-80.1131
+673GF,"Zephyrhills CBOC","6937 Medical View Ln",Zephyrhills,FL,"33541",813-780-2550,"VA Facility",Government,no,"Not Available",28.2059,-82.3201
+0309V,"Arecibo Vet Center","50 Gonzalo Marin St",Arecibo,PR,"00612","787-641-7582 X 28151","VA Facility",Government,no,"Not Available",0,0
+0339V,"Clearwater Vet Center","29259 US Hwy 19 North",Clearwater,FL,"33761","727-549-3600 Or 727-549-3600","VA Facility",Government,no,"Not Available",27.9658,-82.8001
+675GF,"Clermont Vet Center","1655 East Highway 50, Suite 102",Clermont,FL,"34711","352-536-6701 Or 877-927-8387","VA Facility",Government,no,"Not Available",28.545898,-81.7555
+0341V,"Daytona Beach Vet Center","1620 Mason Ave., Suite C","Daytona Beach",FL,"32117","386-366-6600 Or 386-366-6600","VA Facility",Government,no,"Not Available",29.21203,-81.0657
+0311V,"Fort Lauderdale Vet Center","3666 W. Oakland Park Blvd.","Lauderdale Lakes",FL,"33311",954-714-2381,"VA Facility",Government,no,"Not Available",26.16532,-80.1985
+0330V,"Fort Myers Vet Center","4110 Center Pointe Drive, Unit 204","Ft. Myers",FL,"33916","239-652-1861 Or 877-927-8387","VA Facility",Government,no,"Not Available",26.6217,-81.8406
+0331V,"Gainesville Vet Center","105 NW 75th Street, Suite #2",Gainesville,FL,"32607","352-331-1408 Or 877-927-8387","VA Facility",Government,no,"Not Available",29.6545,-82.422386
+0305V,"Jacksonville Vet Center","3728 Phillips Highway, Suite 31",Jacksonville,FL,"32207","904-399-8351 Or 904-399-8351","VA Facility",Government,no,"Not Available",30.28736,-81.63335
+0337V,"Jupiter Vet Center","6650 W. Indiantown Rd., Suite 120",Jupiter,FL,"33458","561-422-1220 Or 561-422-1220","VA Facility",Government,no,"Not Available",26.934444,-80.136856
+03101V,"Key Largo Vet Center Outstation","105662 Overseas Hwy.","Key Largo",FL,"33037","305-451-0164 Or 877-927-8387","VA Facility",Government,no,"Not Available",25.161482,-80.38247
+0340V,"Lakeland Vet Center","1370 Ariana St.",Lakeland,FL,"33803","863-284-0841 Or 863-284-0841","VA Facility",Government,no,"Not Available",28.025854,-81.97894
+0332V,"Melbourne Vet Center","2098 Sarno Road",Melbourne,FL,"32935","321-254-3410 Or 877-927-8387","VA Facility",Government,no,"Not Available",28.12169,-80.65558
+0310V,"Miami Vet Center","8280 NW 27th St Suite 511",Miami,FL,"33122","305-718-3712 Or 305-718-3712","VA Facility",Government,no,"Not Available",25.799692,-80.336395
+0348V,"Naples Vet Center","2705 Horseshoe Dr. South, Suite #204",Naples,FL,"34104","239-403-2377 Or 877-927-8387","VA Facility",Government,no,"Not Available",26.16184,-81.77219
+344,"Ocala Vet Center","3300 SW 34th Avenue, Suite 140",Ocala,FL,"34474","352-237-1947 Or 877-927-8387","VA Facility",Government,no,"Not Available",29.151766,-82.17551
+0314V,"Orlando Vet Center","5575 S. Semoran Blvd., Suite #30",Orlando,FL,"32822","407-857-2800 Or 407-857-2800","VA Facility",Government,no,"Not Available",28.48248,-81.310104
+0326V,"Palm Beach Vet Center","4996 10th Ave North, Suite 6",Greenacres,FL,"33463","561-422-1201 Or 561-422-1201","VA Facility",Government,no,"Not Available",26.631065,-80.122665
+0338V,"Pasco County Vet Center","5139 Deer Park Drive","New Port Richey",FL,"34653","727-372-1854 Or 727-372-1854","VA Facility",Government,no,"Not Available",28.2442,-82.7193
+0336V,"Pompano Beach Vet Center","2300 West Sample Road, Suite 102",Pompano,FL,"33073","954-984-1669 Or 877-927-8387","VA Facility",Government,no,"Not Available",0,0
+0312V,"Ponce Vet Center","35 Mayor Street, Suite 1",Ponce,PR,"00730","787-841-3260 Or 787-841-3260","VA Facility",Government,no,"Not Available",0,0
+0300V,"RCS Southeast District 2 District Office","450 Carillon Parkway, Suite 150","St. Petersburg",FL,"33716","727-398-9343 Or 727-398-9343","VA Facility",Government,no,"Not Available",27.88889,-82.66944
+0307V,"San Juan Vet Center","Cond. Medical Center Plaza Suite LC 8, 9 & 11, Urb. La Riviera","Rio Piedras",PR,"00921","787-749-4409 Or 877-927-8387","VA Facility",Government,no,"Not Available",0,0
+0320V,"Sarasota Vet Center","4801 Swift Rd. Suite A",Sarasota,FL,"34231","941-927-8285 Or 877-927-8387","VA Facility",Government,no,"Not Available",27.283916,-82.514145
+03121V,"St. Croix Vet Center Outstation","The Village Mall, RR 2 Box 10553 Kingshill","St. Croix",VI,"00850","340-778-5553 Or 787-641-7582 X 25613","VA Facility",Government,no,"Not Available",38.1765,-86.5826
+0301V,"St. Petersburg Vet Center","6798 Crosswinds Drive, Bldg A","St. Petersburg",FL,"33710","727-549-3633 Or 877-927-8387","VA Facility",Government,no,"Not Available",27.79047,-82.7337
+03122V,"St. Thomas Vet Center Outstation","50 Estate Thomas, Medical Foundation Buiding Suite 101","St. Thomas",VI,"00802","340-774-5017 Or 787-641-7582 X 25507","VA Facility",Government,no,"Not Available",48.6306,-97.4713
+0325V,"Tallahassee Vet Center","2002 Old St. Augustine Road",Tallahassee,FL,"32301",850-942-8810,"VA Facility",Government,no,"Not Available",30.426197,-84.24688
+0318V,"Tampa Vet Center","Fountain Oaks Business Plaza; 3637 W. Waters Ave., Suite 600",Tampa,FL,"33614","813-228-2621 Or 813-228-2621","VA Facility",Government,no,"Not Available",27.872,-82.4388
+10N9,"VISN 9: VA MidSouth Healthcare Network","1801 West End Ave., Suite 600",Nashville,TN,"37203",615-695-2200,"VA Facility",Government,no,"Not Available",36.1659,-86.7844
+596,"Lexington VA Medical Center","1101 Veterans Drive",Lexington,KY,"40502",859-233-4511,"VA Facility",Government,no,"Not Available",42.4473,-71.2245
+626,"Tennessee Valley Healthcare System","1310 24th Avenue South",Nashville,TN,"37212",615-327-4751,"VA Facility",Government,no,"Not Available",36.142414,-86.80479
+596A4,"Lexington VAMC: Cooper Division","1101 Veterans Drive",Lexington,KY,"40502","859-281-4900 Or 859-233-4511","VA Facility",Government,no,"Not Available",42.4473,-71.2245
+596,"Lexington VAMC: Leestown Division","2250 Leestown Rd",Lexington,KY,"40511","859-233-4511 Or 859-281-4900","VA Facility",Government,no,"Not Available",38.077587,-84.54163
+614,"Memphis VA Medical Center","1030 Jefferson Avenue",Memphis,TN,"38104","901-523-8990 Or 901-523-8990","VA Facility",Government,no,"Not Available",35.142464,-90.02515
+621,"Mountain Home VAMC/Johnson City","Corner of Lamont Street and Veterans Way","Mountain Home",TN,"37684","423-926-1171 Or 423-926-1171","VA Facility",Government,no,"Not Available",30.1746,-99.3803
+603,"Robley Rex VA Medical Center","800 Zorn Avenue",Louisville,KY,"40206","502-287-4000 Or 502-287-4000","VA Facility",Government,no,"Not Available",38.270893,-85.6941
+626A4,"Tennessee Valley Healthcare System - Alvin C. York (Murfreesboro) Campus","3400 Lebanon Pike",Murfreesboro,TN,"37129","615-867-6000 Or 615-867-6000","VA Facility",Government,no,"Not Available",35.908054,-86.38373
+626,"Tennessee Valley Healthcare System - Nashville Campus","1310 24th Avenue South",Nashville,TN,"37212","615-327-4751 Or 615-327-4751","VA Facility",Government,no,"Not Available",36.142414,-86.80479
+621,"Bristol, Virginia OPC","2426 Lee Highway",Bristol,VA,"24202",276-645-4520,"VA Facility",Government,no,"Not Available",36.62954,-82.14808
+626,"Charlotte Avenue (Nashville) VA Clinic","1919 Charlotte Avenue",Nashville,TN,"37203",615-873-6503,"VA Facility",Government,no,"Not Available",36.15748,-86.80191
+626GF,"Chattanooga VA Clinic","6098 Debra Rd Suite 5200 Bldg 6200",Chattanooga,TN,"37411",423-893-6500,"VA Facility",Government,no,"Not Available",35.0456,-85.3097
+626GH,"Cookeville, Tennessee OPC","851 S. Willow Avenue Suite 108",Cookeville,TN,"38501",931-284-4060,"VA Facility",Government,no,"Not Available",36.144985,-85.52289
+626GX,"Hopkinsville, Kentucky OPC","1002 South Virginia Street",Hopkinsville,KY,"42240",270-885-2106,"VA Facility",Government,no,"Not Available",36.86455,-87.48827
+626GN,"McMinnville, Tennessee OPC","1014 S. Chancery Street",McMinnville,TN,"37110",931-474-7700,"VA Facility",Government,no,"Not Available",35.66253,-85.78597
+626GO,"Pointe Center Outpatient Clinic (Chattanooga)","1208 Pointe Center Drive",Chattanooga,TN,"37421",423-893-6500,"VA Facility",Government,no,"Not Available",35.0456,-85.3097
+626,"Women Veterans Healthcare Center (Nashville, TN)","1919 Charlotte Avenue, Suite 300",Nashville,TN,"37203",615-327-4751,"VA Facility",Government,no,"Not Available",36.1659,-86.7844
+6301,"Athens VA Clinic","1320 Decatur Pike",Athens,TN,"37303",423-746-1410,"VA Facility",Government,no,"Not Available",35.44948,-84.6172
+626GC,"Bowling Green VA Clinic","600 US 31 West Bypass, Suite 12","Bowling Green",KY,"42101",270-782-0120,"VA Facility",Government,no,"Not Available",35.1499,-81.2123
+626,"Clarksville Dental Clinic","2291 Dalton Drive, Suite F.",Clarksville,TN,"37043",,"VA Facility",Government,no,"Not Available",39.9758,-80.0549
+626GE,"Clarksville VA Clinic","782 Weatherly Dr.",Clarksville,TN,"37043",931-645-3552,"VA Facility",Government,no,"Not Available",39.9758,-80.0549
+614GE,"Covington, Tennessee (North Memphis), CBOC","3461 Austin Peay Highway",Memphis,TN,"38127",901-261-4500,"VA Facility",Government,no,"Not Available",35.21992,-89.910416
+626GA,"Dover (Stewart County), Tennessee CBOC","1225 Spring Street",Dover,TN,"37058",931-232-5138,"VA Facility",Government,no,"Not Available",36.479477,-87.81392
+614,"Dyersburg, Tennessee CBOC","433 East Parkview Street",Dyersburg,TN,"38024",731-287-7289,"VA Facility",Government,no,"Not Available",36.046345,-89.37962
+626,"Harriman Clinic","2305 North Gateway Ave., Suite 2",Harriman,TN,"37748",865-882-2010,"VA Facility",Government,no,"Not Available",35.977,-84.4625
+614,"Helena, Arkansas CBOC","131 Quarles Lane",Helena,AR,"72342",870-228-3644,"VA Facility",Government,no,"Not Available",34.554462,-90.648125
+614,"Holly Springs CBOC","1700 Crescent Meadow Dr","Holly Springs",MS,"38635",662-252-2552,"VA Facility",Government,no,"Not Available",34.7746,-89.4533
+626QC,"International Plaza CBOC","2 International Plaza, Suite 300",Nashville,TN,"37217",615-367-5928,"VA Facility",Government,no,"Not Available",36.127193,-86.695755
+614GG,"Jackson, Tennessee CBOC","180 Old Hickory Blvd",Jackson,TN,"38305",731-661-2750,"VA Facility",Government,no,"Not Available",35.65321,-88.83493
+614GB,"Jonesboro, Arkansas CBOC","2908 Caraway Road",Jonesboro,AR,"72401","870-277-0778 Or 870-268-6962","VA Facility",Government,no,"Not Available",35.80957,-90.67815
+621,"Jonesville Rural Outreach Clinic","32613 Wilderness Road, Suite 101",Jonesville,VA,"24263",276-346-2595,"VA Facility",Government,no,"Not Available",34.836,-81.6809
+621,"Knoxville, Tennessee CBOC","8033 Ray Mears Blvd.",Knoxville,TN,"37919",865-545-4592,"VA Facility",Government,no,"Not Available",35.923336,-84.04693
+621,"LaFollette (Campbell County), Tennessee CBOC","130 Independence Lane",LaFollette,TN,"37757",423-563-7666,"VA Facility",Government,no,"Not Available",0,0
+621,"Marion Rural Outreach Clinic","4451 Lee Highway",Marion,VA,"24354",276-783-2756,"VA Facility",Government,no,"Not Available",41.5637,-72.9257
+626,"Maury County CBOC","833 Nashville Highway",Columbia,TN,"38401",931-981-6930,"VA Facility",Government,no,"Not Available",35.62945,-87.02559
+626,"Meharry (Nashville General)","1810 Albion Street",Nashville,TN,"37208",615-873-6700,"VA Facility",Government,no,"Not Available",36.16626,-86.80563
+621GE,"Morristown, Tennessee CBOC","925 E. Morris Boulevard",Morristown,TN,"37813",423-586-9100,"VA Facility",Government,no,"Not Available",36.215782,-83.28268
+614GF,"Nonconnah Boulevard Primary Care Clinic","1689 Nonconnah Boulevard",Memphis,TN,"38132",901-271-4900,"VA Facility",Government,no,"Not Available",35.071,-90.00735
+621,"Norton, Virginia CBOC","654 Highway 58 East",Norton,VA,"24273",276-679-8010,"VA Facility",Government,no,"Not Available",41.9668,-71.187
+621GA,"Rogersville, Tennessee CBOC","401 Scenic Drive",Rogersville,TN,"37857",423-235-1471,"VA Facility",Government,no,"Not Available",36.40194,-83.01576
+614GD,"Savannah, Tennessee CBOC","765 Florence Rd",Savannah,TN,"38372",731-925-2300,"VA Facility",Government,no,"Not Available",35.21224,-88.2393
+621,"Sevierville Clinic","1124 Blanton Dr",Sevierville,TN,"37862",865-286-6950,"VA Facility",Government,no,"Not Available",35.8681,-83.5618
+626GG,"Tullahoma, Tennessee CBOC","225 Von Karman Rd","Arnold Air Force Base",TN,"37389",931-454-6134,"VA Facility",Government,no,"Not Available",0,0
+614,"Tupelo VA Clinic","1114 Commonwealth Blvd",Tupelo,MS,"38804",662-840-6366,"VA Facility",Government,no,"Not Available",34.2499,-88.7168
+596GD,"VA Clinic Berea","209 Pauline Drive",Berea,KY,"40403",859-986-1259,"VA Facility",Government,no,"Not Available",39.1365,-80.9337
+596,"VA Clinic Hazard","210 Black Gold Blvd",Hazard,KY,"41701",606-436-2350,"VA Facility",Government,no,"Not Available",37.2495,-83.1932
+596GB,"VA Clinic Morehead","333 Beacon Hill Rd",Morehead,KY,"40351",606-784-3004,"VA Facility",Government,no,"Not Available",38.2075,-83.3989
+596GA,"VA Clinic Somerset","163 Tower Circle",Somerset,KY,"42503",606-676-0786,"VA Facility",Government,no,"Not Available",40.0084,-79.0781
+603GH,"VA Healthcare Center, Carrollton","1911 US Highway 227",Carrollton,KY,"41008",502-287-6060,"VA Facility",Government,no,"Not Available",33.5082,-89.9204
+603GD,"VA Healthcare Center, Dupont Kentucky CBOC","4010 Dupont Circle",Louisville,KY,"40207",502-287-6986,"VA Facility",Government,no,"Not Available",38.232937,-85.631355
+603GA,"VA Healthcare Center, Ft. Knox Kentucky","851 Ireland Loop","Ft Knox",KY,"40121",502-624-9396,"VA Facility",Government,no,"Not Available",37.90122,-85.94276
+603GF,"VA Healthcare Center, Grayson","619 Elizabethtown Road",Clarkson,KY,"42726",866-653-8232,"VA Facility",Government,no,"Not Available",43.2331,-77.9275
+603GB,"VA Healthcare Center, New Albany IN","4347 Security Parkway","New Albany",IN,"47150","502-287-4100 Or 502-287-4100","VA Facility",Government,no,"Not Available",38.363068,-85.81108
+603GE,"VA Healthcare Center, Newburg Kentucky","3430 Newburg Road",Louisville,KY,"40218",502-287-6223,"VA Facility",Government,no,"Not Available",38.197586,-85.681854
+603GG,"VA Healthcare Center, Scott County","1467 Scott Valley Drive",Scottsburg,IN,"47170","877-690-1938 Or 877-690-1938","VA Facility",Government,no,"Not Available",36.7605,-78.7695
+603GC,"VA Healthcare Center, Shively Kentucky CBOC","3934 North Dixie Highway, Suite 210",Louisville,KY,"40216",502-287-6000,"VA Facility",Government,no,"Not Available",38.194138,-85.806725
+621,"Vansant Rural Outreach Clinic","1941 Lovers Gap Road, Suite A",Vansant,VA,"24656",276-597-2106,"VA Facility",Government,no,"Not Available",37.1942,-82.1322
+0722V,"Chattanooga Vet Center","951 Eastgate Loop Road Bldg. 5700 - Suite 300",Chattanooga,TN,"37411","423-855-6570 Or 423-855-6570","VA Facility",Government,no,"Not Available",35.009804,-85.21353
+701,"Johnson City Vet Center","2203 McKinley Road, Suite 254","Johnson City",TN,"37604","423-928-8387 Or 423-928-8387","VA Facility",Government,no,"Not Available",36.3134,-82.3535
+720,"Knoxville Vet Center","8033 Ray Mears Blvd",Knoxville,TN,"37914",865-633-0000,"VA Facility",Government,no,"Not Available",35.923336,-84.04693
+203,"Lexington Vet Center","1500 Leestown Rd Suite 104",Lexington,KY,"40511","859-253-0717 Or 859-253-0717","VA Facility",Government,no,"Not Available",38.065773,-84.523636
+202,"Louisville Vet Center","1347 S. Third Street",Louisville,KY,"40208","502-287-6710 Or 502-287-6710","VA Facility",Government,no,"Not Available",38.23077,-85.75937
+0719V,"Memphis Vet Center","1407 Union Ave., Suite 410",Memphis,TN,"38104","901-522-3950 Or 901-522-3950","VA Facility",Government,no,"Not Available",35.136623,-90.01462
+0724V,"Nashville Vet Center","1420 Donelson Pike Suite A-5",Nashville,TN,"37217","615-366-1220 Or 615-366-1220","VA Facility",Government,no,"Not Available",36.097065,-86.67747
+487,"VISN 10: VA Healthcare System","11500 Northlake Drive, Suite 200",Cincinnati,OH,"45249",513-247-4621,"VA Facility",Government,no,"Not Available",39.276237,-84.34727
+10N11,"VISN 11: Veterans In Partnership (Now VISN 10)","24 Frank Lloyd Wright Drive, Lobby L","Ann Arbor",MI,"48113",,"VA Facility",Government,no,"Not Available",42.31775,-83.6821
+6463,"Homeless Team, Veteran Health Indiana","1099 N. Meridian St.",Indianapolis,IN,"46204","317-988-5284 Or 317-988-5284","VA Facility",Government,no,"Not Available",39.782703,-86.15747
+610,"VA Northern Indiana Health Care System","2121 Lake Ave.","Fort Wayne",IN,"46805","260-426-5431 Or 260-426-5431","VA Facility",Government,no,"Not Available",41.08974,-85.11045
+655,"Aleda E. Lutz VA Medical Center","1500 Weiss Street",Saginaw,MI,"48602","989-497-2500 Or 800-406-5143","VA Facility",Government,no,"Not Available",43.443695,-83.96086
+515,"Battle Creek VA Medical Center","5500 Armstrong Road","Battle Creek",MI,"49037",269-966-5600,"VA Facility",Government,no,"Not Available",42.3173,-85.1782
+757,"Chalmers P. Wylie Ambulatory Care Center","420 N James Road",Columbus,OH,"43219",614-257-5200,"VA Facility",Government,no,"Not Available",39.980396,-82.91203
+538,"Chillicothe VA Medical Center","17273 State Route 104",Chillicothe,OH,"45601",740-773-1141,"VA Facility",Government,no,"Not Available",41.0851,-92.5277
+539,"Cincinnati VA Medical Center","3200 Vine Street",Cincinnati,OH,"45220",513-861-3100,"VA Facility",Government,no,"Not Available",39.13792,-84.509514
+539A4,"Cincinnati VA Medical Center-Fort Thomas","1000 S. Ft Thomas Ave","Ft. Thomas",KY,"41075",859-572-6202,"VA Facility",Government,no,"Not Available",39.0889,-84.44801
+552,"Dayton VA Medical Center","4100 W. 3rd Street",Dayton,OH,"45428","937-268-6511 Or 937-268-6511","VA Facility",Government,no,"Not Available",39.749374,-84.253174
+553,"John D. Dingell VA Medical Center","4646 John R",Detroit,MI,"48201","313-576-1000 Or 313-576-1000","VA Facility",Government,no,"Not Available",42.355137,-83.06039
+541,"Louis Stokes Cleveland VA Medical Center","10701 East Boulevard",Cleveland,OH,"44106",216-791-3800,"VA Facility",Government,no,"Not Available",41.6857,-81.6728
+583,"Richard L. Roudebush VA Medical Center (Indianapolis VA Medical Center)","1481 W. 10th Street",Indianapolis,IN,"46202","317-554-0000 Or 317-554-0000","VA Facility",Government,no,"Not Available",39.779716,-86.18758
+506,"VA Ann Arbor Healthcare System","2215 Fuller Road","Ann Arbor",MI,"48105","734-769-7100 Or 734-769-7100","VA Facility",Government,no,"Not Available",42.28566,-83.71592
+610,"VA Northern Indiana Health Care System - Marion Campus","1700 East 38th Street",Marion,IN,"46953","765-674-3321 Or 765-674-3321","VA Facility",Government,no,"Not Available",40.523746,-85.63726
+610A4,"VA Northern Indiana Health Care System-Fort Wayne Campus","2121 Lake Ave.","Fort Wayne",IN,"46805","260-426-5431 Or 260-426-5431","VA Facility",Government,no,"Not Available",41.08974,-85.11045
+583QA,"Bloomington Mental Health Outpatient Clinic","1332 West Arch Haven Avenue",Bloomington,IN,"47403",812-349-4406,"VA Facility",Government,no,"Not Available",39.161076,-86.55194
+541BY,"Canton Outpatient Clinic","733 Market Avenue South",Canton,OH,"44702",330-489-4600,"VA Facility",Government,no,"Not Available",40.79339,-81.37653
+583QC,"Terre Haute Mental Health Outpatient Clinic","70W Honey Creek Pkwy","Terre Haute",IN,"47802",812-232-8325,"VA Facility",Government,no,"Not Available",39.42494,-87.41705
+506QB,"VA Ann Arbor - Green Road Outpatient Clinic","2500 Green Road","Ann Arbor",MI,"48105",734-769-7100,"VA Facility",Government,no,"Not Available",42.30916,-83.69277
+506QA,"VA Ann Arbor - Packard Road Outpatient Clinic","3800 Packard Road","Ann Arbor",MI,"48108",734-769-7100,"VA Facility",Government,no,"Not Available",42.24532,-83.687454
+506GA,"VA Ann Arbor - Toledo Annex","2595 Arlington Avenue",Toledo,OH,"43614",,"VA Facility",Government,no,"Not Available",41.623123,-83.60686
+583GF,"Wakeman VA Clinic","Building 1010",Edinburgh,IN,"46124",812-348-0300,"VA Facility",Government,no,"Not Available",39.3847,-85.9023
+541BZ,"Youngstown Outpatient Clinic","2031 Belmont Avenue",Youngstown,OH,"44505",330-740-9200,"VA Facility",Government,no,"Not Available",41.126682,-80.66435
+541GG,"Akron Community Based Outpatient Clinic","55 W. Waterloo",Akron,OH,"44319",330-724-7715,"VA Facility",Government,no,"Not Available",41.02876,-81.52917
+538GA,"Athens Community Based Outpatient Clinic","510 West Union Street",Athens,OH,"45701",740-593-7314,"VA Facility",Government,no,"Not Available",39.331062,-82.12392
+655GF,"Bad Axe Community Based Outpatient Clinic","1142 S. Van Dyke RD, Suite 100","Bad Axe",MI,"48413",989-269-7445,"VA Facility",Government,no,"Not Available",43.800236,-83.04325
+539GA,"Bellevue Community Based Outpatient Clinic","103 Landmark Drive, Suite 300",Bellevue,KY,"41073",859-392-3840,"VA Facility",Government,no,"Not Available",39.10029,-84.48472
+515GC,"Benton Harbor VA Outpatient Clinic","115 West Main Street","Benton Harbor",MI,"49022",269-934-9123,"VA Facility",Government,no,"Not Available",42.11607,-86.455154
+583GB,"Bloomington VA Clinic","455 South Landmark Avenue",Bloomington,IN,"47403",812-336-5723,"VA Facility",Government,no,"Not Available",39.16402,-86.55629
+655GG,"Cadillac Community Based Outpatient Clinic","1909 North Mitchell St",Cadillac,MI,"49601",231-775-4401,"VA Facility",Government,no,"Not Available",44.278004,-85.406685
+538,"Cambridge Community Based Outpatient Clinic","2146 Southgate Pkwy",Cambridge,OH,"43725",740-432-1963,"VA Facility",Government,no,"Not Available",40.00885,-81.57982
+655GH,"Cheboygan County Community Based Outpatient Clinic","14540 Mackinaw Hwy","Mackinaw City",MI,"49701",231-436-5176,"VA Facility",Government,no,"Not Available",45.76145,-84.73206
+655GE,"Clare Community Outpatient Clinic","11775 N Isabella Rd",Clare,MI,"48617",989-386-8113,"VA Facility",Government,no,"Not Available",43.811226,-84.74836
+655GD,"Clement C. Van Wagoner Outpatient Clinic","180 North State Avenue",Alpena,MI,"49707",989-356-8720,"VA Facility",Government,no,"Not Available",45.061,-83.430756
+539GB,"Clermont County Community Based Outpatient Clinic","4600 Beechwood Road",Cincinnati,OH,"45244",513-943-3680,"VA Facility",Government,no,"Not Available",39.11444,-84.30561
+541GH,"East Liverpool/Calcutta Community Based Outpatient Clinic","15655 St Rt. 170, Suite A",Calcutta,OH,"43920",330-386-4303,"VA Facility",Government,no,"Not Available",40.673294,-80.57691
+539,"Florence Community Based Outpatient Clinic","7310 Turfway Rd.",Florence,KY,"41042",859-282-4480,"VA Facility",Government,no,"Not Available",38.3903,-105.1186
+655GA,"Gaylord VA Outpatient Clinic","806 South Otsego",Gaylord,MI,"49735",989-732-7525,"VA Facility",Government,no,"Not Available",45.0275,-84.6748
+539GF,"Georgetown Community Based Outpatient Clinic","474 Home Street",Georgetown,OH,"45121",937-378-3413,"VA Facility",Government,no,"Not Available",38.856293,-83.898125
+610A4,"Goshen VA Outpatient Clinic","2606 Peddlers Village Road Suite 210",Goshen,IN,"46526","574-534-6108 Or 877-292-0968","VA Facility",Government,no,"Not Available",39.953,-111.9008
+655QB,"Grand Traverse VA Clinic","880 Munson Avenue","Traverse City",MI,"49686","231-932-9720 Or 800-406-5143 X 11412","VA Facility",Government,no,"Not Available",44.7631,-85.6206
+655GI,"Grayling Community Based Outpatient Clinic","1680 Hartwick Pines Road",Grayling,MI,"49738",989-344-2002,"VA Facility",Government,no,"Not Available",44.70946,-84.71005
+757GB,"Grove City Community Based Outpatient Clinic","1955 Ohio Drive","Grove City",OH,"43123","614-257-5800 Or 888-615-9448 X 5800","VA Facility",Government,no,"Not Available",39.880787,-83.05464
+539GE,"Hamilton Community Based Outpatient Clinic","1750 South Erie Highway",Hamilton,OH,"45011",513-870-9444,"VA Facility",Government,no,"Not Available",39.37911,-84.54975
+6464,"Indy West VA Clinic","3850 Shore Dr. Suite 203",Indianapolis,IN,"46254","317-988-1772 Or 317-988-1772","VA Facility",Government,no,"Not Available",39.82476,-86.28068
+538GD,"Lancaster Community Based Outpatient Clinic","1703 North Memorial Drive",Lancaster,OH,"43130",740-653-6145,"VA Facility",Government,no,"Not Available",39.73196,-82.617905
+515GB,"Lansing VA Outpatient Clinic","2025 South Washington Avenue",Lansing,MI,"48910",517-267-3925,"VA Facility",Government,no,"Not Available",42.71088,-84.55337
+539GC,"Lawrenceburg (Dearborn) Community Based Outpatient Clinic","1600 Flossie Drive",Greendale,IN,"47025",812-539-2313,"VA Facility",Government,no,"Not Available",42.937,-87.9981
+552GB,"Lima Community Based Outpatient Clinic","1303 Bellefontaine Ave",Lima,OH,"45804",419-222-5788,"VA Facility",Government,no,"Not Available",40.731922,-84.081825
+6108,"Lorain Community Based Outpatient Clinic","5255 N. Abbe Rd.","Sheffield Village",OH,"44035",440-934-9158,"VA Facility",Government,no,"Not Available",41.426277,-82.07694
+541GD,"Mansfield Community Based Outpatient Clinic","1025 South Trimble Rd.",Mansfield,OH,"44906",419-529-4602,"VA Facility",Government,no,"Not Available",40.738087,-82.55166
+538GC,"Marietta Community Based Outpatient Clinic","27843 State Route 7",Marietta,OH,"45750",740-568-0412,"VA Facility",Government,no,"Not Available",33.9526,-84.5499
+757,"Marion Community Based Outpatient Clinic","1203 Delaware Avenue, Corporate Center #2",Marion,OH,"43302","740-223-8809 Or 888-615-9448 X 5920","VA Facility",Government,no,"Not Available",40.569786,-83.12243
+583GC,"Martinsville VA Outpatient Clinic","2200 John R. Wooden Drive",Martinsville,IN,"46151","317-988-0120 Or 317-554-0000 X 80120","VA Facility",Government,no,"Not Available",39.427006,-86.40602
+541GE,"McCafferty Community Based Outpatient Clinic","4242 Lorain Avenue",Cleveland,OH,"44113",216-939-0699,"VA Facility",Government,no,"Not Available",41.479897,-81.71472
+552GA,"Middletown Community Based Outpatient Clinic","4337 N. Union Road",Middletown,OH,"45005",513-423-8387,"VA Facility",Government,no,"Not Available",39.509254,-84.31619
+610,"Muncie/Anderson VA Outpatient Clinic","2600 W White River Blvd",Muncie,IN,"47303",765-254-5602,"VA Facility",Government,no,"Not Available",40.186367,-85.41668
+515GA,"Muskegon VA Outpatient Clinic","5000 Hakes Dr.",Muskegon,MI,"49441",231-798-4445,"VA Facility",Government,no,"Not Available",43.164448,-86.2334
+541,"New Philadelphia Community Based Outpatient Clinic","1260 Monroe Ave, Suite 1A","New Philadelphia",OH,"44663",330-602-5339,"VA Facility",Government,no,"Not Available",40.7404,-76.1474
+757-N,"Newark Community Based Outpatient Clinic","1855 W. Main Street",Newark,OH,"43055","740-788-8329 Or 888-615-9448 X 5900","VA Facility",Government,no,"Not Available",40.041317,-82.4684
+655GC,"Oscoda VA Outpatient Clinic","5671 Skeel Avenue, Suite 4",Oscoda,MI,"48750",989-747-0026,"VA Facility",Government,no,"Not Available",44.451687,-83.351974
+541GF,"Painesville Community Based Outpatient Clinic","7 West Jackson Street",Painesville,OH,"44077",440-357-6740,"VA Facility",Government,no,"Not Available",41.725227,-81.2485
+541GL,"Parma Community Based Outpatient Clinic","8787 Brookpark Road",Parma,OH,"44129",216-739-7000,"VA Facility",Government,no,"Not Available",41.4048,-81.7229
+610GD,"Peru Community Based Outpatient Clinic","750 N Broadway",Peru,IN,"46970",765-472-8907,"VA Facility",Government,no,"Not Available",40.76819,-86.078384
+553,"Pontiac VA Outpatient Clinic","44200 Woodward Avenue, Suite 208",Pontiac,MI,"48341",248-332-4540,"VA Facility",Government,no,"Not Available",36.5225,-92.5633
+538GB,"Portsmouth Community Based Outpatient Clinic","840 Gallia Street",Portsmouth,OH,"45662",740-353-3236,"VA Facility",Government,no,"Not Available",38.734104,-82.99568
+541,"Ravenna Community Based Outpatient Clinic","6751 N Chestnut St",Ravenna,OH,"44266",330-296-3641,"VA Facility",Government,no,"Not Available",41.174595,-81.24526
+552GC,"Richmond Community Based Outpatient Clinic","1010 N. J Street",Richmond,IN,"47374",765-973-6915,"VA Facility",Government,no,"Not Available",39.84063,-84.888824
+655AA,"Saginaw VA Healthcare Annex","4241 Barnard Road",Saginaw,MI,"48603","800-406-5143 X 11230","VA Facility",Government,no,"Not Available",43.468258,-83.96569
+541GC,"Sandusky Community Based Outpatient Clinic","3416 Columbus Avenue",Sandusky,OH,"44870",419-625-7350,"VA Facility",Government,no,"Not Available",41.41938,-82.69002
+610A4,"South Bend VA Outpatient Clinic","333 W. Western Ave","South Bend",IN,"46601","866-436-1291 Or 866-436-1291","VA Facility",Government,no,"Not Available",41.67231,-86.25395
+552GD,"Springfield Community Based Outpatient Clinic","512 South Burnett Road",Springfield,OH,"45505",937-328-3385,"VA Facility",Government,no,"Not Available",39.915005,-83.77042
+610BY,"St. Joseph County VA Clinic","1540 Trinity Place",Mishawaka,IN,"46545",574-272-9000,"VA Facility",Government,no,"Not Available",41.662,-86.1586
+583GA,"Terre Haute VA Clinic","110 W Honeycreek Pkwy","Terre Haute",IN,"47802",812-232-2890,"VA Facility",Government,no,"Not Available",39.424934,-87.41767
+655GB,"Traverse City VA Outpatient Clinic","3271 RACQUET CLUB DRIVE","Traverse City",MI,"49684","231-932-9720 Or 800-406-5143 X 11412","VA Facility",Government,no,"Not Available",44.7631,-85.6206
+506GB,"VA Ann Arbor - Flint Community Based Outpatient Clinic","2360 South Linden Road",Flint,MI,"48532",810-720-2913,"VA Facility",Government,no,"Not Available",42.991943,-83.77245
+506GC,"VA Ann Arbor - Jackson Community Based Outpatient Clinic","4328 Page Avenue","Michigan Center",MI,"49254",517-764-3609,"VA Facility",Government,no,"Not Available",42.235546,-84.33686
+506GA,"VA Ann Arbor - Toledo Community Based Outpatient Clinic","1200 South Detroit Avenue",Toledo,OH,"43614",419-259-2000,"VA Facility",Government,no,"Not Available",41.6868,-83.4394
+541GI,"Warren Community Based Outpatient Clinic","1460 Tod Ave (NW)",Warren,OH,"44485",330-392-0311,"VA Facility",Government,no,"Not Available",41.246456,-80.83477
+583GE,"West Lafayette VA Clinic","3851 N. River Road",Lafayette,IN,"47906",,"VA Facility",Government,no,"Not Available",40.412487,-86.97694
+538GF,"Wilmington Community-Based Outpatient Clinic","448 West Main Street",Wilmington,OH,"45177",937-382-3949,"VA Facility",Government,no,"Not Available",39.44553,-83.8363
+515BY,"Wyoming Health Care Center","5838 Metro Way",Wyoming,MI,"49519",616-249-5300,"VA Facility",Government,no,"Not Available",37.5823,-81.6018
+553GA,"Yale VA Outpatient Clinic","7470 Brockway Road",Yale,MI,"48097",810-387-3211,"VA Facility",Government,no,"Not Available",43.138046,-82.79886
+757GA,"Zanesville Community Based Outpatient Clinic","2800 Maple Avenue",Zanesville,OH,"43701","740-453-7725 Or 888-615-9448 X 5751","VA Facility",Government,no,"Not Available",39.974194,-82.01204
+204,"Cincinnati Vet Center","801B W. 8th St. Suite 126",Cincinnati,OH,"45203","513-763-3500 Or 513-763-3500","VA Facility",Government,no,"Not Available",39.103344,-84.52966
+0205V,"Cleveland Vet Center","5310 1/2 Warrensville Center Rd","Maple Heights",OH,"44137","216-707-7901 Or 216-707-7901","VA Facility",Government,no,"Not Available",41.41617,-81.53732
+0221V,"Columbus Vet Center","30 Spruce Street",Columbus,OH,"43215",614-257-5550,"VA Facility",Government,no,"Not Available",39.97233,-83.00369
+0225V,"Dayton Vet Center","627 Edwin C. Moses Blvd.,6th Floor, East Medical Plaza",Dayton,OH,"45417","937-461-9150 Or 937-461-9150","VA Facility",Government,no,"Not Available",39.74863,-84.19844
+0401V,"Dearborn Vet Center","19855 Outer Drive, Suite 105 W",Dearborn,MI,"48124","313-277-1428 Or 313-277-1428","VA Facility",Government,no,"Not Available",42.303585,-83.26335
+402,"Detroit Vet Center","11214 East Jefferson Avenue",Detroit,MI,"48214",313-822-1141,"VA Facility",Government,no,"Not Available",42.36637,-82.97188
+0409V,"Fort Wayne Vet Center","5800 Fairfield Ave., Suite 265","Fort Wayne",IN,"46807","260-460-1456 Or 260-460-1456","VA Facility",Government,no,"Not Available",41.03154,-85.14336
+403,"Grand Rapids Vet Center","2050 Breton Rd SE","Grand Rapids",MI,"49546",616-285-5795,"VA Facility",Government,no,"Not Available",42.926167,-85.60905
+0413V,"Indianapolis Vet Center","8330 Naab Road, Suite 103",Indianapolis,IN,"46260","317-988-1600 Or 317-988-1600","VA Facility",Government,no,"Not Available",39.911648,-86.198395
+0437V,"Macomb County Vet Center","42621 Garfield Rd. Suite 105","Clinton Township",MI,"48038","586-412-0107 Or 586-412-0107","VA Facility",Government,no,"Not Available",42.610115,-82.95288
+02061V,"McCafferty Vet Center Outstation","4242 Lorain Avenue Suite 203",Cleveland,OH,"44113","216-939-0784 Or 877-927-8387","VA Facility",Government,no,"Not Available",41.479897,-81.71472
+0206V,"Parma Vet Center","5700 Pearl Road Suite 102",Parma,OH,"44129","440-845-5023 Or 440-845-5023","VA Facility",Government,no,"Not Available",41.406796,-81.74186
+0417V,"Peoria Vet Center","8305 N. Allen Road, Suite 1",Peoria,IL,"61615","309-689-9708 Or 309-689-9708","VA Facility",Government,no,"Not Available",40.788372,-89.63111
+0438V,"Pontiac Vet Center","44200 Woodward Avenue, Suite 108",Pontiac,MI,"48341","248-874-1015 Or 248-874-1015","VA Facility",Government,no,"Not Available",36.5225,-92.5633
+433,"Saginaw Vet Center","5360 Hampton Place",Saginaw,MI,"48604","989-321-4650 Or 989-321-4650","VA Facility",Government,no,"Not Available",37.0239,-94.4683
+0421V,"Springfield, IL Vet Center","2980 Baker Drive",Springfield,IL,"62703","217-492-4955 Or 217-492-4955","VA Facility",Government,no,"Not Available",39.762154,-89.64444
+0241V,"Stark County Vet Center","601 Cleveland Ave N, Suite C",Canton,OH,"44702","330-454-3120 Or 330-454-3120","VA Facility",Government,no,"Not Available",40.79531,-81.37779
+0234V,"Toledo Vet Center","1565 S. Byrne Road, Suite 104",Toledo,OH,"43614","419-213-7533 Or 877-927-8387","VA Facility",Government,no,"Not Available",41.6112,-83.625755
+445,"Traverse City Vet Center","3766 N US 31 South","Traverse City",MI,"49684","231-935-0051 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.7631,-85.6206
+506,"VA Ann Arbor - North Campus Research Complex","2800 Plymouth Road","Ann Arbor",MI,"48105",734-769-7100,"VA Facility",Government,no,"Not Available",42.30256,-83.705765
+506,"VA Ann Arbor - Offsite Warehouse","844 Highland Drive","Ann Arbor",MI,"48105",734-769-7100,"VA Facility",Government,no,"Not Available",42.22654,-83.72491
+506,"VA Ann Arbor Business Office","2200 Commonwealth Blvd","Ann Arbor",MI,"48105",734-769-7100,"VA Facility",Government,no,"Not Available",42.307255,-83.69625
+506,"VA Ann Arbor Finance & Payroll Office","3001 Earhart Road","Ann Arbor",MI,"48105",734-769-7100,"VA Facility",Government,no,"Not Available",42.325016,-83.68348
+10N12,"VISN 12: VA Great Lakes Health Care System","11301 W. Cermak Road, Suite 810",Westchester,IL,"60154",708-492-3900,"VA Facility",Government,no,"Not Available",41.84804,-87.90505
+556,"Captain James A. Lovell Federal Health Care Center","3001 Green Bay Road","North Chicago",IL,"60064","847-688-1900 Or 847-688-1900","VA Facility",Government,no,"Not Available",42.30826,-87.86246
+695,"Clement J. Zablocki Veterans Affairs Medical Center","5000 West National Avenue",Milwaukee,WI,"53295",414-384-2000,"VA Facility",Government,no,"Not Available",43.020367,-87.97142
+578,"Edward Hines Jr. VA Hospital","5000 South 5th Ave",Hines,IL,"60141",708-202-8387,"VA Facility",Government,no,"Not Available",37.9834,-80.7181
+537,"Jesse Brown VA Medical Center","820 South Damen Avenue",Chicago,IL,"60612","312-569-8387 Or 312-569-8387","VA Facility",Government,no,"Not Available",41.8712,-87.67639
+585,"Oscar G. Johnson VA Medical Center","325 East H Street","Iron Mountain",MI,"49801",906-774-3300,"VA Facility",Government,no,"Not Available",45.81145,-88.06337
+676,"Tomah VA Medical Center","500 E. Veterans Street",Tomah,WI,"54660",608-372-3971,"VA Facility",Government,no,"Not Available",44.00095,-90.50921
+550,"VA Illiana Health Care System","1900 East Main Street",Danville,IL,"61832","217-554-3000 Or 217-554-3000","VA Facility",Government,no,"Not Available",37.8216,-122.0
+607,"William S. Middleton Memorial Veterans Hospital","2500 Overlook Terrace",Madison,WI,"53705","608-256-1901 Or 888-478-8321","VA Facility",Government,no,"Not Available",43.073982,-89.429085
+1007,"1007 USS Tranquillity","3420 Illinois Street","Great Lakes",IL,"60088",847-688-6755,"VA Facility",Government,no,"Not Available",42.30789,-87.85014
+1523,"1523 USS Red Rover","3350 Illinois Street","Great Lakes",IL,"60088",847-688-5568,"VA Facility",Government,no,"Not Available",42.30791,-87.85014
+537BY,"Adam Benjamin, Jr. OPC","9301 Madison Street","Crown Point",IN,"46307",219-662-5000,"VA Facility",Government,no,"Not Available",41.417,-87.3653
+695BY,"Appleton Clinic (John H. Bradley)","10 Tri-Park Way",Appleton,WI,"54914",920-831-0070,"VA Facility",Government,no,"Not Available",44.281895,-88.453674
+537HA,"Auburn Gresham (Chicago) Clinic","7731 S Halsted St",Chicago,IL,"60620",773-962-3700,"VA Facility",Government,no,"Not Available",41.75367,-87.644104
+578GD,"Aurora Clinic","161 South Lincolnway","North Aurora",IL,"60542",630-859-2504,"VA Facility",Government,no,"Not Available",41.80079,-88.32549
+607GD,"Baraboo Clinic","1670 South Blvd",Baraboo,WI,"53913",608-356-9318,"VA Facility",Government,no,"Not Available",43.4807,-89.7399
+607GE,"Beaver Dam Clinic","215 Corporate Drive, Suite D","Beaver Dam",WI,"53916",920-356-9415,"VA Facility",Government,no,"Not Available",37.3557,-86.8627
+537GA,"Chicago Heights Clinic","30 E. 15th Street (Suite 314)","Chicago Heights",IL,"60411",708-754-8880,"VA Facility",Government,no,"Not Available",41.504265,-87.64218
+676GE,"Clark County Outpatient Clinic","8 Johnson Street",Owen,WI,"54460",715-229-4701,"VA Facility",Government,no,"Not Available",44.9586,-90.5539
+695GC,"Cleveland Clinic","1205 North Avenue",Cleveland,WI,"53015","920-693-5600 Or 920-693-5600","VA Facility",Government,no,"Not Available",43.92128,-87.75155
+556GA,"Evanston Clinic","1942 Dempster Street",Evanston,IL,"60202",847-869-6315,"VA Facility",Government,no,"Not Available",42.041096,-87.69995
+556,"Fisher Clinic, Bldg. 237","2470 Sampson Street","Great Lakes",IL,"60088",847-688-2469,"VA Facility",Government,no,"Not Available",42.312874,-87.83964
+607GF,"Freeport Clinic","750 Kiwanis Drive, Suite 250",Freeport,IL,"61032",815-235-4881,"VA Facility",Government,no,"Not Available",42.29079,-89.67082
+695GD,"Green Bay Clinic (Milo C. Huempfner)","2851 University Avenue","Green Bay",WI,"54311","920-431-2500 Or 877-204-7970","VA Facility",Government,no,"Not Available",44.5213,-87.94072
+585GA,"Hancock Clinic","787 Market Street",Hancock,MI,"49930",906-482-7762,"VA Facility",Government,no,"Not Available",41.954,-75.2805
+1231,"Hoffman Estates","4885 Hoffman Blvd","Hoffman Estates",IL,"60192",847-645-1443,"VA Facility",Government,no,"Not Available",42.0428,-88.0798
+585GD,"Ironwood Clinic","629 W. Cloverland Dr. Suite 1",Ironwood,MI,"49938",906-932-0032,"VA Facility",Government,no,"Not Available",46.46337,-90.183044
+607GC,"Janesville Clinic","2419 Morse Street",Janesville,WI,"53545",608-758-9300,"VA Facility",Government,no,"Not Available",42.72222,-88.99433
+578GA,"Joliet Clinic","1201 Eagle St",Joliet,IL,"60432",815-740-8100,"VA Facility",Government,no,"Not Available",41.535557,-88.05301
+1111,"Kankakee Clinic","581 William Latham Drive, Suite 301",Bourbonnais,IL,"60914",815-932-3823,"VA Facility",Government,no,"Not Available",41.162605,-87.8785
+556GD,"Kenosha Clinic","8207 22nd Avenue",Kenosha,WI,"53140","262-653-9286 Or 262-653-9286","VA Facility",Government,no,"Not Available",42.555126,-87.83505
+537a,"Lakeside Clinic","211 E. Ontario St., 12th Floor",Chicago,IL,"60611",312-469-4850,"VA Facility",Government,no,"Not Available",41.89342,-87.61852
+2970,"LaSalle Clinic","4461 N Progress Blvd",Peru,IL,"61354",815-223-9678,"VA Facility",Government,no,"Not Available",37.0581,-96.0841
+585,"Manistique Outreach Clinic","813 East Lakeshore Drive",Manistique,MI,"49854",906-341-3420,"VA Facility",Government,no,"Not Available",45.948757,-86.23988
+585HA,"Marquette Clinic","1414 W. Fair Ave Suite 285",Marquette,MI,"49855",906-226-4618,"VA Facility",Government,no,"Not Available",46.5568,-87.416
+556GC,"McHenry Clinic","3715 Municipal Drive",McHenry,IL,"60050",815-759-2306,"VA Facility",Government,no,"Not Available",42.3334,-88.2668
+585GC,"Menominee Clinic","1110 10th Avenue, Suite 101",Menominee,MI,"49858",906-863-1286,"VA Facility",Government,no,"Not Available",45.10786,-87.616394
+578GG,"Oak Lawn Clinic","10201 S. Cicero","Oak Lawn",IL,"60453",708-499-3675,"VA Facility",Government,no,"Not Available",41.707726,-87.74034
+237,"OHMD Occupational Health Medicine Department","2410 Sampson Street","Great Lakes",IL,"60088",847-688-6712,"VA Facility",Government,no,"Not Available",42.312893,-87.83964
+585GB,"Rhinelander Clinic","639 West Kemp Street",Rhinelander,WI,"54501",715-362-4080,"VA Facility",Government,no,"Not Available",45.6799,-89.346
+676GC,"River Valley Clinic","2600 State Road","La Crosse",WI,"54601",608-784-3886,"VA Facility",Government,no,"Not Available",43.81284,-91.21725
+607HA,"Rockford Clinic","816 Featherstone Road",Rockford,IL,"61107",815-227-0081,"VA Facility",Government,no,"Not Available",42.27791,-88.9972
+585HB,"Sault Ste. Marie Clinic","509 Osborn Blvd. Suite 306","Sault Ste. Marie",MI,"49783",906-253-9383,"VA Facility",Government,no,"Not Available",46.498116,-84.34945
+695GA,"Union Grove Clinic","21425 Spring Street","Union Grove",WI,"53182",262-878-7000,"VA Facility",Government,no,"Not Available",42.698612,-88.08003
+556GE,"USS Osborne Dental Clinic","3440 Ohio Street","Great Lakes",IL,"60088",847-688-2100,"VA Facility",Government,no,"Not Available",42.3096,-87.8467
+676GA,"Wausau Clinic","515 South 32nd Avenue",Wausau,WI,"54401",715-842-2834,"VA Facility",Government,no,"Not Available",44.958927,-89.67598
+676GD,"Wisconsin Rapids Clinic","555 West Grand Ave.","Wisconsin Rapids",WI,"54495",715-424-4682,"VA Facility",Government,no,"Not Available",44.394993,-89.830055
+695,"Community Resource and Referral Center - Milwaukee","1818 Martin Luther King Jr. Drive",Milwaukee,WI,"53212",414-263-7673,"VA Facility",Government,no,"Not Available",43.054127,-87.91425
+550BY,"Bob Michel VA Outpatient Clinic","7717 N. Orange Prairie Road",Peoria,IL,"61615",309-589-6800,"VA Facility",Government,no,"Not Available",40.7312,-89.6031
+550GA,"Decatur VA Outpatient Clinic","3035 East Mound Road",Decatur,IL,"62526",217-875-2670,"VA Facility",Government,no,"Not Available",39.892822,-88.914024
+607AA,"Madison Central Clinic","2500 Overlook Terrace",Madison,WI,"53705","888-856-9039 X 17059","VA Facility",Government,no,"Not Available",43.073982,-89.429085
+607AB,"Madison West Annex Clinic","1 Science Court",Madison,WI,"53711",608-280-7059,"VA Facility",Government,no,"Not Available",43.059372,-89.468864
+550GF,"Mattoon Community Based Outpatient Clinic","501 Lakeland Blvd.",Mattoon,IL,"61938",217-258-3370,"VA Facility",Government,no,"Not Available",39.478317,-88.37655
+550GD,"Springfield VA Outpatient Clinic","5850 South 6th Street, Suite A",Springfield,IL,"62703",217-529-5046,"VA Facility",Government,no,"Not Available",39.7495,-89.606
+676,"VA River Valley Integrated Health Center","1525 Losey Blvd South",LaCrosse,WI,"54601",608-787-6411,"VA Facility",Government,no,"Not Available",43.79642,-91.21983
+0436V,"Aurora Vet Center","750 Shoreline Drive, Suite 150",Aurora,IL,"60504","630-585-1853 Or 630-585-1853","VA Facility",Government,no,"Not Available",41.74383,-88.22525
+0407V,"Chicago Heights Vet Center","1010 Dixie Hwy, 2nd Floor","Chicago Heights",IL,"60411","708-754-8885 Or 708-754-8885","VA Facility",Government,no,"Not Available",41.513294,-87.64522
+0410V,"Chicago Vet Center","3348 W. 87th Street, Suite 2",Chicago,IL,"60652","773-962-3740 Or 773-962-3740","VA Facility",Government,no,"Not Available",41.735046,-87.71181
+0434V,"Escanaba Vet Center","3500 Ludington Street, Suite # 110",Escanaba,MI,"49829","906-233-0244 Or 877-927-8387","VA Facility",Government,no,"Not Available",45.7452,-87.0646
+0420V,"Evanston Vet Center","1901 Howard St",Evanston,IL,"60202","847-332-1019 Or 847-332-1019","VA Facility",Government,no,"Not Available",42.01934,-87.69962
+0412V,"Gary Area Vet Center","107 E. 93rd Ave","Crown Point",IN,"46307","219-736-5633 Or 877-927-8387","VA Facility",Government,no,"Not Available",41.449306,-87.33577
+0441V,"Green Bay Vet Center","1600 S. Ashland Ave","Green Bay",WI,"54304","920-435-5650 Or 920-435-5650","VA Facility",Government,no,"Not Available",44.500378,-88.038445
+0442V,"La Crosse Vet Center","20 Copeland Ave.","La Crosse",WI,"54603","608-782-4403 Or 877-927-8387","VA Facility",Government,no,"Not Available",43.821068,-91.24907
+0419V,"Madison Vet Center","1291 N. Sherman Ave",Madison,WI,"53704","608-264-5342 Or 608-264-5342","VA Facility",Government,no,"Not Available",43.11412,-89.36377
+0415V,"Milwaukee Vet Center","7910 N. 76th Street, Suite 100",Milwaukee,WI,"53223",414-902-5561,"VA Facility",Government,no,"Not Available",43.0389,-87.9065
+0411V,"Oak Park Vet Center","1515 South Harlem","Forest Park",IL,"60130",708-457-8805,"VA Facility",Government,no,"Not Available",33.6221,-84.3691
+0435V,"Orland Park Vet Center","8651 W.159th Street, Suite 1","Orland Park",IL,"60462",708-444-0561,"VA Facility",Government,no,"Not Available",41.60169,-87.83271
+0447V,"Rockford Vet Center","7015 Rote Road, Suite 105",Rockford,IL,"61107","815-395-1276 Or 877-927-8387","VA Facility",Government,no,"Not Available",45.0883,-93.7344
+444,"South Bend Vet Center","4727 Miami Street","South Bend",IN,"46614","574-231-8480 Or 877-927-8387","VA Facility",Government,no,"Not Available",41.627018,-86.234795
+4421,"Wausau Vet Center","605 S 24th Ave, Suite 24",Wausau,WI,"54401","715-842-1724 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.957066,-89.66565
+10N15,"VISN 15: VA Heartland Network","1201 Walnut St, Suite 800","Kansas City",MO,"64106",816-701-3000,"VA Facility",Government,no,"Not Available",39.099815,-94.582054
+657,"VA St. Louis Health Care System","1 Jefferson Barracks Drive","Saint Louis",MO,"63125",314-652-4100,"VA Facility",Government,no,"Not Available",38.509212,-90.28942
+657,"VA St. Louis Health Care System - John Cochran Division","915 North Grand Blvd.","Saint Louis",MO,"63106",314-652-4100,"VA Facility",Government,no,"Not Available",38.641426,-90.22986
+589A4,"Harry S. Truman Memorial","800 Hospital Drive",Columbia,MO,"65201","573-814-6000 Or 573-814-6000","VA Facility",Government,no,"Not Available",38.937588,-92.32859
+657A4,"John J. Pershing VA Medical Center","1500 N. Westwood Blvd.","Poplar Bluff",MO,"63901","573-686-4151 Or 573-686-4151","VA Facility",Government,no,"Not Available",36.7715,-90.418
+589,"Kansas City VA Medical Center","4801 Linwood Boulevard","Kansas City",MO,"64128",816-861-4700,"VA Facility",Government,no,"Not Available",39.067238,-94.52744
+657A5,"Marion VA Medical Center","2401 West Main Street",Marion,IL,"62959","618-997-5311 Or 618-997-5311","VA Facility",Government,no,"Not Available",37.729828,-88.95548
+589A7,"Robert J. Dole VA Medical Center","5500 E. Kellogg",Wichita,KS,"67218","316-685-2221 Or 316-685-2221","VA Facility",Government,no,"Not Available",37.5567,-97.4102
+589A5,"VA Eastern Kansas Health Care System - Colmery-O'Neil VA Medical Center","2200 SW Gage Boulevard",Topeka,KS,"66622","785-350-3111 Or 785-350-3111","VA Facility",Government,no,"Not Available",39.027374,-95.72494
+589A6,"VA Eastern Kansas Health Care System - Dwight D. Eisenhower VA Medical Center","4101 S. 4th Street",Leavenworth,KS,"66048","913-682-2000 Or 913-682-2000","VA Facility",Government,no,"Not Available",39.279087,-94.9005
+657A0,"VA St. Louis Health Care System - Jefferson Barracks Division","1 Jefferson Barracks Drive","Saint Louis",MO,"63125",314-652-4100,"VA Facility",Government,no,"Not Available",38.509212,-90.28942
+657A5,"Enterprise Way VA Clinic","1301 Enterprise Way Suite 68",Marion,IL,"62959",618-993-1008,"VA Facility",Government,no,"Not Available",37.74047,-88.93996
+657J,"Evansville Health Care Center","6211 E. Waterford Blvd.",Evansville,IN,"47715",812-465-6202,"VA Facility",Government,no,"Not Available",38.0319,-87.5389
+657A5,"Heartland Street VA Clinic","3404 Heartland Street",Marion,IL,"62959",,"VA Facility",Government,no,"Not Available",41.5637,-72.9257
+589,"Johnson County/Radiation Oncology VA Clinic","10500 Mastin St","Overland Park",KS,"66212",816-922-2750,"VA Facility",Government,no,"Not Available",38.941135,-94.701965
+589JE,"Platte City","2303 Higgins Suite F","Platte City",MO,"64079","800-952-8387 X 59141","VA Facility",Government,no,"Not Available",39.3818,-94.7825
+657GA,"Belleville Clinic","6500 W Main St",Belleville,IL,"62223",314-286-6988,"VA Facility",Government,no,"Not Available",38.554073,-90.0401
+5240,"Belton CBOC","209 Cunningham Industrial Parkway",Belton,MO,"64012",816-922-2161,"VA Facility",Government,no,"Not Available",38.809227,-94.504654
+589GZ,"Cameron Clinic","1111 Euclid Dr",Cameron,MO,"64429","816-922-2500 X 54251","VA Facility",Government,no,"Not Available",35.2869,-79.1797
+657A4,"Cape Girardeau Community-Based Outpatient Clinic","3051 William St.","Cape Girardeau",MO,"63703",573-339-0909,"VA Facility",Government,no,"Not Available",37.30073,-89.568634
+657GT,"Carbondale Community Based Outpatient Clinic","1130 East Walnut Street",Carbondale,IL,"62901",618-351-1031,"VA Facility",Government,no,"Not Available",37.726982,-89.19631
+589GM,"Chanute - Neosho Memorial Medical Center","629 South Plummer",Chanute,KS,"66720","800-574-8387 X 54453","VA Facility",Government,no,"Not Available",37.675755,-95.47092
+589G2,"Dodge City, Kansas CBOC","2201 Summerlon Circle","Dodge City",KS,"67843","888-878-6881 X 57450","VA Facility",Government,no,"Not Available",37.802,-99.9982
+657GM,"Effingham Community Based Outpatient Clinic","1011 Ford Avenue",Effingham,IL,"62401",217-347-7600,"VA Facility",Government,no,"Not Available",43.7612,-70.9964
+589GN,"Emporia CBOC","919 W. 12th Avenue, Suite D",Emporia,KS,"66801","800-574-8387 X 54451","VA Facility",Government,no,"Not Available",38.412285,-96.19184
+589JB,"Excelsior Springs MO CBOC","197 McCleary Rd","Excelsior Springs",MO,"64024","816-922-2970 Or 816-861-4700 X 52970","VA Facility",Government,no,"Not Available",39.341568,-94.26308
+657GI,"Farmington CBOC","1580 W. Columbia St",Farmington,MO,"63640",573-760-1365,"VA Facility",Government,no,"Not Available",37.77193,-90.444756
+589gf,"Fort Leonard Wood CBOC","700 GW Lane Street",Waynesville,MO,"65583",573-774-2285,"VA Facility",Government,no,"Not Available",31.14,-81.8314
+589GV,"Ft Scott CBOC","902 Horton Street","Ft. Scott",KS,"66701","800-574-8387 X 54750","VA Facility",Government,no,"Not Available",37.830357,-94.713615
+589GP,"Garnett - Anderson County Hospital","421 South Maple",Garnett,KS,"66032","800-574-8387 X 54453","VA Facility",Government,no,"Not Available",32.5965,-81.2465
+657GO,"Hanson Community Based Outpatient Clinic","926 Veterans Drive",Hanson,KY,"42413",270-322-8019,"VA Facility",Government,no,"Not Available",37.436,-87.4529
+657GU,"Harrisburg Community Based Outpatient Clinic","608 Rollie Moore Drive",Harrisburg,IL,"62946",618-252-6150,"VA Facility",Government,no,"Not Available",39.8095,-83.171
+589A7,"Hays, Kansas CBOC","207-B E. 7th",Hays,KS,"67601","888-878-6881 X 41000","VA Facility",Government,no,"Not Available",38.86904,-99.33027
+589ZZ,"Honor Annex","4251 Northern Avenue","Kansas City",MO,"64133",816-861-4700,"VA Facility",Government,no,"Not Available",39.04498,-94.45213
+657,"Hope Recovery Center VA St. Louis Health Care System","515 North Jefferson Avenue","St. Louis",MO,"63103","314-652-4100 X 55500 Or 800-228-5459 X 55500","VA Facility",Government,no,"Not Available",38.634754,-90.21337
+589,"Hutchinson, Kansas CBOC","1625 E 30th Ave",Hutchinson,KS,"67502","888-878-6881 X 41100","VA Facility",Government,no,"Not Available",38.08652,-97.89665
+589G8,"Jefferson City VA CBOC","2707 W Edgewood Dr","Jefferson City",MO,"65109",573-635-0233,"VA Facility",Government,no,"Not Available",38.570843,-92.21489
+589GR,"Junction City","1169 Southwind Drive","Junction City",KS,"66441","800-574-8387 X 54670","VA Facility",Government,no,"Not Available",33.0638,-92.7565
+589a4,"Kirksville VA CBOC/North East Missouri Health Council","1510 North Crown Drive",Kirksville,MO,"63501",660-627-8387,"VA Facility",Government,no,"Not Available",40.20692,-92.57394
+589GH,"Lake of the Ozarks CBOC","940 Executive Drive","Osage Beach",MO,"65065",573-302-7890,"VA Facility",Government,no,"Not Available",38.1122,-92.6901
+589GU,Lawrence,"2200 Harvard Road",Lawrence,KS,"66049","800-574-8387 X 54650","VA Facility",Government,no,"Not Available",38.9643,-95.26153
+589G3,"Liberal, Kansas CBOC","2 Rock Island Road, Suite 200",Liberal,KS,"67901","888-878-6881 X 57400","VA Facility",Government,no,"Not Available",37.038788,-100.92228
+5236,"Louisburg-Paola Clinic","501 South Hospital Drive",Paola,KS,"66071",816-922-2160,"VA Facility",Government,no,"Not Available",38.569992,-94.863716
+589JD,"Marshfield VA Clinic","1240 Banning Street",Marshfield,MO,"65706",417-468-1963,"VA Facility",Government,no,"Not Available",37.344913,-92.92716
+657GR,"Mayfield Community Based Outpatient Clinic","1253 Paris Road Suite A",Mayfield,KY,"42066",270-247-2455,"VA Facility",Government,no,"Not Available",36.72426,-88.62816
+589GX,"Mexico VA CBOC","3460 South Clark Street",Mexico,MO,"65265",573-581-9630,"VA Facility",Government,no,"Not Available",40.8223,-86.1155
+589ZX,"Mobile Medical Unit","4801 Linwood Blvd","Kansas City",MO,"64128","816-861-4700 X 52977 Or 800-525-1483 X 52977","VA Facility",Government,no,"Not Available",39.067238,-94.52744
+657GK,"Mt. Vernon Community Based Outpatient Clinic","4105 N. Water Tower Place","Mt. Vernon",IL,"62864",618-246-2910,"VA Facility",Government,no,"Not Available",38.307262,-88.941864
+589GD,"Nevada Clinic","322 South Prewitt",Nevada,MO,"64772","816-861-4700 X 54235","VA Facility",Government,no,"Not Available",37.83659,-94.37613
+657GP,"Owensboro Community Based Outpatient Clinic","3400 New Hartford Road",Owensboro,KY,"42303",270-684-5034,"VA Facility",Government,no,"Not Available",37.7375,-87.09166
+657GL,"Paducah Community Based Outpatient Clinic","2620 Perkins Creek Dr.",Paducah,KY,"42001",270-444-8465,"VA Facility",Government,no,"Not Available",37.0269,-88.6481
+657GG,"Paragould Community-Based Outpatient Clinic","2420 Linwood Drive - Suite 3",Paragould,AR,"72450",870-236-9756,"VA Facility",Government,no,"Not Available",36.0584,-90.4973
+589G5,"Parsons, Kansas CBOC","1907 Harding Dr.",Parsons,KS,"67357","888-878-6881 X 41060","VA Facility",Government,no,"Not Available",39.196,-79.6203
+657GW,"Pocahontas Community-Based Outpatient Clinic","300 Camp Rd",Pocahontas,AR,"72455",870-248-0571,"VA Facility",Government,no,"Not Available",32.4743,-90.2862
+657GN,"Salem (MO) Community-Based Outpatient Clinic","35629 MO-Hwy 72",Salem,MO,"65560",573-729-6626,"VA Facility",Government,no,"Not Available",37.2935,-80.0548
+589GW,"Salina, Kansas CBOC","1410 E. Iron, Suite 1",Salina,KS,"67401","888-878-6881 X 41020","VA Facility",Government,no,"Not Available",38.840443,-97.589294
+589JA,"Sedalia VA Clinic","3320 West 10th Street",Sedalia,MO,"65301",660-826-3800,"VA Facility",Government,no,"Not Available",38.704,-93.27141
+589JC,"Shawnee VA Clinic","6830 Anderson St",Shawnee,KS,"66226",816-922-2750,"VA Facility",Government,no,"Not Available",39.0417,-94.7202
+657GV,"Sikeston CBOC","903 South Kingshighway",Sikeston,MO,"63801",573-472-2139,"VA Facility",Government,no,"Not Available",36.886517,-89.5912
+657GD,"St. Charles Clinic","844 Waterbury Falls Drive","O'Fallon",MO,"63368",314-286-6988,"VA Facility",Government,no,"Not Available",38.5923,-89.9112
+589GY,"St. James VA Clinic","207 Matlock Drive","St. James",MO,"65559",573-265-0448,"VA Facility",Government,no,"Not Available",39.5626,-77.758
+589GI,"St. Joseph Clinic","3302 S. Belt Hwy Suite P",ST.JOSEPH,MO,"64503","800-952-8387 X 56925","VA Facility",Government,no,"Not Available",39.737244,-94.80113
+657DY,"St. Louis CBOC","6854 Parker Road",Florissant,MO,"63033",314-286-6988,"VA Facility",Government,no,"Not Available",38.796257,-90.23481
+657,"VA St. Louis Health Care System Primary Care Team 1 Annex","4974 Manchester Avenue","St. Louis",MO,"63110",314-289-6566,"VA Facility",Government,no,"Not Available",38.625465,-90.26762
+657,"VA St. Louis Health Care System Primary Care Team 2 Annex","2727 Washington Avenue","St. Louis",MO,"63103",314-289-7659,"VA Facility",Government,no,"Not Available",38.635654,-90.21635
+657GQ,"Vincennes Community Based Outpatient Clinic","1813 Willow Street Suite 6A",Vincennes,IN,"47591",812-882-0894,"VA Facility",Government,no,"Not Available",38.657276,-87.53027
+589G1,"Warrensburg Clinic","702 E. Young St.",Warrensburg,MO,"64093","816-922-2500 X 54281","VA Facility",Government,no,"Not Available",38.77199,-93.720215
+657GS,"Washington MO CBOC","1627 A Roy Drive",Washington,MO,"63090","314-289-7950 Or 800-228-5459 X 57950","VA Facility",Government,no,"Not Available",38.8951,-77.0364
+657A4,"West Plains CBOC","1801 E. State Route K","West Plains",MO,"65775",417-257-2454,"VA Facility",Government,no,"Not Available",36.726402,-91.88993
+589GJ,"Wyandotte CBOC","21 N 12th Street, Bethany Medical Building, Suite 110","Kansas City",KS,"66102","800-952-8387 X 56990","VA Facility",Government,no,"Not Available",39.104305,-94.640076
+0443V,"Columbia Vet Center","4040 Rangeline Street, Suite 105",Columbia,MO,"65202","573-814-6206 Or 573-814-6206","VA Facility",Government,no,"Not Available",38.991932,-92.32376
+0422V,"East St. Louis Vet Center","1265 N. 89th Street Suite 5","East St. Louis",IL,"62203","618-397-6602 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.596157,-90.05323
+0418V,"Evansville Vet Center","1100 N. Burkhardt Rd",Evansville,IN,"47715","812-473-5993 Or 812-473-5993","VA Facility",Government,no,"Not Available",37.986885,-87.474
+0408V,"Kansas City Vet Center","4800 Main Street, Suite 107","Kansas City",MO,"64112","816-753-1866 Or 816-753-1866","VA Facility",Government,no,"Not Available",39.03929,-94.587105
+0432V,"Manhattan Vet Center","205 South 4th Street, Suite B",Manhattan,KS,"66502","785-350-4920 Or 785-350-4920","VA Facility",Government,no,"Not Available",39.178177,-96.56182
+0400V,"RCS Midwest District 3 District Office","2122 Kratky Rd., Suite 130","St. Louis",MO,"63114",314-894-6190,"VA Facility",Government,no,"Not Available",38.697098,-90.406784
+0414V,"St. Louis Vet Center","2901 Olive","St. Louis",MO,"63103",314-531-5355,"VA Facility",Government,no,"Not Available",38.634422,-90.22021
+0426V,"Wichita Vet Center","251 N. Water St.",Wichita,KS,"67202","316-265-0889 Or 877-927-8397","VA Facility",Government,no,"Not Available",37.68888,-97.339554
+10N16,"VISN 16: South Central VA Health Care Network","715 S. Pear Orchard Road",Ridgeland,MS,"39157",601-206-6900,"VA Facility",Government,no,"Not Available",32.403606,-90.123535
+502,"Alexandria VA Health Care System","2495 Shreveport Hwy 71 N",Pineville,LA,"71360",318-473-0010,"VA Facility",Government,no,"Not Available",31.353516,-92.43374
+598,"Central Arkansas Veterans Healthcare System Eugene J. Towbin Healthcare Center","2200 Fort Roots Drive","North Little Rock",AR,"72114",501-257-1000,"VA Facility",Government,no,"Not Available",34.773396,-92.289375
+598,"Central Arkansas Veterans Healthcare System John L. McClellan Memorial Veterans Hospital","4300 West 7th Street","Little Rock",AR,"72205",501-257-1000,"VA Facility",Government,no,"Not Available",34.744892,-92.32114
+586,"G.V. (Sonny) Montgomery VA Medical Center","1500 E. Woodrow Wilson Drive",Jackson,MS,"39216",601-362-4471,"VA Facility",Government,no,"Not Available",32.32652,-90.165695
+520,"Gulf Coast Veterans Health Care System","400 Veterans Avenue",Biloxi,MS,"39531",228-523-5000,"VA Facility",Government,no,"Not Available",30.414478,-88.94722
+580,"Michael E. DeBakey VA Medical Center","2002 Holcombe Blvd.",Houston,TX,"77030","713-791-1414 Or 713-791-1414","VA Facility",Government,no,"Not Available",29.705933,-95.39014
+667,"Overton Brooks VA Medical Center","510 E. Stoner Ave.",Shreveport,LA,"71101","318-221-8411 Or 318-221-8411","VA Facility",Government,no,"Not Available",32.49999,-93.73993
+667,Shreveport,"510 E Stoner Ave",Shreveport,LA,"71101",,"VA Facility",Government,no,"Not Available",32.49999,-93.73993
+629,"Southeast Louisiana Veterans Health Care System","2400 Canal Street","New Orleans",LA,"70119","800-935-8387 Or 800-935-8387","VA Facility",Government,no,"Not Available",29.963257,-90.08411
+564,"Veterans Health Care System of the Ozarks","1100 N. College Avenue",Fayetteville,AR,"72703","479-443-4301 Or 479-443-4301","VA Facility",Government,no,"Not Available",36.077305,-94.157074
+580,"Katy VA Outpatient Clinic","750 Westgreen Blvd",Katy,TX,"77450",281-578-4600,"VA Facility",Government,no,"Not Available",29.778257,-95.73581
+629BY,"Baton Rouge Outpatient Clinic","7968 Essen Park Ave.","Baton Rouge",LA,"70809",225-761-3400,"VA Facility",Government,no,"Not Available",30.403616,-91.099525
+77701,"Beaumont VA Outpatient Clinic","3420 Veterans Circle",Beaumont,TX,"77707","409-981-8550 Or 800-833-7734","VA Facility",Government,no,"Not Available",30.0861,-94.1018
+629,"Bogalusa VA Outpatient Clinic","521 Ontario Avenue",Bogalusa,LA,"70427",985-735-9029,"VA Facility",Government,no,"Not Available",30.791603,-89.86743
+564,"Branson OPC","5571 North Gretna Rd",Branson,MO,"65616","417-243-2300 Or 417-243-2300","VA Facility",Government,no,"Not Available",36.645756,-93.27286
+580BZ,"Charles Wilson VA Outpatient Clinic","2206 North John Redditt Drive",Lufkin,TX,"75904","936-671-4300 Or 800-209-3120","VA Facility",Government,no,"Not Available",31.356213,-94.76453
+586GF,"Columbus Clinic","824 Alabama St",Columbus,MS,"39702",662-244-0391,"VA Facility",Government,no,"Not Available",33.493317,-88.36798
+580,"Conroe VA Outpatient Clinic","690 South Loop 336 West, 3rd & 4th Floors",Conroe,TX,"77304","936-522-4000 Or 800-553-2278 X 10900","VA Facility",Government,no,"Not Available",30.2673,-95.3218
+598GG,"Conway CBOC","1520 East Dave Ward Drive",Conway,AR,"72032",501-548-0500,"VA Facility",Government,no,"Not Available",36.4235,-77.2729
+520-GC,"Eglin CBOC","100 Veterans Way","Eglin AFB",FL,"32542",866-520-7359,"VA Facility",Government,no,"Not Available",30.4694,-86.528
+598GB,"El Dorado CBOC","1702 North West Ave.","El Dorado",AR,"71730",870-875-5900,"VA Facility",Government,no,"Not Available",33.228554,-92.665634
+502GF,"Fort Polk CBOC","3353 University Parkway",Leesville,LA,"71446",337-392-3800,"VA Facility",Government,no,"Not Available",40.4517,-81.2121
+629,"Franklin VA Outpatient Clinic","603 Haifleigh Street",Franklin,LA,"70538",337-828-9092,"VA Facility",Government,no,"Not Available",29.805956,-91.49894
+564GB,"Ft Smith OPC","1500 Dodson Ave Sparks Medical Plaza","Ft Smith",AR,"72917",479-441-2600,"VA Facility",Government,no,"Not Available",35.3859,-94.3986
+500GC,"Galveston VA Outpatient Clinic","3828 Avenue N",Galveston,TX,"77550","409-761-3200 Or 800-553-2278 X 11000","VA Facility",Government,no,"Not Available",29.291033,-94.80806
+564BY,"Gene Taylor CBOC","600 N Main","Mt Vernon",MO,"65712","417-466-4000 Or 417-466-4000","VA Facility",Government,no,"Not Available",37.108696,-93.818886
+586GC,"Greenville CBOC","1502 S Colorado St",Greenville,MS,"38703",662-332-9872,"VA Facility",Government,no,"Not Available",33.385975,-91.0301
+629,"Hammond VA Outpatient Clinic","1131 South Morrison Boulevard",Hammond,LA,"70403",985-902-5100,"VA Facility",Government,no,"Not Available",30.488743,-90.48272
+564GA,"Harrison OPC","707 N Main St",Harrison,AR,"72601",870-741-3592,"VA Facility",Government,no,"Not Available",36.236847,-93.10711
+586GD,"Hattiesburg CBOC","5003 Hardy Street, Tower B, Suite 402",Hattiesburg,MS,"39402",601-296-3530,"VA Facility",Government,no,"Not Available",31.2889,-89.3427
+598GC,"Hot Springs CBOC","177 Sawtooth Oak St","Hot Springs",AR,"71901","501-520-6250 Or 501-520-6250","VA Facility",Government,no,"Not Available",34.5037,-93.0552
+502GD,"Houma CBOC","6433 West Park Avenue",Houma,LA,"70364","985-851-0188 Or 800-935-8387 X 0","VA Facility",Government,no,"Not Available",29.621208,-90.748245
+564GE,"Jay CBOC","1569 N. Main St.",Jay,OK,"74346","918-253-1900 Or 918-253-1900","VA Facility",Government,no,"Not Available",36.43826,-94.78232
+502GA,"Jennings Clinic","1907 Johnson St.",Jennings,LA,"70546",337-824-1000,"VA Facility",Government,no,"Not Available",30.239265,-92.66137
+520BZ,"Joint Ambulatory Care Center","790 Veterans Way",Pensacola,FL,"32507",850-912-2000,"VA Facility",Government,no,"Not Available",30.397266,-87.29239
+667,"Knight Street Clinic","3000 Knight Street Building 5",Shreveport,LA,"71105","318-221-8411 X 7411","VA Facility",Government,no,"Not Available",32.6076,-93.7526
+586GA,"Kosciusko CBOC","405 West Adams",Kosciusko,MS,"39090",662-289-2880,"VA Facility",Government,no,"Not Available",32.9911,-89.5168
+502GB,"Lafayette CBOC Campus A—Specialty and Primary Care","3149 Ambassador Caffery Parkway",Lafayette,LA,"70501",337-706-3415,"VA Facility",Government,no,"Not Available",30.18702,-92.075
+502GB,"Lafayette CBOC Campus B—Mental Health","309 St. Julien Avenue",Lafayette,LA,"70506",337-706-3415,"VA Facility",Government,no,"Not Available",30.213179,-92.02821
+502GL,"Lake Charles CBOC","3601 Gerstner Memorial Drive, Hwy14","Lake Charles",LA,"70607",337-475-9500,"VA Facility",Government,no,"Not Available",30.158312,-93.15324
+580GF,"Lake Jackson VA Outpatient Clinic","208 Oak Drive South","Lake Jackson",TX,"77566",979-230-4852,"VA Facility",Government,no,"Not Available",29.031244,-95.45573
+667GC,"Longview CBOC","1005 N. Eastman Rd.",Longview,TX,"75601","903-247-8262 Or 800-957-8262","VA Facility",Government,no,"Not Available",32.513065,-94.71108
+586GG,McComb,"1308 Harrison Ave",McComb,MS,"39648",601-250-0965,"VA Facility",Government,no,"Not Available",31.249437,-90.469894
+598GD,"Mena CBOC","300 S. Morrow Road",Mena,AR,"71953","501-609-2700 Or 855-838-2369","VA Facility",Government,no,"Not Available",34.5914,-94.1951
+586GB,"Meridian CBOC","2103 13th St",Meridian,MS,"39301",601-482-3275,"VA Facility",Government,no,"Not Available",32.36986,-88.699455
+520GA,"Mobile Outpatient Clinic","1504 Springhill Ave.",Mobile,AL,"36604","251-219-3900 Or 251-219-3900","VA Facility",Government,no,"Not Available",30.692453,-88.07212
+667GB,"Monroe CBOC","1691 Bienville Dr",Monroe,LA,"71203","318-343-6100 Or 800-832-3525","VA Facility",Government,no,"Not Available",39.441,-84.5757
+598GA,"Mountain Home CBOC","759 Hwy 62 East","Mountain Home",AR,"72653","870-594-8387 Or 877-338-8003","VA Facility",Government,no,"Not Available",36.345554,-92.37713
+586GE,"Natchez CBOC","105 Northgate Drive, Suite 2",Natchez,MS,"39120",601-442-7141,"VA Facility",Government,no,"Not Available",31.5604,-91.4032
+502GG,"Natchitoches CBOC","740 Keyser Avenue",Natchitoches,LA,"71457",318-357-3300,"VA Facility",Government,no,"Not Available",31.753004,-93.07155
+629,"New Orleans VA Outpatient Clinic","2400 Canal Street","New Orleans",LA,"70119",,"VA Facility",Government,no,"Not Available",29.963257,-90.08411
+564,"Ozark, Arkansas OPC","2713 West Commercial",Ozark,AR,"72949","479-508-1000 Or 479-508-1000","VA Facility",Government,no,"Not Available",35.49001,-93.855194
+520GB,"Panama City Outpatient Clinic","2600 Veterans Way(along Magnolia Beach Road)","Panama City Beach",FL,"32408","850-636-7000 Or 888-231-5047 X 7331","VA Facility",Government,no,"Not Available",30.2798,-85.8118
+598,"Pine Bluff CBOC","4747 Dusty Lake Drive Suite 203","Pine Bluff",AR,"71603",870-541-9300,"VA Facility",Government,no,"Not Available",34.2284,-92.0032
+580,"Richmond VA Outpatient Clinic","22001 Southwest Freeway, Suite 200",Richmond,TX,"77469","832-595-7700 Or 800-553-2278 X 10000","VA Facility",Government,no,"Not Available",37.5538,-77.4603
+598GH,"Russellville CBOC","3106 West 2nd CT",Russellville,AR,"72801",479-880-5100,"VA Facility",Government,no,"Not Available",35.28474,-93.16528
+598,"Searcy CBOC","1120 S Main St",Searcy,AR,"72143",501-207-4700,"VA Facility",Government,no,"Not Available",35.25888,-91.73588
+629E,"Slidell VA Outpatient Clinic","60491 Doss Dr Ste B",Slidell,LA,"70460","985-690-2626 Or 985-690-2626","VA Facility",Government,no,"Not Available",30.2774,-89.7826
+629,"St. John VA Outpatient Clinic","4004 West Airline Hwy.",Reserve,LA,"70084",504-565-4705,"VA Facility",Government,no,"Not Available",48.5487,-104.4974
+667GA,"Texarkana CBOC","910 Realtor Ave",Texarkana,AR,"71854","870-216-2242 Or 800-571-8387","VA Facility",Government,no,"Not Available",33.4701,-94.03299
+580,"Texas City VA Outpatient Clinic","9300 Emmett F. Lowry Expressway, Suite 206","Texas City",TX,"77591","409-986-2900 Or 800-553-2278 X 10500","VA Facility",Government,no,"Not Available",29.401304,-95.01783
+580GH,"Tomball VA Outpatient Clinic","1200 W. Main Street",Tomball,TX,"77375",281-516-1505,"VA Facility",Government,no,"Not Available",30.091705,-95.62763
+0734V,"Alexandria Vet Center","5803 Coliseum Blvd., Sute D",Alexandria,LA,"71303","318-466-4327 Or 877-927-8387","VA Facility",Government,no,"Not Available",31.295115,-92.49501
+0725V,"Baton Rouge Vet Center","7850 Anselmo Lane, Suite B","Baton Rouge",LA,"70810","225-761-3140 Or 225-761-3140","VA Facility",Government,no,"Not Available",30.392668,-91.100845
+0744v,"Bay County Vet Center","3109 Minnesota Ave, Suite 101","Panama City",FL,"32405","850-522-6102 Or 850-522-6102","VA Facility",Government,no,"Not Available",30.208765,-85.6455
+735,"Beaumont Vet Center","990 IH10 North, Suite 180",Beaumont,TX,"77702","409-347-0124 Or 409-347-0124","VA Facility",Government,no,"Not Available",30.0861,-94.1018
+0737V,"Biloxi Vet Center","288 Veterans Ave",Biloxi,MS,"39531","228-388-9938 Or 228-388-9938","VA Facility",Government,no,"Not Available",30.40239,-88.94716
+0727V,"Fayetteville Vet Center","1416 N. College Ave.",Fayetteville,AR,"72703","479-582-7152 Or 479-582-7152","VA Facility",Government,no,"Not Available",36.08108,-94.156654
+0710V,"Houston Southwest Vet Center","10103 Fondren Road, Suite 470",Houston,TX,"77096",713-523-0884,"VA Facility",Government,no,"Not Available",29.67084,-95.50856
+0731V,"Houston Vet Center","14300 Cornerstone Village Dr., Suite 110",Houston,TX,"77014","281-537-7812 Or 281-537-7812","VA Facility",Government,no,"Not Available",29.988022,-95.48308
+0711V,"Houston West Vet Center","701 N. Post Oak Road Suite 102",Houston,TX,"77024","713-682-2288 Or 713-682-2288","VA Facility",Government,no,"Not Available",29.77968,-95.45675
+0709V,"Jackson Vet Center","1755 Lelia Dr. Suite 104",Jackson,MS,"39216","601-985-2560 Or 601-985-2560","VA Facility",Government,no,"Not Available",32.33308,-90.144554
+0713V,"Little Rock Vet Center","201 W. Broadway St. Suite A","North Little Rock",AR,"72114","501-324-6395 Or 501-324-6395","VA Facility",Government,no,"Not Available",34.756107,-92.26903
+0741V,"Mobile Vet Center","3221 Springhill Ave Bldg 2, Suite C",Mobile,AL,"36607","251-478-5906 Or 251-478-5906","VA Facility",Government,no,"Not Available",30.6589,-88.178
+0717V,"New Orleans Vet Center","1250 Poydras Street, 4th Floor, Suite 400","New Orleans",LA,"70113",504-507-4977,"VA Facility",Government,no,"Not Available",29.9547,-90.0751
+0743V,"Okaloosa County Vet Center","6 11th Avenue, Suite G 1",Shalimar,FL,"32579","850-651-1000 Or 850-651-1000","VA Facility",Government,no,"Not Available",30.447157,-86.57846
+0742V,"Pensacola Vet Center","4504 Twin Oaks Drive",Pensacola,FL,"32506","850-456-6113 Or 850-456-5886","VA Facility",Government,no,"Not Available",30.409218,-87.27792
+0704V,"Shreveport Vet Center","2800 Youree Dr. Bldg. 1, Suite 105",Shreveport,LA,"71104","318-861-1776 Or 318-861-1776","VA Facility",Government,no,"Not Available",32.6076,-93.7526
+0736V,"Springfield, MO Vet Center","3616 S. Campbell",Springfield,MO,"65807","417-881-4197 Or 417-881-4197","VA Facility",Government,no,"Not Available",37.14929,-93.29583
+10N17,"VISN 17: VA Heart of Texas Health Care Network","2301 East Lamar Blvd., Suite 650",Arlington,TX,"76006",817-652-1111,"VA Facility",Government,no,"Not Available",32.761486,-97.07099
+504,"Amarillo VA Health Care System","6010 Amarillo Boulevard, West",Amarillo,TX,"79106","806-355-9703 Or 806-355-9703","VA Facility",Government,no,"Not Available",35.4015,-101.8951
+674,"Central Texas Veterans Health Care System","1901 Veterans Memorial Drive",Temple,TX,"76504","254-778-4811 Or 254-778-4811","VA Facility",Government,no,"Not Available",31.079578,-97.34862
+756,"El Paso VA Health Care System","5001 North Piedras Street","El Paso",TX,"79930",915-564-6100,"VA Facility",Government,no,"Not Available",31.820763,-106.46147
+671,"South Texas Veterans Health Care System","7400 Merton Minter Blvd.","San Antonio",TX,"78229","210-617-5300 Or 210-617-5300","VA Facility",Government,no,"Not Available",38.1838,-122.5914
+549,"VA North Texas Health Care System","4500 South Lancaster Road",Dallas,TX,"75216","800-849-3597 Or 214-742-8387","VA Facility",Government,no,"Not Available",32.69437,-96.79336
+740,"VA Texas Valley Coastal Bend Health Care System","2601 Veterans Drive",Harlingen,TX,"78550","956-291-9000 Or 855-864-0516","VA Facility",Government,no,"Not Available",26.1906,-97.6961
+519,"West Texas VA Health Care System","300 Veterans Blvd.","Big Spring",TX,"79720","432-263-7361 Or 432-263-7361","VA Facility",Government,no,"Not Available",32.23064,-101.47079
+549,"Dallas VA Medical Center","4500 S. Lancaster Rd.",Dallas,TX,"75216","800-849-3597 Or 800-849-3597","VA Facility",Government,no,"Not Available",32.694347,-96.79335
+674A4,"Doris Miller Department of Veterans Affairs Medical Center","4800 Memorial Drive",Waco,TX,"76711","254-752-6581 Or 254-752-6581","VA Facility",Government,no,"Not Available",31.513947,-97.16254
+671A4,"Kerrville VA Hospital","3600 Memorial Blvd",Kerrville,TX,"78028",866-487-1653,"VA Facility",Government,no,"Not Available",30.015045,-99.118126
+549A4,"Sam Rayburn Memorial Veterans Center","1201 E. 9th St.",Bonham,TX,"75418","800-924-8387 Or 800-924-8387","VA Facility",Government,no,"Not Available",33.58155,-96.16723
+674BY,"Austin Outpatient Clinic","7901 Metropolis Drive",Austin,TX,"78744","512-823-4000 Or 800-423-2111","VA Facility",Government,no,"Not Available",30.3264,-97.7713
+671,"Balcones Heights Outpatient Clinic","4522 Fredericksburg Road, Suites A-10 and A-88","San Antonio",TX,"78201",210-732-1802,"VA Facility",Government,no,"Not Available",29.492617,-98.55369
+740GC,"Corpus Christi OPC","5283 Old Brownsville Road,","Corpus Christi",TX,"78405",361-806-5600,"VA Facility",Government,no,"Not Available",27.75859,-97.456085
+740,"Corpus Christi PACT Annex","5227 Old Brownsville Road, Suite 11","Corpus Christi",TX,"78405",361-806-5600,"VA Facility",Government,no,"Not Available",27.759275,-97.45505
+740,"Corpus Christi VA Speciality Outpatient Clinic","205 S. Enterprize Parkway","Corpus Christi",TX,"78405",361-939-6510,"VA Facility",Government,no,"Not Available",27.777,-97.4632
+549,"Fort Worth Outpatient Clinic","2201 SE Loop 820","Fort Worth",TX,"76119","800-443-9672 Or 817-730-0000","VA Facility",Government,no,"Not Available",32.66894,-97.29961
+671,"Frank M. Tejeda VA Outpatient Clinic","5788 Eckhert Road","San Antonio",TX,"78240",210-699-2100,"VA Facility",Government,no,"Not Available",29.517317,-98.59535
+740GD,"Laredo Outpatient Clinic","4602 N. Bartlett",Laredo,TX,"78041",956-523-7850,"VA Facility",Government,no,"Not Available",40.0427,-93.4461
+504BY,"Lubbock Clinic","6104 Avenue Q South Drive",Lubbock,TX,"79412",806-472-3400,"VA Facility",Government,no,"Not Available",33.537964,-101.85425
+740GB,"McAllen Outpatient Clinic","901 E. Hackberry Ave.",McAllen,TX,"78503",956-618-7100,"VA Facility",Government,no,"Not Available",26.208422,-98.2105
+671,"North Central Federal OPC","17440 Henderson Pass","San Antonio",TX,"78232",210-483-2900,"VA Facility",Government,no,"Not Available",38.1838,-122.5914
+549,"Polk Street VA Clinic","4243 S. Polk Street",Dallas,TX,"75224",214-372-8100,"VA Facility",Government,no,"Not Available",32.69242,-96.83995
+671,"San Antonio Dental Clinic","8410 Data Point","San Antonio",TX,"78229",210-949-8900,"VA Facility",Government,no,"Not Available",29.517626,-98.56916
+671,"Shavano Park Outpatient Clinic","4350 Lockhill-Selma Road, Suite 200","San Antonio",TX,"78249",210-949-3773,"VA Facility",Government,no,"Not Available",38.1838,-122.5914
+674,"Temple VA Clinic Annex","4501 South General Bruce Drive, Suite 75",Temple,TX,"76502","254-743-1624 Or 254-743-1627","VA Facility",Government,no,"Not Available",31.086763,-97.39863
+549GA,"Tyler VA Primary Care Clinic","7916 S. Broadway Ave.",Tyler,TX,"75703","855-375-6930 Or 903-266-5900","VA Facility",Government,no,"Not Available",32.262688,-95.30751
+671,"Victoria OPC","1908 North Laurent Street, Suite 150",Victoria,TX,"77901",361-582-7700,"VA Facility",Government,no,"Not Available",28.810976,-96.991264
+519HC,"Abilene CBOC","3850 Ridgemont",Abilene,TX,"79606",325-695-3252,"VA Facility",Government,no,"Not Available",32.404293,-99.76582
+671GH,"Beeville CBOC","302 South Hillside Dr",Beeville,TX,"78102",361-358-9912,"VA Facility",Government,no,"Not Available",28.406782,-97.73223
+549GE,"Bridgeport CBOC","1713 South FM 51",Decatur,TX,"76234",940-627-7001,"VA Facility",Government,no,"Not Available",34.6059,-86.9833
+674GB,"Brownwood CBOC","2600 Memorial Park Drive",Brownwood,TX,"76801",325-641-0568,"VA Facility",Government,no,"Not Available",31.7093,-98.9912
+674GC,"Bryan/College Station CBOC","1651 Rock Prairie Road, Ste. 100","College Station",TX,"77845",979-680-0361,"VA Facility",Government,no,"Not Available",30.582659,-96.29087
+674GD,"Cedar Park CBOC","600 N. Bell Boulevard","Cedar Park",TX,"78613",512-219-2340,"VA Facility",Government,no,"Not Available",30.51541,-97.82645
+504GB,"Childress Clinic","1001 Highway 83 North",Childress,TX,"79201",940-937-8528,"VA Facility",Government,no,"Not Available",34.3673,-100.3565
+504BZ,"Clovis CBOC","921 East Llano Estacado",Clovis,NM,"88101",575-763-4335,"VA Facility",Government,no,"Not Available",34.433884,-103.194916
+504HB,"Dalhart VA Community Based Outpatient Clinic","325 Denver Ave",Dalhart,TX,"79022",806-249-0673,"VA Facility",Government,no,"Not Available",36.06303,-102.5219
+549GD,"Denton CBOC","2223 Colorado Blvd.",Denton,TX,"76205",940-891-6350,"VA Facility",Government,no,"Not Available",38.2757,-82.8278
+756GB,"Eastside El Paso CBOC","2400 Trawood Drive, Suite 200","El Paso",TX,"79936",915-217-2428,"VA Facility",Government,no,"Not Available",31.76511,-106.315895
+519HB,"Fort Stockton Clinic","2071 North Main","Fort Stockton",TX,"79735",432-685-2110,"VA Facility",Government,no,"Not Available",30.6791,-102.7875
+549GF,"Granbury CBOC","601 Fall Creek Hwy.",Granbury,TX,"76049",817-326-3902,"VA Facility",Government,no,"Not Available",32.469315,-97.69639
+549GH,"Greenville CBOC","4006 Wellington Rd., Suite 100A",Greenville,TX,"75401",903-450-1143,"VA Facility",Government,no,"Not Available",33.129063,-96.12283
+519GB,"Hobbs CBOC","1601 N Turner (4th Floor)",Hobbs,NM,"88240",575-391-0354,"VA Facility",Government,no,"Not Available",32.7026,-103.136
+674HB,"LaGrange Rural OutReach Clinic","890 E Travis St",LaGrange,TX,"78945",979-968-5878,"VA Facility",Government,no,"Not Available",29.90971,-96.868614
+756GA,"Las Cruces CBOC","1635 Don Roser","Las Cruces",NM,"88001",575-522-1241,"VA Facility",Government,no,"Not Available",32.3123,-106.7783
+671GL,"New Braunfels CBOC","705 Landa Street, Suite C","New Braunfels",TX,"78130",830-643-0717,"VA Facility",Government,no,"Not Available",29.705301,-98.13165
+671,"NorthEast 410 /San Antonio Clinic","2391 NE Loop 410 Ste 101","San Antonio",TX,"78217",210-590-0247,"VA Facility",Government,no,"Not Available",29.516327,-98.42043
+671,"Northwest 410/San Antonio Clinic","4318 Woodcock Ste 120","San Antonio",TX,"78228",210-736-4051,"VA Facility",Government,no,"Not Available",29.485802,-98.56912
+674GA,"Palestine CBOC","2000 So. Loop 256, Suite 124",Palestine,TX,"75801",903-723-9006,"VA Facility",Government,no,"Not Available",31.7942,-95.662
+671,"Pecan Valley CBOC","4243 E. Southcross, Ste 204","San Antonio",TX,"78222",210-337-4316,"VA Facility",Government,no,"Not Available",29.374807,-98.41205
+519GA,"Permian Basin Community Based Outpatient Clinic","8050 E. Hwy 191",Odessa,TX,"79762",432-685-2110,"VA Facility",Government,no,"Not Available",45.2597,-96.3289
+6427,"Plano CBOC","3804 W 15th Street",Plano,TX,"75075",972-801-4200,"VA Facility",Government,no,"Not Available",33.0198,-96.6989
+519HF,"San Angelo Clinic","2018 Pulliam","San Angelo",TX,"76905",325-658-6138,"VA Facility",Government,no,"Not Available",31.470688,-100.40485
+671,"Seguin CBOC","526 E. Court Street",Seguin,TX,"78155",830-372-1697,"VA Facility",Government,no,"Not Available",29.56896,-97.9608
+549GC,"Sherman CBOC","3811 US 75 N",Sherman,TX,"75090",903-487-0477,"VA Facility",Government,no,"Not Available",45.8712,-68.4178
+671,"South Bexar/San Antonio Clinic","4610 E Southcross Blvd Ste 100","San Antonio",TX,"78222",210-648-1491,"VA Facility",Government,no,"Not Available",29.374544,-98.402145
+519AB,"Stamford Clinic","1601 N Columbia",Stamford,TX,"79553",325-695-3252,"VA Facility",Government,no,"Not Available",41.3089,-73.3637
+671,"SW Military CBOC","1714 SW Military Dr., Suite 101","San Antonio",TX,"78221",210-923-0777,"VA Facility",Government,no,"Not Available",29.35664,-98.51999
+733,"Abilene Vet Center","3564 N. 6th St.",Abilene,TX,"79603","325-232-7925 Or 325-232-7925","VA Facility",Government,no,"Not Available",32.455303,-99.76634
+0702V,"Amarillo Vet Center","3414 Olsen Blvd. Suite E",Amarillo,TX,"79109","806-354-9779 Or 806-354-9779","VA Facility",Government,no,"Not Available",35.185078,-101.88002
+0732V,"Arlington Vet Center","3337 West Pioneer Parkway",Pantego,TX,"76013","817-274-0981 Or 817-274-0981","VA Facility",Government,no,"Not Available",32.711346,-97.16024
+0703V,"Austin Vet Center","2015 S. I.H. 35, Southcliff Bldg., Suite 101",Austin,TX,"78741","512-416-1314 Or 512-416-1314","VA Facility",Government,no,"Not Available",30.3264,-97.7713
+0705V,"Corpus Christi Vet Center","4646 Corona Suite 250","Corpus Christi",TX,"78411","361-854-9961 Or 361-854-9961","VA Facility",Government,no,"Not Available",27.713821,-97.38916
+5461,"Dallas Vet Center","8610 Greenville Ave., Suite 125",Dallas,TX,"75243","214-361-5896 Or 214-361-5896","VA Facility",Government,no,"Not Available",32.894432,-96.75287
+0707V,"El Paso Vet Center","1155 Westmoreland Suite 121","El Paso",TX,"79925","915-772-0013 Or 915-772-0013","VA Facility",Government,no,"Not Available",31.778967,-106.38721
+0708V,"Fort Worth Vet Center","6620 Hawk Creek Avenue","Westworth Village",TX,"76114","817-921-9095 Or 877-927-8387","VA Facility",Government,no,"Not Available",0,0
+0726V,"Killeen Vet Center","302 Millers Crossing, Suite #4","Harker Heights",TX,"76548","254-953-7100 Or 877-927-8387","VA Facility",Government,no,"Not Available",31.06693,-97.6638
+0712V,"Laredo Vet Center","6999 McPherson Road Suite 102",Laredo,TX,"78041","956-723-4680 Or 956-723-4680","VA Facility",Government,no,"Not Available",27.572512,-99.47259
+0714V,"Lubbock Vet Center","3106 50th st sute 400",Lubbock,TX,"79413","806-792-9782 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.54874,-101.881485
+0715V,"McAllen Vet Center","2108 S M Street, MedPoint Plaza, Unit 2",McAllen,TX,"78503","956-631-2147 Or 956-631-2147","VA Facility",Government,no,"Not Available",26.2034,-98.23
+0730V,"Mesquite Vet Center","502 West Kearney, Suite 300",Mesquite,TX,"75149","972-288-8030 Or 972-288-8030","VA Facility",Government,no,"Not Available",32.770718,-96.602806
+716,"Midland Vet Center","4400 N. Midland Drive, Suite 540",Midland,TX,"79707","432-697-8222 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.122,-87.1917
+0700V,"RCS Continental District 4, Zone 2 District Office","4500 S. Lancaster Rd. Building 69",Dallas,TX,"75216","214-857-1254 Or 214-857-1254","VA Facility",Government,no,"Not Available",32.694347,-96.79335
+0721V,"San Antonio Northeast Vet Center","9504 IH 35 N, Suite 214","San Antonio",TX,"78233","210-650-0422 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.1838,-122.5914
+0729V,"San Antonio Northwest Vet Center","9910 W Loop 1604 N, Suite 126","San Antonio",TX,"78254","210-688-0606 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.1838,-122.5914
+10N19,"VISN 19: Rocky Mountain Network","4100 E. Mississippi Ave., 11th floor",Glendale,CO,"80246",303-202-8165,"VA Facility",Government,no,"Not Available",39.696564,-104.939606
+623,"Eastern Oklahoma VA Health Care System (Jack C. Montgomery VAMC)","1011 Honor Heights Drive",Muskogee,OK,"74401","918-577-3000 Or 918-577-3000","VA Facility",Government,no,"Not Available",35.7479,-95.3697
+635,"Oklahoma City VA Health Care System","921 N.E. 13th Street","Oklahoma City",OK,"73104","405-456-1000 Or 405-456-1000","VA Facility",Government,no,"Not Available",35.48231,-97.49622
+554,"VA Eastern Colorado Health Care System(ECHCS)","1055 Clermont Street",Denver,CO,"80220",303-399-8020,"VA Facility",Government,no,"Not Available",39.73255,-104.93508
+436,"VA Montana Health Care System","3687 Veterans Drive","Fort Harrison",MT,"59636",406-442-6410,"VA Facility",Government,no,"Not Available",46.6048,-112.0917
+660,"VA Salt Lake City Health Care System","500 Foothill Drive","Salt Lake City",UT,"84148",801-582-1565,"VA Facility",Government,no,"Not Available",40.758488,-111.84073
+442,"Cheyenne VA Medical","2360 E. Pershing Blvd.",Cheyenne,WY,"82001","307-778-7550 Or 307-778-7550","VA Facility",Government,no,"Not Available",41.145813,-104.7888
+575,"Grand Junction VA Medical Center","2121 North Avenue","Grand Junction",CO,"81501","970-242-0731 Or 970-242-0731","VA Facility",Government,no,"Not Available",39.077374,-108.54048
+666,"Sheridan VA Medical Center","1898 Fort Road",Sheridan,WY,"82801","307-672-3473 Or 307-672-3473","VA Facility",Government,no,"Not Available",44.826782,-106.98457
+666,"Afton Outreach Clinic","125 South Washington",Afton,WY,"83110",307-886-5266,"VA Facility",Government,no,"Not Available",41.0344,-94.2016
+554GI,"Burlington Telehealth Clinic","1177 Rose Avenue",Burlington,CO,"80807",719-346-5239,"VA Facility",Government,no,"Not Available",39.300983,-102.265015
+6402,"Ernest Childers VA Outpatient Clinic / Tulsa","9322 E. 41st St.",Tulsa,OK,"74145",918-628-2518,"VA Facility",Government,no,"Not Available",36.104477,-95.87215
+666,"Evanston Primary Care Telehealth Outreach Clinic","1565 South Highway 150 #E",Evanston,WY,"82930",877-733-6128,"VA Facility",Government,no,"Not Available",42.0411,-87.6901
+575,"Glenwood Springs VA Telehealth Clinic","2425 S Grand Ave., Suite 101","Glenwood Springs",CO,"81601",970-945-1007,"VA Facility",Government,no,"Not Available",39.528496,-107.32537
+436,"Hamilton Primary Care Telehealth Outreach Clinic","299 Fairgrounds Suite A",Hamilton,MT,"59840",406-363-3352,"VA Facility",Government,no,"Not Available",46.25502,-114.15041
+436QC,"Helena VA Sleep Clinic","2271 Deerfield Lane",Helena,MT,"59601",406-447-7443,"VA Facility",Government,no,"Not Available",46.57023,-111.97614
+554,"Jewell Clinic","14400 E Jewell Ave",Aurora,CO,"80012",303-283-5400,"VA Facility",Government,no,"Not Available",39.682083,-104.82089
+442,"Laramie Mobile Telehealth Clinic","2901 Armory Road",Laramie,WY,"82702","888-483-9127 X 3816","VA Facility",Government,no,"Not Available",41.3114,-105.5911
+575,"Moab VA Telehealth Clinic","702 South Main Street",Moab,UT,"84532",435-719-4144,"VA Facility",Government,no,"Not Available",38.4506,-109.6027
+436,"Plentywood Primary Care Telehealth Outreach Clinic","440 West Laurel Ave.",Plentywood,MT,"59254",406-765-3718,"VA Facility",Government,no,"Not Available",48.778694,-104.56304
+442,"Rawlins PCTOC","1809 East Daley Street",Rawlins,WY,"82301",307-324-5578,"VA Facility",Government,no,"Not Available",41.796143,-107.21673
+554,"Salida Telehealth Clinic","920 Rush Drive",Salida,CO,"81201",719-539-8666,"VA Facility",Government,no,"Not Available",37.7187,-121.0899
+6422,"South Oklahoma City VA Clinic","7919 Mid America Blvd.","Oklahoma City",OK,"73135",405-855-6000,"VA Facility",Government,no,"Not Available",35.388805,-97.41268
+442,"Sterling Mobile Telehealth Clinic","100 College Dr.",Sterling,CO,"80751","888-483-9127 X 3816","VA Facility",Government,no,"Not Available",40.637978,-103.19676
+442,"Torrington Mobile Telehealth Clinic","908 West 25th Ave.",Torrington,WY,"82240","888-483-9127 X 3816","VA Facility",Government,no,"Not Available",42.068966,-104.19548
+623BY01,"Tulsa Behavioral Medicine Clinic","10159 E 11th Street",Tulsa,OK,"74128","918-610-2000 Or 918-610-2000","VA Facility",Government,no,"Not Available",36.148,-95.86382
+436HC,"VA Montana Health Care System, Havre CBOC","130 13th Street, Suite 1",Havre,MT,"59501",406-265-4304,"VA Facility",Government,no,"Not Available",48.53932,-109.6853
+442,"Wheatland Mobile Telehealth Clinic","759 East Cole Street",Wheatland,WY,"82201","888-483-9127 X 3816","VA Facility",Government,no,"Not Available",42.045074,-104.95171
+666,"Worland Primary Care Telehealth Outreach Clinic","510 South 15th., Suite D",Worland,WY,"82401",877-483-0370,"VA Facility",Government,no,"Not Available",44.01252,-107.94842
+635,"Ada CBOC","717 Better Now Plaza",Ada,OK,"74820",580-436-2262,"VA Facility",Government,no,"Not Available",40.7695,-83.8227
+567GC,"Alamosa /San Luis Valley Clinic/Sierra Blanca Clinic","622 Del Sol Drive",Alamosa,CO,"81101",719-587-6800,"VA Facility",Government,no,"Not Available",37.4695,-105.87
+635GF,"Altus VA Clinic","1604 N. Main, Highway 283",Altus,OK,"73521",580-482-0721,"VA Facility",Government,no,"Not Available",34.65482,-99.33396
+436GA,"Anaconda VA Community Based Outpatient Clinic","118 East 7th St., Suite 2A",Anaconda,MT,"59711",406-496-3000,"VA Facility",Government,no,"Not Available",46.124325,-112.95442
+635HB,"Ardmore VA Clinic","2002 12th Ave NW, Suite E",Ardmore,OK,"73401",580-222-0400,"VA Facility",Government,no,"Not Available",34.187466,-97.153885
+554GB,"Aurora Outpatient Clinic","13701 E Mississippi Ave Gateway Medical Bldg #200",Aurora,CO,"80012",303-398-6340,"VA Facility",Government,no,"Not Available",41.7606,-88.3201
+436GH,"Billings VA Community Based Outpatient Clinic with Specialty Clinic","Outpatient: 1775 Spring Creek Lane; Specialty Clinic: 1766 Majestic Lane",Billings,MT,"59102",406-373-3500,"VA Facility",Government,no,"Not Available",45.9783,-108.1945
+635GC,"Blackwell VA Clinic","1009 W. Ferguson Ave.",Blackwell,OK,"74631",580-363-0052,"VA Facility",Government,no,"Not Available",36.796967,-97.29587
+436GD,"Bozeman VA Community Based Outpatient Clinic","300 N. Willson, Suite 703G",Bozeman,MT,"59715",406-582-5300,"VA Facility",Government,no,"Not Available",45.68204,-111.03872
+666GB,"Casper Outpatient Clinic","4140 S. Poplar Str.",Casper,WY,"82601",866-338-5168,"VA Facility",Government,no,"Not Available",42.81012,-106.343544
+666GD,"Cody Outpatient Clinic","1432 Rumsey Avenue",Cody,WY,"82421",307-587-4015,"VA Facility",Government,no,"Not Available",44.527145,-109.05949
+575GB,"Craig Telehealth Clinic","785 Russell Street - Suite 400",Craig,CO,"81625",970-824-6721,"VA Facility",Government,no,"Not Available",40.519424,-107.54609
+436,"Cut Bank VA Community Based Outpatient Clinic","#8 2nd Ave SE","Cut Bank",MT,"59427",406-873-9047,"VA Facility",Government,no,"Not Available",48.634796,-112.330124
+501GJ,"Durango CCBOC","1970 East Third Avenue, Suite 102",Durango,CO,"81301",970-247-2214,"VA Facility",Government,no,"Not Available",37.2841,-107.874466
+660GK,"Elko Outreach Clinic","2719 Argent Ave. #9",Elko,NV,"89801",775-738-0188,"VA Facility",Government,no,"Not Available",40.841846,-115.78992
+5901,"Enid VA Clinic","915 E Owen K. Garriott, Suite G",Enid,OK,"73701",580-977-1855,"VA Facility",Government,no,"Not Available",36.390648,-97.86482
+442GC,"Fort Collins Outpatient Clinic","2509 Research Blvd.","Fort Collins",CO,"80526","970-224-1550 Or 970-224-1550","VA Facility",Government,no,"Not Available",40.555664,-105.08729
+666GB,"Gillette Outpatient Clinic","604 express Drive",Gillette,WY,"82718",866-621-1887,"VA Facility",Government,no,"Not Available",40.6921,-74.4718
+436GI,"Glasgow VA Community Based Outpatient Clinic","630 Second Ave. South, Suite A",Glasgow,MT,"59230",406-228-4101,"VA Facility",Government,no,"Not Available",48.1947,-106.63871
+436GK,"Glendive VA Community Based Outpatient Clinic","2000 Montana Ave.",Glendive,MT,"59330",406-377-4755,"VA Facility",Government,no,"Not Available",47.127228,-104.68935
+554/GC,"Golden Outpatient Clinic","1020 Johnson Road",Golden,CO,"80401",303-914-2680,"VA Facility",Government,no,"Not Available",39.74029,-105.20192
+436GB,"Great Falls VA Community Based Outpatient Clinic","1417 9th Street South, Suite 200 and 300","Great Falls",MT,"59405",406-791-3200,"VA Facility",Government,no,"Not Available",47.48997,-111.29218
+623GA,"Hartshorne VA Outpatient Clinic","1429 Pennsylvania Ave.",Hartshorne,OK,"74547",888-878-1598,"VA Facility",Government,no,"Not Available",34.842693,-95.54845
+660,"Idaho Falls Outreach Clinic","3544 East 17th Street","Idaho Falls",ID,"83406",208-522-2922,"VA Facility",Government,no,"Not Available",43.48186,-111.961975
+6421,"Jack C. Montgomery East","2414 E. Shawnee Bypass",Muskogee,OK,"74403",918-577-3699,"VA Facility",Government,no,"Not Available",35.770924,-95.3399
+436GF,"Kalispell VA Community Based Outpatient Clinic","31 Three Mile Dr., Suite 102",Kalispell,MT,"59901",406-758-2700,"VA Facility",Government,no,"Not Available",48.21142,-114.33203
+554GG,"La Junta Outpatient Clinic","1100 Carson Ave., Suite 104","La Junta",CO,"81050",719-383-5195,"VA Facility",Government,no,"Not Available",37.978893,-103.54871
+554GH,"Lamar Outpatient Clinic","1401 South Main Street, Suite 2",Lamar,CO,"81052",719-336-0315,"VA Facility",Government,no,"Not Available",38.07654,-102.618164
+635GA,"Lawton/Ft. Sill VA Clinic","4303 Pittman and Thomas, Building 4303","Fort Sill",OK,"73503",580-585-5600,"VA Facility",Government,no,"Not Available",34.6813,-98.4925
+436,"Lewistown VA Community Based Outpatient Clinic","629 NE Main St., Suite 1",Lewistown,MT,"59457",406-535-4790,"VA Facility",Government,no,"Not Available",47.070553,-109.415794
+442,"Loveland Community Clinic","5200 Hahns Peak Drive",Loveland,CO,"80538",970-962-4900,"VA Facility",Government,no,"Not Available",40.412712,-105.00748
+623GC,"McCurtain County Community Based Outpatient Clinic","903 SE Washington St.",Idabel,OK,"74745",580-920-7200,"VA Facility",Government,no,"Not Available",33.895565,-94.81764
+436GJ,"Miles City VA Community Based Outreach Clinic/ Nursing Home","210 S. Winchester","Miles City",MT,"59301",406-874-5600,"VA Facility",Government,no,"Not Available",46.406296,-105.83044
+436GC,"Missoula VA Community Based Outpatient Clinic","2687 Palmer St., Suite C",Missoula,MT,"59808",406-493-3700,"VA Facility",Government,no,"Not Available",46.887005,-114.03008
+575GA,"Montrose Outpatient Clinic","154 Colorado Avenue",Montrose,CO,"81401",970-249-7791,"VA Facility",Government,no,"Not Available",38.470642,-107.871895
+635,"North May Oklahoma City VA Clinic","2915 Pine Ridge Road","Oklahoma City",OK,"73120",405-752-6500,"VA Facility",Government,no,"Not Available",35.59251,-97.56757
+660GB,"Ogden CBOC","982 Chambers Street","South Ogden",UT,"84403",801-479-4105,"VA Facility",Government,no,"Not Available",41.166492,-111.95761
+660GE,"Orem CBOC","1443 West 800 North, Suite #302",Orem,UT,"84057",801-235-0953,"VA Facility",Government,no,"Not Available",40.2969,-111.6946
+554GE,"PFC Floyd K. Lindstrom Clinic at Colorado Springs","3141 Centennial Boulevard","Colorado Springs",CO,"80907",719-327-5660,"VA Facility",Government,no,"Not Available",38.8247,-104.562
+660GA,"Pocatello CBOC","500 S 11th Ave",Pocatello,ID,"83201",208-232-6214,"VA Facility",Government,no,"Not Available",42.86736,-112.43386
+660,"Price CBOC","189 South 600 West, Suite B",Price,UT,"84501",435-613-0342,"VA Facility",Government,no,"Not Available",39.59684,-110.79974
+554GD,"Pueblo Outpatient Clinic","4776 Eagleridge Circle",Pueblo,CO,"81008",719-553-1000,"VA Facility",Government,no,"Not Available",38.1286,-104.5523
+666GC,"Riverton Outpatient Clinic","2300 Rose Lane",Riverton,WY,"82501",866-338-2609,"VA Facility",Government,no,"Not Available",43.03563,-108.42055
+666GF,"Rock Springs Outpatient Clinic","1401 Gateway","Rock Springs",WY,"82901",866-381-2830,"VA Facility",Government,no,"Not Available",43.4599,-89.9319
+660GD,"Roosevelt CBOC","245 West 200 North",Roosevelt,UT,"84066",435-725-1050,"VA Facility",Government,no,"Not Available",40.302086,-109.995995
+442GB,"Sidney VA Outpatient Clinic","1116 10th Ave",Sidney,NE,"69162",308-254-6085,"VA Facility",Government,no,"Not Available",41.140823,-102.976555
+660GG,"St. George CBOC","230 North 1680 East, Building N","St. George",UT,"84790",435-634-7608,"VA Facility",Government,no,"Not Available",56.6,-169.5417
+635GE,"Stillwater VA Clinic","320 N. Perkins Avenue",Stillwater,OK,"74074",405-707-8100,"VA Facility",Government,no,"Not Available",40.3234,-81.3084
+623,"Vinita Outpatient Clinic","269 S 7th St",Vinita,OK,"74301",918-713-5400,"VA Facility",Government,no,"Not Available",36.63692,-95.14327
+660GJ,"Western Salt Lake CBOC","2750 South 5600 West","West Valley City",UT,"84120",801-417-5734,"VA Facility",Government,no,"Not Available",40.709984,-112.02493
+635GB,"Wichita Falls VA Clinic","149 Hart Street","Sheppard Air Force Base",TX,"76311",940-257-0000,"VA Facility",Government,no,"Not Available",0,0
+0509V,"Billings Vet Center","2795 Enterprise Ave., Suite 1",Billings,MT,"59102","406-657-6071 Or 406-657-6071","VA Facility",Government,no,"Not Available",45.75003,-108.58542
+527,"Boulder Vet Center","4999 Pearl East Circle, Suite 106",Boulder,CO,"80301","303-440-7306 Or 877-927-8387","VA Facility",Government,no,"Not Available",40.02116,-105.23718
+0519V,"Casper Vet Center","1030 North Poplar, Suite B",Casper,WY,"82601","307-261-5355 Or 307-261-5355","VA Facility",Government,no,"Not Available",42.860615,-106.33267
+0501V,"Cheyenne Vet Center","3219 E Pershing Blvd",Cheyenne,WY,"82001","307-778-7370 Or 307-778-7370","VA Facility",Government,no,"Not Available",41.145607,-104.77146
+525,"Colorado Springs Vet Center","602 South Nevada Avenue","Colorado Springs",CO,"80903","719-471-9992 Or 719-471-9992","VA Facility",Government,no,"Not Available",38.82535,-104.822044
+0504V,"Denver Vet Center","7465 East First Avenue Suite B",Denver,CO,"80230",303-326-0645,"VA Facility",Government,no,"Not Available",39.718548,-104.90127
+0543V,"Fort Collins Vet Center","702 W Drake Builing C","Fort Collins",CO,"80526","970-221-5176 Or 970-221-5176","VA Facility",Government,no,"Not Available",40.552666,-105.087814
+526,"Grand Junction Vet Center","2472 Patterson Road Unit 16","Grand Junction",CO,"81505","970-245-4156 Or 970-245-4156","VA Facility",Government,no,"Not Available",39.091896,-108.59437
+538,"Great Falls Vet Center","615 2nd Avenue North","Great Falls",MT,"59401","406-452-9048 Or 406-452-9048","VA Facility",Government,no,"Not Available",47.507515,-111.29696
+5281,"Helena Outstation","1301 Elm Street Suite C",Helena,MT,"59601",406-457-8060,"VA Facility",Government,no,"Not Available",46.607727,-112.01875
+539,"Kalispell Vet Center","690 North Meridian Road, Suite 101",Kalispell,MT,"59901",406-257-7308,"VA Facility",Government,no,"Not Available",48.189045,-114.330666
+0728V,"Lawton Vet Center","1016 SW C Avenue, Suite B",Lawton,OK,"73501",580-585-5880,"VA Facility",Government,no,"Not Available",34.605194,-98.40351
+528,"Missoula Vet Center","910 Brooks St.",Missoula,MT,"59801",406-721-4918,"VA Facility",Government,no,"Not Available",46.855923,-114.007286
+5141,"Ogden Outstation","2357 N 400 E Washington Blvd","North Ogden",UT,"84414",801-737-9737,"VA Facility",Government,no,"Not Available",41.30123,-111.968796
+0718V,"Oklahoma City Vet Center","6804 N. Robinson Avenue","Oklahoma City",OK,"73116","405-456-5184 Or 877-927-8387","VA Facility",Government,no,"Not Available",35.540695,-97.51643
+531,"Pocatello Vet Center","1800 Garrett Way, Suite 47",Pocatello,ID,"83201","208-232-0316 Or 208-232-0316","VA Facility",Government,no,"Not Available",42.87654,-112.458466
+532,"Provo Vet Center","360 S. State Street Bldg C Suite 103",Orem,UT,"84058",801-377-1117,"VA Facility",Government,no,"Not Available",40.29056,-111.69216
+542,"Pueblo Vet Center","1515 Fortino Blvd., Suite 130",Pueblo,CO,"81008",719-583-4058,"VA Facility",Government,no,"Not Available",38.312466,-104.62828
+0500V,"RCS Continental District 4 District Office","789 Sherman Street, Suite 570",Denver,CO,"80203","303-577-5205 Or 303-577-5207","VA Facility",Government,no,"Not Available",39.728817,-104.98489
+0540v,"Saint George Vet Center","1664 South Dixie Drive, Suite C-102","St. George",UT,"84770","435-673-4494 Or 435-673-4494","VA Facility",Government,no,"Not Available",56.6,-169.5417
+514,"Salt Lake Vet Center","22 West Fireclay Avenue",Murray,UT,"84107","801-266-1499 Or 877-927-8387","VA Facility",Government,no,"Not Available",40.677994,-111.89191
+0723V,"Tulsa Vet Center","14002 E. 21st Street",Tulsa,OK,"74134","918-628-2760 Or 918-628-2760","VA Facility",Government,no,"Not Available",36.13344,-95.82066
+10N20,"VISN 20: Northwest Network","1601 4th Plain Blvd Building 17, 4th Floor, Suite 403",Vancouver,WA,"98661",360-619-5925,"VA Facility",Government,no,"Not Available",45.6387,-122.6615
+463,"Alaska VA Healthcare System","1201 North Muldoon Road",Anchorage,AK,"99504","907-257-4700 Or 907-257-4700","VA Facility",Government,no,"Not Available",61.23116,-149.74269
+648,"Portland VA Medical Center","3710 SW U.S. Veterans Hospital Road",Portland,OR,"97239","503-220-8262 Or 503-220-8262","VA Facility",Government,no,"Not Available",45.49641,-122.68452
+663,"VA Puget Sound Health Care System","1660 S. Columbian Way",Seattle,WA,"98108","206-762-1010 Or 206-762-1010","VA Facility",Government,no,"Not Available",47.56228,-122.311424
+663A4,"VA Puget Sound Health Care System - American Lake Division","9600 Veterans Dr",Lakewood,WA,"98493","253-582-8440 Or 253-582-8440","VA Facility",Government,no,"Not Available",40.0979,-74.2176
+663,"VA Puget Sound Health Care System - Seattle Division","1660 S. Columbian Way",Seattle,WA,"98108","206-762-1010 Or 206-762-1010","VA Facility",Government,no,"Not Available",47.56228,-122.311424
+531,"Boise VA Medical Center","500 West Fort Street",Boise,ID,"83702",208-422-1000,"VA Facility",Government,no,"Not Available",43.61825,-116.194214
+687,"Jonathan M. Wainwright Memorial VA Medical Center","77 Wainwright Drive","Walla Walla",WA,"99362","888-687-8863 Or 509-525-5200","VA Facility",Government,no,"Not Available",46.052536,-118.35569
+668,"Mann-Grandstaff VA Medical Center","4815 N. Assembly Street",Spokane,WA,"99205",509-434-7000,"VA Facility",Government,no,"Not Available",47.701454,-117.47557
+653,"Roseburg VA Health Care System","913 NW Garden Valley Blvd.",Roseburg,OR,"97471",541-440-1000,"VA Facility",Government,no,"Not Available",43.228924,-123.36807
+648A4,"VA Portland Health Care System - Vancouver Campus","1601 E. Fourth Plain Blvd",Vancouver,WA,"98661",360-696-4061,"VA Facility",Government,no,"Not Available",45.639336,-122.65486
+692,"White City or VA Southern Oregon Rehabilitation Center","8495 Crater Lake Hwy.","White City",OR,"97503",541-826-2111,"VA Facility",Government,no,"Not Available",42.440937,-122.834885
+531,"Burns Oregon Outpatient Clinic","271 N Egan Ave",Burns,OR,"97720",541-573-3339,"VA Facility",Government,no,"Not Available",43.588093,-119.059525
+463,"Juneau VA Outreach Clinic","709 West 9th Street, Suite 150",Juneau,AK,"99801","907-796-4300 Or 907-796-4300","VA Facility",Government,no,"Not Available",58.301617,-134.4209
+668,"Libby RHC","211 E. Second St.",Libby,MT,"59923",406-293-8711,"VA Facility",Government,no,"Not Available",48.393345,-115.548874
+531,"Mountain Home Idaho Outpatient Clinic","815 North 6th East","Mountain Home",ID,"83647",208-580-2001,"VA Facility",Government,no,"Not Available",43.137764,-115.69252
+648,"Newport Outreach Clinic","1010 SW Coast Highway",Newport,OR,"97365",541-265-4182,"VA Facility",Government,no,"Not Available",44.62718,-124.06144
+531,"Salmon Idaho Outpatient Clinic","705 Lena Street",Salmon,ID,"83467",208-756-8515,"VA Facility",Government,no,"Not Available",45.173313,-113.89316
+668,"Sandpoint RHC","420 N. 2nd Ave. Suite-200",Sandpoint,ID,"83864",208-263-0450,"VA Facility",Government,no,"Not Available",48.276367,-116.54873
+648GE,"The Dalles Outreach Clinic","704 Veterans Drive","The Dalles",OR,"97058",541-296-3937,"VA Facility",Government,no,"Not Available",45.600388,-121.12573
+648,"West Linn CBOC","1750 SW Blankenship Rd Ste 300","West Linn",OR,"97068",503-210-4900,"VA Facility",Government,no,"Not Available",45.3657,-122.6123
+0523V,"Yakima Valley Vet Center","2119 W. Lincoln",Yakima,WA,"98902",509-457-2736,"VA Facility",Government,no,"Not Available",46.603485,-120.537346
+648GA,"Bend CBOC","2650 NE Courtney Drive",Bend,OR,"97701","541-647-5200 Or 855-213-8002","VA Facility",Government,no,"Not Available",44.071987,-121.26456
+653BY,"BHRRS - Behavioral Health Recovery & Reintegration Services","211 E 7th Ave Suite 118",Eugene,OR,"97401",541-440-1000,"VA Facility",Government,no,"Not Available",44.052135,-123.089455
+663GB,"Bremerton CBOC","925 Adele Avenue",Bremerton,WA,"98312",360-473-0340,"VA Facility",Government,no,"Not Available",47.56878,-122.662964
+653GB,"Brookings VA Clinic","840 Railroad St",Brookings,OR,"97415",541-412-1152,"VA Facility",Government,no,"Not Available",42.05251,-124.28958
+531GG,"Caldwell Idaho Outpatient Clinic","4521 Thomas Jefferson Drive",Caldwell,ID,"83605",208-454-4820,"VA Facility",Government,no,"Not Available",39.7478,-81.5165
+648ZZ,"Community Resource and Referral Center (CRRC)","308 SW 1st Ave",Portland,OR,"97204","503-808-1256 Or 800-949-1004 X 51256","VA Facility",Government,no,"Not Available",45.520313,-122.67219
+653BY,"Eugene Health Care Center","3355 Chad Dr.",Eugene,OR,"97408",541-607-0897,"VA Facility",Government,no,"Not Available",44.087612,-123.05653
+463GA,"Fairbanks VA Community Based Outpatient Clinic","Bldg 4076, Neeley Road, Room 1J-101","Fort Wainwright",AK,"99703","907-361-6370 Or 907-361-6370","VA Facility",Government,no,"Not Available",64.8145,-147.6263
+648GE,"Fairview Clinic","1800 NE Market Drive",Fairview,OR,"97024",503-660-0600,"VA Facility",Government,no,"Not Available",36.8434,-87.3039
+687,"Grangeville (ID) VA Outpatient Clinic","711 West North Street",Grangeville,ID,"83850",208-983-4671,"VA Facility",Government,no,"Not Available",45.927563,-116.12766
+692SS,"Grants Pass West VA CBOC","1877 Williams Hwy","Grants Pass",OR,"97527",541-955-5551,"VA Facility",Government,no,"Not Available",42.417038,-123.33931
+648GF,"Hillsboro CBOC","1925 NE Stucki Ave., Suite #300",Hillsboro,OR,"97006",503-906-5000,"VA Facility",Government,no,"Not Available",43.6522,-90.344
+463GB,"Kenai VA Community Based Outpatient Clinic","11312 Kenai Spur Highway, Suite 39",Kenai,AK,"99611","907-395-4100 Or 877-797-8924","VA Facility",Government,no,"Not Available",60.55464,-151.25703
+692GA,"Klamath Falls CBOC","2225 North El Dorado Blvd.","Klamath Falls",OR,"97601",541-273-6206,"VA Facility",Government,no,"Not Available",42.24797,-121.7848
+687GC,"La Grande (OR) Community Based Outpatient Clinic","202 12th Street","La Grande",OR,"97850",541-963-0627,"VA Facility",Government,no,"Not Available",45.313206,-118.08635
+687GB,"Lewiston (ID) Community Based Outpatient Clinic","1630 23rd Avenue, Bldg. 2",Lewiston,ID,"83501",208-746-7784,"VA Facility",Government,no,"Not Available",46.397305,-117.00901
+648GB,"Lincoln City Clinic","4422 NE Devils Lake Road, Suite 2","Lincoln City",OR,"97367",541-265-0547,"VA Facility",Government,no,"Not Available",38.1099,-86.9986
+463GC,"Mat-Su VA Community Based Outpatient Clinic","865 N. Seward Meridian Parkway, Suite 105",Wasilla,AK,"99654","907-631-3100 Or 800-323-8648","VA Facility",Government,no,"Not Available",61.5738,-149.35968
+687TH,"Morrow County VA Telehealth Clinic (Boardman OR)","2 Marine Drive, Suite 103 ~ P.O. Box 1059",Boardman,OR,"97818",541-481-2255,"VA Facility",Government,no,"Not Available",41.0242,-80.6629
+663,"Mount Vernon CBOC","307 S. 13th St., Suite 200","Mount Vernon",WA,"98274",360-848-8500,"VA Facility",Government,no,"Not Available",48.41875,-122.32529
+653GA,"North Bend VA Clinic","2191 Marion Street","North Bend",OR,"97459",541-756-8002,"VA Facility",Government,no,"Not Available",43.40408,-124.23651
+648GD,"North Coast CBOC","91400 N. Neacoxie Street, building 7315",Warrenton,OR,"97146","503-220-8262 X 52593","VA Facility",Government,no,"Not Available",38.7135,-77.7953
+"668GB (North Idaho)","North Idaho CBOC","915 W. Emma Avenue","Coeur d 'Alene",ID,"83814",208-665-1700,"VA Facility",Government,no,"Not Available",47.69261,-116.79611
+663GB,"North Olympic Peninsula","1114 Georgiana St","Port Angeles",WA,"98362",360-565-7420,"VA Facility",Government,no,"Not Available",48.11315,-123.41334
+687GA,"Richland (WA) Community Based Outpatient Clinic","825 Jadwin Ave., Ste. 250, Federal Bldg., 2nd Floor",Richland,WA,"99352",509-946-1020,"VA Facility",Government,no,"Not Available",46.277122,-119.27524
+648GB,"Salem CBOC","1750 McGilchrist St. SE, Suite 130",Salem,OR,"97302",971-304-2200,"VA Facility",Government,no,"Not Available",44.916733,-123.023155
+663GD,"South Sound CBOC","151 NE Hampe Way",Chehalis,WA,"98532",360-748-3049,"VA Facility",Government,no,"Not Available",46.6271,-123.0092
+531GE,"Twin Falls Idaho Outpatient Clinic","260 2nd Avenue East","Twin Falls",ID,"83301",208-732-0959,"VA Facility",Government,no,"Not Available",42.5551,-114.46718
+663GA,"Valor CBOC Bellevue","13033 Bel-Red Road Suite 210",Bellevue,WA,"98005","425-214-1055 Or 425-214-1055","VA Facility",Government,no,"Not Available",47.621864,-122.165504
+663GA,"Valor CBOC Federal Way","34617 11th Place South Suite 301","Federal Way",WA,"98003",253-336-4142,"VA Facility",Government,no,"Not Available",47.291386,-122.32083
+663GA,"Valor CBOC North Seattle","12360 Lake City Way NE, Suite 200",Seattle,WA,"98125",206-384-4382,"VA Facility",Government,no,"Not Available",47.71814,-122.29588
+687TH,"Wallowa County VA Telehealth Clinic (Enterprise OR)","401 NE 1st Street",Enterprise,OR,"97828",541-426-0219,"VA Facility",Government,no,"Not Available",45.428265,-117.27629
+668,"Wenatchee CBOC","2530 Chester-Kimm Road",Wenatchee,WA,"98801","509-663-7615 Or 509-663-7615","VA Facility",Government,no,"Not Available",47.46406,-120.334
+687HA,"Yakima (WA) Community Based Outpatient Clinic","717 Fruitvale Blvd.",Yakima,WA,"98902",509-966-0199,"VA Facility",Government,no,"Not Available",46.612583,-120.5218
+0502V,"Anchorage Vet Center","4400 Business Park Blvd, Suite B-34",Anchorage,AK,"99503","907-563-6966 Or 877-927-8387","VA Facility",Government,no,"Not Available",61.180626,-149.88925
+0522V,"Bellingham Vet Center","3800 Byron Ave Suite 124",Bellingham,WA,"98229","360-733-9226 Or 877-927-8387","VA Facility",Government,no,"Not Available",48.73362,-122.46637
+0503V,"Boise Vet Center","2424 Bank DrivE, Suite 100",Boise,ID,"83705","208-342-3612 Or 877-927-8387","VA Facility",Government,no,"Not Available",43.59107,-116.211555
+0622V,"Central Oregon Vet Center","1645 NE Forbes Rd. Suite 105",Bend,OR,"97701","541-749-2112 Or 541-749-2112","VA Facility",Government,no,"Not Available",31.0561,-98.509
+626,"Eugene Vet Center","190 East 11th Avenue",Eugene,OR,"97401","541-465-6918 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.0477,-123.08984
+529,"Everett Vet Center","3311 Wetmore Avenue",Everett,WA,"98201",425-252-9701,"VA Facility",Government,no,"Not Available",47.97373,-122.20698
+0511V,"Fairbanks Vet Center","540 4th Ave., Suite 100",Fairbanks,AK,"99701","907-456-4238 Or 877-927-8387","VA Facility",Government,no,"Not Available",64.842415,-147.71849
+0535V,"Federal Way Vet Center","32020 32nd Ave South Suite 110","Federal Way",WA,"98001","253-838-3090 Or 253-838-3090","VA Facility",Government,no,"Not Available",47.3223,-122.3126
+645,"Grants Pass Vet Center","211 S.E. 10th St.","Grants Pass",OR,"97526","541-479-6912 Or 877-927-8387","VA Facility",Government,no,"Not Available",42.43722,-123.322266
+05021V,"Kenai Vet Center Outstation","43299 Kalifornsky Beach Rd. Ste 4",Soldotna,AK,"99669","907-260-7640 Or 877-927-8387","VA Facility",Government,no,"Not Available",60.3208,-150.7989
+0617V,"Portland Vet Center","1505 NE 122nd Ave.",Portland,OR,"97230","503-688-5361 Or 877-927-8387 X 7","VA Facility",Government,no,"Not Available",45.53367,-122.53765
+640,"Salem Vet Center","2645 Portland Road NE, Suite 250",Salem,OR,"97301","503-362-9911 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.961227,-123.014565
+0507V,"Seattle Vet Center","4735 E Marginal Way S, Room 1102",Seattle,WA,"98134","206-658-4225 Or 877-927-8387","VA Facility",Government,no,"Not Available",47.6062,-122.3321
+0510V,"Spokane Vet Center","13109 E Mirabeau Parkway",Spokane,WA,"99216","509-444-8387 Or 509-444-8387","VA Facility",Government,no,"Not Available",47.6597,-117.4291
+508,"Tacoma Vet Center","4916 Center St. Suite E",Tacoma,WA,"98409","253-565-7038 Or 253-565-7038","VA Facility",Government,no,"Not Available",47.234417,-122.50397
+0541V,"Walla Walla County Vet Center","1104 West Poplar","Walla Walla",WA,"99362","509-526-8387 Or 509-526-8387","VA Facility",Government,no,"Not Available",46.059216,-118.35254
+0512V,"Wasilla Vet Center","851 E. West Point Drive Suite 102",Wasilla,AK,"99654","907-376-4318 Or 907-376-4318","VA Facility",Government,no,"Not Available",61.58227,-149.42818
+523,"Yakima Vet Center","2119 W. Lincoln Ave",Yakima,WA,"98902","509-457-2736 Or 509-457-2736","VA Facility",Government,no,"Not Available",46.603485,-120.537346
+687,687,"77 Wainwright Drive","Walla Walla",WA,"99362",,"VA Facility",Government,no,"Not Available",46.052536,-118.35569
+523,"Yakima Valley Vet Center","2119 West Lincoln Avenue",Yakima,WA,"98902",509-457-2736,"VA Facility",Government,no,"Not Available",46.603485,-120.53733
+10N21,"VISN 21: Sierra Pacific Network","201 Walnut Avenue","Mare Island",CA,"94592",707-562-8350,"VA Facility",Government,no,"Not Available",0,0
+662,"San Francisco VA Health Care System","4150 Clement Street","San Francisco",CA,"94121",415-221-4810,"VA Facility",Government,no,"Not Available",37.781143,-122.504105
+570,"Central California VA Health Care System","2615 E. Clinton Avenue",Fresno,CA,"93703","559-225-6100 Or 559-225-6100","VA Facility",Government,no,"Not Available",36.77229,-119.78002
+640,Livermore,"4951 Arroyo Road",Livermore,CA,"94550",925-373-4700,"VA Facility",Government,no,"Not Available",37.637985,-121.763985
+640,"Menlo Park","795 Willow Road","Menlo Park",CA,"94025",650-614-9997,"VA Facility",Government,no,"Not Available",37.46356,-122.15805
+612,"VA Northern California Health Care System","10535 Hospital Way",Mather,CA,"95655","800-382-8387 Or 916-843-7000","VA Facility",Government,no,"Not Available",38.571793,-121.297386
+459,"VA Pacific Islands Health Care System","459 Patterson Road",Honolulu,HI,"96819","808-433-0600 Or 800-214-1306","VA Facility",Government,no,"Not Available",21.36117,-157.88878
+640,"VA Palo Alto Health Care System","3801 Miranda Avenue","Palo Alto",CA,"94304",650-493-5000,"VA Facility",Government,no,"Not Available",37.402836,-122.14173
+654,"VA Sierra Nevada Health Care System","975 Kirman Avenue",Reno,NV,"89502","775-786-7200 Or 775-786-7200","VA Facility",Government,no,"Not Available",39.515854,-119.79849
+593,"VA Southern Nevada Healthcare System","6900 North Pecos Road","N. Las Vegas",NV,"89086",702-791-9024,"VA Facility",Government,no,"Not Available",0,0
+640,"Capitola Clinic","1350 41st Avenue, Suite 102",Capitola,CA,"95010",831-464-5519,"VA Facility",Government,no,"Not Available",36.97057,-121.96488
+612,"Chico Outpatient Clinic","280 Cohasset Road",Chico,CA,"95926","530-879-5000 X 9 Or 530-879-5000","VA Facility",Government,no,"Not Available",39.751648,-121.85145
+612,"Fairfield Outpatient Clinic","103 Bodin Circle, Travis Air Force Base",Fairfield,CA,"94535","707-437-1800 Or 707-437-1800","VA Facility",Government,no,"Not Available",38.267887,-121.95876
+5199,"Major General William H. Gourley VA-DoD Outpatient Clinic","201 Ninth Street",Marina,CA,"93933",831-884-1000,"VA Facility",Government,no,"Not Available",36.6799,-121.7897
+96440,"Manila Outpatient Clinic","1501 Roxas Boulevard","Pasay City",PI,"01302",632-550-3888,"VA Facility",Government,no,"Not Available",0,0
+612,"Mare Island Outpatient Clinic","201 Walnut Avenue",Vallejo,CA,"94592","707-562-8200 Or 707-562-8200","VA Facility",Government,no,"Not Available",38.1041,-122.2566
+612,"Martinez Outpatient Clinic and Community Living Center","150 Muir Road",Martinez,CA,"94553","925-372-2000 Or 925-372-2000","VA Facility",Government,no,"Not Available",37.994648,-122.11164
+612,"McClellan Dental Clinic - Sacramento","5401 Arnold Avenue",McClellan,CA,"95652",916-333-5500,"VA Facility",Government,no,"Not Available",38.6679,-121.4032
+612,"McClellan Outpatient Clinic - Sacramento","5342 Dudley Blvd.",McClellan,CA,"95652","916-561-7400 Or 916-561-7400","VA Facility",Government,no,"Not Available",38.6679,-121.4032
+640,"Modesto Clinic","1225 Oakdale Road",Modesto,CA,"95355",209-557-6200,"VA Facility",Government,no,"Not Available",37.662674,-120.95753
+459,"National Center for PTSD - Pacific Islands Division","3375 Koapaka Street, Suite I-560",Honolulu,HI,"96819",808-566-1546,"VA Facility",Government,no,"Not Available",21.33633,-157.91733
+593GG,"Northeast Primary Care Clinic","4461 E Charleston Blvd","Las Vegas",NV,"89104",702-791-9050,"VA Facility",Government,no,"Not Available",36.158955,-115.07734
+593GD,"Northwest Primary Care Clinic","3968 N Rancho Dr","Las Vegas",NV,"89130",702-791-9020,"VA Facility",Government,no,"Not Available",36.230484,-115.22426
+612,"Oakland Behavioral Health Clinic","525 21st Street",Oakland,CA,"94612","510-587-3400 Or 510-587-3400","VA Facility",Government,no,"Not Available",37.810413,-122.270035
+612,"Oakland Outpatient Clinic","2221 Martin Luther King Jr. Way",Oakland,CA,"94612","510-267-7800 Or 510-267-7800","VA Facility",Government,no,"Not Available",37.812134,-122.27288
+612,"Redding Outpatient Clinic","351 Hartnell Avenue",Redding,CA,"96002","530-226-7555 Or 530-226-7555","VA Facility",Government,no,"Not Available",40.56456,-122.367836
+612,"Sacramento Mental Health Clinic at Mather","10535 Hospital Way",Mather,CA,"95655","916-366-5420 Or 916-366-5420","VA Facility",Government,no,"Not Available",38.571793,-121.297386
+640BY,"San Jose Clinic","80 Great Oaks Boulevard","San Jose",CA,"95119",408-363-3000,"VA Facility",Government,no,"Not Available",37.233974,-121.778854
+654GA,"Sierra Foothills Outpatient Clinic","11985 Heritage Oak Place",Auburn,CA,"95603",530-889-0872,"VA Facility",Government,no,"Not Available",38.940647,-121.099236
+640GB,"Sonora Clinic","13663 Mono Way",Sonora,CA,"95370",209-588-2600,"VA Facility",Government,no,"Not Available",37.5123,-85.9142
+593GE,"Southeast Primary Care Clinic","1020 S Boulder",Henderson,NV,"89015",702-791-9030,"VA Facility",Government,no,"Not Available",36.029716,-114.97094
+593GF,"Southwest Primary Care Clinic","7235 South Buffalo Drive","Las Vegas",NV,"89113",702-791-9040,"VA Facility",Government,no,"Not Available",36.056946,-115.261024
+640,"Stockton Clinic","7777 South Freedom Rd","French Camp",CA,"95231",209-946-3400,"VA Facility",Government,no,"Not Available",33.3026,-89.4085
+4201,"VA Lanai Outreach Clinic","628-B Seventh Street","Lanai City",HI,"96783",808-565-6423,"VA Facility",Government,no,"Not Available",20.826756,-156.91786
+4202,"VA Molokai Outreach Clinic","280 Home Olu Place",Kaunakakai,HI,"96748",808-553-3191,"VA Facility",Government,no,"Not Available",21.109,-156.9093
+612A,Yreka,"101 E Oberlin Rd",Yreka,CA,"96097",530-841-8500,"VA Facility",Government,no,"Not Available",41.716076,-122.63874
+662GG,"Clearlake VA Outpatient Clinic","15145 Lakeshore Drive",Clearlake,CA,"95422",707-995-7200,"VA Facility",Government,no,"Not Available",38.949894,-122.63026
+662GC,"Eureka VA Outpatient Clinic","930 W. Harris",Eureka,CA,"95503",707-269-7500,"VA Facility",Government,no,"Not Available",40.780552,-124.18108
+640GC,"Fremont Clinic","39199 Liberty Street, Building B",Fremont,CA,"94538",510-791-4000,"VA Facility",Government,no,"Not Available",37.550194,-121.9808
+654,"Lahontan Valley VA Clinic","1020 New River Parkway, Suite 304",Fallon,NV,"89406",775-326-2659,"VA Facility",Government,no,"Not Available",39.538,-118.3436
+570GA,"Merced Community-Based Outpatient Clinic","340 E Yosemite Ave",Merced,CA,"95340",209-381-0105,"VA Facility",Government,no,"Not Available",37.33211,-120.46582
+570GC,"Oakhurst Community-Based Outpatient Clinic","40597 Westlake Drive",Oakhurst,CA,"93644",559-683-5300,"VA Facility",Government,no,"Not Available",37.338547,-119.66928
+5119,"Pahrump Community Based Outpatient Clinic","220 South Lola Lane",Pahrump,NV,"89048",775-727-7535,"VA Facility",Government,no,"Not Available",36.2083,-115.9839
+662GE,"San Bruno VA Outpatient Clinic","1001 Sneath Lane, Suite 300, Third Floor","San Bruno",CA,"94066",650-615-6000,"VA Facility",Government,no,"Not Available",37.63524,-122.42477
+662GA,"Santa Rosa VA Outpatient Clinic","3841 Brickway Blvd","Santa Rosa",CA,"95403",707-569-2300,"VA Facility",Government,no,"Not Available",38.51461,-122.79337
+662BU,"SFVA Downtown Clinic","401 3rd Street","San Francisco",CA,"94107",415-281-5100,"VA Facility",Government,no,"Not Available",37.782543,-122.39735
+570,"Tulare Community-Based Outpatient Clinic","1050 N. Cherry Street",Tulare,CA,"93274",559-684-8703,"VA Facility",Government,no,"Not Available",36.22275,-119.33752
+662GD,"Ukiah VA Outpatient Clinic","630 Kings Court",Ukiah,CA,"95482",707-468-7700,"VA Facility",Government,no,"Not Available",39.14806,-123.1984
+459,"VA American Samoa CBOC","Fiatele Teo Army Reserve Bldg","Pago Pago",AS,"96799",684-699-3730,"VA Facility",Government,no,"Not Available",0,0
+654,"VA Carson Valley Outpatient Clinic","1330 Waterloo Lane, Suite 101",Gardnerville,NV,"89410",775-782-5265,"VA Facility",Government,no,"Not Available",38.925064,-119.74963
+654GD,"VA Diamond View Outpatient Clinic","110 Bella Way",Susanville,CA,"96130","530-251-4550 Or 530-251-4550","VA Facility",Government,no,"Not Available",40.4163,-120.653
+459,"VA Guam Community Based Outpatient Clinic","498 Chalan Palayso","Agana Heights",GU,"96910",671-475-5760,"VA Facility",Government,no,"Not Available",0,0
+459,"VA Hilo Community Based Outpatient Clinic","1285 Waianuenue Avenue, Suite 211",Hilo,HI,"96720",808-935-3781,"VA Facility",Government,no,"Not Available",19.717466,-155.11314
+459,"VA Kauai Community Based Outpatient Clinic","4485 Pahe'e Street, Suite 150",Lihue,HI,"96766",808-246-0497,"VA Facility",Government,no,"Not Available",21.968864,-159.38431
+459,"VA Kona Community Based Outpatient Clinic","35-377 Hualalai Road",Kailua-Kona,HI,"96740",808-329-0774,"VA Facility",Government,no,"Not Available",19.6406,-155.9956
+1396,"VA Leeward Community Based Outpatient Clinic","91-2135 Fort Weaver Road","Ewa Beach",HI,"96706",800-214-1306,"VA Facility",Government,no,"Not Available",21.369507,-158.02618
+459,"VA Maui Community Based Outpatient Clinic","203 Ho'ohana Street, Suite 303",Kahului,HI,"96732",808-871-2454,"VA Facility",Government,no,"Not Available",20.88696,-156.46333
+6307,"VA Saipan Outreach Clinic","Marina Heights Business Park",Saipan,MP,"96950","670-323-9000 Or 670-322-0035","VA Facility",Government,no,"Not Available",0,0
+612,"Yuba City Outpatient Clinic","425 Plumas Street","Yuba City",CA,"95991",530-751-4500,"VA Facility",Government,no,"Not Available",39.130913,-121.614136
+616,"American Samoa Vet Center","Ottoville Road, P.O. Box 982942","Pago Pago",AS,"96799","684-699-3760 Or 877-927-8387","VA Facility",Government,no,"Not Available",0,0
+649,"Chico Vet Center","250 Cohasset Road, Suite 40",Chico,CA,"95926","530-899-6300 Or 530-899-6300","VA Facility",Government,no,"Not Available",39.75176,-121.85193
+610,"Citrus Heights Vet Center","5650 Sunrise Blvd., Suite 150","Citrus Heights",CA,"95610","916-535-0420 Or 916-535-0420","VA Facility",Government,no,"Not Available",38.670345,-121.27155
+602,"Concord Vet Center","1333 Willow Pass Road, Suite 106",Concord,CA,"94520","925-680-4526 Or 925-680-4526","VA Facility",Government,no,"Not Available",37.972385,-122.05445
+644,"Eureka Vet Center","2830 G Street, Suite A",Eureka,CA,"95501","707-444-8271 Or 707-444-8271","VA Facility",Government,no,"Not Available",40.782574,-124.16242
+628,"Fresno Vet Center","1320 E. Shaw Ave, Suite 125",Fresno,CA,"93710","559-487-5660 Or 877-927-8387","VA Facility",Government,no,"Not Available",36.808594,-119.76464
+648,"Guam Vet Center","222 Chalan Santo Papa Street, Suite 201",Hagatna,GU,"96910",671-472-7161,"VA Facility",Government,no,"Not Available",0,0
+534,"Henderson Vet Center","400 North Stephanie, Suite 180",Henderson,NV,"89014","702-791-9100 Or 702-791-9100","VA Facility",Government,no,"Not Available",36.05657,-115.0462
+635,"Hilo Vet Center","70 Lanihuli Street, Suite 102",Hilo,HI,"96720","808-969-3833 Or 887-969-3833","VA Facility",Government,no,"Not Available",19.71111,-155.07872
+609,"Honolulu Vet Center","1680 Kapiolani Blvd. Suite F-3",Honolulu,HI,"96814","808-973-8387 Or 877-927-8387","VA Facility",Government,no,"Not Available",21.291153,-157.83807
+0636V,"Kailua-Kona Vet Center","73-4976 Kamanu St",Kailua-Kona,HI,"96740",808-329-0574,"VA Facility",Government,no,"Not Available",19.687277,-156.01602
+633,"Kauai Vet Center","4485 Pahe'e St., Suite 101",Lihue,HI,"96766","808-246-1163 Or 877-927-8387","VA Facility",Government,no,"Not Available",21.968864,-159.38431
+0505V,"Las Vegas Vet Center","7455 W. Washington Ave, Suite 240","Las Vegas",NV,"89128",702-791-9170,"VA Facility",Government,no,"Not Available",36.181328,-115.2531
+634,"Maui Vet Center","157 Ma'a Street",KAHULUI,HI,"96732",808-242-8557,"VA Facility",Government,no,"Not Available",20.8895,-156.4743
+650,"Modesto Vet Center","1219 N. Carpenter Rd., Suite 11-12",Modesto,CA,"95351","209-569-0713 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.652004,-121.031006
+646,"North Bay Vet Center","6010 Commerce Blvd., Ste. 145","Rohnert Park",CA,"94928",707-586-3295,"VA Facility",Government,no,"Not Available",38.352222,-122.71077
+612,"Oakland Vet Center","7700 Edgewater Drive, Suite 125",Oakland,CA,"94621","510-562-7906 Or 510-562-7906","VA Facility",Government,no,"Not Available",37.743034,-122.20435
+647,"Peninsula Vet Center","345 Middlefield Road, Building 1","Menlo Park",CA,"94025","650-617-4300 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.456406,-122.16773
+0600V,"RCS Pacific District 5 District Office","420 Executive Court North Suite A",Fairfield,CA,"94534","707-646-2988 Or 707-646-2988","VA Facility",Government,no,"Not Available",38.230152,-122.12159
+0506V,"Reno Vet Center","5580 Mill St. Suite 600",Reno,NV,"89502","775-323-1294 Or 877-927-8387","VA Facility",Government,no,"Not Available",39.3728,-81.3957
+638,"Sacramento Vet Center","1111 Howe Avenue Suite #390",Sacramento,CA,"95825","916-566-7430 Or 877-927-8387","VA Facility",Government,no,"Not Available",38.584957,-121.41534
+620,"San Francisco Vet Center","505 Polk Street","San Francisco",CA,"94102","415-441-5051 Or 877-927-8387","VA Facility",Government,no,"Not Available",37.78154,-122.418884
+615,"San Jose Vet Center","80 Great Oaks Blvd.","San Jose",CA,"95119","408-993-0729 Or 408-993-0729","VA Facility",Government,no,"Not Available",37.233974,-121.778854
+639,"Santa Cruz County Vet Center","1350 41st Ave, Suite 104",Capitola,CA,"95010","831-464-4575 Or 877-927-8387","VA Facility",Government,no,"Not Available",36.97057,-121.96488
+0621V,"Western Oahu Vet Center","885 Kamokila Boulevard, Suite 105",Kapolei,HI,"96707","808-674-2414 Or 877-927-8387","VA Facility",Government,no,"Not Available",21.330032,-158.08583
+593GH,"Laughlin Rural Outreach Clinic","3650 South Point Circle, Building D, 2nd Floor, Suite 200",Laughlin,NV,"89029",702-298-1100,"VA Facility",Government,no,"Not Available",35.1678,-114.573
+10N22,"VISN 22: Desert Pacific Healthcare Network","300 Oceangate, Suite 700","Long Beach",CA,"90802",562-826-5963,"VA Facility",Government,no,"Not Available",33.766495,-118.1987
+501,"New Mexico VA Health Care System","1501 San Pedro Drive, SE",Albuquerque,NM,"87108","505-265-1711 Or 505-265-1711","VA Facility",Government,no,"Not Available",35.056324,-106.577675
+649,"Northern Arizona VA Health Care System","500 North Highway 89",Prescott,AZ,"86313","928-445-4860 Or 928-445-4860","VA Facility",Government,no,"Not Available",38.0807,-94.7021
+644,"Phoenix VA Health Care System","650 E. Indian School Road",Phoenix,AZ,"85012","602-277-5551 Or 602-277-5551","VA Facility",Government,no,"Not Available",33.494797,-112.0668
+678,"Southern Arizona VA Health Care System","3601 South 6th Avenue",Tucson,AZ,"85723","520-792-1450 Or 520-792-1450","VA Facility",Government,no,"Not Available",32.18126,-110.96826
+691,"VA Greater Los Angeles Healthcare System (GLA)","11301 Wilshire Boulevard","Los Angeles",CA,"90073",310-478-3711,"VA Facility",Government,no,"Not Available",34.0522,-118.2437
+605,"VA Loma Linda Healthcare System","11201 Benton Street","Loma Linda",CA,"92357","909-825-7084 Or 909-825-7084","VA Facility",Government,no,"Not Available",34.051037,-117.25238
+600,"VA Long Beach Healthcare System","5901 E. 7th Street","Long Beach",CA,"90822","562-826-8000 Or 562-826-8000","VA Facility",Government,no,"Not Available",33.775333,-118.11876
+664,"VA San Diego Healthcare System","3350 La Jolla Village Drive","San Diego",CA,"92161",858-552-8585,"VA Facility",Government,no,"Not Available",32.7153,-117.1573
+664,"ASPIRE Center","2121 San Diego Avenue","San Diego",CA,"92110",855-297-8397,"VA Facility",Government,no,"Not Available",32.746605,-117.18952
+605,"Blythe Rural Health Clinic","1273 West Hobson Way",Blythe,CA,"92225",760-921-1224,"VA Facility",Government,no,"Not Available",33.61016,-114.60913
+649,"Chinle Comprehensive Care Facility (Indian Health Services)","Hwy 191 and Hospital Drive",Chinle,AZ,"86503",928-674-7675,"VA Facility",Government,no,"Not Available",36.2391,-109.5747
+649GF,"Holbrook VA Clinic","33 W. Vista Dr.",Holbrook,AZ,"86025",928-524-1050,"VA Facility",Government,no,"Not Available",42.2081,-112.6746
+691GA,"Los Angeles Ambulatory Care Center","351 East Temple Street","Los Angeles",CA,"90012",213-253-2677,"VA Facility",Government,no,"Not Available",34.05251,-118.239746
+649,"Page VA Clinic","801 N Navajo Dr. Ste-B",Page,AZ,"86040",928-645-4966,"VA Facility",Government,no,"Not Available",36.91684,-111.4514
+6381,"Polacca VA Clinic","Highway 264 Mile Post 388",Polacca,AZ,"86042",928-283-4465,"VA Facility",Government,no,"Not Available",35.8479,-110.3696
+664,"Rio Clinic","8989 Rio San Diego, Suite 360","San Diego",CA,"92108",619-228-8000,"VA Facility",Government,no,"Not Available",32.77582,-117.13689
+691A4,"Sepulveda OPC and Nursing Home","16111 Plummer Street","North Hills",CA,"91343","818-891-7711 Or 818-891-7711","VA Facility",Government,no,"Not Available",34.24288,-118.48041
+649,"Tuba City VA Clinic","167 N Main St P.O. Box 600","Tuba City",AZ,"86045",928-283-4465,"VA Facility",Government,no,"Not Available",36.142876,-111.23962
+605BZ,"VA Loma Linda Ambulatory Care Center","26001 Redlands Blvd.",Redlands,CA,"92373",909-825-7084,"VA Facility",Government,no,"Not Available",34.063038,-117.23747
+691,"VA West Los Angeles Healthcare Center","11301 Wilshire Blvd","Los Angeles",CA,"90073",310-478-3711,"VA Facility",Government,no,"Not Available",34.0522,-118.2437
+501GI,"Alamogordo CCBOC","3199 N. White Sands Blvd., Suite D10",Alamogordo,NM,"88310",575-437-9195,"VA Facility",Government,no,"Not Available",32.933743,-105.96381
+600GA,Anaheim,"2569 W Woodland Dr",Anaheim,CA,"92801",714-763-5300,"VA Facility",Government,no,"Not Available",33.849346,-117.97515
+649GE,"Anthem CBOC","41810 North Venture Dr., Bldg. B",Anthem,AZ,"85086","623-249-2300 Or 800-949-1005 X 2300","VA Facility",Government,no,"Not Available",33.8673,-112.1468
+501GA,"Artesia Clinic","2410 W. Main St.,",Artesia,NM,"88210",575-746-3531,"VA Facility",Government,no,"Not Available",32.842644,-104.42751
+691GD,"Bakersfield Community Based Outpatient Clinic","1801 Westwind Drive",Bakersfield,CA,"93301",661-632-1800,"VA Facility",Government,no,"Not Available",35.376835,-119.04256
+678GC,"Casa Grande CBOC","1876 E. Sabin Drive, Building A Ste 15","Casa Grande",AZ,"85122",520-836-2536,"VA Facility",Government,no,"Not Available",32.8795,-111.7574
+664GC,"Chula Vista Clinic","865 3rd Avenue","Chula Vista",CA,"91910",619-409-1600,"VA Facility",Government,no,"Not Available",32.62196,-117.07232
+605GD,Corona,"2045 Compton Avenue, Bldg. 7, Suite 101",Corona,CA,"92881",951-817-8820,"VA Facility",Government,no,"Not Available",33.853207,-117.536194
+649GE,"Cottonwood CBOC","501 S. Willard",Cottonwood,AZ,"86326",928-649-1523,"VA Facility",Government,no,"Not Available",34.73068,-112.02738
+691GF,"East Los Angeles Community Based Outpatient Clinic","5426 E. Olympic Boulevard","City of Commerce",CA,"90040",323-725-7372,"VA Facility",Government,no,"Not Available",34.015556,-118.155075
+664GD,Escondido,"815 East Pennsylvania Avenue",Escondido,CA,"92025",760-466-7020,"VA Facility",Government,no,"Not Available",33.127407,-117.072014
+501GE,"Espanola CCBOC","105 S. Coronado Ave.",Espanola,NM,"87532",505-367-4213,"VA Facility",Government,no,"Not Available",35.99053,-106.08518
+501GB,"Farmington CBOC","3605 English Road",Farmington,NM,"87402",505-326-4383,"VA Facility",Government,no,"Not Available",36.761497,-108.14833
+649GB,"Flagstaff CBOC","1300 W. University Ave. Suite 200",Flagstaff,AZ,"86001","928-226-1056 Or 800-949-1005 X 5650","VA Facility",Government,no,"Not Available",35.184116,-111.670784
+501GD,"Gallup CBOC","2075 NM Hwy 602",Gallup,NM,"87301",505-722-7234,"VA Facility",Government,no,"Not Available",35.5281,-108.7426
+691,"Gardena Community Based Outpatient Clinic","1149 West 190th Street",Gardena,CA,"90248",310-851-4705,"VA Facility",Government,no,"Not Available",33.858334,-118.29599
+644,"Globe-Miami VA Health Care Clinic","5860 S. Hospital Drive, Suite 111",Globe,AZ,"85501",928-425-0027,"VA Facility",Government,no,"Not Available",33.40677,-110.82588
+678GE,"Green Valley CBOC","380 W. Vista Hermosa Drive #140","Green Valley",AZ,"85614",520-399-2291,"VA Facility",Government,no,"Not Available",31.854649,-110.99739
+664GA,"Imperial Valley","1115 South 4th Street","El Centro",CA,"92243",760-352-1506,"VA Facility",Government,no,"Not Available",32.78269,-115.55243
+6425,"Kayenta VA Clinic","394.3 Highway 160",Kayenta,AZ,"86033","928-445-4860 X 3392 Or 800-949-1005 X 3392","VA Facility",Government,no,"Not Available",36.6486,-110.1876
+649GA,"Kingman CBOC","2668 Hualapai Mountain Road",Kingman,AZ,"86401",928-718-7300,"VA Facility",Government,no,"Not Available",45.5495,-68.1995
+600GE,"Laguna Hills","25292 McIntyre Road","Laguna Hills",CA,"92653",949-587-3700,"VA Facility",Government,no,"Not Available",33.596123,-117.67979
+649GC,"Lake Havasu City CBOC","2035 Mesquite, Suite D","Lake Havasu City",AZ,"86403","928-505-7100 Or 800-949-1005 X 7100","VA Facility",Government,no,"Not Available",34.47788,-114.33046
+691,"Lancaster Community Based Outpatient Clinic","340 E Avenue I Suite 108",Lancaster,CA,"93535",661-729-8655,"VA Facility",Government,no,"Not Available",34.70404,-118.12551
+501G2,"Las Vegas CCBOC","624 University Ave.,","Las Vegas",NM,"87701",505-425-1910,"VA Facility",Government,no,"Not Available",35.595673,-105.21634
+644GH,"Midtown VA Clinic","5040 N 15th Ave",Phoenix,AZ,"85015",602-234-7080,"VA Facility",Government,no,"Not Available",33.51061,-112.09123
+664,"Mission Valley Clinic","8810 Rio San Diego Drive","San Diego",CA,"92108",619-400-5000,"VA Facility",Government,no,"Not Available",32.775913,-117.14002
+605GB,Murrieta,"28078 Baxter Rd., Suite 540",Murrieta,CA,"92563",951-290-6500,"VA Facility",Government,no,"Not Available",33.5539,-117.2139
+644GG,"Northeast CBOC (Phoenix)","11390 E. Via Linda Rd. Ste.105",Scottsdale,AZ,"85259",480-579-2200,"VA Facility",Government,no,"Not Available",33.589054,-111.83652
+501GM,"Northwest Metro","1760 Grande Blvd SE","Rio Rancho",NM,"87124",505-896-7200,"VA Facility",Government,no,"Not Available",35.22997,-106.66115
+644GA,"Northwest VA Health Care Clinic","13985 W. Grand Avenue, Suite 101",Surprise,AZ,"85374",623-251-2884,"VA Facility",Government,no,"Not Available",33.6306,-112.3332
+664GB,"Oceanside Clinic","1300 Rancho del Oro Drive",Oceanside,CA,"92056",760-643-2000,"VA Facility",Government,no,"Not Available",33.1959,-117.3795
+691gm,"Oxnard Community Based Outpatient Clinic","1690 Universe Circle",Oxnard,CA,"93033",805-204-9135,"VA Facility",Government,no,"Not Available",34.18277,-119.16113
+605GC,"Palm Desert","41-990 Cook St, Bldg F Ste 1004","Palm Desert",CA,"92211",760-341-5570,"VA Facility",Government,no,"Not Available",33.7225,-116.377
+644GD,"Payson VA Health Care Clinic","903 E Highway 260",Payson,AZ,"85541","928-468-2100 Or 928-468-2100","VA Facility",Government,no,"Not Available",34.251347,-111.32259
+605GE,"Rancho Cucamonga","8599 Haven Ave., Suite 102","Rancho Cucamonga",CA,"91730",909-946-5348,"VA Facility",Government,no,"Not Available",34.095577,-117.57578
+501HB,"Raton CBOC","1493 Whittier Street",Raton,NM,"87440",575-445-2391,"VA Facility",Government,no,"Not Available",36.6873,-104.2485
+678GD,"Safford Clinic","355 N. 8th Avenue",Safford,AZ,"85546",928-428-8010,"VA Facility",Government,no,"Not Available",32.835648,-109.71604
+691GK,"San Luis Obispo Community Based Outpatient Clinic","1288 Morro Street, Ste.200","San Luis Obispo",CA,"93401",805-543-1233,"VA Facility",Government,no,"Not Available",35.279198,-120.660416
+600GB,"Santa Ana","1506 Brookhollow Dr","Santa Ana",CA,"92705",714-434-4600,"VA Facility",Government,no,"Not Available",33.71314,-117.84916
+691GB,"Santa Barbara Community Based Outpatient Clinic","4440 Calle Real,","Santa Barbara",CA,"93110",805-683-1491,"VA Facility",Government,no,"Not Available",34.442417,-119.77877
+501GK,"Santa Fe CBOC","5152 Beckner Road","Santa Fe",NM,"87507",505-986-8645,"VA Facility",Government,no,"Not Available",35.687,-105.9378
+691,"Santa Maria Community Based Outpatient Clinic","1550 East Main Street","Santa Maria",CA,"93454",805-354-6000,"VA Facility",Government,no,"Not Available",34.96743,-120.42733
+644GB,"Show Low VA Health Care Clinic","5171 Cub Lake Road, Suite C380","Show Low",AZ,"85901",928-532-1069,"VA Facility",Government,no,"Not Available",34.202072,-110.02095
+678GA,"Sierra Vista Clinic","101 N. Coronado Drive Suite A","Sierra Vista",AZ,"85635",520-459-1529,"VA Facility",Government,no,"Not Available",31.553316,-110.27763
+501GC,"Silver City Clinic","2950 Leslie Road","Silver City",NM,"88061",575-538-2921,"VA Facility",Government,no,"Not Available",32.79467,-108.26302
+664GE,"Sorrento Valley Clinic","10455 Sorrento Valley Road","San Diego",CA,"92121",858-552-7475,"VA Facility",Government,no,"Not Available",32.89261,-117.21451
+644BY,"Southeast VA Health Care Clinic","3285 S. Val Vista Dr.",Gilbert,AZ,"85297",480-397-2800,"VA Facility",Government,no,"Not Available",35.9879,-92.7163
+644GC,"Southwest Community Based Outpatient Clinic","9250 W. Thomas Rd.",Phoenix,AZ,"85037",623-772-4000,"VA Facility",Government,no,"Not Available",33.47967,-112.25856
+501,"Taos CCBOC","1353 Paseo Del Pueblo Sur",Taos,NM,"87571",575-751-0328,"VA Facility",Government,no,"Not Available",36.37114,-105.595764
+644GE,"Thunderbird VA Health Care Clinic","9424 N. 25th Ave.",Phoenix,AZ,"85021",602-633-6900,"VA Facility",Government,no,"Not Available",33.571198,-112.11228
+501GH,"Truth or Consequences CCBOC","1960 North Date Street","Truth or Consequences",NM,"87901",575-894-7662,"VA Facility",Government,no,"Not Available",33.150505,-107.24602
+678GF,"VA Northwest Tucson Clinic","2945 W. Ina Road",Tucson,AZ,"85741",520-219-2418,"VA Facility",Government,no,"Not Available",32.33738,-111.03047
+678GG,"VA Southeast Tucson Clinic","7395 S. Houghton Road Ste 129",Tucson,AZ,"85747",520-664-1831,"VA Facility",Government,no,"Not Available",32.117203,-110.772675
+605GA,Victorville,"12138 Industrial Boulevard, Suite 120",Victorville,CA,"92395",760-951-2599,"VA Facility",Government,no,"Not Available",34.472652,-117.2829
+600GC,"Villages At Cabrillo","2001 River Ave, Bldg 28","Long Beach",CA,"90806",562-388-8000,"VA Facility",Government,no,"Not Available",46.3523,-124.0543
+600gd,"Whittier/Santa Fe Springs Clinic","10330 Pioneer Blvd Suite 180","Santa Fe Springs",CA,"90670",562-347-2200,"VA Facility",Government,no,"Not Available",33.9472,-118.0854
+470-8262,"Yuma Clinic","3111 S. 4th Avenue",Yuma,AZ,"85364",928-317-9973,"VA Facility",Government,no,"Not Available",32.672523,-114.62432
+0515V,"Albuquerque Vet Center","2001 Mountain Road NW",Albuquerque,NM,"87104","505-346-6562 Or 505-346-6562","VA Facility",Government,no,"Not Available",35.098385,-106.66792
+603,"Antelope Valley Vet Center","38925 Trade Center Drive, Suites I/J",Palmdale,CA,"93551","661-267-1026 Or 661-267-1026","VA Facility",Government,no,"Not Available",34.5794,-118.1165
+601,"Bakersfield Vet Center","1110 Golden State Ave.",Bakersfield,CA,"93301","661-323-8387 Or 661-323-8387","VA Facility",Government,no,"Not Available",44.782,-72.8029
+605,"Chatsworth Vet Center","20946 Devonshire St, Suite 101",Chatsworth,CA,"91311",818-576-0201,"VA Facility",Government,no,"Not Available",34.25723,-118.5896
+05161V,"Chinle Vet Center Outstation","Navajo Route 7, Old BIA Complex-B59",Chinle,AZ,"86503",844-286-7270,"VA Facility",Government,no,"Not Available",36.2391,-109.5747
+614,"Chula Vista Vet Center","180 Otay Lakes Road, Suite 108",Bonita,CA,"91902","877-618-6534 Or 877-618-6534","VA Facility",Government,no,"Not Available",32.659225,-117.03042
+611,"Corona Vet Center","800 Magnolia Avenue Suite 110",Corona,CA,"92879","951-734-0525 Or 951-734-0525","VA Facility",Government,no,"Not Available",33.85894,-117.55446
+607,"Culver City Vet Center","5730 Uplander Way Suite 100","Culver City",CA,"90230","310-641-0326 Or 310-641-0326","VA Facility",Government,no,"Not Available",33.986443,-118.38459
+623,"East Los Angeles Vet Center","5400 E. Olympic Blvd. Suite 140",Commerce,CA,"90022","323-728-9966 Or 323-728-9966","VA Facility",Government,no,"Not Available",34.015686,-118.1557
+0516V,"Farmington Vet Center","4251 E. Main Suite A",Farmington,NM,"87402","505-327-9684 Or 505-327-9684","VA Facility",Government,no,"Not Available",36.759556,-108.15592
+613,"High Desert Vet Center","15095 Amargosa Rd, Suite 107",Victorville,CA,"92394","760-261-5925 Or 760-261-5925","VA Facility",Government,no,"Not Available",34.524727,-117.33031
+5162,"Hopi Vet Center Outstation","P.O. Box 929, 1 Main St.",Hotevilla,AZ,"86030","928-734-5166 Or 928-734-5166","VA Facility",Government,no,"Not Available",35.9278,-110.6729
+536,"Lake Havasu Vet Center","1720 Mesquite, Suite 101","Lake Havasu",AZ,"86403","928-505-0394 Or 928-505-0394","VA Facility",Government,no,"Not Available",34.478374,-114.34081
+530,"Las Cruces Vet Center","1120 Commerce Street, Suite B","Las Cruces",NM,"88001","575-523-9826 Or 575-523-9826","VA Facility",Government,no,"Not Available",32.3123,-106.7783
+0606V,"Los Angeles Vet Center","1045 W. Redondo Beach Blvd. Suite 150",Gardena,CA,"90247","310-767-1221 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.89245,-118.29319
+524,"Mesa Vet Center","1303 South Longmore, Suite 5",Mesa,AZ,"85202","480-610-6727 Or 480-610-6727","VA Facility",Government,no,"Not Available",33.391068,-111.863785
+624,"North Orange County Vet Center","12453 Lewis St. Suite 101","Garden Grove",CA,"92840","714-776-0161 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.78244,-117.897484
+0517V,"Phoenix Vet Center","4020 N. 20th St. #110",Phoenix,AZ,"85016","602-640-2981 Or 602-640-2981","VA Facility",Government,no,"Not Available",33.4934,-112.038925
+0518V,"Prescott Vet Center (Dr. Cameron K. McKinley Vet Center)","3180 Stillwater Drive, Suite A",Prescott,AZ,"86305","928-778-3469 Or 877-927-8387","VA Facility",Government,no,"Not Available",34.59808,-112.46729
+637,"San Bernardino Vet Center","1325 E. Cooley Drive, Suite 101",Colton,CA,"92324","909-801-5762 Or 877-927-8387","VA Facility",Government,no,"Not Available",34.054634,-117.30536
+618,"San Diego Vet Center","2790 Truxtun Road, Suite 130","San Diego",CA,"92106","858-642-1500 Or 858-642-1500","VA Facility",Government,no,"Not Available",32.740627,-117.21285
+0619v,"San Luis Obispo Vet Center","1070 Southwood Drive","San Luis Obispo",CA,"93401","805-782-9101 Or 877-927-8387","VA Facility",Government,no,"Not Available",35.265366,-120.64087
+642,"San Marcos Vet Center","One Civic Center Dr., Suite 150","San Marcos",CA,"92069","855-898-6050 Or 877-927-8387","VA Facility",Government,no,"Not Available",29.8833,-97.9414
+0520V,"Santa Fe Vet Center","2209 Brothers Road Suite 110","Santa Fe",NM,"87505","505-988-6562 Or 505-988-6562","VA Facility",Government,no,"Not Available",35.65078,-105.95243
+5921,"South Orange County Vet Center","26431 Crown Valley Parkway, Suite 100","Mission Viejo",CA,"92691","949-348-6700 Or 877-927-8387","VA Facility",Government,no,"Not Available",33.6,-117.672
+608,"Temecula Vet Center","40935 County Center Drive, Suite A/B",Temecula,CA,"92591","951-302-4849 Or 951-302-4849","VA Facility",Government,no,"Not Available",33.528206,-117.16034
+0521V,"Tucson Vet Center","2525 E. Broadway Blvd Suite 100",Tucson,AZ,"85716",520-882-0333,"VA Facility",Government,no,"Not Available",32.221508,-110.93447
+643,"Ventura Vet Center","790 E. Santa Clara St. Suite 100",Ventura,CA,"93001","805-585-1860 Or 805-585-1860","VA Facility",Government,no,"Not Available",34.279526,-119.28866
+0533V,"West Valley Vet Center","14050 N. 83rd Avenue Suite 170",Peoria,AZ,"85381","623-398-8854 Or 623-398-8854","VA Facility",Government,no,"Not Available",33.612053,-112.23756
+0537V,"Yuma Vet Center","1450 E. 16th St, Suite 103",Yuma,AZ,"85365","928-271-8700 Or 928-271-8700","VA Facility",Government,no,"Not Available",32.69857,-114.60357
+678CG,"Casa Grande Rural Health Care Coordination Center","1179 E. Cottonwood Lane, Suite 1","Casa Grande",AZ,"85122","520-629-4801 Or 520-629-4801","VA Facility",Government,no,"Not Available",32.894085,-111.735535
+600QA,"Community Resource and Referral Center","888 W. Santa Ana Blvd. Suite 150","Santa Ana",CA,"92701","844-838-8300 Or 844-838-8300","VA Facility",Government,no,"Not Available",33.75201,-117.85871
+678SV,"Sierra Vista Rural Health Care Coordination Center","157 North Coronado Drive, Suite B","Sierra Vista",AZ,"85635","520-629-4802 Or 520-629-4802","VA Facility",Government,no,"Not Available",31.552668,-110.27763
+10N23,"VISN 23: VA Midwest Health Care Network","2805 Dodd Road, Suite 250",Eagan,MN,"55121",651-405-5600,"VA Facility",Government,no,"Not Available",44.855087,-93.12877
+437,"Fargo VA Health Care System","2101 Elm Street N.",Fargo,ND,"58102","701-232-3241 Or 701-232-3241","VA Facility",Government,no,"Not Available",46.90639,-96.776855
+636A8,"Iowa City VA Health Care System","601 Highway 6 West","Iowa City",IA,"52246",319-338-0581,"VA Facility",Government,no,"Not Available",41.6611,-91.5302
+618,"Minneapolis VA Health Care System","One Veterans Drive",Minneapolis,MN,"55417",612-725-2000,"VA Facility",Government,no,"Not Available",44.98,-93.2638
+636,"Omaha VA Medical Center--VA Nebraska-Western Iowa HCS","4101 Woolworth Avenue",Omaha,NE,"68105","402-346-8800 Or 800-451-5796","VA Facility",Government,no,"Not Available",41.245132,-95.97476
+656,"St. Cloud VA Health Care System","4801 Veterans Drive","St. Cloud",MN,"56303","320-252-1670 Or 320-252-1670","VA Facility",Government,no,"Not Available",45.5289,-94.5933
+568A4,"VA Black Hills Health Care System - Hot Springs Campus","500 North 5th Street","Hot Springs",SD,"57747","605-745-2000 Or 605-745-2000","VA Facility",Government,no,"Not Available",43.435852,-103.47448
+568,"VA Black Hills Health Care System - Fort Meade Campus","113 Comanche Road","Fort Meade",SD,"57741","605-347-2511 Or 605-347-2511","VA Facility",Government,no,"Not Available",44.412003,-103.46777
+636A6,"VA Central Iowa Health Care System","3600 30th Street","Des Moines",IA,"50310","515-699-5999 Or 515-699-5999","VA Facility",Government,no,"Not Available",41.628147,-93.65877
+636A4,"Grand Island VA Medical Center","2201 No. Broadwell Avenue","Grand Island",NE,"68803","308-382-3660 Or 866-580-1810","VA Facility",Government,no,"Not Available",40.942425,-98.35887
+438,"Royal C. Johnson Veterans Memorial Medical Center","2501 W. 22nd Street, PO Box 5046","Sioux Falls",SD,"57117",605-336-3230,"VA Facility",Government,no,"Not Available",43.53304,-96.75647
+636A8,"Coralville OPC","520 10 Ave Ste 200",Coralville,IA,"52441","319-358-2406 Or 319-688-3365","VA Facility",Government,no,"Not Available",41.6946,-91.5954
+636A5,"Lincoln VA Clinic","600 South 70th Street",Lincoln,NE,"68510","402-489-3802 Or 866-851-6052","VA Facility",Government,no,"Not Available",40.807457,-96.62502
+636QC,"Community Resource and Referral Center - Cedar Rapids","1535 First Ave SE","Cedar Rapids",IA,"52403",319-365-0898,"VA Facility",Government,no,"Not Available",41.988605,-91.651436
+636A6,"Community Resource and Referral Center - Des Moines","1223 Center Street","Des Moines",IA,"50309",515-699-5637,"VA Facility",Government,no,"Not Available",41.59168,-93.63398
+636QI,"Community Resource and Referral Center - Quad Cities","415 North Perry Street",Davenport,IA,"52801",563-328-5800,"VA Facility",Government,no,"Not Available",41.52367,-90.57259
+438GD,"Aberdeen VA Clinic","2301 8th Ave. NE, Suite 225",Aberdeen,SD,"57401",605-229-3500,"VA Facility",Government,no,"Not Available",45.473736,-98.455605
+618GK,"Albert Lea VA Clinic","1665 West Main St.","Albert Lea",MN,"56007",507-377-6051,"VA Facility",Government,no,"Not Available",43.64646,-93.38959
+656,"Alexandria Community Based Outpatient Clinic","515 22nd Avenue East",Alexandria,MN,"56308",320-759-2640,"VA Facility",Government,no,"Not Available",45.867462,-95.37343
+636,"Bellevue VA Clinic","2206 Longo Drive, Suite 102",Bellevue,NE,"68005",402-591-4500,"VA Facility",Government,no,"Not Available",41.15577,-95.92394
+437GE,"Bemidji VA Community Based Outpatient Clinic","1217 Anne St., Bemidji, MN 56601",Bemidji,MN,"56601",218-755-6360,"VA Facility",Government,no,"Not Available",47.4736,-94.8803
+636GF,"Bettendorf VA Clinic","2979 Victoria Street",Bettendorf,IA,"52722",563-332-8528,"VA Facility",Government,no,"Not Available",41.553448,-90.4971
+437GB,"Bismarck VA Community Based Outpatient Clinic","Gateway Mall, 2700 State Street, Suite F",Bismarck,ND,"58503",701-221-9152,"VA Facility",Government,no,"Not Available",46.8083,-100.7837
+656GA,"Brainerd VA Clinic","722 NW 7th Street",Brainerd,MN,"56401",218-855-1115,"VA Facility",Government,no,"Not Available",46.35942,-94.22238
+0405V,"Carroll CBOC","311 S Clark St, Suite 275",Carroll,IA,"51401","712-794-6780 Or 855-794-6780","VA Facility",Government,no,"Not Available",42.05701,-94.86798
+638A8,"Cedar Rapids CBOC","2230 Wiley Blvd SW","Cedar Rapids",IA,"52404",319-369-4340,"VA Facility",Government,no,"Not Available",41.95747,-91.72585
+618GE,"Chippewa Valley VA Clinic","475 Chippewa Mall Drive Suite 418","Chippewa Falls",WI,"54729",715-720-3780,"VA Facility",Government,no,"Not Available",44.92612,-91.38237
+636GU,"Decorah VA Clinic","915 Short St.",Decorah,IA,"52101",563-387-5840,"VA Facility",Government,no,"Not Available",43.291492,-91.797
+437GL,"Devils Lake VA Community Based Outpatient Clinic","1031 7th St. NE","Devils Lake",ND,"58301",701-662-5801,"VA Facility",Government,no,"Not Available",48.1148,-98.850716
+437,"Dickinson VA Community Based Outpatient Clinic","528 - 21st St. W. Suite F",Dickinson,ND,"58601",701-483-1850,"VA Facility",Government,no,"Not Available",46.905,-102.79279
+636GJ,"Dubuque VA Clinic","200 Mercy Dr, Ste 106",Dubuque,IA,"52001",563-588-5520,"VA Facility",Government,no,"Not Available",42.492767,-90.673805
+618GB,"Ely VA Clinic","720 Miners Drive East",Ely,MN,"55731",218-365-0001,"VA Facility",Government,no,"Not Available",39.2474,-114.8886
+437GC,"Fergus Falls VA Community Based Outpatient Clinic","1839 N Park St","Fergus Falls",MN,"56537",218-739-1400,"VA Facility",Government,no,"Not Available",46.302166,-96.07622
+636GK,"Fort Dodge CBOC","2419 2nd Avenue N","Fort Dodge",IA,"50501","515-576-2235 Or 877-578-8846","VA Facility",Government,no,"Not Available",37.732,-99.9354
+636GI,"Galesburg VA Clinic","310 Home Boulevard",Galesburg,IL,"61401","309-343-0311 Or 309-343-0311","VA Facility",Government,no,"Not Available",37.471,-95.3614
+568HB,"Gordon VA Clinic","300 East 8th Street",Gordon,NE,"69343",308-282-1442,"VA Facility",Government,no,"Not Available",42.811832,-102.200356
+437GA,"Grafton VA Community Based Outpatient Clinic","1319 11th St. West",Grafton,ND,"58237",701-352-4059,"VA Facility",Government,no,"Not Available",39.0146,-90.4692
+437GI,"Grand Forks VA Community Based Outpatient Clinic","3221 32nd Avenue South, Suite 700","Grand Forks",ND,"58201",701-335-4380,"VA Facility",Government,no,"Not Available",47.88944,-97.07383
+618GH,"Hayward VA Clinic","15954 River's Edge Drive Suite 103",Hayward,WI,"54843",715-934-5454,"VA Facility",Government,no,"Not Available",46.004047,-91.489845
+618GB,"Hibbing VA Clinic","990 West 41st Street Suite 5",Hibbing,MN,"55746",218-263-1400,"VA Facility",Government,no,"Not Available",47.4001,-92.961655
+636,"Holdrege VA Clinic","1118 Burlington St",Holdrege,NE,"68949",308-995-3760,"VA Facility",Government,no,"Not Available",40.44539,-99.37966
+437,"Jamestown VA Community Based Outpatient","2422 20th St SW",Jamestown,ND,"58401",701-952-4787,"VA Facility",Government,no,"Not Available",42.097,-79.2353
+636A7,"Knoxville CBOC","1607 N. Lincoln Street",Knoxville,IA,"50138","641-828-5019 Or 800-816-8878","VA Facility",Government,no,"Not Available",35.9901,-83.9622
+618GJ,"Lyle C. Pearson VA Clinic","1961 Premier Dr Suite 330",Mankato,MN,"56001",507-387-2939,"VA Facility",Government,no,"Not Available",44.179867,-93.94533
+618GD,"Maplewood VA Clinic","1725 Legacy Parkway, Suite 100",Maplewood,MN,"55109",651-225-5420,"VA Facility",Government,no,"Not Available",44.7475,-87.4793
+636GD,"Marshalltown CBOC","101 Iowa Ave W",Marshalltown,IA,"50158","641-754-6700 Or 877-424-4404","VA Facility",Government,no,"Not Available",42.006947,-92.91202
+636GC,"Mason City CBOC","520 S. Pierce, Suite 150","Mason City",IA,"50401","641-494-5000 Or 800-351-4671","VA Facility",Government,no,"Not Available",43.147163,-93.22106
+568HK,"McLaughlin VA Clinic","Veterans Industries, Sales Barn Rd, P.O. Box 519",McLaughlin,SD,"57642",605-823-4574,"VA Facility",Government,no,"Not Available",45.8144,-100.8104
+437GD,"Minot VA Community Based Outpatient Clinic","5th Medical Group, 10 Missile Avenue",Minot,ND,"58705",701-727-9800,"VA Facility",Government,no,"Not Available",42.2404,-70.762
+568HS,"Mission CBOC","Horizon Health Care, Inc. 153 Main Street",Mission,SD,"57555",605-856-2295,"VA Facility",Government,no,"Not Available",39.0278,-94.6558
+656GB,"Montevideo VA Clinic","1025 North 13th Street",Montevideo,MN,"56265",320-269-2222,"VA Facility",Government,no,"Not Available",44.95535,-95.71118
+568HA,"Newcastle VA Clinic","1124 Washington Blvd.",Newcastle,WY,"57555",307-746-4491,"VA Facility",Government,no,"Not Available",43.848816,-104.188515
+636GA,"Norfolk VA Clinic","710 S 13th, Suite 1200",Norfolk,NE,"68701",402-370-4570,"VA Facility",Government,no,"Not Available",42.02499,-97.42654
+636GB,"North Platte VA Clinic","600 East Francis, Suite 3","North Platte",NE,"69101",308-532-6906,"VA Facility",Government,no,"Not Available",41.122543,-100.75789
+618GI,"Northwest Metro VA Clinic","7545 Veterans Drive",Ramsey,MN,"55303",612-467-1100,"VA Facility",Government,no,"Not Available",39.1366,-89.0914
+636PP,"O'Neill Community-Based Outreach Clinic","555 E. John Street","O'Neill",NE,"68763",402-336-2982,"VA Facility",Government,no,"Not Available",42.462406,-98.64539
+636GS,"Ottumwa VA Clinic","1009 E Pennsylvania Ave",Ottumwa,IA,"52501",641-683-4300,"VA Facility",Government,no,"Not Available",41.027508,-92.389656
+568HH,"Panhandle of Nebraska CBOC","601 S 5th Ave",Scottsbluff,NE,"69361",308-225-5330,"VA Facility",Government,no,"Not Available",41.85344,-103.65583
+568GB,"Pierre VA Clinic","Linn Medical Clinic, 1601 North Harrison, Suite 6",Pierre,SD,"57501",605-945-1710,"VA Facility",Government,no,"Not Available",44.5422,-100.2754
+568HF,"Pine Ridge VA Clinic","Next to Dialysis Building across from IHS Hospital","Pine Ridge",SD,"57770","605-867-2393 X 4033","VA Facility",Government,no,"Not Available",43.0255,-102.5563
+636GG,"Quincy VA Clinic","721 Broadway Street",Quincy,IL,"62301",217-224-3366,"VA Facility",Government,no,"Not Available",39.935753,-91.4044
+568GA,"Rapid City VA Clinic","3625 5th Street","Rapid City",SD,"57701",605-718-1095,"VA Facility",Government,no,"Not Available",44.05007,-103.22412
+618GH,"Rice Lake VA Clinic","2700A College Drive","Rice Lake",WI,"54868",715-236-3355,"VA Facility",Government,no,"Not Available",45.481583,-91.744316
+618GG,"Rochester VA Clinic","3900 Fairway Place NW",Rochester,MN,"55901",507-252-0885,"VA Facility",Government,no,"Not Available",43.1548,-77.6156
+618GJ,"Shakopee VA Clinic","1111 Shakopee Town Square",Shakopee,MN,"55379",952-445-4070,"VA Facility",Government,no,"Not Available",44.7467,-93.5004
+636,"Shenandoah VA Clinic","512 S Fremont",Shenandoah,IA,"51601",712-246-0092,"VA Facility",Government,no,"Not Available",40.758163,-95.37214
+438GC,"Sioux City VA Clinic","1551 Indian Hills Drive, Suite 206","Sioux City",IA,"51104",712-258-4700,"VA Facility",Government,no,"Not Available",42.532574,-96.3904
+618GA,"South Central VA Clinic","1212 Heckman Court","St. James",MN,"56081",507-375-9670,"VA Facility",Government,no,"Not Available",43.970703,-94.618034
+438GA,"Spirit Lake VA Clinic","1310 Lake Street","Spirit Lake",IA,"51360",712-336-6400,"VA Facility",Government,no,"Not Available",43.4222,-95.1022
+636GT,"Sterling VA Outpatient Clinic","406 Avenue C",Sterling,IL,"61081",815-632-6200,"VA Facility",Government,no,"Not Available",41.789516,-89.700195
+618BY,"Twin Ports VA Clinic","3520 Tower Avenue",Superior,WI,"54880",715-398-2400,"VA Facility",Government,no,"Not Available",33.294,-111.0962
+636GH,"Waterloo VA Clinic","945 Tower Park Drive",Waterloo,IA,"50701",319-235-1230,"VA Facility",Government,no,"Not Available",42.4078,-92.2595
+438GF,"Watertown CBOC","917 – 29th Street SE",Watertown,SD,"57201",605-884-2420,"VA Facility",Government,no,"Not Available",42.3709,-71.1828
+437GF,"Williston VA Community Based Outpatient Clinic","205 Main Street",Williston,ND,"58802",701-572-2470,"VA Facility",Government,no,"Not Available",48.1456,-103.62167
+568HP,"Winner VA Clinic","660 West 2nd Street",Winner,SD,"57580",605-842-2443,"VA Facility",Government,no,"Not Available",43.376553,-99.86538
+0446V,"Bismarck Vet Center","619 Riverwood Drive, Suite 105",Bismarck,ND,"58504","701-224-9751 Or 701-224-9751","VA Facility",Government,no,"Not Available",46.794674,-100.80184
+0439V,"Brooklyn Park Vet Center","7001 78th Avenue North, Suite 300","Brooklyn Park",MN,"55445","763-503-2220 Or 877-927-8387","VA Facility",Government,no,"Not Available",45.09529,-93.370834
+0431V,"Cedar Rapids Vet Center","4250 River Center Court NE, Suite D","Cedar Rapids",IA,"52402","319-378-0016 Or 319-378-0016","VA Facility",Government,no,"Not Available",42.019444,-91.70087
+0405V,"Des Moines Vet Center","1821 22nd Street #115","Des Moines",IA,"50266","515-284-4929 Or 515-284-4929","VA Facility",Government,no,"Not Available",41.599247,-93.73604
+0429V,"Duluth Vet Center","4402 Haines Road",Duluth,MN,"55811","218-722-8654 Or 877-927-8387","VA Facility",Government,no,"Not Available",46.829487,-92.174805
+0406V,"Fargo Vet Center","3310 Fiechtner Drive. Suite 100",Fargo,ND,"58103","701-237-0942 Or 701-237-0942","VA Facility",Government,no,"Not Available",46.86399,-96.83272
+589GE,"Grand Forks Vet Center","3001 32nd Ave. S. Suite 6A","Grand Forks",ND,"58201","701-620-1448 Or 877-927-8387","VA Facility",Government,no,"Not Available",47.88944,-97.07062
+0427V,"Lincoln Vet Center","3119 O Street, Suite A",Lincoln,NE,"68510","402-476-9736 Or 402-476-9736","VA Facility",Government,no,"Not Available",40.813408,-96.67602
+4231,"Martin Outstation","P.O. Box 910 105 E. Hwy 18",Martin,SD,"57747","605-685-1300 Or 605-685-1300","VA Facility",Government,no,"Not Available",47.7686,-100.0911
+0404V,"Minot Vet Center","1400 20th Avenue SW Ste 2",Minot,ND,"58701","701-852-0177 Or 877-927-8387","VA Facility",Government,no,"Not Available",48.210842,-101.31301
+0424V,"Omaha Vet Center","3047 S 72nd Street",Omaha,NE,"68124",402-346-6735,"VA Facility",Government,no,"Not Available",41.23105,-96.02388
+0430V,"Quad Cities Vet Center","465 Avenue of the Cities, Suite #140","East Moline",IL,"61244","309-755-3260 Or 309-755-3260","VA Facility",Government,no,"Not Available",41.5212,-90.3858
+0423V,"Rapid City Vet Center","621 6th St, Suite 101","Rapid City",SD,"57701","605-348-0077 Or 877-927-8387","VA Facility",Government,no,"Not Available",44.079773,-103.227394
+0428V,"Sioux City Vet Center","1551 Indian Hills Drive Suite 214","Sioux City",IA,"51104","712-255-3808 Or 712-255-3808","VA Facility",Government,no,"Not Available",42.532574,-96.3904
+0425V,"Sioux Falls Vet Center","3200 W 49th Street","Sioux Falls",SD,"57106","605-330-4552 Or 605-330-4552","VA Facility",Government,no,"Not Available",43.50762,-96.765205
+0416V,"St. Paul Vet Center","550 County Road D West, Suite 10","New Brighton",MN,"55112","651-644-4022 Or 651-644-4022","VA Facility",Government,no,"Not Available",40.7531,-80.2419
+438GE,"Wagner Outreach Clinic","400 West Hwy 46",Wagner,SD,"57380",605-384-2340,"VA Facility",Government,no,"Not Available",43.0401,-98.2874
+,,,,,,,,,,,,
+

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -109,6 +109,7 @@ generate.providers.rehab.default_file = providers/rehab.csv
 generate.providers.hospice.default_file = providers/hospice.csv
 generate.providers.dialysis.default_file = providers/dialysis.csv
 generate.providers.homehealth.default_file = providers/home_health_agencies.csv
+generate.providers.veterans.default_file = providers/va_facilities.csv
 
 # Quit Smoking
 lifecycle.quit_smoking.baseline = 0.01

--- a/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
@@ -13,6 +13,7 @@ public class ProviderTest {
 
   @Test
   public void testLoadProvidersByAbbreviation() {
+    Provider.getProviderList().clear();
     Provider.loadProviders("MA");
     Assert.assertNotNull(Provider.getProviderList());
     Assert.assertFalse(Provider.getProviderList().isEmpty());
@@ -20,6 +21,7 @@ public class ProviderTest {
 
   @Test
   public void testLoadProvidersByStateName() {
+    Provider.getProviderList().clear();
     Provider.loadProviders("Massachusetts");
     Assert.assertNotNull(Provider.getProviderList());
     Assert.assertFalse(Provider.getProviderList().isEmpty());
@@ -85,6 +87,23 @@ public class ProviderTest {
     Assert.assertNotNull(provider);
   }
   
+  @Test
+  public void testVaFacilityOnlyAcceptsVeteran() {
+    Provider.loadProviders("Massachusetts");
+
+    Provider vaProvider = Provider.getProviderList()
+                                  .stream()
+                                  .filter(p -> "VA Facility".equals(p.type))
+                                  .findFirst().get();
+
+    Person veteran = new Person(0L);
+    veteran.attributes.put("veteran", "vietnam");
+    Person nonVet = new Person(1L);
+
+    Assert.assertTrue(vaProvider.accepts(veteran, System.currentTimeMillis()));
+    Assert.assertFalse(vaProvider.accepts(nonVet, System.currentTimeMillis()));
+  }
+
   @Test
   public void testAllFiles() throws Exception {
     // just load all files and make sure they don't crash

--- a/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
@@ -1,6 +1,5 @@
 package org.mitre.synthea.world.agents;
 
-import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -8,7 +7,6 @@ import java.nio.file.Paths;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.world.geography.Location;
 
 public class ProviderTest {
@@ -33,7 +31,7 @@ public class ProviderTest {
     Person person = new Person(0L);
     Location location = new Location("Massachusetts", null);
     location.assignPoint(person, location.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, Provider.INPATIENT);
+    Provider provider = Provider.findClosestService(person, Provider.INPATIENT, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -43,7 +41,7 @@ public class ProviderTest {
     Person person = new Person(0L);
     Location location = new Location("Massachusetts", null);
     location.assignPoint(person, location.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, Provider.AMBULATORY);
+    Provider provider = Provider.findClosestService(person, Provider.AMBULATORY, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -53,7 +51,7 @@ public class ProviderTest {
     Person person = new Person(0L);
     Location location = new Location("Massachusetts", null);
     location.assignPoint(person, location.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, Provider.EMERGENCY);
+    Provider provider = Provider.findClosestService(person, Provider.EMERGENCY, 0);
     Assert.assertNotNull(provider);
   }
   
@@ -63,7 +61,7 @@ public class ProviderTest {
     Person person = new Person(0L);
     Location location = new Location("Massachusetts", "Bedford");
     location.assignPoint(person, location.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, Provider.INPATIENT);
+    Provider provider = Provider.findClosestService(person, Provider.INPATIENT, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -73,7 +71,7 @@ public class ProviderTest {
     Person person = new Person(0L);
     Location location = new Location("Massachusetts", "Bedford");
     location.assignPoint(person, location.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, Provider.AMBULATORY);
+    Provider provider = Provider.findClosestService(person, Provider.AMBULATORY, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -83,7 +81,7 @@ public class ProviderTest {
     Person person = new Person(0L);
     Location location = new Location("Massachusetts", "Bedford");
     location.assignPoint(person, location.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, Provider.EMERGENCY);
+    Provider provider = Provider.findClosestService(person, Provider.EMERGENCY, 0);
     Assert.assertNotNull(provider);
   }
   

--- a/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
@@ -1,7 +1,14 @@
 package org.mitre.synthea.world.agents;
 
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.junit.Assert;
 import org.junit.Test;
+import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.world.geography.Location;
 
 public class ProviderTest {
@@ -78,5 +85,23 @@ public class ProviderTest {
     location.assignPoint(person, location.randomCityName(person.random));
     Provider provider = Provider.findClosestService(person, Provider.EMERGENCY);
     Assert.assertNotNull(provider);
+  }
+  
+  @Test
+  public void testAllFiles() throws Exception {
+    // just load all files and make sure they don't crash
+    URL providersFolder = ClassLoader.getSystemClassLoader().getResource("providers");
+    Path path = Paths.get(providersFolder.toURI());
+    Files.walk(path)
+         .filter(Files::isReadable)
+         .filter(Files::isRegularFile)
+         .filter(p -> p.toString().endsWith(".csv"))
+         .forEach(t -> {
+           try {
+             Provider.loadProviders("Massachusetts", "MA", "providers/" + t.getFileName());
+           } catch (Exception e) {
+             throw new RuntimeException("Failed to load provider file " + t, e);
+           }
+         });
   }
 }


### PR DESCRIPTION
Adds Veterans Health Administration facilities. List of facilities is pulled from https://www.va.gov/directory/guide/rpt_fac_list.cfm , with coordinates geocoded by https://geocoding.geo.census.gov/geocoder/ .

VA facilites only accept veterans, so a new `accept(Person, time)` method is added to Provider. Currently this returns true for all cases except a VA facility and a non-veteran, but in the future we may want to use this to consider capacity, insurance, or other reasons a provider may not accept a patient. This also adds a time parameter to all other provider lookups in the system, though this isn't used at present.