### PR TITLE
Quick fix for exceptions on CSV Exporter Test

### DIFF
--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.util.stream.Collectors;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,8 +46,7 @@ public class CSVExporterTest {
         continue;
       }
 
-      String csvData = Files.readAllLines(csvFile.toPath()).stream()
-          .collect(Collectors.joining("\n"));
+      String csvData = new String(Files.readAllBytes(csvFile.toPath()));
 
       // the CSV exporter doesn't use the SimpleCSV class to write the data,
       // so we can use it here for a level of validation


### PR DESCRIPTION
This may be a Windows-only issue since I've never seen it on Travis, but I often (~50% of test runs) get the following exception in the test suite:

```
org.mitre.synthea.export.CSVExporterTest > testCSVExport FAILED
    java.nio.charset.MalformedInputException: Input length = 1
        at java.nio.charset.CoderResult.throwException(CoderResult.java:281)
        at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:339)
        at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
        at java.io.InputStreamReader.read(InputStreamReader.java:184)
        at java.io.BufferedReader.fill(BufferedReader.java:161)
        at java.io.BufferedReader.readLine(BufferedReader.java:324)
        at java.io.BufferedReader.readLine(BufferedReader.java:389)
        at java.nio.file.Files.readAllLines(Files.java:3205)
        at java.nio.file.Files.readAllLines(Files.java:3242)
        at org.mitre.synthea.export.CSVExporterTest.testCSVExport(CSVExporterTest.java:50)
```

This change fixes this exception by changing how the file is read.