### PR TITLE
Fix encounter filtering bug

### DIFF
--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -172,11 +172,12 @@ public abstract class Exporter {
       filterEntries(encounter.careplans, cutoffDate, endTime, cp -> record.careplanActive(cp.type));
     }
 
+    // if ANY of these are not empty, the encounter is not empty
     Predicate<Encounter> encounterNotEmpty = e ->
-        !e.conditions.isEmpty() && !e.allergies.isEmpty()
-        && !e.observations.isEmpty() && !e.reports.isEmpty()
-        && !e.procedures.isEmpty() && !e.medications.isEmpty()
-        && !e.immunizations.isEmpty() && !e.careplans.isEmpty();
+        !e.conditions.isEmpty() || !e.allergies.isEmpty()
+        || !e.observations.isEmpty() || !e.reports.isEmpty()
+        || !e.procedures.isEmpty() || !e.medications.isEmpty()
+        || !e.immunizations.isEmpty() || !e.careplans.isEmpty();
 
     Predicate<Encounter> isDeathCertification = 
         e -> !e.codes.isEmpty() && DeathModule.DEATH_CERTIFICATION.equals(e.codes.get(0));

--- a/src/test/java/org/mitre/synthea/export/ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/ExporterTest.java
@@ -29,11 +29,13 @@ public class ExporterTest {
     yearsToKeep = 5;
     patient = new Person(12345L);
     record = patient.record;
-    record.encounterStart(endTime, "dummy encounter");
   }
 
   @Test public void test_export_filter_simple_cutoff() {
+    record.encounterStart(time - years(8), "dummy encounter");
     record.observation(time - years(8), "height", 64);
+    
+    record.encounterStart(time - years(4), "dummy encounter");
     record.observation(time - years(4), "weight", 128);
 
     // observations should be filtered to the cutoff date
@@ -48,8 +50,10 @@ public class ExporterTest {
   }
 
   @Test public void test_export_filter_should_keep_old_active_medication() {
+    record.encounterStart(time - years(10), "dummy encounter");
     record.medicationStart(time - years(10), "fakeitol");
 
+    record.encounterStart(time - years(8), "dummy encounter");
     record.medicationStart(time - years(8), "placebitol");
     record.medicationEnd(time - years(6), "placebitol", DUMMY_CODE);
 
@@ -62,9 +66,11 @@ public class ExporterTest {
   }
 
   @Test public void test_export_filter_should_keep_medication_that_ended_during_target() {
+    record.encounterStart(time - years(10), "dummy encounter");
     record.medicationStart(time - years(10), "dimoxinil");
     record.medicationEnd(time - years(9), "dimoxinil", DUMMY_CODE);
 
+    record.encounterStart(time - years(8), "dummy encounter");
     record.medicationStart(time - years(8), "placebitol");
     record.medicationEnd(time - years(4), "placebitol", DUMMY_CODE);
 
@@ -78,9 +84,11 @@ public class ExporterTest {
   }
 
   @Test public void test_export_filter_should_keep_old_active_careplan() {
+    record.encounterStart(time - years(10), "dummy encounter");
     record.careplanStart(time - years(10), "stop_smoking");
     record.careplanEnd(time - years(8), "stop_smoking", DUMMY_CODE);
 
+    record.encounterStart(time - years(12), "dummy encounter");
     record.careplanStart(time - years(12), "healthy_diet");
 
     Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
@@ -92,6 +100,7 @@ public class ExporterTest {
   }
 
   @Test public void test_export_filter_should_keep_careplan_that_ended_during_target() {
+    record.encounterStart(time - years(10), "dummy encounter");
     record.careplanStart(time - years(10), "stop_smoking");
     record.careplanEnd(time - years(1), "stop_smoking", DUMMY_CODE);
 
@@ -105,9 +114,11 @@ public class ExporterTest {
   }
 
   @Test public void test_export_filter_should_keep_old_active_conditions() {
+    record.encounterStart(time - years(10), "dummy encounter");
     record.conditionStart(time - years(10), "fakitis");
     record.conditionEnd(time - years(8), "fakitis");
 
+    record.encounterStart(time - years(10), "dummy encounter");
     record.conditionStart(time - years(10), "fakosis");
 
     Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
@@ -119,9 +130,11 @@ public class ExporterTest {
   }
 
   @Test public void test_export_filter_should_keep_condition_that_ended_during_target() {
+    record.encounterStart(time - years(10), "dummy encounter");
     record.conditionStart(time - years(10), "boneitis");
     record.conditionEnd(time - years(2), "boneitis");
 
+    record.encounterStart(time - years(10), "dummy encounter");
     record.conditionStart(time - years(10), "smallpox");
     record.conditionEnd(time - years(9), "smallpox");
 
@@ -134,8 +147,6 @@ public class ExporterTest {
   }
 
   @Test public void test_export_filter_should_keep_cause_of_death() {
-    record.encounters.clear(); // delete that dummy encounter
-    
     HealthRecord.Code causeOfDeath = 
         new HealthRecord.Code("SNOMED-CT", "Todo-lookup-code", "Rabies");
     patient.recordDeath(time - years(20), causeOfDeath, "death");
@@ -158,17 +169,26 @@ public class ExporterTest {
   }
 
   @Test public void test_export_filter_should_not_keep_old_stuff() {
-    record.encounters.clear(); // delete that dummy encounter
-
     record.encounterStart(time - years(18), "er_visit");
     record.procedure(time - years(20), "appendectomy");
     record.immunization(time - years(12), "flu_shot");
     record.observation(time - years(10), "weight", 123);
-    
 
     Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
-    
+
     assertTrue(filtered.record.encounters.isEmpty());
+  }
+
+  @Test public void test_export_filter_should_keep_old_active_stuff() {
+    // create an old encounter with a diagnosis that isn't ended
+    record.encounterStart(time - years(18), "er_visit");
+    record.conditionStart(time - years(18), "diabetes");
+
+    Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
+
+    assertEquals(1, filtered.record.encounters.size());
+    assertEquals(1, filtered.record.encounters.get(0).conditions.size());
+    assertEquals("diabetes", filtered.record.encounters.get(0).conditions.get(0).type);
   }
   
   private static long years(long numYears) {

--- a/src/test/java/org/mitre/synthea/export/ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/ExporterTest.java
@@ -191,6 +191,23 @@ public class ExporterTest {
     assertEquals("diabetes", filtered.record.encounters.get(0).conditions.get(0).type);
   }
   
+  @Test public void test_export_filter_should_filter_claim_items() {
+    record.encounterStart(time - years(10), "er_visit");
+    record.conditionStart(time - years(10), "something_permanent");
+    record.procedure(time - years(10), "xray");
+    
+    assertEquals(1, record.encounters.size());
+    assertEquals(2, record.encounters.get(0).claim.items.size()); // 1 condition, 1 procedure
+    
+    Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
+    // filter removes the procedure but keeps the open condition
+    assertEquals(1, filtered.record.encounters.size());
+    assertEquals(1, filtered.record.encounters.get(0).conditions.size());
+    assertEquals("something_permanent", filtered.record.encounters.get(0).conditions.get(0).type);
+    assertEquals(1, record.encounters.get(0).claim.items.size());
+    assertEquals("something_permanent", record.encounters.get(0).claim.items.get(0).entry.type);
+  }
+  
   private static long years(long numYears) {
     return Utilities.convertTime("years", numYears);
   }


### PR DESCRIPTION
Fixes a bug in the export filtering logic where encounters (and as such all associated conditions, medications, etc) were not being kept past the filter date. Issue was a flipped && and ||.

Also filters claim items if the corresponding item was removed from the record. I don't think this is the ideal approach, but it's quick and produces valid & internally consistent records. Open to suggestions on improvements.