### PR TITLE
Fix #304

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,9 @@ checkstyle {
 dependencies {
   // This dependency is found on compile classpath of this component and consumers.
   compile 'com.google.code.gson:gson:2.8.0'
-  compile 'ca.uhn.hapi.fhir:hapi-fhir-base:3.1.0'
-  compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:3.1.0'
-  compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:3.1.0'
+  compile 'ca.uhn.hapi.fhir:hapi-fhir-base:3.3.0'
+  compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:3.3.0'
+  compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:3.3.0'
 	// C-CDA export uses Apache FreeMarker templates
 	compile 'org.freemarker:freemarker:2.3.26-incubating'
   // location processing

--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -922,14 +922,9 @@ public class FhirDstu2 {
 
     medicationResource.setPatient(new ResourceReferenceDt(personEntry.getFullUrl()));
     medicationResource.setEncounter(new ResourceReferenceDt(encounterEntry.getFullUrl()));
-    ca.uhn.fhir.model.dstu2.resource.Encounter encounter =
-        (ca.uhn.fhir.model.dstu2.resource.Encounter) encounterEntry.getResource();
-    medicationResource.setPrescriber(encounter.getServiceProvider());
-
     medicationResource.setMedication(mapCodeToCodeableConcept(medication.codes.get(0), RXNORM_URI));
 
     medicationResource.setDateWritten(new DateTimeDt(new Date(medication.start)));
-
     if (medication.stop != 0L) {
       medicationResource.setStatus(MedicationOrderStatusEnum.STOPPED);
     } else {

--- a/src/test/java/org/mitre/synthea/helpers/RandomCollectionTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/RandomCollectionTest.java
@@ -1,7 +1,5 @@
 package org.mitre.synthea.helpers;
 
-import static org.junit.Assert.*;
-
 import java.util.Random;
 
 import org.junit.Assert;
@@ -34,9 +32,9 @@ public class RandomCollectionTest {
     rc.add(0.0, "asian");
     
     Random random = new Random();
-    for (int i=0; i < 10; i++) {
+    for (int i = 0; i < 10; i++) {
       String randomString = rc.next(random);
-      assertEquals("black", randomString);
+      Assert.assertEquals("black", randomString);
     }
   }
   
@@ -44,7 +42,7 @@ public class RandomCollectionTest {
   public void testFixed() {
     Fixed fixed = new Fixed();
     double[] expected = {0.0, 0.5, 0.999, 0.0, 0.5, 0.999, 0.0, 0.5, 0.999};
-    for (int i=0; i < expected.length; i++) {
+    for (int i = 0; i < expected.length; i++) {
       Assert.assertTrue(fixed.nextDouble() == expected[i]);
     }
   }
@@ -61,7 +59,7 @@ public class RandomCollectionTest {
     int asian = 0;
     
     Fixed fixed = new Fixed();
-    for (int i=0; i < 9; i++) {
+    for (int i = 0; i < 9; i++) {
       String notRandomString = rc.next(fixed);
       switch (notRandomString) {
         case "white":
@@ -72,6 +70,8 @@ public class RandomCollectionTest {
           break;
         case "asian":
           asian++;
+          break;
+        default:
           break;
       }
     }


### PR DESCRIPTION
Fixes FHIR DSTU2 MedicationOrder: `MedicationOrder.prescriber` cannot be a reference to an `Organization`.

Also updated HAPI libraries in the process.

And put a cherry on top with a checkstyle fix for an unrelated JUnit test.