### PR TITLE
Fix #281 - Transaction Bundles.

### DIFF
--- a/src/main/java/org/mitre/synthea/export/HospitalExporter.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporter.java
@@ -17,7 +17,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.hl7.fhir.dstu3.model.Address;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.dstu3.model.Bundle.BundleEntryRequestComponent;
 import org.hl7.fhir.dstu3.model.Bundle.BundleType;
+import org.hl7.fhir.dstu3.model.Bundle.HTTPVerb;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.IntegerType;
 import org.hl7.fhir.dstu3.model.Organization;
@@ -31,11 +33,18 @@ public abstract class HospitalExporter {
 
   private static final String SYNTHEA_URI = "http://synthetichealth.github.io/synthea/";
 
+  protected static boolean TRANSACTION_BUNDLE =
+      Boolean.parseBoolean(Config.get("exporter.fhir.transaction_bundle"));
+
   public static void export(long stop) {
     if (Boolean.parseBoolean(Config.get("exporter.hospital.fhir.export"))) {
 
       Bundle bundle = new Bundle();
-      bundle.setType(BundleType.COLLECTION);
+      if (TRANSACTION_BUNDLE) {
+        bundle.setType(BundleType.TRANSACTION);
+      } else {
+        bundle.setType(BundleType.COLLECTION);
+      }
       for (Provider h : Provider.getProviderList()) {
         // filter - exports only those hospitals in use
 
@@ -132,6 +141,14 @@ public abstract class HospitalExporter {
     entry.setFullUrl("urn:uuid:" + resourceID);
 
     entry.setResource(resource);
+
+    if (TRANSACTION_BUNDLE) {
+      BundleEntryRequestComponent request = entry.getRequest();
+      request.setMethod(HTTPVerb.POST);
+      request.setUrl(resource.getResourceType().name());
+      entry.setRequest(request);
+    }
+
     return entry;
   }
 }

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -10,6 +10,7 @@ exporter.ccda.export = false
 exporter.fhir.export = true
 exporter.fhir.use_shr_extensions = true
 exporter.fhir_dstu2.export = false
+exporter.fhir.transaction_bundle = false
 exporter.hospital.fhir.export = true
 exporter.hospital.fhir_dstu2.export = false
 exporter.csv.export = false

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -33,6 +33,7 @@ public abstract class TestHelper {
     Config.set("exporter.ccda.export", "false");
     Config.set("exporter.fhir.export", "false");
     Config.set("exporter.fhir_dstu2.export", "false");
+    Config.set("exporter.fhir.transaction_bundle", "false");
     Config.set("exporter.text.export", "false");
     Config.set("exporter.csv.export", "false");
     Config.set("exporter.hospital.fhir.export", "false");

--- a/src/test/java/org/mitre/synthea/export/FHIRDSTU2ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRDSTU2ExporterTest.java
@@ -53,6 +53,7 @@ public class FHIRDSTU2ExporterTest {
       TestHelper.exportOff();
       Person person = generator.generatePerson(i);
       Config.set("exporter.fhir_dstu2.export", "true");
+      FhirDstu2.TRANSACTION_BUNDLE = person.random.nextBoolean();
       String fhirJson = FhirDstu2.convertToFHIR(person, System.currentTimeMillis());
       IBaseResource resource = ctx.newJsonParser().parseResource(fhirJson);
       ValidationResult result = validator.validateWithResult(resource);

--- a/src/test/java/org/mitre/synthea/export/FHIRExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRExporterTest.java
@@ -57,6 +57,7 @@ public class FHIRExporterTest {
       Person person = generator.generatePerson(i);
       Config.set("exporter.fhir.export", "true");
       Config.set("exporter.fhir.use_shr_extensions", "true");
+      FhirDstu2.TRANSACTION_BUNDLE = person.random.nextBoolean();
       String fhirJson = FhirStu3.convertToFHIR(person, System.currentTimeMillis());
       IBaseResource resource = ctx.newJsonParser().parseResource(fhirJson);
       ValidationResult result = validator.validateWithResult(resource);

--- a/src/test/java/org/mitre/synthea/export/HospitalDSTU2ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/HospitalDSTU2ExporterTest.java
@@ -35,6 +35,7 @@ public class HospitalDSTU2ExporterTest {
     File tempOutputFolder = tempFolder.newFolder();
     Config.set("exporter.baseDirectory", tempOutputFolder.toString());
     Config.set("exporter.hospital.fhir_dstu2.export", "true");
+    Config.set("exporter.fhir.transaction_bundle", "true");
     Provider.loadProviders(null);
     assertNotNull(Provider.getProviderList());
     assertFalse(Provider.getProviderList().isEmpty());

--- a/src/test/java/org/mitre/synthea/export/HospitalExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/HospitalExporterTest.java
@@ -35,6 +35,7 @@ public class HospitalExporterTest {
     File tempOutputFolder = tempFolder.newFolder();
     Config.set("exporter.baseDirectory", tempOutputFolder.toString());
     Config.set("exporter.hospital.fhir.export", "true");
+    Config.set("exporter.fhir.transaction_bundle", "true");
     Provider.loadProviders("Massachusetts");
     assertNotNull(Provider.getProviderList());
     assertFalse(Provider.getProviderList().isEmpty());


### PR DESCRIPTION
Allows users to create FHIR `transaction` Bundles instead of `collection` Bundles.

To enable, modify synthea.properties:

`exporter.fhir.transaction_bundle = false`

Change `false` to `true` and rerun with any FHIR exporter enabled.