### PR TITLE
Fix provider distance check

### DIFF
--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -166,6 +166,7 @@ public class Provider implements QuadTreeData {
         distance = item.getLatLon().distance(coord);
         if (distance < minDistance) {
           closest = (Provider) item;
+          minDistance = distance;
         }
       }
     }

--- a/src/main/resources/templates/ccda/ccda.ftl
+++ b/src/main/resources/templates/ccda/ccda.ftl
@@ -52,10 +52,10 @@
       </assignedAuthoringDevice>
       <representedOrganization>
         <id nullFlavor="NA"/>
-        <name>${preferredAmbulatoryProvider.name}</name>
+        <name>${preferredAmbulatoryProvider.name?replace("&", "&amp;")}</name>
         <telecom nullFlavor="NA"/>
         <addr>
-          <streetAddressLine>${preferredAmbulatoryProvider.address}</streetAddressLine>
+          <streetAddressLine>${preferredAmbulatoryProvider.address?replace("&", "&amp;")}</streetAddressLine>
           <city>${preferredAmbulatoryProvider.city}</city>
           <state>${preferredAmbulatoryProvider.state}</state>
           <postalCode>${preferredAmbulatoryProvider.zip}</postalCode>
@@ -67,10 +67,10 @@
     <assignedCustodian>
       <representedCustodianOrganization>
         <id nullFlavor="NA"/>
-        <name>${preferredAmbulatoryProvider.name}</name>
+        <name>${preferredAmbulatoryProvider.name?replace("&", "&amp;")}</name>
         <telecom nullFlavor="NA"/>
         <addr>
-          <streetAddressLine>${preferredAmbulatoryProvider.address}</streetAddressLine>
+          <streetAddressLine>${preferredAmbulatoryProvider.address?replace("&", "&amp;")}</streetAddressLine>
           <city>${preferredAmbulatoryProvider.city}</city>
           <state>${preferredAmbulatoryProvider.state}</state>
           <postalCode>${preferredAmbulatoryProvider.zip}</postalCode>


### PR DESCRIPTION
Fixes a bug that resulted in nearly every patient being assigned the same provider (in MA that's Shriners, because it's the last provider in the list for MA). Updates the minimum search distance every time it finds a provider within that distance, ensuring the closest provider is picked.

Also escapes "&" in a couple ccda fields - turns out some providers have these in their name or address.