### PR TITLE
Fix for bug in demographics selection

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -46,6 +46,8 @@ public class Generator {
   public TransitionMetrics metrics;
   public static final String DEFAULT_STATE = "Massachusetts";
 
+  private static final String TARGET_AGE = "target_age";
+  
   /**
    * Helper class following the "Parameter Object" pattern.
    * This class provides the default values for Generator, or alternatives may be set.
@@ -234,20 +236,19 @@ public class Generator {
     Person person = null;
     try {
       boolean isAlive = true;
-
-      Demographics city = location.randomCity(new Random(personSeed));
+      int tryNumber = 0;
+      Random randomForDemographics = new Random(personSeed);
+      Demographics city = location.randomCity(randomForDemographics);
+      
+      Map<String, Object> demoAttributes = pickDemographics(randomForDemographics, city);
+      long start = (long) demoAttributes.get(Person.BIRTHDATE);
 
       do {
         List<Module> modules = Module.getModules();
 
         person = new Person(personSeed);
         person.populationSeed = this.options.seed;
-
-        // TODO - this is quick & easy to implement,
-        // but we need to adapt the ruby method of pre-defining all the demographic buckets
-        // and then putting people into those
-        // -- but: how will that work with seeds?
-        long start = setDemographics(person, city);
+        person.attributes.putAll(demoAttributes);
         person.attributes.put(Person.LOCATION, location);
 
         LifecycleModule.birth(person, start);
@@ -301,9 +302,23 @@ public class Generator {
 
         totalGeneratedPopulation.incrementAndGet();
         
+        tryNumber++;
         if (!isAlive) {
           // rotate the seed so the next attempt gets a consistent but different one
           personSeed = new Random(personSeed).nextLong();
+          
+          // if we've tried and failed > 10 times to generate someone over age 90
+          // reduce the age to increase the likelihood of success
+          if (tryNumber > 10 && (int)person.attributes.get(TARGET_AGE) > 90) {
+            // pick a new target age between 85 and 90
+            int newTargetAge = randomForDemographics.nextInt(5) + 85;
+            // the final age bracket is 85-110, but our patients rarely break 100
+            // so reducing a target age to 85-90 shouldn't affect numbers too much
+            demoAttributes.put(TARGET_AGE, newTargetAge);
+            long birthdate = birthdateFromTargetAge(newTargetAge, randomForDemographics);
+            demoAttributes.put(Person.BIRTHDATE, birthdate);
+            start = birthdate;
+          }
         }
 
         // TODO - export is DESTRUCTIVE when it filters out data
@@ -350,61 +365,68 @@ public class Generator {
     }
   }
 
-  private long setDemographics(Person person, Demographics city) {
-    person.attributes.put(Person.CITY, city.city);
-    person.attributes.put(Person.STATE, city.state);
+  private Map<String, Object> pickDemographics(Random random, Demographics city) {
+    Map<String, Object> out = new HashMap<>();
+    out.put(Person.CITY, city.city);
+    out.put(Person.STATE, city.state);
     
-    String race = city.pickRace(person.random);
-    person.attributes.put(Person.RACE, race);
-    String ethnicity = city.ethnicityFromRace((String)person.attributes.get(Person.RACE), person);
-    person.attributes.put(Person.ETHNICITY, ethnicity);
-    String language = city.languageFromEthnicity((String) person.attributes.get(Person.ETHNICITY),
-        person);
-    person.attributes.put(Person.FIRST_LANGUAGE, language);
+    String race = city.pickRace(random);
+    out.put(Person.RACE, race);
+    String ethnicity = city.ethnicityFromRace(race, random);
+    out.put(Person.ETHNICITY, ethnicity);
+    String language = city.languageFromEthnicity(ethnicity, random);
+    out.put(Person.FIRST_LANGUAGE, language);
 
     String gender = null;
     if (options.gender != null) {
       gender = options.gender;
     } else {
-      gender = city.pickGender(person.random);
+      gender = city.pickGender(random);
       if (gender.equalsIgnoreCase("male") || gender.equalsIgnoreCase("M")) {
         gender = "M";
       } else {
         gender = "F";
       }
     }
-    person.attributes.put(Person.GENDER, gender);
+    out.put(Person.GENDER, gender);
 
     // Socioeconomic variables of education, income, and education are set.
-    String education = city.pickEducation(person.random);
-    person.attributes.put(Person.EDUCATION, education);
-    double educationLevel = city.educationLevel(education, person);
-    person.attributes.put(Person.EDUCATION_LEVEL, educationLevel);
+    String education = city.pickEducation(random);
+    out.put(Person.EDUCATION, education);
+    double educationLevel = city.educationLevel(education, random);
+    out.put(Person.EDUCATION_LEVEL, educationLevel);
 
-    int income = city.pickIncome(person.random);
-    person.attributes.put(Person.INCOME, income);
+    int income = city.pickIncome(random);
+    out.put(Person.INCOME, income);
     double incomeLevel = city.incomeLevel(income);
-    person.attributes.put(Person.INCOME_LEVEL, incomeLevel);
+    out.put(Person.INCOME_LEVEL, incomeLevel);
 
-    double occupation = person.rand();
-    person.attributes.put(Person.OCCUPATION_LEVEL, occupation);
+    double occupation = random.nextDouble();
+    out.put(Person.OCCUPATION_LEVEL, occupation);
 
     double sesScore = city.socioeconomicScore(incomeLevel, educationLevel, occupation);
-    person.attributes.put(Person.SOCIOECONOMIC_SCORE, sesScore);
-    person.attributes.put(Person.SOCIOECONOMIC_CATEGORY, city.socioeconomicCategory(sesScore));
+    out.put(Person.SOCIOECONOMIC_SCORE, sesScore);
+    out.put(Person.SOCIOECONOMIC_CATEGORY, city.socioeconomicCategory(sesScore));
 
-    long targetAge;
+    int targetAge;
     if (options.ageSpecified) {
-      targetAge = (long) person.rand(options.minAge, options.maxAge);
+      targetAge = 
+          (int) (options.minAge + ((options.maxAge - options.minAge) * random.nextDouble()));
     } else {
-      targetAge = city.pickAge(person.random);
+      targetAge = city.pickAge(random);
     }
+    out.put(TARGET_AGE, targetAge);
 
+    long birthdate = birthdateFromTargetAge(targetAge, random);
+    out.put(Person.BIRTHDATE, birthdate);
+    
+    return out;
+  }
+  
+  private long birthdateFromTargetAge(long targetAge, Random random) {
     long earliestBirthdate = stop - TimeUnit.DAYS.toMillis((targetAge + 1) * 365L + 1);
     long latestBirthdate = stop - TimeUnit.DAYS.toMillis(targetAge * 365L);
-
-    long birthdate = (long) person.rand(earliestBirthdate, latestBirthdate);
-
-    return birthdate;
+    return 
+        (long) (earliestBirthdate + ((latestBirthdate - earliestBirthdate) * random.nextDouble()));
   }
 }

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -319,8 +319,10 @@ public class Generator {
           personSeed = new Random(personSeed).nextLong();
           
           // if we've tried and failed > 10 times to generate someone over age 90
+          // and the options allow for ages as low as 85
           // reduce the age to increase the likelihood of success
-          if (tryNumber > 10 && (int)person.attributes.get(TARGET_AGE) > 90) {
+          if (tryNumber > 10 && (int)person.attributes.get(TARGET_AGE) > 90
+              && (!options.ageSpecified || options.minAge <= 85)) {
             // pick a new target age between 85 and 90
             int newTargetAge = randomForDemographics.nextInt(5) + 85;
             // the final age bracket is 85-110, but our patients rarely break 100

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -46,6 +46,13 @@ public class Generator {
   public TransitionMetrics metrics;
   public static final String DEFAULT_STATE = "Massachusetts";
 
+  /**
+   * Used only for testing and debugging. Populate this field to keep track of all patients
+   * generated, living or dead, during a simulation. Note that this may result in significantly
+   * increased memory usage as patients cannot be GC'ed.
+   */
+  public List<Person> internalStore;
+  
   private static final String TARGET_AGE = "target_age";
   
   /**
@@ -236,7 +243,7 @@ public class Generator {
     Person person = null;
     try {
       boolean isAlive = true;
-      int tryNumber = 0;
+      int tryNumber = 0; // number of tries to create these demographics
       Random randomForDemographics = new Random(personSeed);
       Demographics city = location.randomCity(randomForDemographics);
       
@@ -287,6 +294,10 @@ public class Generator {
           database.store(person);
         }
 
+        if (internalStore != null) {
+          internalStore.add(person);
+        }
+        
         if (this.metrics != null) {
           metrics.recordStats(person, time);
         }

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -51,7 +51,7 @@ public class Generator {
    * generated, living or dead, during a simulation. Note that this may result in significantly
    * increased memory usage as patients cannot be GC'ed.
    */
-  public List<Person> internalStore;
+  List<Person> internalStore;
   
   private static final String TARGET_AGE = "target_age";
   

--- a/src/main/java/org/mitre/synthea/world/geography/Demographics.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Demographics.java
@@ -91,7 +91,7 @@ public class Demographics {
     return raceDistribution.next(random);
   }
 
-  public String ethnicityFromRace(String race, Person person) {
+  public String ethnicityFromRace(String race, Random random) {
     // https://en.wikipedia.org/wiki/Demographics_of_Massachusetts#Race.2C_ethnicity.2C_and_ancestry
     if (race.equals("white")) {
       RandomCollection<String> whiteEthnicities = new RandomCollection<>();
@@ -108,25 +108,25 @@ public class Demographics {
       whiteEthnicities.add(1.9, "russian");
       whiteEthnicities.add(1.8, "swedish");
       whiteEthnicities.add(1.2, "greek");
-      return whiteEthnicities.next(person.random);
+      return whiteEthnicities.next(random);
     } else if (race.equals("hispanic")) {
       RandomCollection<String> hispanicEthnicities = new RandomCollection<>();
       hispanicEthnicities.add(4.1, "puerto_rican");
       hispanicEthnicities.add(1, "mexican");
       hispanicEthnicities.add(1, "central_american");
       hispanicEthnicities.add(1, "south_american");
-      return hispanicEthnicities.next(person.random);
+      return hispanicEthnicities.next(random);
     } else if (race.equals("black")) {
       RandomCollection<String> blackEthnicities = new RandomCollection<>();
       blackEthnicities.add(1.8, "african");
       blackEthnicities.add(1.8, "dominican");
       blackEthnicities.add(1.8, "west_indian");
-      return blackEthnicities.next(person.random);
+      return blackEthnicities.next(random);
     } else if (race.equals("asian")) {
       RandomCollection<String> asianEthnicities = new RandomCollection<>();
       asianEthnicities.add(2.0, "chinese");
       asianEthnicities.add(1.1, "asian_indian");
-      return asianEthnicities.next(person.random);
+      return asianEthnicities.next(random);
     } else if (race.equals("native")) {
       return "american_indian";
     } else { // race.equals("other")
@@ -134,7 +134,7 @@ public class Demographics {
     }
   }
 
-  public String languageFromEthnicity(String ethnicity, Person person) {
+  public String languageFromEthnicity(String ethnicity, Random random) {
     // https://apps.mla.org/map_data -> search by State MA
     // or see
     // https://apps.mla.org/map_data_results&SRVY_YEAR=2010&geo=state&state_id=25&county_id=
@@ -158,95 +158,95 @@ public class Demographics {
       RandomCollection<String> italianLanguages = new RandomCollection<>();
       italianLanguages.add(95.0, "english");
       italianLanguages.add(5.0, "italian");
-      return italianLanguages.next(person.random);
+      return italianLanguages.next(random);
     } else if (ethnicity.equals("french")) {
       RandomCollection<String> frenchLanguages = new RandomCollection<>();
       frenchLanguages.add(99.0, "english");
       frenchLanguages.add(1.0, "french");
-      return frenchLanguages.next(person.random);
+      return frenchLanguages.next(random);
     } else if (ethnicity.equals("french_canadian")) {
       RandomCollection<String> frenchCanadianLanguages = new RandomCollection<>();
       frenchCanadianLanguages.add(99.0, "english");
       frenchCanadianLanguages.add(1.0, "french");
-      return frenchCanadianLanguages.next(person.random);
+      return frenchCanadianLanguages.next(random);
     } else if (ethnicity.equals("german")) {
       RandomCollection<String> germanLanguages = new RandomCollection<>();
       germanLanguages.add(96.0, "english");
       germanLanguages.add(4.0, "german");
-      return germanLanguages.next(person.random);
+      return germanLanguages.next(random);
     } else if (ethnicity.equals("polish")) {
       return "english";
     } else if (ethnicity.equals("portuguese")) {
       RandomCollection<String> portugueseLanguages = new RandomCollection<>();
       portugueseLanguages.add(37.0, "english");
       portugueseLanguages.add(63.0, "portuguese");
-      return portugueseLanguages.next(person.random);
+      return portugueseLanguages.next(random);
     } else if (ethnicity.equals("russian")) {
       RandomCollection<String> russianLanguages = new RandomCollection<>();
       russianLanguages.add(62.0, "english");
       russianLanguages.add(38.0, "russian");
-      return russianLanguages.next(person.random);
+      return russianLanguages.next(random);
     } else if (ethnicity.equals("swedish")) {
       return "english";
     } else if (ethnicity.equals("greek")) {
       RandomCollection<String> greekLanguages = new RandomCollection<>();
       greekLanguages.add(66.0, "english");
       greekLanguages.add(34.0, "greek");
-      return greekLanguages.next(person.random);
+      return greekLanguages.next(random);
     } else if (ethnicity.equals("puerto_rican")) {
       RandomCollection<String> puertoRicanLanguages = new RandomCollection<>();
       puertoRicanLanguages.add(30.0, "english");
       puertoRicanLanguages.add(70.0, "spanish");
-      return puertoRicanLanguages.next(person.random);
+      return puertoRicanLanguages.next(random);
     } else if (ethnicity.equals("mexican")) {
       RandomCollection<String> mexicanLanguages = new RandomCollection<>();
       mexicanLanguages.add(30.0, "english");
       mexicanLanguages.add(70.0, "spanish");
-      return mexicanLanguages.next(person.random);
+      return mexicanLanguages.next(random);
     } else if (ethnicity.equals("central_american")) {
       RandomCollection<String> centralAmericanLanguages = new RandomCollection<>();
       centralAmericanLanguages.add(30.0, "english");
       centralAmericanLanguages.add(70.0, "spanish");
-      return centralAmericanLanguages.next(person.random);
+      return centralAmericanLanguages.next(random);
     } else if (ethnicity.equals("south_american")) {
       RandomCollection<String> southAmericanLanguages = new RandomCollection<>();
       southAmericanLanguages.add(30.0, "english");
       southAmericanLanguages.add(35.0, "spanish");
       southAmericanLanguages.add(35.0, "portuguese");
-      return southAmericanLanguages.next(person.random);
+      return southAmericanLanguages.next(random);
     } else if (ethnicity.equals("african")) {
       RandomCollection<String> africanLanguages = new RandomCollection<>();
       africanLanguages.add(95.0, "english");
       africanLanguages.add(5.0, "french");
-      return africanLanguages.next(person.random);
+      return africanLanguages.next(random);
     } else if (ethnicity.equals("dominican")) {
       RandomCollection<String> dominicanLanguages = new RandomCollection<>();
       dominicanLanguages.add(30.0, "english");
       dominicanLanguages.add(70.0, "spanish");
-      return dominicanLanguages.next(person.random);
+      return dominicanLanguages.next(random);
     } else if (ethnicity.equals("west_indian")) {
       RandomCollection<String> westIndianLanguages = new RandomCollection<>();
       westIndianLanguages.add(25.0, "english");
       westIndianLanguages.add(35.0, "spanish");
       westIndianLanguages.add(50.0, "french_creole");
-      return westIndianLanguages.next(person.random);
+      return westIndianLanguages.next(random);
     } else if (ethnicity.equals("chinese")) {
       RandomCollection<String> chineseLanguages = new RandomCollection<>();
       chineseLanguages.add(25.0, "english");
       chineseLanguages.add(75.0, "chinese");
-      return chineseLanguages.next(person.random);
+      return chineseLanguages.next(random);
     } else if (ethnicity.equals("asian_indian")) {
       RandomCollection<String> asianIndianLanguages = new RandomCollection<>();
       asianIndianLanguages.add(75.0, "english");
       asianIndianLanguages.add(25.0, "hindi");
-      return asianIndianLanguages.next(person.random);
+      return asianIndianLanguages.next(random);
     } else if (ethnicity.equals("american_indian")) {
       return "english";
     } else if (ethnicity.equals("arab")) {
       RandomCollection<String> arabLanguages = new RandomCollection<>();
       arabLanguages.add(63.0, "english");
       arabLanguages.add(37.0, "arabic");
-      return arabLanguages.next(person.random);
+      return arabLanguages.next(random);
     } else { // in case of invalid ethnicity
       return "english";
     }
@@ -308,7 +308,7 @@ public class Demographics {
     return educationDistribution.next(random);
   }
 
-  public double educationLevel(String level, Person person) {
+  public double educationLevel(String level, Random random) {
     double lessThanHsMin = Double.parseDouble(
         Config.get("generate.demographics.socioeconomic.education.less_than_hs.min", "0.0"));
     double lessThanHsMax = Double.parseDouble(
@@ -328,16 +328,20 @@ public class Demographics {
 
     switch (level) {
       case "less_than_hs":
-        return person.rand(lessThanHsMin, lessThanHsMax);
+        return rand(random, lessThanHsMin, lessThanHsMax);
       case "hs_degree":
-        return person.rand(hsDegreeMin, hsDegreeMax);
+        return rand(random, hsDegreeMin, hsDegreeMax);
       case "some_college":
-        return person.rand(someCollegeMin, someCollegeMax);
+        return rand(random, someCollegeMin, someCollegeMax);
       case "bs_degree":
-        return person.rand(bsDegreeMin, bsDegreeMax);
+        return rand(random, bsDegreeMin, bsDegreeMax);
       default:
         return 0.0;
     }
+  }
+  
+  private static double rand(Random r, double low, double high) {
+    return (low + ((high - low) * r.nextDouble()));
   }
 
   public double socioeconomicScore(double income, double education, double occupation) {

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -48,17 +48,4 @@ public abstract class TestHelper {
     return LocalDateTime.of(year, month, day, hr, min, sec).toInstant(ZoneOffset.UTC)
         .toEpochMilli();
   }
-  
-  /**
-   * Helper method to apply a function to two objects, and assert that the results are equal.
-   * @param base Object to serve as the basis for comparison
-   * @param compare Object to compare against the basis
-   * @param func Function to get a result from both base and compare
-   * @param message Message to display if results are not equal
-   */
-  public static <S,R> void assertEqual(S base, S compare, Function<S,R> func, String message) {
-    R baseResult = func.apply(base);
-    R compareResult = func.apply(compare);
-    Assert.assertEquals(message, baseResult, compareResult);
-  }
 }

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -4,6 +4,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.function.Function;
+
+import org.junit.Assert;
 
 import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.helpers.Config;
@@ -44,5 +47,18 @@ public abstract class TestHelper {
   public static long timestamp(int year, int month, int day, int hr, int min, int sec) {
     return LocalDateTime.of(year, month, day, hr, min, sec).toInstant(ZoneOffset.UTC)
         .toEpochMilli();
+  }
+  
+  /**
+   * Helper method to apply a function to two objects, and assert that the results are equal.
+   * @param base Object to serve as the basis for comparison
+   * @param compare Object to compare against the basis
+   * @param func Function to get a result from both base and compare
+   * @param message Message to display if results are not equal
+   */
+  public static <S,R> void assertEqual(S base, S compare, Function<S,R> func, String message) {
+    R baseResult = func.apply(base);
+    R compareResult = func.apply(compare);
+    Assert.assertEquals(message, baseResult, compareResult);
   }
 }

--- a/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
+++ b/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
@@ -128,23 +128,19 @@ public class GeneratorTest {
     generator.internalStore = new LinkedList<>();
     for (int i = 0; i < numberOfPeople; i++) {
       Person person = generator.generatePerson(i);
-
       
       for (int j = 0; j < generator.internalStore.size(); j++) {
         Person compare = generator.internalStore.get(j);
         
-        TestHelper.assertEqual(person, compare, 
-            p -> p.attributes.get(Person.CITY), "Cities are not equal");
-        TestHelper.assertEqual(person, compare, 
-            p -> p.attributes.get(Person.RACE), "Races are not equal");
+        assertEquals(person.attributes.get(Person.CITY), compare.attributes.get(Person.CITY));
+        assertEquals(person.attributes.get(Person.RACE), compare.attributes.get(Person.RACE));
         
         if (j < 10) {
           // only the first 10 attempts keep the same birthdate.
           // after that it picks a lower target age
-          TestHelper.assertEqual(person, compare,
-              p -> p.attributes.get(Person.BIRTHDATE), "Birthdates are not equal");
+          assertEquals((long)person.attributes.get(Person.BIRTHDATE), 
+                     (long)compare.attributes.get(Person.BIRTHDATE));
         }
-
       }
       
       generator.internalStore.clear();


### PR DESCRIPTION
Currently the Generator will pick a target set of demographics when generating a person, but if the person dies before reaching the target age, it will re-pick demographics. This has the consequence of the population age being skewed low because people with a higher target age are more likely to die along the way.
This change picks demographics once and then re-uses those demographics for each attempt until it succeeds. This change means that those demographics are just stored in a HashMap, there's no Person object yet.

Also brings back a tweak from the Ruby version where if trying to generate a really old patient and failing multiple times, it will reduce the target age to between 85 & 90. Our top age bracket is 85+ so this shouldn't meaningfully affect the overall numbers, unless someone is specifically looking at ages 85+