### PR TITLE
Custom reports from arbitrary SQL

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CustomSqlReport.java
+++ b/src/main/java/org/mitre/synthea/export/CustomSqlReport.java
@@ -1,0 +1,111 @@
+package org.mitre.synthea.export;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+
+import org.mitre.synthea.engine.Generator;
+import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.SimpleCSV;
+import org.mitre.synthea.helpers.Utilities;
+
+/**
+ * The CustomSqlReport exporter produces custom CSV reports based on arbitrary queries provided.
+ * The queries are run against the DataStore database, either file or in-memory.
+ * Queries are defined in a configurable location - specified by config setting 
+ * "exporter.custom_report_queries_file".
+ * 
+ */
+public class CustomSqlReport {
+  
+  /**
+   * Run the exporter to produce the custom reports based on the given population.
+   * 
+   * @param generator
+   *          The generator that was used to produce a population
+   * @throws Exception
+   *           if any exception occurs in reading the queries file, querying the database, or
+   *           writing the results to a CSV file
+   */
+  public static void export(Generator generator) throws Exception {
+    if (generator.database == null) {
+      System.err.println(
+          "Unable to generate Custom Report - No database exists to generate report from.");
+      return;
+    }
+
+    File outDirectory = Exporter.getOutputFolder("reports", null);
+
+    String queriesFile = Config.get("exporter.custom_report_queries_file");
+    String sqlQueries = Utilities.readResource(queriesFile);
+
+    try (Scanner queries = new Scanner(sqlQueries);
+        Connection connection = generator.database.getConnection()) {
+
+      int reportNum = 1;
+      // TODO: version 1 requires queries to be on one line. 
+      // add logic to handle multi-line queries?
+      while (queries.hasNextLine()) {
+        String query = queries.nextLine().trim().toUpperCase();
+
+        if (query.isEmpty() || query.startsWith("--")) {
+          continue; // empty or comment line, ignore it
+        }
+
+        // TODO: allow the creation of views?
+        if (!query.startsWith("SELECT")) {
+          throw new IllegalArgumentException("Custom SQL query must only start with SELECT");
+        }
+
+        List<Map<String, String>> results = new LinkedList<>();
+
+        PreparedStatement stmt = connection.prepareStatement(query);
+
+        ResultSet rs = stmt.executeQuery();
+
+        // get the list of column names from metadata
+        ResultSetMetaData rsmd = rs.getMetaData();
+        List<String> columnNames = new ArrayList<>(rsmd.getColumnCount());
+        for (int i = 1; i <= rsmd.getColumnCount(); i++) {
+          columnNames.add(rsmd.getColumnName(i));
+        }
+
+        while (rs.next()) {
+          Map<String, String> line = new HashMap<>();
+          for (String column : columnNames) {
+            String value = String.valueOf(rs.getObject(column));
+            line.put(column, value);
+          }
+          results.add(line);
+        }
+
+        String resultContent;
+        if (results.isEmpty()) {
+          resultContent = "No results found.";
+        } else {
+          resultContent = SimpleCSV.unparse(results);
+        }
+        
+        // add the query as the first line so it's easy to see what it was
+        String newCsvData = query + System.lineSeparator() + resultContent;
+        Path outFilePath = outDirectory.toPath()
+            .resolve("custom_query" + reportNum + "_" + System.currentTimeMillis() + ".csv");
+
+        Files.write(outFilePath, Collections.singleton(newCsvData), StandardOpenOption.CREATE_NEW);
+        reportNum++;
+      }
+    }
+  }
+}

--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -119,6 +119,15 @@ public abstract class Exporter {
         e.printStackTrace();
       }
     }
+
+    if (Boolean.parseBoolean(Config.get("exporter.custom_report"))) {
+      try {
+        CustomSqlReport.export(generator);
+      } catch (Exception e) {
+        System.err.println("Custom report generation failed!");
+        e.printStackTrace();
+      }
+    }
   }
   
   public static Person filterForExport(Person original, int yearsToKeep, long endTime) {

--- a/src/main/resources/custom_queries.sql
+++ b/src/main/resources/custom_queries.sql
@@ -13,4 +13,4 @@
 
 -- Sample Query 3: select the people that have an active diagnosis of diabetes, along with the age of diagnosis
 
- select p.name, p.gender, DATEADD('MILLISECOND', p.DATE_OF_BIRTH, DATE '1970-01-01') DOB, DATEADD('MILLISECOND', c.start , DATE '1970-01-01') onset_date, DATEDIFF('YEAR', DATEADD('MILLISECOND', p.DATE_OF_BIRTH, DATE '1970-01-01'), DATEADD('MILLISECOND', c.start, DATE '1970-01-01')) age_at_diagnosis   FROM PERSON p, CONDITION c WHERE p.ID = c.PERSON_ID AND c.code = '44054006';
+-- select p.name, p.gender, DATEADD('MILLISECOND', p.DATE_OF_BIRTH, DATE '1970-01-01') DOB, DATEADD('MILLISECOND', c.start , DATE '1970-01-01') onset_date, DATEDIFF('YEAR', DATEADD('MILLISECOND', p.DATE_OF_BIRTH, DATE '1970-01-01'), DATEADD('MILLISECOND', c.start, DATE '1970-01-01')) age_at_diagnosis   FROM PERSON p, CONDITION c WHERE p.ID = c.PERSON_ID AND c.code = '44054006';

--- a/src/main/resources/custom_queries.sql
+++ b/src/main/resources/custom_queries.sql
@@ -1,0 +1,16 @@
+-- Sample Query 1: select everything from the "person" table.
+-- Note that column ordering is not guaranteed.
+
+-- select * from person;
+
+
+
+-- Sample Query 2: select the number of living people.
+
+-- select count(*) from person where person.DATE_OF_DEATH is null;
+
+
+
+-- Sample Query 3: select the people that have an active diagnosis of diabetes, along with the age of diagnosis
+
+ select p.name, p.gender, DATEADD('MILLISECOND', p.DATE_OF_BIRTH, DATE '1970-01-01') DOB, DATEADD('MILLISECOND', c.start , DATE '1970-01-01') onset_date, DATEDIFF('YEAR', DATEADD('MILLISECOND', p.DATE_OF_BIRTH, DATE '1970-01-01'), DATEADD('MILLISECOND', c.start, DATE '1970-01-01')) age_at_diagnosis   FROM PERSON p, CONDITION c WHERE p.ID = c.PERSON_ID AND c.code = '44054006';

--- a/src/main/resources/custom_queries.sql
+++ b/src/main/resources/custom_queries.sql
@@ -1,3 +1,13 @@
+-- CUSTOM REPORT QUERIES
+-- This file contains the queries that will be run, one at a time, to generate custom CSV reports.
+-- Each query will produce 1 report.
+-- Blank lines and lines starting with -- (single line comments) will be ignored.
+-- In this initial implementation, all queries must start with SELECT 
+--   (ie, no creation of views or modification of data allowed)
+-- and each query must be on its own line, entirely on a single line.
+-- See the DataStore class for details on what tables are available.
+
+
 -- Sample Query 1: select everything from the "person" table.
 -- Note that column ordering is not guaranteed.
 

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -17,7 +17,9 @@ exporter.csv.export = false
 exporter.text.export = false
 exporter.cost_access_outcomes_report = true
 exporter.prevalence_report = true
-# note: prevalence report requires a database (set below)
+exporter.custom_report = true
+# note: prevalence and custom reports require a database (set below)
+exporter.custom_report_queries_file = custom_queries.sql
 
 # the number of patients to generate, by default
 # this can be overridden by passing a different value to the Generator constructor

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -17,7 +17,7 @@ exporter.csv.export = false
 exporter.text.export = false
 exporter.cost_access_outcomes_report = true
 exporter.prevalence_report = true
-exporter.custom_report = true
+exporter.custom_report = false
 # note: prevalence and custom reports require a database (set below)
 exporter.custom_report_queries_file = custom_queries.sql
 

--- a/src/test/java/org/mitre/synthea/export/CustomSqlReportTest.java
+++ b/src/test/java/org/mitre/synthea/export/CustomSqlReportTest.java
@@ -1,0 +1,47 @@
+package org.mitre.synthea.export;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.junit.Test;
+import org.mitre.synthea.datastore.DataStore;
+import org.mitre.synthea.helpers.SimpleCSV;
+
+public class CustomSqlReportTest {
+
+  @Test
+  public void testTableToCsv() throws Exception {
+    DataStore testStore = new DataStore(false); // false == use in-memory
+    Connection connection = testStore.getConnection();
+
+    // using a query that doesn't require any data in the DB. 
+    // H2 has a dummy table "dual" with contains 1 column "X" with 1 value "1"
+    // so getting the count and sum of this column both == 1
+    String query = "SELECT COUNT(X) NUM, SUM(X) TOTAL FROM DUAL";
+    String result = CustomSqlReport.queryToCsv(connection, query);
+    
+    assertTrue(result.contains("NUM"));
+    assertTrue(result.contains("TOTAL"));
+    
+    // reparse it to a map so we can check it more "independently"
+    List<LinkedHashMap<String,String>> csvLines = SimpleCSV.parse(result);
+    
+    assertEquals(1, csvLines.size());
+    
+    LinkedHashMap<String,String> resultMap = csvLines.get(0);
+    
+    assertEquals(2, resultMap.size());
+    assertEquals("1", resultMap.get("NUM"));
+    assertEquals("1", resultMap.get("TOTAL"));
+    
+    // try a query that will return no results
+    query = "SELECT 1 FROM DUAL WHERE 42 = 54";
+    result = CustomSqlReport.queryToCsv(connection, query);
+    
+    assertEquals(CustomSqlReport.NO_RESULTS, result);
+  }
+}


### PR DESCRIPTION
Adds the ability to automatically run custom reports after a population is generated, using arbitrary SQL. Queries in the file src/main/resources/custom_queries.sql (configurable) will be run one at a time, and exported to CSV in output/reports. Lines starting with -- will be ignored, so this file includes a few sample queries to get started with.

This is not a "finished product" as it has some limitations but it is sufficiently usable that someone with an understanding of the DataStore data model could produce useful reports. After this is merged I plan to add a wiki page with an overview of the data model.