### PR TITLE
Provider bug fix

### DIFF
--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -273,7 +273,8 @@ public abstract class Exporter {
       return person.attributes.get(Person.ID) + "." + extension;
     } else {
       // ensure unique filenames for now
-      return person.attributes.get(Person.NAME) + "_" + person.attributes.get(Person.ID) + "."
+      return person.attributes.get(Person.NAME).toString().replace(' ', '_') + "_"
+          + person.attributes.get(Person.ID) + "."
           + extension;
     }
   }

--- a/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
@@ -4,6 +4,8 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -128,6 +130,8 @@ public class ProviderTest {
   public void testAllFiles() throws Exception {
     // just load all files and make sure they don't crash
     URL providersFolder = ClassLoader.getSystemClassLoader().getResource("providers");
+    Set<String> providerServices = new HashSet<String>();
+    providerServices.add(Provider.WELLNESS);
     Path path = Paths.get(providersFolder.toURI());
     Files.walk(path)
          .filter(Files::isReadable)
@@ -135,7 +139,8 @@ public class ProviderTest {
          .filter(p -> p.toString().endsWith(".csv"))
          .forEach(t -> {
            try {
-             Provider.loadProviders("Massachusetts", "MA", "providers/" + t.getFileName());
+             Provider.loadProviders("Massachusetts", "MA", "providers/" + t.getFileName(),
+                 providerServices);
            } catch (Exception e) {
              throw new RuntimeException("Failed to load provider file " + t, e);
            }


### PR DESCRIPTION
This pull request fixes a bug when you try to customize providers. If you try to use alternative provider files, the system will break because it was looking for hardcoded filenames.

E.g. changing:
```properties
generate.providers.hospitals.default_file = providers/hospitals.csv
```

to:

```properties
generate.providers.hospitals.default_file = providers/uk_test.csv
```

Would cause no hospitals to offer services, because the code was looking for the string `"providers/hospitals.csv"`

Bonus commit: Changes filenames not to have whitespace, which causes issues with some other programs... for example, Unix command line utils.