### PR TITLE
Make country code an editable property for localization.

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -127,6 +127,8 @@ public class FhirDstu2 {
   protected static boolean TRANSACTION_BUNDLE =
       Boolean.parseBoolean(Config.get("exporter.fhir.transaction_bundle"));
 
+  private static final String COUNTRY_CODE = Config.get("generate.geography.country_code");
+
   @SuppressWarnings("rawtypes")
   private static Map loadRaceEthnicityCodes() {
     String filename = "race_ethnicity_codes.json";
@@ -382,7 +384,10 @@ public class FhirDstu2 {
     addrResource.addLine((String) person.attributes.get(Person.ADDRESS))
         .setCity((String) person.attributes.get(Person.CITY))
         .setPostalCode((String) person.attributes.get(Person.ZIP))
-        .setState(state).setCountry("US");
+        .setState(state);
+    if (COUNTRY_CODE != null) {
+      addrResource.setCountry(COUNTRY_CODE);
+    }
 
     DirectPosition2D coord = (DirectPosition2D) person.attributes.get(Person.COORDINATE);
     if (coord != null) {
@@ -400,8 +405,10 @@ public class FhirDstu2 {
     }
 
     AddressDt birthplace = new AddressDt();
-    birthplace.setCity((String) person.attributes.get(Person.BIRTHPLACE)).setState(state)
-        .setCountry("US");
+    birthplace.setCity((String) person.attributes.get(Person.BIRTHPLACE)).setState(state);
+    if (COUNTRY_CODE != null) {
+      birthplace.setCountry(COUNTRY_CODE);
+    }
     ExtensionDt birthplaceExtension = new ExtensionDt();
     birthplaceExtension.setUrl("http://hl7.org/fhir/StructureDefinition/birthPlace");
     birthplaceExtension.setValue(birthplace);
@@ -1247,8 +1254,10 @@ public class FhirDstu2 {
         .addLine(provider.address)
         .setCity(provider.city)
         .setPostalCode(provider.zip)
-        .setState(provider.state)
-        .setCountry("US");
+        .setState(provider.state);
+    if (COUNTRY_CODE != null) {
+      address.setCountry(COUNTRY_CODE);
+    }
     organizationResource.addAddress(address);
 
     if (provider.phone != null && !provider.phone.isEmpty()) {

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -136,6 +136,8 @@ public class FhirStu3 {
   protected static boolean TRANSACTION_BUNDLE =
       Boolean.parseBoolean(Config.get("exporter.fhir.transaction_bundle"));
 
+  private static final String COUNTRY_CODE = Config.get("generate.geography.country_code");
+
   private static final Table<String,String,String> SHR_MAPPING = loadSHRMapping();
 
   @SuppressWarnings("rawtypes")
@@ -443,11 +445,16 @@ public class FhirStu3 {
     addrResource.addLine((String) person.attributes.get(Person.ADDRESS))
         .setCity((String) person.attributes.get(Person.CITY))
         .setPostalCode((String) person.attributes.get(Person.ZIP))
-        .setState(state).setCountry("US");
+        .setState(state);
+    if (COUNTRY_CODE != null) {
+      addrResource.setCountry(COUNTRY_CODE);
+    }
 
     Address birthplace = new Address();
-    birthplace.setCity((String) person.attributes.get(Person.BIRTHPLACE)).setState(state)
-        .setCountry("US");
+    birthplace.setCity((String) person.attributes.get(Person.BIRTHPLACE)).setState(state);
+    if (COUNTRY_CODE != null) {
+      birthplace.setCountry(COUNTRY_CODE);
+    }
     Extension birthplaceExtension = new Extension(
         "http://hl7.org/fhir/StructureDefinition/birthPlace");
     birthplaceExtension.setValue(birthplace);
@@ -1443,8 +1450,10 @@ public class FhirStu3 {
         .addLine(provider.address)
         .setCity(provider.city)
         .setPostalCode(provider.zip)
-        .setState(provider.state)
-        .setCountry("US");
+        .setState(provider.state);
+    if (COUNTRY_CODE != null) {
+      address.setCountry(COUNTRY_CODE);
+    }
     organizationResource.addAddress(address);
 
     if (provider.phone != null && !provider.phone.isEmpty()) {

--- a/src/main/java/org/mitre/synthea/export/HospitalDSTU2Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalDSTU2Exporter.java
@@ -37,6 +37,8 @@ public abstract class HospitalDSTU2Exporter {
   protected static boolean TRANSACTION_BUNDLE =
       Boolean.parseBoolean(Config.get("exporter.fhir.transaction_bundle"));
 
+  private static final String COUNTRY_CODE = Config.get("generate.geography.country_code");
+
   public static void export(long stop) {
     if (Boolean.parseBoolean(Config.get("exporter.hospital.fhir_dstu2.export"))) {
       
@@ -90,6 +92,9 @@ public abstract class HospitalDSTU2Exporter {
     address.setCity(h.city);
     address.setPostalCode(h.zip);
     address.setState(h.state);
+    if (COUNTRY_CODE != null) {
+      address.setCountry(COUNTRY_CODE);
+    }
     organizationResource.addAddress(address);
 
     Table<Integer, String, AtomicInteger> utilization = h.getUtilization();

--- a/src/main/java/org/mitre/synthea/export/HospitalExporter.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporter.java
@@ -36,6 +36,8 @@ public abstract class HospitalExporter {
   protected static boolean TRANSACTION_BUNDLE =
       Boolean.parseBoolean(Config.get("exporter.fhir.transaction_bundle"));
 
+  private static final String COUNTRY_CODE = Config.get("generate.geography.country_code");
+
   public static void export(long stop) {
     if (Boolean.parseBoolean(Config.get("exporter.hospital.fhir.export"))) {
 
@@ -89,6 +91,9 @@ public abstract class HospitalExporter {
     address.setCity(h.city);
     address.setPostalCode(h.zip);
     address.setState(h.state);
+    if (COUNTRY_CODE != null) {
+      address.setCountry(COUNTRY_CODE);
+    }
     organizationResource.addAddress(address);
 
     Table<Integer, String, AtomicInteger> utilization = h.getUtilization();

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -44,6 +44,7 @@ generate.database_type = in-memory
 # default demographics is every city in the US
 generate.demographics.default_file = geography/demographics.csv
 generate.geography.zipcodes.default_file = geography/zipcodes.csv
+generate.geography.country_code = US
 
 generate.only_dead_patients = false
 


### PR DESCRIPTION
This pull request makes country code an editable property for localization purposes.

Default:
```properties
generate.geography.country_code = US
```

Currently, this property is purely cosmetic for FHIR generated addresses. It has no other purposes, but in the future, we may use it for something more intelligent... for example, for switching between different country specific datasets.