### PR TITLE
Make race comparisons case-insensitive

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Logic.java
+++ b/src/main/java/org/mitre/synthea/engine/Logic.java
@@ -111,7 +111,7 @@ public abstract class Logic {
 
     @Override
     public boolean test(Person person, long time) {
-      return race.equals(person.attributes.get(Person.RACE));
+      return race.equalsIgnoreCase((String) person.attributes.get(Person.RACE));
     }
   }
 

--- a/src/test/java/org/mitre/synthea/engine/LogicTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LogicTest.java
@@ -119,10 +119,10 @@ public class LogicTest {
 
   @Test
   public void test_race_exists() {
-    person.attributes.put(Person.RACE, "White");
+    person.attributes.put(Person.RACE, "white");
     assertTrue(doTest("raceExistsTest"));
 
-    person.attributes.put(Person.RACE, "Native");
+    person.attributes.put(Person.RACE, "native");
     assertFalse(doTest("raceDoesNotExistTest"));
   }
 


### PR DESCRIPTION
Race comparisons are currently broken because the modules use capitalized strings (ex. "White") whereas the engine uses all lower-case (ex. "asian"). Rather than fix all the modules and the module builder, we can just use a case-insensitive match.