### PR TITLE
Update Encounter.diagnosePastConditions, fixes #351

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -525,9 +525,17 @@ public abstract class State implements Cloneable {
     }
 
     private void diagnosePastConditions(Person person, long time) {
+      // reminder: history[0] is current state, history[size-1] is Initial
       for (State state : person.history) {
-        if (state instanceof OnsetState && !((OnsetState) state).diagnosed) {
-          ((OnsetState) state).diagnose(person, time);
+        if (state instanceof OnsetState) {
+          OnsetState onset = (OnsetState) state;
+          
+          if (!onset.diagnosed && this.name.equals(onset.targetEncounter)) {
+            onset.diagnose(person, time);
+          }
+        } else if (state instanceof Encounter && state.name.equals(this.name)) {
+          // a prior instance of hitting this same state. no need to go back any further
+          break;
         }
       }
     }

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -152,6 +152,32 @@ public class StateTest {
   }
 
   @Test
+  public void condition_onset_diagnosed_by_target_encounter() { 
+    Module module = getModule("condition_onset.json");
+    
+    State condition = module.getState("Diabetes");
+    // Should pass through this state immediately without calling the record
+    assertTrue(condition.process(person, time));
+    person.history.add(0, condition);
+    
+    // The encounter comes next (and add it to history);
+    State encounter = module.getState("ED_Visit");
+
+    assertTrue(encounter.process(person, time));
+    person.history.add(0, encounter);
+
+    assertEquals(1, person.record.encounters.size());
+    Encounter enc = person.record.encounters.get(0);
+    Code code = enc.codes.get(0);
+    assertEquals("50849002", code.code);
+    assertEquals("Emergency Room Admission", code.display);
+    assertEquals(1, enc.conditions.size());
+    code = enc.conditions.get(0).codes.get(0);
+    assertEquals("73211009", code.code);
+    assertEquals("Diabetes mellitus", code.display);
+  }
+
+  @Test
   public void condition_onset_during_encounter() {
     Module module = getModule("condition_onset.json");
     // The encounter comes first (and add it to history);


### PR DESCRIPTION
Makes 2 changes to Encounter.diagnosePastConditions:

1 - checks whether the current encounter state is the target encounter of an onset state before diagnosing it
2 - breaks out of the loop early if it finds a previous instance of the same state (which would have diagnosed anything prior to that)