### PR TITLE
Re-fix Encounter.diagnosePastConditions

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -533,7 +533,7 @@ public abstract class State implements Cloneable {
           if (!onset.diagnosed && this.name.equals(onset.targetEncounter)) {
             onset.diagnose(person, time);
           }
-        } else if (state instanceof Encounter && state.name.equals(this.name)) {
+        } else if (state instanceof Encounter && state != this && state.name.equals(this.name)) {
           // a prior instance of hitting this same state. no need to go back any further
           break;
         }

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -157,14 +157,13 @@ public class StateTest {
     
     State condition = module.getState("Diabetes");
     // Should pass through this state immediately without calling the record
-    assertTrue(condition.process(person, time));
     person.history.add(0, condition);
-    
+    assertTrue(condition.process(person, time));
+
     // The encounter comes next (and add it to history);
     State encounter = module.getState("ED_Visit");
-
+    person.history.add(0, encounter); // states are added to history before being processed
     assertTrue(encounter.process(person, time));
-    person.history.add(0, encounter);
 
     assertEquals(1, person.record.encounters.size());
     Encounter enc = person.record.encounters.get(0);


### PR DESCRIPTION
Just introduced in a recent PR, the changes to Encounter.diagnosePastConditions broke diagnosing past conditions.

Note the comment at the beginning of the method:
`// reminder: history[0] is current state, history[size-1] is Initial`
So current state is an Encounter, which has the same name as itself, so it would always hit the `else` condition and break out before diagnosing anything.
Simplest fix is to just not break when you are not looking at the current state, ie when `!= this`. The unit test didn't catch it previously because it added the state to history after processing, which isn't how the modules actually work.