### PR TITLE
Fix diagnostic report including the correct number of observations.

### DIFF
--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -509,8 +509,8 @@ public class HealthRecord {
     Encounter encounter = currentEncounter(time);
     List<Observation> observations = new ArrayList<Observation>();
     if (encounter.observations.size() > numberOfObservations) {
-      int fromIndex = encounter.observations.size() - numberOfObservations - 1;
-      int toIndex = encounter.observations.size() - 1;
+      int fromIndex = encounter.observations.size() - numberOfObservations;
+      int toIndex = encounter.observations.size();
       observations.addAll(encounter.observations.subList(fromIndex, toIndex));
     } else {
       observations.addAll(encounter.observations);

--- a/src/test/java/org/mitre/synthea/world/concepts/HealthRecordTest.java
+++ b/src/test/java/org/mitre/synthea/world/concepts/HealthRecordTest.java
@@ -1,0 +1,61 @@
+package org.mitre.synthea.world.concepts;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
+import org.mitre.synthea.world.concepts.HealthRecord.Report;
+
+public class HealthRecordTest {
+
+  @Test
+  public void testReportAllObs() {
+    Person person = new Person(0L);
+    HealthRecord record = new HealthRecord(person);
+    Encounter encounter = record.encounterStart(0L, EncounterType.WELLNESS.toString());
+    record.observation(0L, "A", "A");
+    record.observation(0L, "B", "B");
+    record.observation(0L, "C", "C");
+    Report report = record.report(0L, "R", 3);
+    
+    Assert.assertEquals(3, encounter.observations.size());
+    Assert.assertEquals(3, report.observations.size());
+    Assert.assertEquals("A", report.observations.get(0).value);
+    Assert.assertEquals("B", report.observations.get(1).value);
+    Assert.assertEquals("C", report.observations.get(2).value);
+  }
+
+  @Test
+  public void testReportSomeObs() {
+    Person person = new Person(0L);
+    HealthRecord record = new HealthRecord(person);
+    Encounter encounter = record.encounterStart(0L, EncounterType.WELLNESS.toString());
+    record.observation(0L, "A", "A");
+    record.observation(0L, "B", "B");
+    record.observation(0L, "C", "C");
+    Report report = record.report(0L, "R", 2);
+    
+    Assert.assertEquals(3, encounter.observations.size());
+    Assert.assertEquals(2, report.observations.size());
+    Assert.assertEquals("B", report.observations.get(0).value);
+    Assert.assertEquals("C", report.observations.get(1).value);
+  }
+
+  @Test
+  public void testReportTooManyObs() {
+    Person person = new Person(0L);
+    HealthRecord record = new HealthRecord(person);
+    Encounter encounter = record.encounterStart(0L, EncounterType.WELLNESS.toString());
+    record.observation(0L, "A", "A");
+    record.observation(0L, "B", "B");
+    record.observation(0L, "C", "C");
+    Report report = record.report(0L, "R", 4);
+    
+    Assert.assertEquals(3, encounter.observations.size());
+    Assert.assertEquals(3, report.observations.size());
+    Assert.assertEquals("A", report.observations.get(0).value);
+    Assert.assertEquals("B", report.observations.get(1).value);
+    Assert.assertEquals("C", report.observations.get(2).value);
+  } 
+}


### PR DESCRIPTION
Fixes DiagnosticReport to include the correct set of observations. Apparently this has been broken for a while... like 8 months. Blah.