### PR TITLE
Migrate lung cancer probability calculations to GMF

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -95,7 +95,6 @@ public final class LifecycleModule extends Module {
       grow(person, time);
     }
     startSmoking(person, time);
-    chanceOfLungCancer(person, time);
     startAlcoholism(person, time);
     quitSmoking(person, time);
     quitAlcoholism(person, time);
@@ -794,58 +793,6 @@ public final class LifecycleModule extends Module {
     }
 
     return ((year * -0.4865) + 996.41) / 100.0;
-  }
-
-  private static void chanceOfLungCancer(Person person, long time) {
-    // TODO - make this calculation more elaborate, based on duration smoking, timestep-dependent
-
-    /*
-     * Overall, the chance that a man will develop lung cancer in his lifetime is about 1 in 14;
-     * for a woman, the risk is about 1 in 17.
-     * http://www.cancer.org/cancer/lungcancer-non-smallcell/detailedguide/non-small-cell-lung-
-     * cancer-key-statistics
-     * 
-     * Men who smoke are 23 times more likely to develop lung cancer.
-     * Women are 13 times more likely, compared to never smokers.
-     * http://www.lung.org/lung-health-and-diseases/lung-disease-lookup/lung-cancer/learn-about-
-     * lung-cancer/lung-cancer-fact-sheet.html
-     * 
-     * In a 2006 European study, the risk of developing lung cancer was:
-     * 0.2 percent for men who never smoked (0.4% for women);
-     * 5.5 percent of male former smokers (2.6% in women);
-     * 15.9 percent of current male smokers (9.5% for women);
-     * 24.4 percent for male "heavy smokers" defined as smoking more than 5 cigarettes per day
-     * (18.5 percent for women) 
-     * https://www.verywell.com/what-percentage-of-smokers-get-lung-cancer-2248868
-     */
-
-    boolean isSmoker = (boolean) person.attributes.getOrDefault(Person.SMOKER, false);
-    boolean quitSmoking = person.attributes.containsKey(QUIT_SMOKING_AGE);
-    boolean isMale = "M".equals(person.attributes.get(Person.GENDER));
-
-    double probabilityOfLungCancer;
-
-    if (isMale) {
-      // male rates
-      if (isSmoker) {
-        probabilityOfLungCancer = 0.244;
-      } else if (quitSmoking) {
-        probabilityOfLungCancer = 0.055;
-      } else {
-        probabilityOfLungCancer = 0.002;
-      }
-    } else {
-      // female rates
-      if (isSmoker) {
-        probabilityOfLungCancer = 0.185;
-      } else if (quitSmoking) {
-        probabilityOfLungCancer = 0.026;
-      } else {
-        probabilityOfLungCancer = 0.004;
-      }
-    }
-
-    person.attributes.put("probability_of_lung_cancer", probabilityOfLungCancer);
   }
 
   private static void startAlcoholism(Person person, long time) {

--- a/src/main/resources/modules/lung_cancer.json
+++ b/src/main/resources/modules/lung_cancer.json
@@ -28,7 +28,8 @@
       ]
     },
     "Lung Cancer Probabilities": {
-      "type": "Simple",
+      "type": "CallSubmodule",
+      "submodule": "lung_cancer/lung_cancer_probabilities",
       "distributed_transition": [
         {
           "distribution": {
@@ -50,7 +51,7 @@
         "http://www.cancer.org/cancer/lungcancer-non-smallcell/detailedguide/non-small-cell-lung-cancer-key-statistics",
         "Men who smoke are 23 times more likely to develop lung cancer. Women are 13 times more likely, compared to never smokers.",
         "http://www.lung.org/lung-health-and-diseases/lung-disease-lookup/lung-cancer/learn-about-lung-cancer/lung-cancer-fact-sheet.html",
-        "In a 2006 European study, the risk of developing lung cancer was: 0.2 percent for men who never smoked (0.4% for women); 5.5 percent of male former smokers (2.6% in women); 15.9 percent of current male smokers (9.5% for women); 24.4 percent for male “heavy smokers” defined as smoking more than 5 cigarettes per day (18.5 percent for women)",
+        "In a 2006 European study, the risk of developing lung cancer was: 0.2 percent for men who never smoked (0.4% for women); 5.5 percent of male former smokers (2.6% in women); 15.9 percent of current male smokers (9.5% for women); 24.4 percent for male 'heavy smokers' defined as smoking more than 5 cigarettes per day (18.5 percent for women)",
         "https://www.verywell.com/what-percentage-of-smokers-get-lung-cancer-2248868"
       ]
     },
@@ -138,7 +139,7 @@
         "low": 50,
         "high": 250
       },
-      "direct_transition": "Fatigue"
+      "direct_transition": "Sweats"
     },
     "Sweats": {
       "type": "Symptom",

--- a/src/main/resources/modules/lung_cancer/lung_cancer_probabilities.json
+++ b/src/main/resources/modules/lung_cancer/lung_cancer_probabilities.json
@@ -1,0 +1,135 @@
+{
+  "name": "Lung Cancer Probabilities",
+  "remarks": [
+    "Overall, the chance that a man will develop lung cancer in his lifetime is about 1 in 14;",
+    "for a woman, the risk is about 1 in 17.",
+    "http://www.cancer.org/cancer/lungcancer-non-smallcell/detailedguide/non-small-cell-lung-",
+    "cancer-key-statistics",
+    "",
+    "Men who smoke are 23 times more likely to develop lung cancer.",
+    "Women are 13 times more likely, compared to never smokers.",
+    "http://www.lung.org/lung-health-and-diseases/lung-disease-lookup/lung-cancer/learn-about-",
+    "lung-cancer/lung-cancer-fact-sheet.html",
+    "",
+    "In a 2006 European study, the risk of developing lung cancer was:",
+    "0.2 percent for men who never smoked (0.4% for women);",
+    "5.5 percent of male former smokers (2.6% in women);",
+    "15.9 percent of current male smokers (9.5% for women);",
+    "24.4 percent for male \"heavy smokers\" defined as smoking more than 5 cigarettes per day",
+    "(18.5 percent for women) ",
+    "https://www.verywell.com/what-percentage-of-smokers-get-lung-cancer-2248868"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "transition": "Female",
+          "condition": {
+            "condition_type": "Gender",
+            "gender": "F"
+          }
+        },
+        {
+          "transition": "Male",
+          "condition": {
+            "condition_type": "Gender",
+            "gender": "M"
+          }
+        }
+      ],
+      "remarks": [
+        "TODO - make this calculation more elaborate, based on duration smoking, timestep-dependent"
+      ]
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Male": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "transition": "Male_Smoker",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "smoker",
+            "operator": "==",
+            "value": true
+          }
+        },
+        {
+          "transition": "Male_Quit",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "quit smoking age",
+            "operator": "is not nil"
+          }
+        },
+        {
+          "transition": "Male_Nonsmoker"
+        }
+      ]
+    },
+    "Female": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "transition": "Female_Smoker",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "smoker",
+            "operator": "==",
+            "value": true
+          }
+        },
+        {
+          "transition": "Female_Quit",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "quit smoking age",
+            "operator": "is not nil"
+          }
+        },
+        {
+          "transition": "Female_Nonsmoker"
+        }
+      ]
+    },
+    "Male_Smoker": {
+      "type": "SetAttribute",
+      "attribute": "probability_of_lung_cancer",
+      "direct_transition": "Terminal",
+      "value": 0.244
+    },
+    "Male_Quit": {
+      "type": "SetAttribute",
+      "attribute": "probability_of_lung_cancer",
+      "direct_transition": "Terminal",
+      "value": 0.055
+    },
+    "Male_Nonsmoker": {
+      "type": "SetAttribute",
+      "attribute": "probability_of_lung_cancer",
+      "direct_transition": "Terminal",
+      "value": 0.002
+    },
+    "Female_Smoker": {
+      "type": "SetAttribute",
+      "attribute": "probability_of_lung_cancer",
+      "direct_transition": "Terminal",
+      "value": 0.185
+    },
+    "Female_Quit": {
+      "type": "SetAttribute",
+      "attribute": "probability_of_lung_cancer",
+      "direct_transition": "Terminal",
+      "value": 0.026
+    },
+    "Female_Nonsmoker": {
+      "type": "SetAttribute",
+      "attribute": "probability_of_lung_cancer",
+      "direct_transition": "Terminal",
+      "value": 0.004
+    }
+  }
+}


### PR DESCRIPTION
Moves the logic that calculates probability of lung cancer from the java-based LifecycleModule to a new submodule. This is intended to be as close to a 1-1 translation of the java logic as possible, but only called once since the value is only read once.

New submodule:
![lung_cancer_probabilities](https://user-images.githubusercontent.com/13512036/42571846-286d67c6-84e6-11e8-946d-290ca71d0749.png)

(note the extra transition change in the lung_cancer module just fixes an unreachable state)