### PR TITLE
Fix current encounter in submodules.

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -207,6 +207,10 @@ public abstract class State implements Cloneable {
       // e.g. "submodule": "medications/otc_antihistamine"
       List<State> moduleHistory = person.history;
       Module submod = Module.getModuleByPath(submodule);
+      HealthRecord.Encounter encounter = person.getCurrentEncounter(module);
+      if (encounter != null) {
+        person.setCurrentEncounter(submod, encounter);
+      }
       boolean completed = submod.process(person, time);
 
       if (completed) {
@@ -218,6 +222,11 @@ public abstract class State implements Cloneable {
         person.history = moduleHistory;
         // add this state to history to indicate we returned to this module
         person.history.add(0, this);
+        // start using the current encounter, it may have changed
+        encounter = person.getCurrentEncounter(submod);
+        if (encounter != null) {
+          person.setCurrentEncounter(module, encounter);
+        }
 
         return true;
       } else {
@@ -609,7 +618,7 @@ public abstract class State implements Cloneable {
     public boolean process(Person person, long time) {
       HealthRecord.Encounter encounter = person.getCurrentEncounter(module);
 
-      if (targetEncounter == null
+      if (targetEncounter == null || targetEncounter.trim().length() == 0
           || (encounter != null && targetEncounter.equals(encounter.name))) {
         diagnose(person, time);
       } else if (assignToAttribute != null && codes != null) {

--- a/src/test/resources/generic/encounter_with_submodule.json
+++ b/src/test/resources/generic/encounter_with_submodule.json
@@ -1,0 +1,36 @@
+{
+  "name": "encounter_with_submodule",
+  "remarks": [
+    "A simple module that starts an encounter, calls a submodule, and then ends an encounter."
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "EncounterOutside"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "CallSubmodule": {
+      "type": "CallSubmodule",
+      "submodule": "submodules/admission",
+      "direct_transition": "EndEncounterOutside"
+    },
+    "EndEncounterOutside": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
+    },
+    "EncounterOutside": {
+      "type": "Encounter",
+      "encounter_class": "ambulatory",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "1234",
+          "display": "SNOMED Code"
+        }
+      ],
+      "direct_transition": "CallSubmodule"
+    }
+  }
+}

--- a/src/test/resources/generic/submodules/admission.json
+++ b/src/test/resources/generic/submodules/admission.json
@@ -1,0 +1,53 @@
+{
+  "name": "Admission",
+  "remarks": [
+    "A submodule that diagnoses the patient with a condition, admits them as an inpatient, and allows them to recover for 5 days."
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "ConditionOnset"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "ConditionOnset": {
+      "type": "ConditionOnset",
+      "assign_to_attribute": "condition",
+      "target_encounter": "",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 5678,
+          "display": "Condition"
+        }
+      ],
+      "direct_transition": "EndEncounterInside"
+    },
+    "EndEncounterInside": {
+      "type": "EncounterEnd",
+      "direct_transition": "AdmitAsInpatient"
+    },
+    "AdmitAsInpatient": {
+      "type": "Encounter",
+      "encounter_class": "inpatient",
+      "reason": "condition",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 9876,
+          "display": "Inpatient"
+        }
+      ],
+      "direct_transition": "Recovery"
+    },
+    "Recovery": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 5,
+        "unit": "days"
+      },
+      "direct_transition": "Terminal"
+    }
+  }
+}


### PR DESCRIPTION
Fixes a bug where submodules did not have a current encounter, unless it was declared within the submodule. This now allows for submodules to add things to the current encounter, and even end the current encounter and start a new encounter (e.g. ADT).

Also, this PR now allows conditions to be diagnosed if the target_encounter is empty (previously allowed it correctly allowed `null` but not empty).