### PR TITLE
Replace VitalSign enums with Strings

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -374,7 +374,7 @@ public class Generator {
       System.out.format("SYMPTOMS: %d\n", person.symptomTotal());
       System.out.println(person.record.textSummary());
       System.out.println("VITAL SIGNS");
-      for (VitalSign vitalSign : person.vitalSigns.keySet()) {
+      for (String vitalSign : person.vitalSigns.keySet()) {
         System.out.format("  * %25s = %6.2f\n", vitalSign,
             person.getVitalSign(vitalSign).doubleValue());
       }

--- a/src/main/java/org/mitre/synthea/engine/Logic.java
+++ b/src/main/java/org/mitre/synthea/engine/Logic.java
@@ -447,7 +447,7 @@ public abstract class Logic {
    * the Symptom State.
    */
   public static class VitalSign extends Logic {
-    private org.mitre.synthea.world.concepts.VitalSign vitalSign;
+    private String vitalSign;
     private String operator;
     private double value;
 

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1054,7 +1054,7 @@ public abstract class State implements Cloneable {
    * not a physical metric, so it should not be stored in a VitalSign.
    */
   public static class VitalSign extends State {
-    private org.mitre.synthea.world.concepts.VitalSign vitalSign;
+    private String vitalSign;
     private String unit;
     private Range<Double> range;
     private Exact<Double> exact;
@@ -1123,7 +1123,7 @@ public abstract class State implements Cloneable {
     private Exact<Object> exact;
     private Code valueCode;
     private String attribute;
-    private org.mitre.synthea.world.concepts.VitalSign vitalSign;
+    private String vitalSign;
     private String category;
     private String unit;
 

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -70,7 +70,7 @@ public class Person implements Serializable, QuadTreeData {
   public final long seed;
   public long populationSeed;
   public Map<String, Object> attributes;
-  public Map<VitalSign, Double> vitalSigns;
+  public Map<String, Double> vitalSigns;
   private Map<String, Map<String, Integer>> symptoms;
   private Map<String, Map<String, Boolean>> symptomStatuses;
   public EventList events;
@@ -82,7 +82,7 @@ public class Person implements Serializable, QuadTreeData {
     this.seed = seed; // keep track of seed so it can be exported later
     random = new Random(seed);
     attributes = new ConcurrentHashMap<String, Object>();
-    vitalSigns = new ConcurrentHashMap<VitalSign, Double>();
+    vitalSigns = new ConcurrentHashMap<String, Double>();
     symptoms = new ConcurrentHashMap<String, Map<String, Integer>>();
     symptomStatuses = new ConcurrentHashMap<String, Map<String, Boolean>>();
     events = new EventList();
@@ -215,11 +215,11 @@ public class Person implements Serializable, QuadTreeData {
     symptomStatuses.get(highestType).put(highestCause, true);
   }
 
-  public Double getVitalSign(VitalSign vitalSign) {
+  public Double getVitalSign(String vitalSign) {
     return vitalSigns.get(vitalSign);
   }
 
-  public void setVitalSign(VitalSign vitalSign, double value) {
+  public void setVitalSign(String vitalSign, double value) {
     vitalSigns.put(vitalSign, value);
   }
 

--- a/src/main/java/org/mitre/synthea/world/concepts/VitalSign.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/VitalSign.java
@@ -1,66 +1,26 @@
 package org.mitre.synthea.world.concepts;
 
-import com.google.gson.annotations.SerializedName;
-
-public enum VitalSign {
-
-  @SerializedName("Height") HEIGHT,
-  @SerializedName("Weight") WEIGHT, 
-  @SerializedName("Height Percentile") HEIGHT_PERCENTILE, 
-  @SerializedName("Weight Percentile") WEIGHT_PERCENTILE, 
-  @SerializedName("BMI") BMI, 
-  @SerializedName("Systolic Blood Pressure") SYSTOLIC_BLOOD_PRESSURE, 
-  @SerializedName("Diastolic Blood Pressure") DIASTOLIC_BLOOD_PRESSURE, 
-  @SerializedName("Blood Glucose") BLOOD_GLUCOSE, 
-  @SerializedName("Glucose") GLUCOSE, 
-  @SerializedName("Urea Nitrogen") UREA_NITROGEN, 
-  @SerializedName("Creatinine") CREATININE, 
-  @SerializedName("Calcium") CALCIUM, 
-  @SerializedName("Sodium") SODIUM, 
-  @SerializedName("Potassium") POTASSIUM, 
-  @SerializedName("Chloride") CHLORIDE, 
-  @SerializedName("Carbon Dioxide") CARBON_DIOXIDE, 
-  @SerializedName("Total Cholesterol") TOTAL_CHOLESTEROL, 
-  @SerializedName("Triglycerides") TRIGLYCERIDES, 
-  @SerializedName("LDL") LDL,
-  @SerializedName("HDL") HDL, 
-  @SerializedName("Microalbumin Creatinine Ratio") MICROALBUMIN_CREATININE_RATIO, 
-  @SerializedName("EGFR") EGFR;
-
-  /**
-   * Name of the VitalSign. Cached as a string for better lookup performance.
-   */
-  private final String name;
-  
-  private VitalSign() {
-    String n;
-    try {
-      n = getClass().getField(this.name())
-          .getAnnotation(SerializedName.class).value();
-
-    } catch (Exception e) {
-      // should never happen
-      n = this.name();
-    }
-    this.name = n;
-  }
-  
-  /**
-   * Get the VitalSign enum matching the given string.
-   * @param text Name of a Vital Sign, ex "Systolic Blood Pressure"
-   * @return VitalSign with the given name
-   */
-  public static VitalSign fromString(String text) {
-    for (VitalSign type : VitalSign.values()) {
-      String typeText = type.name;
-      if (text.equalsIgnoreCase(typeText)) {
-        return type;
-      }
-    }
-    return VitalSign.valueOf(text);
-  }
-
-  public String toString() {
-    return this.name;
-  }
+public abstract class VitalSign {
+  public static final String HEIGHT = "Height";
+  public static final String WEIGHT = "Weight";
+  public static final String HEIGHT_PERCENTILE = "Height Percentile";
+  public static final String WEIGHT_PERCENTILE = "Weight Percentile";
+  public static final String BMI = "BMI";
+  public static final String SYSTOLIC_BLOOD_PRESSURE = "Systolic Blood Pressure";
+  public static final String DIASTOLIC_BLOOD_PRESSURE = "Diastolic Blood Pressure";
+  public static final String BLOOD_GLUCOSE = "Blood Glucose";
+  public static final String GLUCOSE = "Glucose";
+  public static final String UREA_NITROGEN = "Urea Nitrogen";
+  public static final String CREATININE = "Creatinine";
+  public static final String CALCIUM = "Calcium";
+  public static final String SODIUM = "Sodium";
+  public static final String POTASSIUM = "Potassium";
+  public static final String CHLORIDE = "Chloride";
+  public static final String CARBON_DIOXIDE = "Carbon Dioxide";
+  public static final String TOTAL_CHOLESTEROL = "Total Cholesterol";
+  public static final String TRIGLYCERIDES = "Triglycerides";
+  public static final String LDL = "LDL";
+  public static final String HDL = "HDL";
+  public static final String MICROALBUMIN_CREATININE_RATIO = "Microalbumin Creatinine Ratio";
+  public static final String EGFR = "EGFR";
 }


### PR DESCRIPTION
Enums are a useful tool when one has a comprehensive set of concepts. We have nowhere near a comprehensive set of vital signs, so an enum is likely not appropriate. This changes vital signs to be a String instead, allowing for arbitrary vital signs to be set and used in any module.
To minimize the changes needed across the code, I left in the VitalSign class with a set of predefined constants. These are the vital signs that the core system knows about. If and as these are migrated to GMF we can delete those.

Key point: This should have no outward-facing impact, purely an implementation detail. The module builder already allows free text in `vital_sign` fields.