### PR TITLE
WIP: Expressions using CQL Engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,11 @@ dependencies {
   compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
   compile group: 'org.apache.commons', name: 'commons-text', version: '1.2'
 
+  compile group: 'org.opencds.cqf', name: 'cql-engine', version: '1.2.20'
+  compile group: 'info.cqframework', name: 'cql', version: '1.2.20'
+  compile group: 'info.cqframework', name: 'model', version: '1.2.20'
+  compile group: 'info.cqframework', name: 'cql-to-elm', version: '1.2.20'
+
   // Java 9 no longer includes these APIs by default
   compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.0'
   compile 'org.glassfish.jaxb:jaxb-runtime:2.3.0'

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1056,6 +1056,7 @@ public abstract class State implements Cloneable {
     private String unit;
     private Range<Double> range;
     private Exact<Double> exact;
+    private String expression;
 
     @Override
     public VitalSign clone() {
@@ -1064,6 +1065,7 @@ public abstract class State implements Cloneable {
       clone.exact = exact;
       clone.vitalSign = vitalSign;
       clone.unit = unit;
+      clone.expression = expression;
       return clone;
     }
 
@@ -1074,6 +1076,9 @@ public abstract class State implements Cloneable {
       } else if (range != null) {
         double value = person.rand(range.low, range.high);
         person.setVitalSign(vitalSign, value);
+      } else if (expression != null) {
+        Number value = (Number) ExpressionProcessor.evaluate(expression, person, time);
+        person.setVitalSign(vitalSign, value.doubleValue());
       } else {
         throw new RuntimeException(
             "VitalSign state has no exact quantity or low/high range: " + this);
@@ -1124,6 +1129,7 @@ public abstract class State implements Cloneable {
     private org.mitre.synthea.world.concepts.VitalSign vitalSign;
     private String category;
     private String unit;
+    private String expression;
 
     @Override
     public Observation clone() {
@@ -1136,6 +1142,7 @@ public abstract class State implements Cloneable {
       clone.vitalSign = vitalSign;
       clone.category = category;
       clone.unit = unit;
+      clone.expression = expression;
       return clone;
     }
 
@@ -1153,7 +1160,9 @@ public abstract class State implements Cloneable {
         value = person.getVitalSign(vitalSign);
       } else if (valueCode != null) {
         value = valueCode;
-      }
+      } else if (expression != null) {
+        value = ExpressionProcessor.evaluate(expression, person, time);
+      } 
       HealthRecord.Observation observation = person.record.observation(time, primaryCode, value);
       observation.name = this.name;
       observation.codes.addAll(codes);

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -17,6 +17,7 @@ import org.mitre.synthea.engine.Transition.ConditionalTransitionOption;
 import org.mitre.synthea.engine.Transition.DirectTransition;
 import org.mitre.synthea.engine.Transition.DistributedTransition;
 import org.mitre.synthea.engine.Transition.DistributedTransitionOption;
+import org.mitre.synthea.helpers.ExpressionProcessor;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.modules.EncounterModule;
 import org.mitre.synthea.world.agents.Person;
@@ -338,6 +339,7 @@ public abstract class State implements Cloneable {
   public static class SetAttribute extends State {
     private String attribute;
     private Object value;
+    private String expression;
 
     @Override
     protected void initialize(Module module, String name, JsonObject definition) {
@@ -358,11 +360,16 @@ public abstract class State implements Cloneable {
       SetAttribute clone = (SetAttribute) super.clone();
       clone.attribute = attribute;
       clone.value = value;
+      clone.expression = expression;
       return clone;
     }
 
     @Override
     public boolean process(Person person, long time) {
+      if (expression != null) {
+        value = ExpressionProcessor.evaluate(expression, person, time);
+      }
+
       if (value != null) {
         person.attributes.put(attribute, value);
       } else if (person.attributes.containsKey(attribute)) {

--- a/src/main/java/org/mitre/synthea/helpers/ExpressionProcessor.java
+++ b/src/main/java/org/mitre/synthea/helpers/ExpressionProcessor.java
@@ -1,0 +1,143 @@
+package org.mitre.synthea.helpers;
+
+import java.io.ByteArrayInputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.cqframework.cql.cql2elm.CqlTranslator;
+import org.cqframework.cql.cql2elm.LibraryManager;
+import org.cqframework.cql.cql2elm.ModelManager;
+import org.cqframework.cql.elm.execution.ExpressionDef;
+import org.cqframework.cql.elm.execution.Library;
+import org.mitre.synthea.world.agents.Person;
+import org.opencds.cqf.cql.elm.execution.ExpressionDefEvaluator;
+import org.opencds.cqf.cql.execution.Context;
+import org.opencds.cqf.cql.execution.CqlLibraryReader;
+
+public abstract class ExpressionProcessor {
+
+  public static void initialize() {
+
+  }
+
+  public static Object evaluate(String expression, Person person, long time) {
+    try {
+      StringBuilder wrappedExpression = new StringBuilder();
+
+      wrappedExpression.append("library Synthea version '1'\n\ncontext Patient\n\n");
+
+      // identify the attributes that are used
+      Set<String> attributes = new HashSet<>();
+
+      Pattern pattern = Pattern.compile("#\\{.+?\\}");
+
+      Matcher matcher = pattern.matcher(expression);
+
+      while (matcher.find()) {
+        String key = matcher.group();
+        String attr = key.substring(2, key.length() - 1).trim(); // lop off #{ and }
+        attributes.add(attr);
+
+        // clean up the expression so we can plug it in later
+        expression = expression.replace(key, attr);
+      }
+
+      for (String attr : attributes) {
+        Object value = person.attributes.get(attr);
+
+        if (!(value instanceof Number)) {
+          throw new IllegalArgumentException("attempted to use attribute " + attr + " with value "
+              + value + " in calculation but it is not a number.");
+        }
+
+        wrappedExpression.append("\ndefine ").append(attr).append(": ").append(value);
+
+      }
+
+      wrappedExpression.append("\ndefine result: ");
+      wrappedExpression.append(expression);
+
+      // try and parse it as CQL.
+      String elm = cqlToElm(wrappedExpression.toString());
+
+      Library library = CqlLibraryReader
+          .read(new ByteArrayInputStream(elm.getBytes(StandardCharsets.UTF_8)));
+
+      Context context = new Context(library);
+
+      Object retVal = null;
+
+      for (ExpressionDef statement : library.getStatements().getDef()) {
+        if (!(statement instanceof ExpressionDefEvaluator)) {
+          // This skips over any FunctionDef statements for starters.
+          continue;
+        }
+        // if (!statement.getAccessLevel().value().equals("Public")) {
+        // // Note: It appears that Java interns the string "Public"
+        // // since using != here also seems to work.
+        // continue;
+        // }
+
+        retVal = statement.evaluate(context);
+      }
+
+      return wrap(retVal);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static Object wrap(Object o) {
+    if (o == null || o instanceof Number || o instanceof String) {
+      return o;
+    } else if (o instanceof BigDecimal) {
+      // wrap BigDecimals as Longs or Doubles, to make logic elsewhere in the engine easier
+      BigDecimal bd = (BigDecimal) o;
+
+      if (isIntegerValue(bd)) {
+        o = bd.longValue();
+      } else {
+        o = bd.doubleValue();
+      }
+    } else if (o instanceof BigInteger) {
+      // wrap BigIntegers as Longs, same reason
+      o = ((BigInteger) o).longValue();
+    }
+
+    return o;
+  }
+
+  private static boolean isIntegerValue(BigDecimal bd) {
+    // https://stackoverflow.com/a/12748321
+    return bd.signum() == 0 || bd.scale() <= 0 || bd.stripTrailingZeros().scale() <= 0;
+  }
+
+  private static String cqlToElm(String cql) {
+    ModelManager modelManager = new ModelManager();
+    LibraryManager libraryManager = new LibraryManager(modelManager);
+
+    ArrayList<CqlTranslator.Options> options = new ArrayList<>();
+    options.add(CqlTranslator.Options.EnableDateRangeOptimization);
+
+    CqlTranslator translator = CqlTranslator.fromText(cql, modelManager, libraryManager,
+        options.toArray(new CqlTranslator.Options[options.size()]));
+
+    if (translator.getErrors().size() > 0) {
+      return null;
+    }
+
+    String elm = translator.toXml();
+
+    if (translator.getErrors().size() > 0) {
+      return null;
+    }
+
+    return elm;
+  }
+}

--- a/src/test/java/org/mitre/synthea/helpers/ExpressionProcessorTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/ExpressionProcessorTest.java
@@ -3,32 +3,32 @@ package org.mitre.synthea.helpers;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.mitre.synthea.world.agents.Person;
 
 public class ExpressionProcessorTest {
-
-  @Before
-  public void setup() {
-    ExpressionProcessor.initialize();
-  }
-  
   @Test
   public void testBasic() {
     String exp = "10 + 3";
     Object result = ExpressionProcessor.evaluate(exp, null, 0L);
     assertEquals(13, result);
+    
+    exp = "25 / 2";
+    result = ExpressionProcessor.evaluate(exp, null, 0L);
+    assertEquals(12.5, result);
+    
+    exp = "2 * (10 + 6) + 4 + 3 * ((10 / 2) * (9 / 3))";
+    result = ExpressionProcessor.evaluate(exp, null, 0L);
+    assertEquals(81L, result);
   } 
   
-  
   @Test
-  public void testWithAttributes() {
+  public void testWithPersonAttributes() {
     Person p = new Person(0L);
     p.attributes.put("age", 26);
     String exp = "#{age} / 2 + 7";
     Object result = ExpressionProcessor.evaluate(exp, p, 0L);
     assertTrue(result instanceof Number);
-    assertEquals(20, ((Number)result).longValue());
-  } 
+    assertEquals(20L, ((Number)result).longValue());
+  }
 }

--- a/src/test/java/org/mitre/synthea/helpers/ExpressionProcessorTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/ExpressionProcessorTest.java
@@ -1,0 +1,34 @@
+package org.mitre.synthea.helpers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mitre.synthea.world.agents.Person;
+
+public class ExpressionProcessorTest {
+
+  @Before
+  public void setup() {
+    ExpressionProcessor.initialize();
+  }
+  
+  @Test
+  public void testBasic() {
+    String exp = "10 + 3";
+    Object result = ExpressionProcessor.evaluate(exp, null, 0L);
+    assertEquals(13, result);
+  } 
+  
+  
+  @Test
+  public void testWithAttributes() {
+    Person p = new Person(0L);
+    p.attributes.put("age", 26);
+    String exp = "#{age} / 2 + 7";
+    Object result = ExpressionProcessor.evaluate(exp, p, 0L);
+    assertTrue(result instanceof Number);
+    assertEquals(20, ((Number)result).longValue());
+  } 
+}

--- a/src/test/resources/generic/observation.json
+++ b/src/test/resources/generic/observation.json
@@ -11,6 +11,14 @@
             "vital_sign" : "Systolic Blood Pressure",
             "exact" : { "quantity" : 120 },
             "unit" : "mmHg",
+            "direct_transition" : "ExpressionVitalSign"
+        },
+        
+        "ExpressionVitalSign" : {
+            "type" : "VitalSign",
+            "vital_sign" : "Diastolic Blood Pressure",
+            "expression" : "120 - 40",
+            "unit" : "mmHg",
             "direct_transition" : "SomeEncounter"
         },
 
@@ -56,6 +64,20 @@
                 "code": "25428-4",
                 "display": "Glucose [Presence] in Urine by Test strip"
             },
+            "direct_transition" : "ExpressionObservation"
+        },
+        
+        "ExpressionObservation": {
+        	"type" : "Observation",
+            "category" : "procedure",
+            "codes" : [
+                {
+                    "system" : "LOINC",
+                    "code" : "39156-5",
+                    "display" : "Body mass index (BMI) [Ratio]"
+                }
+            ],
+            "expression" : "(#{weight_lbs} / Power(#{height_in}, 2)) * 703",
             "direct_transition" : "Terminal"
         },
 

--- a/src/test/resources/generic/set_attribute.json
+++ b/src/test/resources/generic/set_attribute.json
@@ -15,6 +15,13 @@
         "Set_Attribute_2": {
             "type": "SetAttribute",
             "attribute" : "Current Opioid Prescription",
+            "direct_transition": "Set_Attribute_3"
+        },
+        
+        "Set_Attribute_3": {
+            "type": "SetAttribute",
+            "attribute" : "Maximum Heart Rate",
+            "expression": "220 - #{age}",
             "direct_transition": "Terminal"
         },
 


### PR DESCRIPTION
For discussion:
Implements a simple "expressions" concept (#189) using a CQL engine. SetAttribute, Observations, and VitalSigns now include an "expression" field which gets translated and passed to a CQL engine for evaluation.  The details of the implementation are all abstracted away in a new ExpressionProcessor class. The translation layer allows for selected attributes, identified with a ruby-esque "#{attr}", on the patient to be referenced and added to the evaluation context.

For example, the expression "#{age} / 2 + 7" for a patient with the attribute "age" defined as 26 will result in the following CQL being evaluated:

```
library Synthea version '1'

context Patient


define age: 26
define result: age / 2 + 7
```

My goal here was to enable the kind of basic calculations that are used in the current Java modules, without forcing module writers to care about the details and boilerplate of CQL.


Some open questions:
1. Do we want to allow more complex logic, perhaps allowing people to write raw/multiline CQL to be passed directly to the engine?
2. How should we support referencing vital signs? I do like keeping vital signs separate from attributes, but at the same time if we can define arbitrary vital signs there isn't much distinguishing them and it may be easier to just merge vital signs back into attributes.
3. How should we support referencing the current time? (Ex. to reproduce the current smoking logic which uses a linear formula based on the current year) Do we want to add any convenience items or leverage the existing CQL date operators?
4. Is this missing anything else?