### PR TITLE
Add diagnostic reports to text export

### DIFF
--- a/src/main/java/org/mitre/synthea/export/TextExporter.java
+++ b/src/main/java/org/mitre/synthea/export/TextExporter.java
@@ -25,6 +25,7 @@ import org.mitre.synthea.world.concepts.HealthRecord.ImagingStudy;
 import org.mitre.synthea.world.concepts.HealthRecord.Medication;
 import org.mitre.synthea.world.concepts.HealthRecord.Observation;
 import org.mitre.synthea.world.concepts.HealthRecord.Procedure;
+import org.mitre.synthea.world.concepts.HealthRecord.Report;
 
 /**
  * Exporter for a simple human-readable text format per person.
@@ -167,6 +168,7 @@ public class TextExporter {
     List<Encounter> encounters = person.record.encounters;
     List<Entry> conditions = new ArrayList<>();
     List<Entry> allergies = new ArrayList<>();
+    List<Report> reports = new ArrayList<>();
     List<Observation> observations = new ArrayList<>();
     List<Procedure> procedures = new ArrayList<>();
     List<Medication> medications = new ArrayList<>();
@@ -177,6 +179,7 @@ public class TextExporter {
     for (Encounter encounter : person.record.encounters) {
       conditions.addAll(encounter.conditions);
       allergies.addAll(encounter.allergies);
+      reports.addAll(encounter.reports);
       observations.addAll(encounter.observations);
       procedures.addAll(encounter.procedures);
       medications.addAll(encounter.medications);
@@ -189,6 +192,7 @@ public class TextExporter {
     Collections.reverse(encounters);
     Collections.reverse(conditions);
     Collections.reverse(allergies);
+    Collections.reverse(reports);
     Collections.reverse(observations);
     Collections.reverse(procedures);
     Collections.reverse(medications);
@@ -230,6 +234,12 @@ public class TextExporter {
     }
     breakline(textRecord);
 
+    textRecord.add("REPORTS:");
+    for (Report report : reports) {
+      diagnosticReport(textRecord, report);
+    }
+    breakline(textRecord);
+    
     textRecord.add("OBSERVATIONS:");
     for (Observation observation : observations) {
       observation(textRecord, observation);
@@ -444,6 +454,7 @@ public class TextExporter {
 
     //Create lists for only the items that occurred at the encounter
     List<Entry> encounterConditions = new ArrayList<>();
+    List<Report> encounterReports = new ArrayList<>();
     List<Observation> encounterObservations = new ArrayList<>();
     List<Procedure> encounterProcedures = new ArrayList<>();
     List<Medication> encounterMedications = new ArrayList<>();
@@ -452,6 +463,7 @@ public class TextExporter {
     List<ImagingStudy> encounterImagingStudies = new ArrayList<>();
 
     encounterConditions.addAll(encounter.conditions);
+    encounterReports.addAll(encounter.reports);
     encounterObservations.addAll(encounter.observations);
     encounterProcedures.addAll(encounter.procedures);
     encounterMedications.addAll(encounter.medications);
@@ -482,6 +494,12 @@ public class TextExporter {
     textRecord.add("   CARE PLANS:");
     for (CarePlan careplan : encounterCareplans) {
       careplan(textRecord, careplan, false);
+    }
+    textRecord.add("   ");
+
+    textRecord.add("   REPORTS:");
+    for (Report report : encounterReports) {
+      diagnosticReport(textRecord, report);
     }
     textRecord.add("   ");
 
@@ -589,6 +607,24 @@ public class TextExporter {
   }
 
   /**
+   * Write lines for a Diagnostic Report to the exported record.
+   *
+   * @param textRecord
+   *          Text format record, as a list of lines
+   * @param observation
+   *          The Report to add to the export
+   */
+  private static void diagnosticReport(List<String> textRecord, Report report) {
+    // note that this is largely the same as the MultiObservation
+    String obsTime = dateFromTimestamp(report.start);
+    String obsDesc = report.codes.get(0).display;
+
+    textRecord.add("  " + obsTime + " : " + obsDesc);
+    
+    observationGroup(textRecord, report.observations);
+  }
+  
+  /**
    * Write lines for an Observation with multiple parts to the exported record.
    *
    * @param textRecord
@@ -602,7 +638,19 @@ public class TextExporter {
 
     textRecord.add("  " + obsTime + " : " + obsDesc);
 
-    for (Observation subObs : observation.observations) {
+    observationGroup(textRecord, observation.observations);
+  }
+  
+  /**
+   * Common logic for outputting a group of observations,
+   * intended to be used by MultiObservations and DiagnosticReports.
+   * @param textRecord
+   *          Text format record, as a list of lines
+   * @param observation
+   *          The group of Observations to add to the export
+   */
+  private static void observationGroup(List<String> textRecord, List<Observation> subObservations) {
+    for (Observation subObs : subObservations) {
       String value = ExportHelper.getObservationValue(subObs);
       String unit = subObs.unit != null ? subObs.unit : "";
       String subObsDesc = subObs.codes.get(0).display;

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -38,6 +38,7 @@ public abstract class TestHelper {
     Config.set("exporter.fhir_dstu2.export", "false");
     Config.set("exporter.fhir.transaction_bundle", "false");
     Config.set("exporter.text.export", "false");
+    Config.set("exporter.text.per_encounter_export", "false");
     Config.set("exporter.csv.export", "false");
     Config.set("exporter.hospital.fhir.export", "false");
     Config.set("exporter.hospital.fhir_dstu2.export", "false");

--- a/src/test/java/org/mitre/synthea/export/TextExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/TextExporterTest.java
@@ -31,6 +31,7 @@ public class TextExporterTest {
       TestHelper.exportOff();
       Person person = generator.generatePerson(i);
       Config.set("exporter.text.export", "true");
+      Config.set("exporter.text.per_encounter_export", "true");
       Exporter.export(person, System.currentTimeMillis());
     }
 


### PR DESCRIPTION
For whatever reason Diagnostic Reports were missing from the text exporter. This PR adds them, using the same format as MultiObservations like blood pressure.

```
  2013-12-21 : Lipid Panel
           - Total Cholesterol                        178.0 mg/dL
           - Triglycerides                            107.5 mg/dL
           - Low Density Lipoprotein Cholesterol      96.9 mg/dL
           - High Density Lipoprotein Cholesterol     59.7 mg/dL
```

Now all the clinical record entries are present in the exported text records. (I say clinical because Claims are not included.)

Samples:
Full -- [Son314_Leffler128_7765ccad-6f66-41b0-8ed7-b7cee4d1273b.txt](https://github.com/synthetichealth/synthea/files/2224072/Son314_Leffler128_7765ccad-6f66-41b0-8ed7-b7cee4d1273b.txt)

Per-encounter --  [Son314_Leffler128_7765ccad-6f66-41b0-8ed7-b7cee4d1273b_5.txt](https://github.com/synthetichealth/synthea/files/2224073/Son314_Leffler128_7765ccad-6f66-41b0-8ed7-b7cee4d1273b_5.txt)