### PR TITLE
restore default demographics

### DIFF
--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -45,7 +45,7 @@ generate.database_type = none
 # none = no database, limits certain features but increases throughput
 
 # default demographics is every city in the US
-generate.demographics.default_file = geography/veteran_demographics.csv
+generate.demographics.default_file = geography/demographics.csv
 generate.geography.zipcodes.default_file = geography/zipcodes.csv
 generate.geography.country_code = US
 generate.geography.timezones.default_file = geography/timezones.csv


### PR DESCRIPTION
Restore the default set of demographics, instead of the veteran demographics which have different age frequencies and are highly weighted towards males