### PR TITLE
CSVExporter and CDWExporter Format Issue Fix

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CDWExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CDWExporter.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Locale;
 
 import org.apache.sis.geometry.DirectPosition2D;
 import org.mitre.synthea.engine.Event;
@@ -1262,12 +1263,12 @@ public class CDWExporter {
         break;
       case "29463-7": // weight
         // convert from kg to lbs
-        value = String.format("%.1f", ((Double) observation.value * 2.20462));
+        value = String.format(Locale.US, "%.1f", ((Double) observation.value * 2.20462));
         s.append(value).append(",,,");
         break;
       case "8302-2": // height
         // convert from cm to inches
-        value = String.format("%.1f", ((Double) observation.value * 0.393701));
+        value = String.format(Locale.US, "%.1f", ((Double) observation.value * 0.393701));
         s.append(value).append(",,,");
         break;
       case "72514-3": // pain

--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -466,7 +466,7 @@ public class CSVExporter {
     s.append(coding.code).append(',');
     s.append(clean(coding.display)).append(',');
 
-    s.append(String.format("%.2f", procedure.cost())).append(',');
+    s.append(String.format(Locale.US, "%.2f", procedure.cost())).append(',');
 
     if (procedure.reasons.isEmpty()) {
       s.append(','); // reason code & desc
@@ -509,7 +509,7 @@ public class CSVExporter {
     s.append(clean(coding.display)).append(',');
 
     BigDecimal cost = medication.cost();
-    s.append(cost).append(',');
+    s.append(String.format(Locale.US, "%.2f", cost)).append(',');
     long dispenses = 1; // dispenses = refills + original
     // makes the math cleaner and more explicit. dispenses * unit cost = total cost
     
@@ -547,7 +547,7 @@ public class CSVExporter {
     BigDecimal totalCost = cost
         .multiply(BigDecimal.valueOf(dispenses))
         .setScale(2, RoundingMode.DOWN); // truncate to 2 decimal places
-    s.append(totalCost).append(',');
+    s.append(String.format(Locale.US, "%.2f", totalCost)).append(',');
 
     if (medication.reasons.isEmpty()) {
       s.append(','); // reason code & desc
@@ -583,7 +583,7 @@ public class CSVExporter {
     s.append(coding.code).append(',');
     s.append(clean(coding.display)).append(',');
 
-    s.append(String.format("%.2f", immunization.cost()));
+    s.append(String.format(Locale.US, "%.2f", immunization.cost()));
 
     s.append(NEWLINE);
     write(s.toString(), immunizations);

--- a/src/main/java/org/mitre/synthea/export/ExportHelper.java
+++ b/src/main/java/org/mitre/synthea/export/ExportHelper.java
@@ -3,6 +3,7 @@ package org.mitre.synthea.export;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.Locale;
 
 import org.hl7.fhir.dstu3.model.Condition;
 import org.mitre.synthea.world.concepts.HealthRecord;
@@ -33,7 +34,7 @@ public abstract class ExportHelper {
       value = (String)observation.value;
     } else if (observation.value instanceof Double) {
       // round to 1 decimal place for display
-      value = String.format("%.1f", observation.value);
+      value = String.format(Locale.US, "%.1f", observation.value);
     } else if (observation.value != null) {
       value = observation.value.toString();
     }


### PR DESCRIPTION
It was not possible to run

./gradlew build check test

without errors in Germany (for example), because numeric values were formatted with a ',' instead of a '.', which leads to wrong formatted csv files. I recently added an equal pull request which was merged, but i have overseen some formatting issues.