### PR TITLE
Adding logic to the constructor for wellness encounters. 

### DIFF
--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -53,16 +53,39 @@ public class Utilities {
     return convertTime("years", (long) (years - 1970));
   }
 
-  public static int getYear(long time) {
+  public static int getCalendarPart(long time, int part){
     Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
     calendar.setTimeInMillis(time);
-    return calendar.get(Calendar.YEAR);
+    return calendar.get(part);
+  }
+
+  public static int getYear(long time) {
+    return getCalendarPart(time, Calendar.YEAR);
   }
 
   public static int getMonth(long time) {
-    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-    calendar.setTimeInMillis(time);
-    return calendar.get(Calendar.MONTH) + 1;
+    return getCalendarPart(time, Calendar.MONTH) +1;
+  }
+
+  public static int getDay(long time){
+    return getCalendarPart(time, Calendar.DATE);
+  }
+
+  public static int getDayOfWeek(long time){
+    return getCalendarPart(time, Calendar.DAY_OF_WEEK);
+  }
+
+  public static int getHour(long time){
+    return getCalendarPart(time, Calendar.HOUR);
+  }
+
+  public static boolean isWeekend(long time){
+    return (getDayOfWeek(time) == Calendar.SATURDAY ||
+            getDayOfWeek(time) == Calendar.SUNDAY);
+  }
+
+  public static boolean isBusinessHours(long time){
+    return getHour(time)>=8 && getHour(time)<=16;
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 
 import org.mitre.synthea.helpers.Utilities;
@@ -310,6 +311,20 @@ public class HealthRecord {
 
     public Encounter(long time, String type) {
       super(time, type);
+      if (type.equalsIgnoreCase(EncounterType.WELLNESS.toString())){
+        // Check if time is a weekday
+        Calendar c = Calendar.getInstance();
+        c.setTimeInMillis(time);
+        while (Utilities.isWeekend(time)){
+          c.add(Calendar.DATE, 1);
+          time = c.getTimeInMillis();
+        }
+        // Check if time isn't between business hours
+        if(!Utilities.isBusinessHours(time)){
+          c.set(Calendar.HOUR, 8);
+        }
+        this.start = c.getTimeInMillis();
+      }
       if (type.equalsIgnoreCase(EncounterType.EMERGENCY.toString())) {
         // Emergency encounters should take at least an hour.
         this.stop = this.start + TimeUnit.MINUTES.toMillis(60);

--- a/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
@@ -32,6 +32,46 @@ public class UtilitiesTest {
   }
 
   @Test
+  public void testGetHour() {
+    assertEquals(0, Utilities.getHour(0L));
+    // the time as of this writing, 2017-09-07
+    assertEquals(11, Utilities.getHour(1504783221000L));
+    assertEquals(11, Utilities.getHour(1234567890000L));
+  }
+
+  @Test
+  public void testGetDay() {
+    assertEquals(1, Utilities.getDay(0L));
+    // the time as of this writing, 2017-09-07
+    assertEquals(7, Utilities.getDay(1504783221000L));
+    assertEquals(13, Utilities.getDay(1234567890000L));
+  }
+
+  @Test
+  public void testIsWeekend() {
+    assertEquals(false, Utilities.isWeekend(0L));
+    // the time as of this writing, 2017-09-07
+    assertEquals(false, Utilities.isWeekend(1504783221000L));
+    assertEquals(true, Utilities.isWeekend(1503832821000L));
+  }
+
+  @Test
+  public void testGetDayOfWeek() {
+    assertEquals(5, Utilities.getDayOfWeek(0L));
+    // the time as of this writing, 2017-09-07
+    assertEquals(5, Utilities.getDayOfWeek(1504783221000L));
+    assertEquals(1, Utilities.getDayOfWeek(1503832821000L));
+  }
+
+  @Test
+  public void testIsBusinessHours() {
+    assertEquals(false, Utilities.isBusinessHours(0L));
+    // the time as of this writing, 2017-09-07
+    assertEquals(true, Utilities.isBusinessHours(1504783221000L));
+    assertEquals(true, Utilities.isBusinessHours(1234567890000L));
+  }
+
+  @Test
   public void testCompareObjects() {
     Object lhs = new String("foo");
     Object rhs = new String("foobar");

--- a/src/test/java/org/mitre/synthea/modules/EncounterModuleTest.java
+++ b/src/test/java/org/mitre/synthea/modules/EncounterModuleTest.java
@@ -1,0 +1,56 @@
+package org.mitre.synthea.modules;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mitre.synthea.engine.Event;
+import org.mitre.synthea.helpers.Utilities;
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.HealthRecord;
+import org.mitre.synthea.world.concepts.HealthRecord.Code;
+import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.LinkedList;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+public class EncounterModuleTest {
+
+    private Person person;
+    private long time;
+
+    @Before
+    public void setup() throws IOException {
+        person = new Person(0L);
+
+        person.history = new LinkedList<>();
+
+        long birthTime = time - Utilities.convertTime("years", 35);
+        person.attributes.put(Person.BIRTHDATE, birthTime);
+        person.events.create(birthTime, Event.BIRTH, "Generator.run", true);
+
+        time = 1503832821000L; // Is a Sunday
+    }
+
+    @Test
+    public void testEncounterWellness() {
+        Encounter encounter = person.record.encounterStart(time,
+                HealthRecord.EncounterType.WELLNESS.toString());
+        assertEquals("WELLNESS", encounter.type);
+        long timeArray[] = new long[]{ encounter.start, encounter.stop };
+        for(long l: timeArray){
+            Calendar c = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+            c.setTimeInMillis(l);
+            // Ensure start/stop are a weekday
+            assertEquals(c.get(Calendar.DAY_OF_WEEK) != Calendar.SATURDAY, true);
+            assertEquals(c.get(Calendar.DAY_OF_WEEK) != Calendar.SUNDAY, true);
+            // Ensure start/stop are during business hours
+            assertEquals(c.get(Calendar.HOUR)>=8 && c.get(Calendar.HOUR)<=16, true);
+        }
+    }
+}


### PR DESCRIPTION
#133 
Wellness encounters will be only on weekdays, during business hours.

This is a first pass -- the referenced issue talks about wanting a more flexibility around setup. For this pass, I've set all WELLNESS encounters to business days during business hours.

I'm opening this up to start the discussion of what the community wants to control this (configuration? and if so, how configurable?)

Thanks!