### PR TITLE
Non native speakers 165

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -417,10 +417,10 @@ public class FhirDstu2 {
     }
 
     AddressDt birthplace = new AddressDt();
-    birthplace.setCity((String) person.attributes.get(Person.BIRTHPLACE)).setState(state);
-    if (COUNTRY_CODE != null) {
-      birthplace.setCountry(COUNTRY_CODE);
-    }
+    birthplace.setCity((String) person.attributes.get(Person.BIRTH_CITY))
+            .setState((String) person.attributes.get(Person.BIRTH_STATE))
+            .setCountry((String) person.attributes.get(Person.BIRTH_COUNTRY));
+
     ExtensionDt birthplaceExtension = new ExtensionDt();
     birthplaceExtension.setUrl("http://hl7.org/fhir/StructureDefinition/birthPlace");
     birthplaceExtension.setValue(birthplace);

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -459,10 +459,10 @@ public class FhirR4 {
     }
 
     Address birthplace = new Address();
-    birthplace.setCity((String) person.attributes.get(Person.BIRTHPLACE)).setState(state);
-    if (COUNTRY_CODE != null) {
-      birthplace.setCountry(COUNTRY_CODE);
-    }
+    birthplace.setCity((String) person.attributes.get(Person.BIRTH_CITY))
+            .setState((String) person.attributes.get(Person.BIRTH_STATE))
+            .setCountry((String) person.attributes.get(Person.BIRTH_COUNTRY));
+
     Extension birthplaceExtension = new Extension(
         "http://hl7.org/fhir/StructureDefinition/birthPlace");
     birthplaceExtension.setValue(birthplace);

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -469,10 +469,10 @@ public class FhirStu3 {
     }
 
     Address birthplace = new Address();
-    birthplace.setCity((String) person.attributes.get(Person.BIRTHPLACE)).setState(state);
-    if (COUNTRY_CODE != null) {
-      birthplace.setCountry(COUNTRY_CODE);
-    }
+    birthplace.setCity((String) person.attributes.get(Person.BIRTH_CITY))
+            .setState((String) person.attributes.get(Person.BIRTH_STATE))
+            .setCountry((String) person.attributes.get(Person.BIRTH_COUNTRY));
+
     Extension birthplaceExtension = new Extension(
         "http://hl7.org/fhir/StructureDefinition/birthPlace");
     birthplaceExtension.setValue(birthplace);

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -165,7 +165,11 @@ public final class LifecycleModule extends Module {
       // should never happen in practice, but can happen in unit tests
       location.assignPoint(person, city);
       person.attributes.put(Person.ZIP, location.getZipCode(city));
-      attributes.put(Person.BIRTHPLACE, location.randomCityName(person.random));
+      if ("english".equalsIgnoreCase((String) attributes.get(Person.FIRST_LANGUAGE))) {
+        attributes.put(Person.BIRTHPLACE, location.randomCityName(person.random));
+      } else {
+        attributes.put(Person.BIRTHPLACE, location.randomCityNameByEthnicity(person.random, (String) person.attributes.get(Person.ETHNICITY)));
+      }
     }
     
     boolean hasStreetAddress2 = person.rand() < 0.5;

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -165,11 +165,16 @@ public final class LifecycleModule extends Module {
       // should never happen in practice, but can happen in unit tests
       location.assignPoint(person, city);
       person.attributes.put(Person.ZIP, location.getZipCode(city));
+      String[] birthPlace;
       if ("english".equalsIgnoreCase((String) attributes.get(Person.FIRST_LANGUAGE))) {
-        attributes.put(Person.BIRTHPLACE, location.randomCityName(person.random));
+        birthPlace = location.randomBirthPlace(person.random);
       } else {
-        attributes.put(Person.BIRTHPLACE, location.randomCityNameByEthnicity(person.random, (String) person.attributes.get(Person.ETHNICITY)));
+        birthPlace = location.randomBirthplaceByEthnicity(person.random, (String) person.attributes.get(Person.ETHNICITY));
       }
+      attributes.put(Person.BIRTH_CITY, birthPlace[0]);
+      attributes.put(Person.BIRTH_STATE, birthPlace[1]);
+      attributes.put(Person.BIRTH_COUNTRY, birthPlace[2]);
+      attributes.put(Person.BIRTHPLACE, birthPlace[3]);  //For CSV exports so we don't break any existing schemas
     }
     
     boolean hasStreetAddress2 = person.rand() < 0.5;

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -45,6 +45,9 @@ public class Person implements Serializable, QuadTreeData {
   public static final String STATE = "state";
   public static final String ZIP = "zip";
   public static final String BIRTHPLACE = "birthplace";
+  public static final String BIRTH_CITY = "birth_city";
+  public static final String BIRTH_STATE = "birth_state";
+  public static final String BIRTH_COUNTRY = "birth_country";
   public static final String COORDINATE = "coordinate";
   public static final String NAME_MOTHER = "name_mother";
   public static final String NAME_FATHER = "name_father";

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Random;
 
 import com.google.gson.Gson;
+import org.apache.commons.lang3.ArrayUtils;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
@@ -158,6 +159,19 @@ public class Location {
   }
 
   /**
+   * Method which wraps the randomCityName() call for birthplaces
+   */
+  public String[] randomBirthPlace(Random random) {
+    String[] birthPlace = new String[4];
+    birthPlace[0] = randomCityName(random);
+    birthPlace[1] = this.state;
+    birthPlace[2] = "US";
+    birthPlace[3] = birthPlace[0] + ", " + birthPlace[1] + ", " + birthPlace[2];
+
+    return birthPlace;
+  }
+
+  /**
    * Method which returns a city from the foreignPlacesOfBirth map if the map contains values for an ethnicity
    * In the case an ethnicity is not present the method returns the value from a call to randomCityName()
    *
@@ -165,18 +179,28 @@ public class Location {
    * @param ethnicity the ethnicity to look for cities in
    * @return A String representing the place of birth
    */
-  public String randomCityNameByEthnicity(Random random, String ethnicity) {
-    String placeOfBirth;
-    List<String> cities = foreignPlacesOfBirth.get(ethnicity.toLowerCase());
+  public String[] randomBirthplaceByEthnicity(Random random, String ethnicity) {
+    String[] birthPlace;
 
+    List<String> cities = foreignPlacesOfBirth.get(ethnicity.toLowerCase());
     if (cities != null && cities.size() > 0) {
       int upperBound = cities.size();
-      placeOfBirth = cities.get(random.nextInt(upperBound));
+      String randomBirthPlace = cities.get(random.nextInt(upperBound));
+      String[] split = randomBirthPlace.split(",");
+
+      //make sure we have exactly 3 elements (city, state, country_abbr) if not fallback to some random US location
+      if (split.length != 3) {
+        birthPlace = randomBirthPlace(random);
+      } else {
+        //concatenate all the results together, adding spaces behind commas for readability
+        birthPlace = ArrayUtils.addAll(split, new String[] {randomBirthPlace.replaceAll(",", ", ")});
+      }
+
     } else {  //if we can't find a foreign city at least return something
-      placeOfBirth = randomCityName(random);
+      birthPlace = randomBirthPlace(random);
     }
 
-    return placeOfBirth;
+    return birthPlace;
   }
 
   /**
@@ -342,7 +366,7 @@ public class Location {
   /**
    * Load a resource which contains foreign places of birth based on ethnicity in json format:
    *
-   * {"ethnicity":["city1", "city2"..., "cityN"]}
+   * {"ethnicity":["city1,state1,country1", "city2,state2,country2"..., "cityN,stateN,countryN"]}
    *
    * see src/main/resources/foreign_birthplace.json for a working example
    * package protected for testing

--- a/src/main/resources/geography/foreign_birthplace.json
+++ b/src/main/resources/geography/foreign_birthplace.json
@@ -1,125 +1,125 @@
 {
   "africa": [
-    "Algiers",
-    "Oran",
-    "Constantine",
-    "Annaba",
-    "Blida"
+  "Algiers,Algiers Province,DZ",
+    "Oran,Oran Province,DZ",
+    "Constantine,Constantine Province,DZ",
+    "Annaba,Annaba Provice,DZ",
+    "Blida,Blida Province,DZ"
   ],
   "arabic": [
-    "Riyadh",
-    "Najran",
-    "Al-Mubarraz",
-    "Khamis Mushayt",
-    "Jeddah"
+    "Riyadh,Riyadh,SA",
+    "Najran,Najran,SA",
+    "Al-Mubarraz,Eastern Province,SA",
+    "Khamis Mushayt,Asir,SA",
+    "Jeddah,Tihamah,SA"
   ],
   "central_american": [
-    "Guatemala City",
-    "Panama City",
-    "San Jose",
-    "Tegucigalpa",
-    "San Salvador"
+    "Guatemala City,Guatemala,GT",
+    "Panama City,Panama,PA",
+    "San Jose,San Jose,CR",
+    "Tegucigalpa,Francisco Morazán,HN",
+    "San Salvador,El Salvador,SV"
   ],
   "chinese": [
-    "Hong Kong",
-    "Macau",
-    "Beijing",
-    "Chongqing",
-    "Shanghai"
+    "Hong Kong,Hong Kong Special Administrative Region,CN",
+    "Macau,Macao Special Administrative Region of the People's Republic of China,CN",
+    "Beijing,Beijing Municipality,CN",
+    "Chongqing,Chongqing Municipality,CN",
+    "Shanghai,Shanghai Municipality,CN"
   ],
   "dominican": [
-    "Roseau",
-    "Portsmouth",
-    "Salisbury",
-    "Wesley",
-    "Marigot"
+    "Roseau,Saint George,DM",
+    "Portsmouth,Saint John Parish,DM",
+    "Salisbury,Saint Joseph Parish,DM",
+    "Wesley,Saint Andrew Parish,DM",
+    "Marigot,Saint Andrew Parish,DM"
   ],
   "french": [
-    "Paris",
-    "Marseille",
-    "Lyon",
-    "Toulouse",
-    "Nice"
+    "Paris,Ile-de-France,FR",
+    "Marseille,Provence-Alpes-Cote d'Azur,FR",
+    "Lyon,Auvergne-Rhone-Alpes,FR",
+    "Toulouse,Occitanie,FR",
+    "Nice,Provence-Alpes-Cote d'Azur,FR"
   ],
   "french_canadian": [
-    "Quebec",
-    "Montreal",
-    "Boucherville",
-    "Terrebonne",
-    "Longueuil"
+    "Quebec City,Quebec,CA",
+    "Montreal,Quebec,CA",
+    "Boucherville,Quebec,CA",
+    "Terrebonne,Quebec,CA",
+    "Longueuil,Quebec,CA"
   ],
   "german": [
-    "Berlin",
-    "Hamburg",
-    "Munich",
-    "Cologne",
-    "Frankfurt"
+    "Berlin,Berlin,DE",
+    "Hamburg,Hamburg,DE",
+    "Munich,Bavaria,DE",
+    "Cologne,North Rhine-Westphalia,DE",
+    "Frankfurt,Hesse,DE"
   ],
   "greek": [
-    "Athens",
-    "Thessaloniki",
-    "Patras",
-    "Heraklion",
-    "Larissa"
+    "Athens,Athens Prefecture,GR",
+    "Thessaloniki,Thessaloniki Prefecture,GR",
+    "Patras,Achaea,GR",
+    "Heraklion,Heraklion Prefecture,GR",
+    "Larissa,Larissa Prefecture,GR"
   ],
   "indian": [
-    "Mumbai",
-    "Delhi",
-    "Bangalore",
-    "Hyderabad",
-    "Ahmedabad"
+    "Mumbai,Maharashtra,IN",
+    "Delhi,Delhi,IN",
+    "Bangalore,Karnataka,IN",
+    "Hyderabad,Andhra Pradesh,IN",
+    "Ahmedabad,Gujarat,IN"
   ],
   "italian": [
-    "Rome",
-    "Milan",
-    "Naples",
-    "Turin",
-    "Palermo"
+    "Rome,Lazio,IT",
+    "Milan,Lombardy,IT",
+    "Naples,Campania,IT",
+    "Turin,Piedmont,IT",
+    "Palermo,Sicily,IT"
   ],
   "mexican": [
-    "Mexico City",
-    "Ecatapec",
-    "Gaudalajara",
-    "Puebla",
-    "Juarez"
+    "Mexico City,Mexico City,MX",
+    "La Paz,Baja California,MX",
+    "Gaudalajara,Jalisco,MX",
+    "Puebla,Puebla,MX",
+    "Juarez,Chihuahua,MX"
   ],
   "portuguese": [
-    "Lisbon",
-    "Funchal",
-    "Braga",
-    "Almada",
-    "Porto"
+    "Lisbon,Estremadura,PT",
+    "Funchal,Madeira,PT",
+    "Braga,Minho,PT",
+    "Faro,Algarve,PT",
+    "Porto,Douro Litoral,PT"
   ],
   "puerto_rican": [
-    "San Juan",
-    "Ponce",
-    "Carolina",
-    "Bayamon",
-    "Caguas"
+    "San Juan,Puerto Rico,PR",
+    "Ponce,Puerto Rico,PR",
+    "Carolina,Puerto Rico,PR",
+    "Bayamon,Puerto Rico,PR",
+    "Caguas,Puerto Rico,PR"
   ],
   "russian": [
-    "Moscow",
-    "St Petersburg",
-    "Novosibirsk",
-    "Yekaterinburg",
-    "Nizhny Novgorod"
+    "Moscow,Moscow,RU",
+    "St Petersburg,St Petersburg,RU",
+    "Novosibirsk,Novosibirsk Oblast,RU",
+    "Yekaterinburg,Sverdlovsk Oblast,RU",
+    "Nizhny Novgorod,Nizhny Novgorod Oblast,RU"
   ],
   "south_american": [
-    "Sao Paulo",
-    "Rio de Janerio",
-    "Salvador",
-    "Brasilia",
-    "Lima",
-    "Bogota",
-    "Santiago",
-    "Caracas",
-    "Buenos Aires"
+    "Sao Paulo,Sao Paulo,BR",
+    "Rio de Janerio,Rio de Janerio,BR",
+    "Salvador,Bahia,BR",
+    "Brasilia,Federal District,BR",
+    "Lima,Lima Province,PE",
+    "Bogota,Bogota,CO",
+    "Santiago,Santiago Province,CL",
+    "Caracas,Capital District,VE",
+    "Buenos Aires,Ciudad de Buenos Aires,AR"
   ],
   "west_indian": [
-    "Santo Domingo",
-    "Port-au-Prince",
-    "Havana",
-    "Kingston",
-    "Santiago de los Caballeros"
+    "Santo Domingo,National District,DO",
+    "Port-au-Prince,Haiti,HT",
+    "Havana,Havana,CU",
+    "Kingston,Kingston,JM",
+    "Santiago de los Caballeros,Santiago,DO"
   ]
 }

--- a/src/main/resources/geography/foreign_birthplace.json
+++ b/src/main/resources/geography/foreign_birthplace.json
@@ -1,0 +1,125 @@
+{
+  "africa": [
+    "Algiers",
+    "Oran",
+    "Constantine",
+    "Annaba",
+    "Blida"
+  ],
+  "arabic": [
+    "Riyadh",
+    "Najran",
+    "Al-Mubarraz",
+    "Khamis Mushayt",
+    "Jeddah"
+  ],
+  "central_american": [
+    "Guatemala City",
+    "Panama City",
+    "San Jose",
+    "Tegucigalpa",
+    "San Salvador"
+  ],
+  "chinese": [
+    "Hong Kong",
+    "Macau",
+    "Beijing",
+    "Chongqing",
+    "Shanghai"
+  ],
+  "dominican": [
+    "Roseau",
+    "Portsmouth",
+    "Salisbury",
+    "Wesley",
+    "Marigot"
+  ],
+  "french": [
+    "Paris",
+    "Marseille",
+    "Lyon",
+    "Toulouse",
+    "Nice"
+  ],
+  "french_canadian": [
+    "Quebec",
+    "Montreal",
+    "Boucherville",
+    "Terrebonne",
+    "Longueuil"
+  ],
+  "german": [
+    "Berlin",
+    "Hamburg",
+    "Munich",
+    "Cologne",
+    "Frankfurt"
+  ],
+  "greek": [
+    "Athens",
+    "Thessaloniki",
+    "Patras",
+    "Heraklion",
+    "Larissa"
+  ],
+  "indian": [
+    "Mumbai",
+    "Delhi",
+    "Bangalore",
+    "Hyderabad",
+    "Ahmedabad"
+  ],
+  "italian": [
+    "Rome",
+    "Milan",
+    "Naples",
+    "Turin",
+    "Palermo"
+  ],
+  "mexican": [
+    "Mexico City",
+    "Ecatapec",
+    "Gaudalajara",
+    "Puebla",
+    "Juarez"
+  ],
+  "portuguese": [
+    "Lisbon",
+    "Funchal",
+    "Braga",
+    "Almada",
+    "Porto"
+  ],
+  "puerto_rican": [
+    "San Juan",
+    "Ponce",
+    "Carolina",
+    "Bayamon",
+    "Caguas"
+  ],
+  "russian": [
+    "Moscow",
+    "St Petersburg",
+    "Novosibirsk",
+    "Yekaterinburg",
+    "Nizhny Novgorod"
+  ],
+  "south_american": [
+    "Sao Paulo",
+    "Rio de Janerio",
+    "Salvador",
+    "Brasilia",
+    "Lima",
+    "Bogota",
+    "Santiago",
+    "Caracas",
+    "Buenos Aires"
+  ],
+  "west_indian": [
+    "Santo Domingo",
+    "Port-au-Prince",
+    "Havana",
+    "Kingston",
+    "Santiago de los Caballeros"
+  ]
+}

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -54,6 +54,7 @@ generate.demographics.default_file = geography/demographics.csv
 generate.geography.zipcodes.default_file = geography/zipcodes.csv
 generate.geography.country_code = US
 generate.geography.timezones.default_file = geography/timezones.csv
+generate.geography.foreign.birthplace.default_file = geography/foreign_birthplace.json
 
 # maximum distance to look for a provider for a given patient, in km
 generate.maximum_provider_search_distance = 2000

--- a/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
+++ b/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
@@ -1,12 +1,15 @@
 package org.mitre.synthea.world.geography;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mitre.synthea.helpers.Config;
@@ -73,5 +76,56 @@ public class LocationTest {
     }
     String message = mismatches.toString();
     Assert.assertEquals(message, 0, mismatches.size());
+  }
+
+  @Test
+  public void testForeignPlaceOfBirthFileLoad() {
+    Map<String, List<String>> map = Location.loadCitiesByLanguage("geography/foreign_birthplace_simple.json");
+    Set<String> expectedCities = ImmutableSet.of("german", "west_indian");
+
+    Assert.assertNotNull("Expected Non-Null map", map);
+    Assert.assertEquals("Expected foreign_birthplace resource to contain 2 ethnicities", 2, map.size());
+    for (String key : map.keySet()) {
+      Assert.assertTrue("Unexpected key found in map " + key, expectedCities.contains(key));
+      Assert.assertEquals("Expected size to be 1 for key: " + key, 1, map.get(key).size());
+    }
+  }
+
+  @Test
+  public void testInvalidForeignPlaceOfBirthFileLoad() {
+    Map<String, List<String>> map = Location.loadCitiesByLanguage("geography/this_isnt_a_file.json");
+    Assert.assertNotNull(map);
+    Assert.assertEquals("Expected map to be empty", 0, map.size());
+  }
+
+  @Test
+  public void testMalformedForeignPlaceOfBirthFileLoad() {
+    Map<String, List<String>> map = Location.loadCitiesByLanguage("geography/malformed_foreign_birthplace.json");
+    Assert.assertNotNull(map);
+    Assert.assertEquals("Expected map to be empty", 0, map.size());
+  }
+
+  @Test
+  public void testGetForeignPlaceOfBirth_HappyPath() {
+    Location location = new Location("Massachusetts", null);
+    Random random = new Random(0);
+    String placeOfBirth = location.randomCityNameByEthnicity(random, "german");
+    Assert.assertEquals("Expected to receive 'Berlin'", "Berlin", placeOfBirth);
+  }
+
+  @Test
+  public void testGetForeignPlaceOfBirth_MissingValue() {
+    Location location = new Location("Massachusetts", null);
+    Random random = new Random(0);
+    String placeOfBirth = location.randomCityNameByEthnicity(random, "unknown_ethnicity");
+    Assert.assertEquals("Expected to receive 'Rehoboth'", "Rehoboth", placeOfBirth);
+  }
+
+  @Test
+  public void testGetForeignPlaceOfBirth_EmptyValue() {
+    Location location = new Location("Massachusetts", null);
+    Random random = new Random(0);
+    String placeOfBirth = location.randomCityNameByEthnicity(random, "empty_ethnicity");
+    Assert.assertEquals("Expected to receive 'Rehoboth'", "Rehoboth", placeOfBirth);
   }
 }

--- a/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
+++ b/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
@@ -1,7 +1,6 @@
 package org.mitre.synthea.world.geography;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -109,23 +108,54 @@ public class LocationTest {
   public void testGetForeignPlaceOfBirth_HappyPath() {
     Location location = new Location("Massachusetts", null);
     Random random = new Random(0);
-    String placeOfBirth = location.randomCityNameByEthnicity(random, "german");
-    Assert.assertEquals("Expected to receive 'Berlin'", "Berlin", placeOfBirth);
+    String[] placeOfBirth = location.randomBirthplaceByEthnicity(random, "german");
+    Assert.assertEquals("Expected to receive 'Munich'", "Munich", placeOfBirth[0]);
+    Assert.assertEquals("Expected to receive 'Bavaria'", "Bavaria", placeOfBirth[1]);
+    Assert.assertEquals("Expected to receive 'DE'", "DE", placeOfBirth[2]);
+    Assert.assertEquals("Expected to receive 'Munich, Bavaria, DE'", "Munich, Bavaria, DE", placeOfBirth[3]);
+  }
+
+  @Test
+  public void testGetForeignPlaceOfBirth_ValidStringInvalidFormat_1() {
+    Location location = new Location("Massachusetts", null);
+    Random random = new Random(0);
+    String[] placeOfBirth = location.randomBirthplaceByEthnicity(random, "too_many_elements");
+    Assert.assertEquals("Expected to receive 'Stoughton'", "Stoughton", placeOfBirth[0]);
+    Assert.assertEquals("Expected to receive 'Massachusetts'", "Massachusetts", placeOfBirth[1]);
+    Assert.assertEquals("Expected to receive 'US'", "US", placeOfBirth[2]);
+    Assert.assertEquals("Expected to recieve 'Stoughton, Massachusetts, US'", "Stoughton, Massachusetts, US", placeOfBirth[3]);
+  }
+
+  @Test
+  public void testGetForeignPlaceOfBirth_ValidStringInvalidFormat_2() {
+    Location location = new Location("Massachusetts", null);
+    Random random = new Random(0);
+    String[] placeOfBirth = location.randomBirthplaceByEthnicity(random, "not_enough_elements");
+    Assert.assertEquals("Expected to receive 'Stoughton'", "Stoughton", placeOfBirth[0]);
+    Assert.assertEquals("Expected to receive 'Massachusetts'", "Massachusetts", placeOfBirth[1]);
+    Assert.assertEquals("Expected to receive 'US'", "US", placeOfBirth[2]);
+    Assert.assertEquals("Expected to recieve 'Stoughton, Massachusetts, US'", "Stoughton, Massachusetts, US", placeOfBirth[3]);
   }
 
   @Test
   public void testGetForeignPlaceOfBirth_MissingValue() {
     Location location = new Location("Massachusetts", null);
     Random random = new Random(0);
-    String placeOfBirth = location.randomCityNameByEthnicity(random, "unknown_ethnicity");
-    Assert.assertEquals("Expected to receive 'Rehoboth'", "Rehoboth", placeOfBirth);
+    String[] placeOfBirth = location.randomBirthplaceByEthnicity(random, "unknown_ethnicity");
+    Assert.assertEquals("Expected to receive 'Rehoboth'", "Rehoboth", placeOfBirth[0]);
+    Assert.assertEquals("Expected to receive 'Massachusetts'", "Massachusetts", placeOfBirth[1]);
+    Assert.assertEquals("Expected to receive 'US'", "US", placeOfBirth[2]);
+    Assert.assertEquals("Expected to recieve 'Rehoboth, Massachusetts, US'", "Rehoboth, Massachusetts, US", placeOfBirth[3]);
   }
 
   @Test
   public void testGetForeignPlaceOfBirth_EmptyValue() {
     Location location = new Location("Massachusetts", null);
     Random random = new Random(0);
-    String placeOfBirth = location.randomCityNameByEthnicity(random, "empty_ethnicity");
-    Assert.assertEquals("Expected to receive 'Rehoboth'", "Rehoboth", placeOfBirth);
+    String placeOfBirth[] = location.randomBirthplaceByEthnicity(random, "empty_ethnicity");
+    Assert.assertEquals("Expected to receive 'Rehoboth'", "Rehoboth", placeOfBirth[0]);
+    Assert.assertEquals("Expected to receive 'Massachusetts'", "Massachusetts", placeOfBirth[1]);
+    Assert.assertEquals("Expected to receive 'US'", "US", placeOfBirth[2]);
+    Assert.assertEquals("Expected to recieve 'Rehoboth, Massachusetts, US'", "Rehoboth, Massachusetts, US", placeOfBirth[3]);
   }
 }

--- a/src/test/resources/geography/foreign_birthplace.json
+++ b/src/test/resources/geography/foreign_birthplace.json
@@ -1,0 +1,9 @@
+{
+  "empty_ethnicity": [],
+  "german": [
+    "Berlin"
+  ],
+  "west_indian": [
+    "Santo Domingo"
+  ]
+}

--- a/src/test/resources/geography/foreign_birthplace.json
+++ b/src/test/resources/geography/foreign_birthplace.json
@@ -1,9 +1,15 @@
 {
   "empty_ethnicity": [],
   "german": [
-    "Berlin"
+    "Munich,Bavaria,DE"
   ],
   "west_indian": [
-    "Santo Domingo"
+    "Santo Domingo,National District,DO"
+  ],
+  "too_many_elements": [
+    "Rome,Lazio,IT,extra"
+  ],
+  "not_enough_elements": [
+    "Athens,Athens Prefecture"
   ]
 }

--- a/src/test/resources/geography/foreign_birthplace_simple.json
+++ b/src/test/resources/geography/foreign_birthplace_simple.json
@@ -1,0 +1,8 @@
+{
+  "german": [
+    "Berlin"
+  ],
+  "west_indian": [
+    "Santo Domingo"
+  ]
+}

--- a/src/test/resources/geography/foreign_birthplace_simple.json
+++ b/src/test/resources/geography/foreign_birthplace_simple.json
@@ -1,8 +1,8 @@
 {
   "german": [
-    "Berlin"
+    "Munich,Bavaria,DE"
   ],
   "west_indian": [
-    "Santo Domingo"
+    "Santo Domingo,National District,DO"
   ]
 }

--- a/src/test/resources/geography/malformed_foreign_birthplace.json
+++ b/src/test/resources/geography/malformed_foreign_birthplace.json
@@ -1,0 +1,1 @@
+"thisIsntJson":true


### PR DESCRIPTION
This PR adds the enhancement when a patient is a non-native English speaker, that patient will have a foreign place of birth, #165 

How it works:
A reference file of ethnicities to cities should be created.  Format is:
{"ethnicity1": ["city1", "city2", ... "cityN"],
"ethnicity2": ["city1", "city2", ... "cityN"],
...
"ethnicityN": ["city1", "city2", ... "cityN"]}
File location can be declared in the synthea.properties file with the "generate.geography.foreign.birthplace.default_file" flag.

During the LifecycleModule, when a non-english first language is found instead of calling Location.randomCityName() we instead call Location.randomCityNameByEthnicity() which references the previously mentioned json file containing maps from ethnicities to cities.  Once the list of cities is accessed (based on the patient's ethnicity) a city is chosen based on the patient's assigned random.  If for any reason a city cannot be chosen (no cities for an ethnicity, ethnicity not contained in the file, etc) the method falls back to choosing a city from Location.randomCityName()

Caveats:
- I did very little city research, simply grabbing a list of the 5 most populous cities in each "region" and using those locations in the src/main/resources/foreign_birthplace.json file included in this PR.  - Additionally the Location.randomCityNameByEthnicity() method does not do any selection based on population size like Location.randomCityName() does, mainly because I don't have access (or the time unfortunately) to put together an exhaustive list of world cities (sorry!).
- Currently it's possible in regions that have multiple main languages for a patient to have a birth city where the language isn't the official language.  For example it would be possible for a person with a south_american ethnicity and a first_language of Spanish, but a birth city of Rio de Janerio (where the Official language is Portuguese).  While this is certainly a possibility, it seems more likely that patient would have a different birth city.  Future enhancements could target this area of functionality.


Commits:
- Adds multiple json files to support a limited foreign birthplace
- Updates the Lifecycle.birth() to pick a birth location based on the Person's defined first language
- Updates Location to be able to pull in a json file for foreign birthplaces
- Adds a method to get a random city name by ethnicity