### PR TITLE
WIP: Fix flapping test #454

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -1768,7 +1768,7 @@ public class FhirStu3 {
         (org.hl7.fhir.dstu3.model.Encounter) encounterEntry.getResource();
     MedicationRequestRequesterComponent requester = new MedicationRequestRequesterComponent();
     requester.setAgent(encounter.getParticipantFirstRep().getIndividual());
-    requester.setOnBehalfOf(encounter.getServiceProvider());
+    requester.setOnBehalfOfTarget(encounter.getServiceProviderTarget());
     medicationResource.setRequester(requester);
 
     if (medication.stop != 0L) {


### PR DESCRIPTION
This PR attempts to fix an intermittent test failure in FHIRSTU3ExporterTest.testFHIRSTU3Export() which seemed to be caused by a malformation of the Fhir extension "onBehalfOf" where the resource type was a "MedicationRequest".  See the attached log file in #454 
Full disclosure:  I'm not very familiar with the Fhir format, and wasn't able to grok exactly what format this particular tag should take, but noticed flipping the assignment from "onBehalfOf" to "onBehalfOfTarget" seemed to resolve the failures I observed so figured I'd throw a PR in for your review and feedback.
Additionally this PR refactors some of the validation/verification code into a common method and adds a test specifically for this intermittent failure by calling out the specific seed I observed the failure from.

Changes:
- attempts to fix the flapping test which fails intermittently
- refactors some common code out for error validation/verification
- adds a new test which tests specifically for the flapping test case by using person.seed: 3579459278049789113L