### PR TITLE
FHIR Update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ repositories {
   // Use jcenter for resolving your dependencies.
   // You can declare any Maven/Ivy/file repository here.
   jcenter()
+  mavenCentral()
+  maven {
+    url "https://oss.sonatype.org/content/repositories/snapshots"
+  }
 }
 
 checkstyle {
@@ -28,10 +32,10 @@ checkstyle {
 dependencies {
   // This dependency is found on compile classpath of this component and consumers.
   compile 'com.google.code.gson:gson:2.8.0'
-  compile 'ca.uhn.hapi.fhir:hapi-fhir-base:3.4.0'
-  compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:3.4.0'
-  compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:3.4.0'
-  compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:3.4.0'
+  compile 'ca.uhn.hapi.fhir:hapi-fhir-base:3.7.0-SNAPSHOT'
+  compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:3.7.0-SNAPSHOT'
+  compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:3.7.0-SNAPSHOT'
+  compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:3.7.0-SNAPSHOT'
   // C-CDA export uses Apache FreeMarker templates
   compile 'org.freemarker:freemarker:2.3.26-incubating'
   // location processing
@@ -65,10 +69,10 @@ dependencies {
   testCompile 'org.mockito:mockito-core:2.19.0'
   testCompile 'org.powermock:powermock-module-junit4:1.7.1'
   testCompile 'org.powermock:powermock-api-mockito2:1.7.1'
-  testCompile 'ca.uhn.hapi.fhir:hapi-fhir-validation:3.4.0'
-  testCompile 'ca.uhn.hapi.fhir:hapi-fhir-validation-resources-dstu3:3.4.0'
-  testCompile 'ca.uhn.hapi.fhir:hapi-fhir-validation-resources-dstu2:3.4.0'
-  testCompile 'ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:3.4.0'
+  testCompile 'ca.uhn.hapi.fhir:hapi-fhir-validation:3.7.0-SNAPSHOT'
+  testCompile 'ca.uhn.hapi.fhir:hapi-fhir-validation-resources-dstu3:3.7.0-SNAPSHOT'
+  testCompile 'ca.uhn.hapi.fhir:hapi-fhir-validation-resources-dstu2:3.7.0-SNAPSHOT'
+  testCompile 'ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:3.7.0-SNAPSHOT'
   testCompile 'com.helger:ph-schematron:5.0.6'
   testCompile 'com.phloc:phloc-schematron:2.7.1'
   testCompile 'com.phloc:phloc-commons:4.4.11'

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -20,7 +20,6 @@ import org.hl7.fhir.r4.model.AllergyIntolerance;
 import org.hl7.fhir.r4.model.AllergyIntolerance.AllergyIntoleranceCategory;
 import org.hl7.fhir.r4.model.AllergyIntolerance.AllergyIntoleranceCriticality;
 import org.hl7.fhir.r4.model.AllergyIntolerance.AllergyIntoleranceType;
-import org.hl7.fhir.r4.model.Basic;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
@@ -290,37 +289,37 @@ public class FhirR4 {
     patientResource.addIdentifier().setSystem("https://github.com/synthetichealth/synthea")
         .setValue((String) person.attributes.get(Person.ID));
 
-    Code mrnCode = new Code("http://hl7.org/fhir/v2/0203", "MR", "Medical Record Number");
+    Code mrnCode = new Code("http://terminology.hl7.org/CodeSystem/v2-0203", "MR", "Medical Record Number");
     patientResource.addIdentifier()
-        .setType(mapCodeToCodeableConcept(mrnCode, "http://hl7.org/fhir/v2/0203"))
+        .setType(mapCodeToCodeableConcept(mrnCode, "http://terminology.hl7.org/CodeSystem/v2-0203"))
         .setSystem("http://hospital.smarthealthit.org")
         .setValue((String) person.attributes.get(Person.ID));
 
-    Code ssnCode = new Code("http://hl7.org/fhir/identifier-type", "SB", "Social Security Number");
+    Code ssnCode = new Code("http://terminology.hl7.org/CodeSystem/v2-0203", "SSN", "Social Security Number");
     patientResource.addIdentifier()
-        .setType(mapCodeToCodeableConcept(ssnCode, "http://hl7.org/fhir/identifier-type"))
+        .setType(mapCodeToCodeableConcept(ssnCode, "http://terminology.hl7.org/CodeSystem/v2-0203"))
         .setSystem("http://hl7.org/fhir/sid/us-ssn")
         .setValue((String) person.attributes.get(Person.IDENTIFIER_SSN));
 
     if (person.attributes.get(Person.IDENTIFIER_DRIVERS) != null) {
-      Code driversCode = new Code("http://hl7.org/fhir/v2/0203", "DL", "Driver's License");
+      Code driversCode = new Code("http://terminology.hl7.org/CodeSystem/v2-0203", "DL", "Driver's License");
       patientResource.addIdentifier()
-          .setType(mapCodeToCodeableConcept(driversCode, "http://hl7.org/fhir/v2/0203"))
+          .setType(mapCodeToCodeableConcept(driversCode, "http://terminology.hl7.org/CodeSystem/v2-0203"))
           .setSystem("urn:oid:2.16.840.1.113883.4.3.25")
           .setValue((String) person.attributes.get(Person.IDENTIFIER_DRIVERS));
     }
 
     if (person.attributes.get(Person.IDENTIFIER_PASSPORT) != null) {
-      Code passportCode = new Code("http://hl7.org/fhir/v2/0203", "PPN", "Passport Number");
+      Code passportCode = new Code("http://terminology.hl7.org/CodeSystem/v2-0203", "PPN", "Passport Number");
       patientResource.addIdentifier()
-          .setType(mapCodeToCodeableConcept(passportCode, "http://hl7.org/fhir/v2/0203"))
+          .setType(mapCodeToCodeableConcept(passportCode, "http://terminology.hl7.org/CodeSystem/v2-0203"))
           .setSystem(SHR_EXT + "passportNumber")
           .setValue((String) person.attributes.get(Person.IDENTIFIER_PASSPORT));
     }
 
     // We do not yet account for mixed race
     Extension raceExtension = new Extension(
-        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race");
+        "http://hl7.org/fhir/us/core-r4/StructureDefinition/us-core-race");
     String race = (String) person.attributes.get(Person.RACE);
 
     String raceDisplay;
@@ -356,14 +355,12 @@ public class FhirR4 {
 
     Extension raceTextExtension = new Extension("text");
     raceTextExtension.setValue(new StringType(raceDisplay));
-
     raceExtension.addExtension(raceTextExtension);
-
     patientResource.addExtension(raceExtension);
 
     // We do not yet account for mixed ethnicity
     Extension ethnicityExtension = new Extension(
-        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity");
+        "http://hl7.org/fhir/us/core-r4/StructureDefinition/us-core-ethnicity");
     String ethnicity = (String) person.attributes.get(Person.ETHNICITY);
 
     String ethnicityDisplay;
@@ -436,7 +433,7 @@ public class FhirR4 {
     patientResource.setBirthDate(new Date(birthdate));
 
     Extension birthSexExtension = new Extension(
-        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex");
+        "http://hl7.org/fhir/us/core-r4/StructureDefinition/us-core-birthsex");
     if (person.attributes.get(Person.GENDER).equals("M")) {
       patientResource.setGender(AdministrativeGender.MALE);
       birthSexExtension.setValue(new CodeType("M"));
@@ -480,15 +477,17 @@ public class FhirR4 {
 
     String maritalStatus = ((String) person.attributes.get(Person.MARITAL_STATUS));
     if (maritalStatus != null) {
-      Code maritalStatusCode = new Code("http://hl7.org/fhir/v3/MaritalStatus", maritalStatus,
-          maritalStatus);
+      Code maritalStatusCode = new Code("http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+          maritalStatus, maritalStatus);
       patientResource.setMaritalStatus(
-          mapCodeToCodeableConcept(maritalStatusCode, "http://hl7.org/fhir/v3/MaritalStatus"));
+          mapCodeToCodeableConcept(maritalStatusCode,
+              "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus"));
     } else {
-      Code maritalStatusCode = new Code("http://hl7.org/fhir/v3/MaritalStatus", "S",
-          "Never Married");
+      Code maritalStatusCode = new Code("http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+          "S", "Never Married");
       patientResource.setMaritalStatus(
-          mapCodeToCodeableConcept(maritalStatusCode, "http://hl7.org/fhir/v3/MaritalStatus"));
+          mapCodeToCodeableConcept(maritalStatusCode,
+              "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus"));
     }
 
     DirectPosition2D coord = person.getLatLon();
@@ -503,7 +502,8 @@ public class FhirR4 {
       patientResource.setDeceased(convertFhirDateTime(person.record.death, true));
     }
 
-    String generatedBySynthea = "Generated by <a href=\"https://github.com/synthetichealth/synthea\">Synthea</a>."
+    String generatedBySynthea =
+        "Generated by <a href=\"https://github.com/synthetichealth/synthea\">Synthea</a>."
         + "Version identifier: " + Utilities.SYNTHEA_VERSION + " . "
         + "  Person seed: " + person.seed
         + "  Population seed: " + person.populationSeed;
@@ -532,23 +532,6 @@ public class FhirR4 {
           SHR_EXT + "shr-demographics-SocialSecurityNumber-extension",
           new StringType(ssn));
       patientResource.addExtension(ssnExtension);
-
-      Basic personResource = new Basic();
-      // the only required field on this patient resource is code
-
-      Coding fixedCode = new Coding(
-          "http://standardhealthrecord.org/fhir/basic-resource-type",
-          "shr-entity-Person", "shr-entity-Person");
-      personResource.setCode(new CodeableConcept().addCoding(fixedCode));
-
-      Meta personMeta = new Meta();
-      personMeta.addProfile(SHR_EXT + "shr-entity-Person");
-      personResource.setMeta(personMeta);
-
-      BundleEntryComponent personEntry = newEntry(bundle, personResource);
-      patientResource.addExtension()
-          .setUrl(SHR_EXT + "shr-entity-Person-extension")
-          .setValue(new Reference(personEntry.getFullUrl()));
     }
 
     // DALY and QALY values

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -1226,8 +1226,6 @@ public class FhirR4 {
       }
     }
 
-    // TODO R4 Medication Dosage Exceptions
-    /*
     if (medication.prescriptionDetails != null) {
       JsonObject rxInfo = medication.prescriptionDetails;
       Dosage dosage = new Dosage();
@@ -1280,7 +1278,7 @@ public class FhirR4 {
       dosageInstruction.add(dosage);
       medicationResource.setDosageInstruction(dosageInstruction);
     }
-    */
+
     if (USE_SHR_EXTENSIONS) {
       medicationResource.addExtension()
           .setUrl(SHR_EXT + "shr-base-ActionCode-extension")


### PR DESCRIPTION
- Update the HAPI libraries to 3.7.0-SNAPSHOT to include the first normative release of FHIR R4.
- Update the FHIR R4 exporter to align with the normative version.