### PR TITLE
Log warning instead of crashing if git is not present, addresses #462

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,16 +120,22 @@ task concepts(type: JavaExec) {
 
 task versionTxt() {
   doLast {
-    // the ruby version uses `git rev-parse HEAD` which just produces the long commit hash.
-    // "git describe" can use tags or fallback to the commit hash if necessary.
-    // this assumes (as does the ruby version) that git will always be present when building
-    String[] cmd = ["git", "describe", "--tags", "--always"]
-    Process p = Runtime.getRuntime().exec(cmd)
-    p.waitFor()
-    def version = org.apache.commons.io.IOUtils.toString(p.getInputStream(), java.nio.charset.StandardCharsets.UTF_8)
-    def file = new File("$projectDir/src/main/resources/version.txt")
-    file.createNewFile()
-    file.text = version
+    try {
+      // the ruby version uses `git rev-parse HEAD` which just produces the long commit hash.
+      // "git describe" can use tags or fallback to the commit hash if necessary.
+      // this assumes (as does the ruby version) that git will always be present when building
+      String[] cmd = ["git", "describe", "--tags", "--always"]
+      Process p = Runtime.getRuntime().exec(cmd)
+      p.waitFor()
+      def version = org.apache.commons.io.IOUtils.toString(p.getInputStream(), java.nio.charset.StandardCharsets.UTF_8)
+      def file = new File("$projectDir/src/main/resources/version.txt")
+      file.createNewFile()
+      file.text = version
+    } catch (e) {
+      // ex. if git is not installed, or if we can't write the file for some reason. it's not critical to the execution so don't crash
+      logger.warn("Warning: unable to create version.txt. Generated records will not indicate which version of Synthea was used to create them.")
+      logger.warn(e.getMessage())
+    }
   }
 }
 


### PR DESCRIPTION
Just wraps the `versionTxt` build task in a try-catch block and writes the exception message to the console if anything goes wrong, for example, if someone downloaded the repo using the download zip option instead of cloning it because they don't have git installed.  Git isn't required or used for any other aspect of synthea so it doesn't make sense to me to have it be a hard requirement. Fixes #462.

Sample error message (I changed the call from "git" to "badgit" here to intentionally trigger it):
```
λ .\run_synthea.bat

> Task :versionTxt
Warning: unable to create version.txt. Generated records will not indicate which version of Synthea was used to create them.
Cannot run program "badgit": CreateProcess error=2, The system cannot find the file specified

> Task :run
Loading C:\Users\dehall\synthea\build\resources\main\modules\allergic_rhinitis.json
...
```