### PR TITLE
Fix #457 Truncated lines in ndjson files.

### DIFF
--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -144,7 +144,7 @@ public abstract class Exporter {
    * @param file Path to the new file.
    * @param contents The contents of the file.
    */
-  private static void appendToFile(Path file, String contents) {
+  private static synchronized void appendToFile(Path file, String contents) {
     try {
       if (Files.notExists(file)) {
         Files.createFile(file);


### PR DESCRIPTION
This was being caused by multiple threads written to the ndjson files simultaneously. Synchronization of the output method solved the problem.