### PR TITLE
removed extra comma delimiter in provider csv exporter

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -804,7 +804,7 @@ public class CSVExporter {
       String value = (String) provider.attributes.getOrDefault(attribute, "");
       s.append(clean(value)).append(',');
     }
-    s.append(provider.getEncounterCount()).append(',');
+    s.append(provider.getEncounterCount());
 
     s.append(NEWLINE);
 


### PR DESCRIPTION
An extra comma delimiter at the end of each record was being exported to the provider csv file.