### PR TITLE
Respect SNOMED-CT coded medication orders within FHIR exports

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -990,7 +990,12 @@ public class FhirDstu2 {
     ca.uhn.fhir.model.dstu2.resource.Encounter encounter =
         (ca.uhn.fhir.model.dstu2.resource.Encounter) encounterEntry.getResource();
     medicationResource.setPrescriber(encounter.getParticipantFirstRep().getIndividual());
-    medicationResource.setMedication(mapCodeToCodeableConcept(medication.codes.get(0), RXNORM_URI));
+
+    Code code = medication.codes.get(0);
+    String system = code.system.equals("SNOMED-CT")
+        ? SNOMED_URI
+        : RXNORM_URI;
+    medicationResource.setMedication(mapCodeToCodeableConcept(code, system));
 
     medicationResource.setDateWritten(new DateTimeDt(new Date(medication.start)));
     if (medication.stop != 0L) {

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -1183,7 +1183,11 @@ public class FhirR4 {
     medicationResource.setSubject(new Reference(personEntry.getFullUrl()));
     medicationResource.setEncounter(new Reference(encounterEntry.getFullUrl()));
 
-    medicationResource.setMedication(mapCodeToCodeableConcept(medication.codes.get(0), RXNORM_URI));
+    Code code = medication.codes.get(0);
+    String system = code.system.equals("SNOMED-CT")
+        ? SNOMED_URI
+        : RXNORM_URI;
+    medicationResource.setMedication(mapCodeToCodeableConcept(code, system));
 
     medicationResource.setAuthoredOn(new Date(medication.start));
     medicationResource.setIntent(MedicationRequestIntent.ORDER);

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -1765,7 +1765,11 @@ public class FhirStu3 {
     medicationResource.setSubject(new Reference(personEntry.getFullUrl()));
     medicationResource.setContext(new Reference(encounterEntry.getFullUrl()));
 
-    medicationResource.setMedication(mapCodeToCodeableConcept(medication.codes.get(0), RXNORM_URI));
+    Code code = medication.codes.get(0);
+    String system = code.system.equals("SNOMED-CT")
+        ? SNOMED_URI
+        : RXNORM_URI;
+    medicationResource.setMedication(mapCodeToCodeableConcept(code, system));
 
     medicationResource.setAuthoredOn(new Date(medication.start));
     medicationResource.setIntent(MedicationRequestIntent.ORDER);


### PR DESCRIPTION
This pull request adds the ability to specify "SNOMED-CT" within the "system" field of a code within a MedicationOrder state definition.

With this change, the FHIR DSTU2, STU3 and R4 generators will now correctly output the SNOMED CT URI ("http://snomed.info/sct"), rather than ignoring the value in the module and defaulting to the RxNorm URI.