### PR TITLE
Provider Finder Behaviors

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -1532,8 +1532,8 @@ public class FhirR4 {
       medicationResource.setMeta(meta);
     } else if (USE_SHR_EXTENSIONS) {
       medicationResource.addExtension()
-      .setUrl(SHR_EXT + "shr-base-ActionCode-extension")
-      .setValue(PRESCRIPTION_OF_DRUG_CC);
+        .setUrl(SHR_EXT + "shr-base-ActionCode-extension")
+        .setValue(PRESCRIPTION_OF_DRUG_CC);
     
       medicationResource.setMeta(new Meta()
           .addProfile(SHR_EXT + "shr-medication-MedicationRequested"));

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -406,7 +406,7 @@ public class Person implements Serializable, QuadTreeData {
   }
 
   public void setProvider(EncounterType type, long time) {
-    Provider provider = Provider.findClosestService(this, type, time);
+    Provider provider = Provider.findService(this, type, time);
     setProvider(type, provider);
   }
 

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/IProviderFinder.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/IProviderFinder.java
@@ -1,0 +1,22 @@
+package org.mitre.synthea.world.agents.behaviors;
+
+import java.util.List;
+
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
+
+/**
+ * Find a particular provider by service.
+ */
+public interface IProviderFinder {
+  /**
+   * Find a provider with a specific service for the person.
+   * @param providers The list of eligible providers.
+   * @param person The patient who requires the service.
+   * @param service The service required. For example, EncounterType.AMBULATORY.
+   * @param time The date/time within the simulated world, in milliseconds.
+   * @return Service provider or null if none is available.
+   */
+  public Provider find(List<Provider> providers, Person person, EncounterType service, long time);
+}

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderNearest.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderNearest.java
@@ -1,0 +1,41 @@
+package org.mitre.synthea.world.agents.behaviors;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
+
+public class ProviderFinderNearest implements IProviderFinder {
+
+  @Override
+  public Provider find(List<Provider> providers, Person person, EncounterType service, long time) {
+    double distance;
+    double minDistance = Double.MAX_VALUE;
+    List<Provider> options = new ArrayList<Provider>();
+
+    for (Provider provider : providers) {
+      if (provider.accepts(person, time)
+          && (provider.hasService(service) || service == null)) {
+        distance = provider.getLatLon().distance(person.getLatLon());
+        if (distance < minDistance) {
+          options.clear();
+          options.add(provider);
+          minDistance = distance;
+        } else if (distance == minDistance) {
+          options.add(provider);
+        }
+      }
+    }
+
+    if (options.isEmpty()) {
+      return null;
+    } else if (options.size() == 1) {
+      return options.get(0);
+    } else {
+      // there are a few equally good options, pick one randomly.
+      return options.get(person.randInt(options.size()));
+    }
+  }
+}

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderQuality.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderQuality.java
@@ -1,0 +1,40 @@
+package org.mitre.synthea.world.agents.behaviors;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
+
+public class ProviderFinderQuality implements IProviderFinder {
+
+  private IProviderFinder nearest = new ProviderFinderNearest();
+
+  @Override
+  public Provider find(List<Provider> providers, Person person, EncounterType service, long time) {
+    List<Provider> options = new ArrayList<>();
+    double bestQuality = Double.NEGATIVE_INFINITY;
+
+    for (Provider provider : providers) {
+      if (provider.accepts(person, time)
+          && (provider.hasService(service) || service == null)) {
+        if (provider.quality > bestQuality) {
+          options.clear();
+          options.add(provider);
+          bestQuality = provider.quality;
+        } else if (provider.quality == bestQuality) {
+          options.add(provider);
+        }
+      }
+    }
+
+    if (options.isEmpty()) {
+      return null;
+    } else if (options.size() == 1) {
+      return options.get(0);
+    } else {
+      return nearest.find(options, person, service, time);
+    }
+  }
+}

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderRandom.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderRandom.java
@@ -1,0 +1,32 @@
+package org.mitre.synthea.world.agents.behaviors;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
+
+public class ProviderFinderRandom implements IProviderFinder {
+
+  @Override
+  public Provider find(List<Provider> providers, Person person, EncounterType service, long time) {
+    List<Provider> options = new ArrayList<Provider>();
+
+    for (Provider provider : providers) {
+      if (provider.accepts(person, time)
+          && (provider.hasService(service) || service == null)) {
+        options.add(provider);
+      }
+    }
+
+    if (options.isEmpty()) {
+      return null;
+    } else if (options.size() == 1) {
+      return options.get(0);
+    } else {
+      // there are a few equally good options, pick one randomly.
+      return options.get(person.randInt(options.size()));
+    }
+  }
+}

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -64,10 +64,7 @@ generate.geography.country_code = US
 generate.geography.timezones.default_file = geography/timezones.csv
 generate.geography.foreign.birthplace.default_file = geography/foreign_birthplace.json
 
-# maximum distance to look for a provider for a given patient, in km
-generate.maximum_provider_search_distance = 2000
-# set to 2000km to support the model that veterans only seek care at VA facilities
-
+# Set to true if you want every patient to be dead.
 generate.only_dead_patients = false
 
 # if true, tracks and prints out details of transition tables for each module upon completion
@@ -142,6 +139,18 @@ generate.providers.homehealth.default_file = providers/home_health_agencies.csv
 generate.providers.veterans.default_file = providers/va_facilities.csv
 generate.providers.urgentcare.default_file = providers/urgent_care_facilities.csv
 generate.providers.primarycare.default_file = providers/primary_care_facilities.csv
+
+# Provider selection behavior
+# How patients select a provider organization:
+#  nearest - select the closest provider. See generate.providers.maximum_search_distance
+#  quality - select the best provider if quality is known. Otherwise nearest.
+#  random  - select randomly.
+#  network - select the nearest provider in your insurance network. same as random except it changes every time the patient switches insurance provider.
+generate.providers.selection_behavior = nearest
+
+# maximum distance to look for a provider for a given patient, in km
+# set to 2000km to support the model that veterans only seek care at VA facilities
+generate.providers.maximum_search_distance = 2000
 
 # Quit Smoking
 lifecycle.quit_smoking.baseline = 0.01

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -25,6 +25,7 @@ public class CSVExporterTest {
   public void testCSVExport() throws Exception {
     TestHelper.exportOff();
     Config.set("exporter.csv.export", "true");
+    Config.set("exporter.csv.folder_per_run", "false");
     File tempOutputFolder = tempFolder.newFolder();
     Config.set("exporter.baseDirectory", tempOutputFolder.toString());
 

--- a/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
@@ -76,7 +76,7 @@ public class ProviderTest {
     Provider.loadProviders(location);
     Person person = new Person(0L);
     location.assignPoint(person, location.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, EncounterType.INPATIENT, 0);
+    Provider provider = Provider.findService(person, EncounterType.INPATIENT, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -85,7 +85,7 @@ public class ProviderTest {
     Provider.loadProviders(location);
     Person person = new Person(0L);
     location.assignPoint(person, location.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, EncounterType.AMBULATORY, 0);
+    Provider provider = Provider.findService(person, EncounterType.AMBULATORY, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -94,7 +94,7 @@ public class ProviderTest {
     Provider.loadProviders(location);
     Person person = new Person(0L);
     location.assignPoint(person, location.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, EncounterType.EMERGENCY, 0);
+    Provider provider = Provider.findService(person, EncounterType.EMERGENCY, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -103,7 +103,7 @@ public class ProviderTest {
     Provider.loadProviders(location);
     Person person = new Person(0L);
     location.assignPoint(person, location.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, EncounterType.URGENTCARE, 0);
+    Provider provider = Provider.findService(person, EncounterType.URGENTCARE, 0);
     Assert.assertNotNull(provider); 
   }
   
@@ -112,7 +112,7 @@ public class ProviderTest {
     Provider.loadProviders(city);
     Person person = new Person(0L);
     city.assignPoint(person, city.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, EncounterType.INPATIENT, 0);
+    Provider provider = Provider.findService(person, EncounterType.INPATIENT, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -121,7 +121,7 @@ public class ProviderTest {
     Provider.loadProviders(city);
     Person person = new Person(0L);
     city.assignPoint(person, city.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, EncounterType.AMBULATORY, 0);
+    Provider provider = Provider.findService(person, EncounterType.AMBULATORY, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -130,7 +130,7 @@ public class ProviderTest {
     Provider.loadProviders(city);
     Person person = new Person(0L);
     city.assignPoint(person, city.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, EncounterType.EMERGENCY, 0);
+    Provider provider = Provider.findService(person, EncounterType.EMERGENCY, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -139,7 +139,7 @@ public class ProviderTest {
     Provider.loadProviders(city);
     Person person = new Person(0L);
     city.assignPoint(person, city.randomCityName(person.random));
-    Provider provider = Provider.findClosestService(person, EncounterType.URGENTCARE, 0);
+    Provider provider = Provider.findService(person, EncounterType.URGENTCARE, 0);
     Assert.assertNotNull(provider);
   }
   

--- a/src/test/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderTest.java
@@ -1,0 +1,127 @@
+package org.mitre.synthea.world.agents.behaviors;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.sis.geometry.DirectPosition2D;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
+
+public class ProviderFinderTest {
+  
+  private List<Provider> providers;
+  private Person person;
+
+  @Before
+  public void setup() {
+    person = new Person(0L);
+    DirectPosition2D coordinate = new DirectPosition2D(0, 0);
+    person.attributes.put(Person.COORDINATE, coordinate);
+    
+    providers = new ArrayList<Provider>();
+    for (int i = 1; i <= 3; i += 1) {
+      Provider provider = new Provider();
+      provider.id = i + "";
+      provider.getCoordinates().setLocation(i, i);
+      provider.quality = i;
+      provider.servicesProvided.add(EncounterType.WELLNESS);
+      providers.add(provider);
+    }
+  }
+
+  @Test
+  public void testNearest() {
+    ProviderFinderNearest finder = new ProviderFinderNearest();
+    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, 0L);
+    Assert.assertNotNull(provider);
+    Assert.assertEquals("1", provider.id);
+  }
+
+  @Test
+  public void testAnyNearest() {
+    ProviderFinderNearest finder = new ProviderFinderNearest();
+    Provider provider = finder.find(providers, person, null, 0L);
+    Assert.assertNotNull(provider);
+    Assert.assertEquals("1", provider.id);
+  }
+
+  @Test
+  public void testManyNearest() {
+    ProviderFinderNearest finder = new ProviderFinderNearest();
+    List<Provider> options = new ArrayList<Provider>();
+    options.addAll(providers);
+    options.addAll(providers);
+    Provider provider = finder.find(options, person, EncounterType.WELLNESS, 0L);
+    Assert.assertNotNull(provider);
+    Assert.assertEquals("1", provider.id);
+  }
+
+  @Test
+  public void testNoNearest() {
+    ProviderFinderNearest finder = new ProviderFinderNearest();
+    List<Provider> options = new ArrayList<Provider>();
+    Provider provider = finder.find(options, person, EncounterType.WELLNESS, 0L);
+    Assert.assertNull(provider);
+  }
+
+  @Test
+  public void testQuality() {
+    ProviderFinderQuality finder = new ProviderFinderQuality();
+    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, 0L);
+    Assert.assertNotNull(provider);
+    Assert.assertEquals("3", provider.id);
+  }
+
+  @Test
+  public void testAnyQuality() {
+    ProviderFinderQuality finder = new ProviderFinderQuality();
+    Provider provider = finder.find(providers, person, null, 0L);
+    Assert.assertNotNull(provider);
+    Assert.assertEquals("3", provider.id);
+  }
+
+  @Test
+  public void testManyQuality() {
+    ProviderFinderQuality finder = new ProviderFinderQuality();
+    List<Provider> options = new ArrayList<Provider>();
+    options.addAll(providers);
+    options.addAll(providers);
+    Provider provider = finder.find(options, person, EncounterType.WELLNESS, 0L);
+    Assert.assertNotNull(provider);
+    Assert.assertEquals("3", provider.id);
+  }
+
+  @Test
+  public void testNoQuality() {
+    ProviderFinderQuality finder = new ProviderFinderQuality();
+    List<Provider> options = new ArrayList<Provider>();
+    Provider provider = finder.find(options, person, EncounterType.WELLNESS, 0L);
+    Assert.assertNull(provider);
+  }
+
+  @Test
+  public void testRandom() {
+    ProviderFinderRandom finder = new ProviderFinderRandom();
+    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, 0L);
+    Assert.assertNotNull(provider);
+  }
+
+  @Test
+  public void testAnyRandom() {
+    ProviderFinderRandom finder = new ProviderFinderRandom();
+    Provider provider = finder.find(providers, person, null, 0L);
+    Assert.assertNotNull(provider);
+  }
+
+  @Test
+  public void testNoRandom() {
+    ProviderFinderRandom finder = new ProviderFinderRandom();
+    List<Provider> options = new ArrayList<Provider>();
+    Provider provider = finder.find(options, person, EncounterType.WELLNESS, 0L);
+    Assert.assertNull(provider);
+  }
+}


### PR DESCRIPTION
This pull request adds the ability to change patient behavior in how they find or select a provider.

Prior to this pull request, the implicit behavior was equivalent to `nearest` and is the default behavior.

- `nearest` - choose the nearest provider that offers the service needed. If there are several with the same distance, one is selected randomly. This is the default behavior.
- `quality` - choose the best quality provider (within range) that offers the service needed. If there are several, it chooses the nearest.
- `random` - choose a random provider that offers the service needed.
- `network` - choose a provider that offers the service needed that is within the patient's insurance network. Currently, this is equivalent to `random` every time the patient switches insurance. When Payer-Provider insurance networks are added (TBD) this will diverge from `random`.

## synthea.properties
```properties
generate.providers.selection_behavior = nearest
```

## command line
```
./run_synthea --generate.providers.selection_behavior [nearest|quality|random|network]
```

