### PR TITLE
Fix FHIR Encounter class codes

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -619,7 +619,7 @@ public class FhirR4 {
       encounterResource.addType(mapCodeToCodeableConcept(code, SNOMED_URI));
     }
 
-    encounterResource.setClass_(new Coding().setCode(encounter.type));
+    encounterResource.setClass_(new Coding().setCode(EncounterType.fromString(encounter.type).code()));
     encounterResource
         .setPeriod(new Period()
             .setStart(new Date(encounter.start))
@@ -909,7 +909,7 @@ public class FhirR4 {
    * @param personEntry Entry for the person
    * @param bundle The Bundle to add to
    * @param encounterEntry The current Encounter
-   * @param claim the Claim object
+   * @param claimEntry the Claim object
    * @param person the person the health record belongs to
    * @param encounter the current Encounter as an object
    * @return the added entry

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -619,7 +619,11 @@ public class FhirR4 {
       encounterResource.addType(mapCodeToCodeableConcept(code, SNOMED_URI));
     }
 
-    encounterResource.setClass_(new Coding().setCode(EncounterType.fromString(encounter.type).code()));
+
+    Coding classCode = new Coding();
+    classCode.setCode(EncounterType.fromString(encounter.type).code());
+    classCode.setSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode");
+    encounterResource.setClass_(classCode);
     encounterResource
         .setPeriod(new Period()
             .setStart(new Date(encounter.start))

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -608,7 +608,7 @@ public class FhirStu3 {
       encounterResource.addType(mapCodeToCodeableConcept(code, SNOMED_URI));
     }
 
-    encounterResource.setClass_(new Coding().setCode(encounter.type));
+    encounterResource.setClass_(new Coding().setCode(EncounterType.fromString(encounter.type).code()));
     encounterResource
         .setPeriod(new Period()
             .setStart(new Date(encounter.start))
@@ -886,7 +886,7 @@ public class FhirStu3 {
    * @param personEntry Entry for the person
    * @param bundle The Bundle to add to
    * @param encounterEntry The current Encounter
-   * @param claim the Claim object
+   * @param claimEntry the Claim object
    * @param person the person the health record belongs to
    * @param encounter the current Encounter as an object
    * @return the added entry

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -608,7 +608,10 @@ public class FhirStu3 {
       encounterResource.addType(mapCodeToCodeableConcept(code, SNOMED_URI));
     }
 
-    encounterResource.setClass_(new Coding().setCode(EncounterType.fromString(encounter.type).code()));
+    Coding classCode = new Coding();
+    classCode.setCode(EncounterType.fromString(encounter.type).code());
+    classCode.setSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode");
+    encounterResource.setClass_(classCode);
     encounterResource
         .setPeriod(new Period()
             .setStart(new Date(encounter.start))

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -288,7 +288,14 @@ public class HealthRecord {
   }
 
   public enum EncounterType {
-    WELLNESS, AMBULATORY, OUTPATIENT, INPATIENT, EMERGENCY, URGENTCARE;
+    WELLNESS("AMB"), AMBULATORY("AMB"), OUTPATIENT("AMB"), INPATIENT("IMP"), EMERGENCY("EMER"), URGENTCARE("AMB");
+
+    // http://www.hl7.org/implement/standards/fhir/v3/ActEncounterCode/vs.html
+    private final String code;
+
+    EncounterType(String code) {
+      this.code = code;
+    }
 
     public static EncounterType fromString(String value) {
       if (value == null) {
@@ -297,6 +304,8 @@ public class HealthRecord {
         return EncounterType.valueOf(value.toUpperCase());
       }
     }
+
+    public String code() { return this.code; }
 
     public String toString() {
       return this.name().toLowerCase();


### PR DESCRIPTION
When exporting Encounter FHIR resources, Synthea is currently outputting
a lowercased version of the EncounterType enum for the Encounter.class
element. However, this value should be from the ActEncounterCode VS:
http://www.hl7.org/implement/standards/fhir/v3/ActEncounterCode/vs.html

This change adds the appropriate value into the EncounterType enum and
updates the STU3 and R4 exporters to use it.