### PR TITLE
Support the creation of MedicationAdministration resources for MedicationOrder states

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -780,13 +780,15 @@ public abstract class State implements Cloneable {
    * prescribed. MedicationOrder states may only be processed during an Encounter, and so must occur
    * after the target Encounter state and before the EncounterEnd. See the Encounter section above
    * for more details. The MedicationOrder state supports identifying a previous ConditionOnset or
-   * the name of an attribute as the reason for the prescription.
+   * the name of an attribute as the reason for the prescription. Adding a 'administration' field
+   * allows for the MedicationOrder to also export a MedicationAdministration into the exported FHIR record.
    */
   public static class MedicationOrder extends State {
     private List<Code> codes;
     private String reason;
     private JsonObject prescription; // TODO make this a Component
     private String assignToAttribute;
+    private boolean administration;
 
     @Override
     public MedicationOrder clone() {
@@ -795,6 +797,7 @@ public abstract class State implements Cloneable {
       clone.reason = reason;
       clone.prescription = prescription;
       clone.assignToAttribute = assignToAttribute;
+      clone.administration = administration;
       return clone;
     }
 
@@ -823,6 +826,7 @@ public abstract class State implements Cloneable {
       }
 
       medication.prescriptionDetails = prescription;
+      medication.administration = administration;
 
       if (assignToAttribute != null) {
         person.attributes.put(assignToAttribute, medication);

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -1,6 +1,7 @@
 package org.mitre.synthea.export;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.dstu2.valueset.MedicationAdministrationStatusEnum;
 
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
@@ -71,6 +72,9 @@ import org.hl7.fhir.dstu3.model.ImagingStudy.InstanceAvailability;
 import org.hl7.fhir.dstu3.model.Immunization;
 import org.hl7.fhir.dstu3.model.Immunization.ImmunizationStatus;
 import org.hl7.fhir.dstu3.model.IntegerType;
+import org.hl7.fhir.dstu3.model.MedicationAdministration;
+import org.hl7.fhir.dstu3.model.MedicationAdministration.MedicationAdministrationDosageComponent;
+import org.hl7.fhir.dstu3.model.MedicationAdministration.MedicationAdministrationStatus;
 import org.hl7.fhir.dstu3.model.MedicationRequest;
 import org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestIntent;
 import org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestRequesterComponent;
@@ -1873,7 +1877,77 @@ public class FhirStu3 {
     // create new claim for medication
     medicationClaim(personEntry, bundle, encounterEntry, medication.claim, medicationEntry);
 
+    // Create new administration for medication, if needed
+    if (medication.administration) {
+      medicationAdministration(personEntry, bundle, encounterEntry, medication, medicationResource);
+    }
+
     return medicationEntry;
+  }
+  
+  /**
+   * Add a MedicationAdministration if needed for the given medication
+   * 
+   * @param personEntry       The Entry for the Person
+   * @param bundle            Bundle to add the MedicationAdministration to
+   * @param encounterEntry    Current Encounter entry
+   * @param medication        The Medication
+   * @param medicationRequest The related medicationRequest
+   * @return The added Entry
+   */
+  private static BundleEntryComponent medicationAdministration(BundleEntryComponent personEntry, Bundle bundle, 
+    BundleEntryComponent encounterEntry, Medication medication, MedicationRequest medicationRequest) {
+    MedicationAdministration medicationResource = new MedicationAdministration();
+
+    medicationResource.setSubject(new Reference(personEntry.getFullUrl()));
+    medicationResource.setContext(new Reference(encounterEntry.getFullUrl()));
+
+    Code code = medication.codes.get(0);
+    String system = code.system.equals("SNOMED-CT") ? SNOMED_URI : RXNORM_URI;
+
+    medicationResource.setMedication(mapCodeToCodeableConcept(code, system));
+    medicationResource.setEffective(new DateTimeType(new Date(medication.start)));
+
+    medicationResource.setStatus(MedicationAdministrationStatus.fromCode("completed"));
+
+    if (medication.prescriptionDetails != null) {
+      JsonObject rxInfo = medication.prescriptionDetails;
+      MedicationAdministrationDosageComponent dosage = new MedicationAdministrationDosageComponent();
+
+      // as_needed is true if present
+      if ((rxInfo.has("dosage")) && (!rxInfo.has("as_needed"))) {
+        Quantity dose = new SimpleQuantity().setValue(
+            rxInfo.get("dosage").getAsJsonObject().get("amount").getAsDouble());
+        dosage.setDose((SimpleQuantity) dose);
+
+        if (rxInfo.has("instructions")) {
+          for (JsonElement instructionElement : rxInfo.get("instructions").getAsJsonArray()) {
+            JsonObject instruction = instructionElement.getAsJsonObject();
+
+            dosage.setText(instruction.get("display").getAsString());
+          }
+        }
+      }
+      medicationResource.setDosage(dosage);
+    }
+
+    if (!medication.reasons.isEmpty()) {
+      // Only one element in list
+      Code reason = medication.reasons.get(0);
+      for (BundleEntryComponent entry : bundle.getEntry()) {
+        if (entry.getResource().fhirType().equals("Condition")) {
+          Condition condition = (Condition) entry.getResource();
+          // Only one element in list
+          Coding coding = condition.getCode().getCoding().get(0);
+          if (reason.code.equals(coding.getCode())) {
+            medicationResource.addReasonReference().setReference(entry.getFullUrl());
+          }
+        }
+      }
+    }
+
+    BundleEntryComponent medicationAdminEntry = newEntry(bundle, medicationResource);
+    return medicationAdminEntry;
   }
 
   private static final Code PRESCRIPTION_OF_DRUG_CODE =

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -158,6 +158,7 @@ public class HealthRecord {
     public Code stopReason;
     public JsonObject prescriptionDetails;
     public Claim claim;
+    public boolean administration;
 
     public Medication(long time, String type) {
       super(time, type);

--- a/src/main/resources/modules/lung_cancer.json
+++ b/src/main/resources/modules/lung_cancer.json
@@ -830,7 +830,8 @@
           "display": "Cisplatin 50 MG Injection"
         }
       ],
-      "direct_transition": "SCLC Chemotheraphy IB"
+      "direct_transition": "SCLC Chemotheraphy IB",
+      "administration": true
     },
     "SCLC Chemotheraphy IB": {
       "type": "MedicationEnd",
@@ -853,7 +854,8 @@
           "display": "Etoposide 100 MG Injection"
         }
       ],
-      "direct_transition": "SCLC Chemotheraphy IIB"
+      "direct_transition": "SCLC Chemotheraphy IIB",
+      "administration": true
     },
     "SCLC Chemotheraphy IIB": {
       "type": "MedicationEnd",
@@ -937,7 +939,8 @@
           "display": "Cisplatin 50 MG Injection"
         }
       ],
-      "direct_transition": "NSCLC Chemotheraphy IB"
+      "direct_transition": "NSCLC Chemotheraphy IB",
+      "administration": true
     },
     "NSCLC Chemotheraphy IB": {
       "type": "MedicationEnd",
@@ -960,7 +963,8 @@
           "display": "PACLitaxel 100 MG Injection"
         }
       ],
-      "direct_transition": "NSCLC Chemotheraphy IIB"
+      "direct_transition": "NSCLC Chemotheraphy IIB",
+      "administration": true
     },
     "NSCLC Chemotheraphy IIB": {
       "type": "MedicationEnd",

--- a/src/main/resources/modules/surgery/general_anesthesia.json
+++ b/src/main/resources/modules/surgery/general_anesthesia.json
@@ -34,7 +34,8 @@
       "remarks": [
         "TODO: look into Phenobarbital (can cause apnea), Etomidate (risk of nausea), Ketamine (increased secretions, risk of laryngospasm and hallucinations), Dexmedetomidine",
         "https://www.ncbi.nlm.nih.gov/books/NBK493199/"
-      ]
+      ],
+      "administration": true
     },
     "Intubation": {
       "type": "Procedure",
@@ -61,7 +62,8 @@
           "display": "Midazolam 1 MG/ML Injectable Solution"
         }
       ],
-      "direct_transition": "Midazolam_End"
+      "direct_transition": "Midazolam_End",
+      "administration": true
     },
     "Anxiolytic": {
       "type": "Simple",
@@ -94,7 +96,8 @@
           "display": "Diazepam 5 MG/ML Injectable Solution"
         }
       ],
-      "direct_transition": "Diazepam_End"
+      "direct_transition": "Diazepam_End",
+      "administration": true
     },
     "Lorazepam": {
       "type": "MedicationOrder",
@@ -105,7 +108,8 @@
           "display": "Lorazepam 2 MG/ML Injectable Solution"
         }
       ],
-      "direct_transition": "Lorazepam_End"
+      "direct_transition": "Lorazepam_End",
+      "administration": true
     },
     "Antiemetic": {
       "type": "MedicationOrder",
@@ -120,7 +124,8 @@
       "remarks": [
         "4mg is the most common dose for Ondansetron and virtually all anesthesia patients receive it prior to general anesthesia.",
         "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5509245/"
-      ]
+      ],
+      "administration": true
     },
     "Paralytic": {
       "type": "MedicationOrder",
@@ -139,7 +144,8 @@
         "",
         "In one study of general anesthetics, Rocuronium was used in 96.7% of cases",
         "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5500064/"
-      ]
+      ],
+      "administration": true
     },
     "Fentanyl": {
       "type": "MedicationOrder",
@@ -150,7 +156,8 @@
           "display": "Fentanyl"
         }
       ],
-      "direct_transition": "Fentanyl_End"
+      "direct_transition": "Fentanyl_End",
+      "administration": true
     },
     "Analgesic": {
       "type": "Simple",
@@ -186,7 +193,8 @@
           "display": "Remifentanil"
         }
       ],
-      "direct_transition": "Remifentanil_End"
+      "direct_transition": "Remifentanil_End",
+      "administration": true
     },
     "Alfentanil": {
       "type": "MedicationOrder",
@@ -197,7 +205,8 @@
           "display": "Alfentanil"
         }
       ],
-      "direct_transition": "Alfentanil_End"
+      "direct_transition": "Alfentanil_End",
+      "administration": true
     },
     "Sufentanil": {
       "type": "MedicationOrder",
@@ -208,7 +217,8 @@
           "display": "Sufentanil"
         }
       ],
-      "direct_transition": "Sufentanil_End"
+      "direct_transition": "Sufentanil_End",
+      "administration": true
     },
     "Isoflurane": {
       "type": "MedicationOrder",
@@ -219,7 +229,8 @@
           "display": "Isoflurane 999 MG/ML Inhalant Solution"
         }
       ],
-      "direct_transition": "Isoflurane_End"
+      "direct_transition": "Isoflurane_End",
+      "administration": true
     },
     "Volatile_Anesthetic": {
       "type": "Simple",
@@ -253,7 +264,8 @@
           "display": "desflurane 990 MG/ML Inhalant Solution"
         }
       ],
-      "direct_transition": "Desflurane_End"
+      "direct_transition": "Desflurane_End",
+      "administration": true
     },
     "Sevoflurane": {
       "type": "MedicationOrder",
@@ -264,7 +276,8 @@
           "display": "sevoflurane 1000 MG/ML Inhalant Solution"
         }
       ],
-      "direct_transition": "Sevoflurane_End"
+      "direct_transition": "Sevoflurane_End",
+      "administration": true
     },
     "Midazolam_End": {
       "type": "MedicationEnd",

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -34,6 +34,8 @@ import org.mitre.synthea.world.concepts.VitalSign;
 import org.mockito.Mockito;
 import org.powermock.reflect.Whitebox;
 
+import ca.uhn.fhir.model.dstu2.resource.MedicationOrder;
+
 public class StateTest {
 
   private Person person;
@@ -878,6 +880,23 @@ public class StateTest {
   }
 
   @Test
+  public void medication_order_assigns_administered_attribute() {
+    person.attributes.remove("Diabetes Medication");
+    Module module = getModule("medication_order.json");
+    State encounter = module.getState("Wellness_Encounter");
+    simulateWellnessEncounter(module);
+    assertTrue(encounter.process(person, time));
+    person.history.add(encounter);
+
+    State med = module.getState("Metformin_With_Administration");
+    assertTrue(med.process(person, time));
+
+    HealthRecord.Medication medication = (HealthRecord.Medication) person.attributes
+        .get("Diabetes Medication");
+    assertTrue(medication.administration);
+  }
+
+  @Test
   public void medication_order_assigns_entity_attribute() {
     person.attributes.remove("Diabetes Medication");
     Module module = getModule("medication_order.json");
@@ -889,9 +908,10 @@ public class StateTest {
     State med = module.getState("Metformin");
     assertTrue(med.process(person, time));
 
-    HealthRecord.Medication medication = (HealthRecord.Medication) person.attributes
-        .get("Diabetes Medication");
+    HealthRecord.Medication medication = (HealthRecord.Medication) person.attributes.get("Diabetes Medication");
     assertEquals(time, medication.start);
+
+    assertFalse(medication.administration);
 
     Code code = medication.codes.get(0);
     assertEquals("860975", code.code);

--- a/src/test/resources/generic/medication_order.json
+++ b/src/test/resources/generic/medication_order.json
@@ -32,6 +32,21 @@
             "reason": "Diabetes",
             "direct_transition": "Metformin_With_Dosage"
         },
+        "Metformin_With_Administration": {
+          "type": "MedicationOrder",
+          "target_encounter": "Wellness_Encounter",
+          "codes": [
+            {
+              "system": "RxNorm",
+              "code": "860975",
+              "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
+            }
+          ],
+          "assign_to_attribute": "Diabetes Medication",
+          "reason": "Diabetes",
+          "direct_transition": "Metformin_With_Dosage",
+          "administration": true
+        },
         "Metformin_With_Dosage": {
             "type": "MedicationOrder",
             "target_encounter": "Wellness_Encounter",


### PR DESCRIPTION
Companion PR to https://github.com/synthetichealth/module-builder/pull/245. Adds support in the State engine, HealthRecord, and FHIR Exporters for an `administration` attribute on `MedicationOrder` states. 