### PR TITLE
Make wellness encounters use wellness providers.

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -489,7 +489,7 @@ public abstract class State implements Cloneable {
           person.setCurrentEncounter(module, encounter);
 
           // find closest provider and increment encounters count
-          Provider provider = person.getProvider(EncounterType.AMBULATORY, time);
+          Provider provider = person.getProvider(EncounterType.WELLNESS, time);
           person.addCurrentProvider(module.name, provider);
           int year = Utilities.getYear(time);
           provider.incrementEncounters(EncounterType.WELLNESS, year);

--- a/src/main/java/org/mitre/synthea/modules/EncounterModule.java
+++ b/src/main/java/org/mitre/synthea/modules/EncounterModule.java
@@ -43,8 +43,8 @@ public final class EncounterModule extends Module {
       "Well child visit (procedure)");
   public static final Code GENERAL_EXAM = new Code("SNOMED-CT", "162673000",
       "General examination of patient (procedure)");
-  public static final Code ENCOUNTER_URGENTCARE = new Code("SNOMED-CT", "371883000",
-      "Outpatient procedure (procedure)");
+  public static final Code ENCOUNTER_URGENTCARE = new Code("SNOMED-CT", "702927004",
+      "Urgent care clinic (procedure)");
   // NOTE: if new codes are added, be sure to update getAllCodes below
 
   public EncounterModule() {
@@ -62,7 +62,7 @@ public final class EncounterModule extends Module {
       Encounter encounter = person.encounterStart(time, EncounterType.WELLNESS);
       encounter.name = "Encounter Module Scheduled Wellness";
       encounter.codes.add(ENCOUNTER_CHECKUP);
-      Provider prov = person.getProvider(EncounterType.AMBULATORY, time);
+      Provider prov = person.getProvider(EncounterType.WELLNESS, time);
       prov.incrementEncounters(EncounterType.WELLNESS, year);
       encounter.provider = prov;
       encounter.clinician = prov.chooseClinicianList(ClinicianSpecialty.GENERAL_PRACTICE, 

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -55,6 +55,7 @@ public class StateTest {
     Provider mock = Mockito.mock(Provider.class);
     mock.uuid = "Mock-UUID";
     person.setProvider(EncounterType.AMBULATORY, mock);
+    person.setProvider(EncounterType.WELLNESS, mock);
     person.setProvider(EncounterType.EMERGENCY, mock);
     person.setProvider(EncounterType.INPATIENT, mock);
 

--- a/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
@@ -89,6 +89,14 @@ public class FHIRR4ExporterTest {
                  * properly referenced. Running $validate on test servers finds this valid...
                  */
                 valid = true;
+              } else if (emessage.getMessage().contains(
+                  "per-1: If present, start SHALL have a lower value than end")) {
+                /*
+                 * The per-1 invariant does not account for daylight savings time... so, if the
+                 * daylight savings switch happens between the start and end, the validation
+                 * fails, even if it is valid.
+                 */
+                valid = true; // ignore this error
               }
               if (!valid) {
                 System.out.println(parser.encodeResourceToString(entry.getResource()));

--- a/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
@@ -101,6 +101,14 @@ public class FHIRSTU3ExporterTest {
                  * starting with "urn:uuid"
                  */
                 valid = true; // ignore this error
+              } else if (emessage.getMessage().contains(
+                  "per-1: If present, start SHALL have a lower value than end")) {
+                /*
+                 * The per-1 invariant does not account for daylight savings time... so, if the
+                 * daylight savings switch happens between the start and end, the validation
+                 * fails, even if it is valid.
+                 */
+                valid = true; // ignore this error
               }
 
               if (!valid) {

--- a/src/test/java/org/mitre/synthea/helpers/AttributesTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/AttributesTest.java
@@ -7,13 +7,21 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.util.Map;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mitre.synthea.helpers.Attributes.Inventory;
 
 public class AttributesTest {
+
+  private static Map<String,Inventory> inventory = null;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    inventory = Attributes.getAttributeInventory();
+  }
+
   @Test
   public void testAttributes() throws Exception {
-    Map<String,Inventory> inventory = Attributes.getAttributeInventory();
     assertNotNull(inventory);
     assertFalse(inventory.isEmpty());
     assertFalse(inventory.containsKey(""));
@@ -21,7 +29,6 @@ public class AttributesTest {
 
   @Test
   public void testGraphs() throws Exception {
-    Map<String,Inventory> inventory = Attributes.getAttributeInventory();
     String filename = "TestAttributesGraph";
     Attributes.graph(inventory, filename, true);
     File file = new File("./output/" + filename + ".png");

--- a/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
@@ -65,7 +65,7 @@ public class TransitionMetricsTest {
       // seeds chosen by experimentation, to ensure we hit "Pre_Examplitis" at least once
       person = new Person(seed); 
       person.attributes.put(Person.GENDER, "M");
-      person.setProvider(EncounterType.AMBULATORY, Mockito.mock(Provider.class));
+      person.setProvider(EncounterType.WELLNESS, Mockito.mock(Provider.class));
       time = System.currentTimeMillis();
       person.attributes.put(Person.BIRTHDATE, time);
       person.events.create(time, Event.BIRTH, "transition metrics test", true);


### PR DESCRIPTION
This PR has two changes

- Makes wellness encounters actually use wellness providers -- previously it was using ambulatory providers.

- Fixes occasionally incorrect FHIR validation errors on `Period` datatypes, when the `start` appears to be after the `end` but the validation is not correctly accounting for timezone offset changes (i.e. daylight savings time).