### PR TITLE
Add missing component observations to concepts list

### DIFF
--- a/src/main/java/org/mitre/synthea/helpers/Concepts.java
+++ b/src/main/java/org/mitre/synthea/helpers/Concepts.java
@@ -1,5 +1,6 @@
 package org.mitre.synthea.helpers;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -131,6 +132,15 @@ public class Concepts {
     if (state.has("activities")) {
       List<Code> codes = Code.fromJson(state.getAsJsonArray("activities"));
       inventoryCodes(concepts, codes, module);
+    }
+
+    if (state.has("observations")) {
+        // MultiObservations and DiagnosticReports
+        JsonArray observations = state.getAsJsonArray("observations");
+        observations.forEach(obs -> {
+            // subobservations are full instances of the Observation state
+            inventoryState(concepts, obs.getAsJsonObject(), module);
+        });
     }
 
     if (state.has("prescription")) {


### PR DESCRIPTION
The `concepts` task is supposed to list out all of the concept codes used within the modules, but I noticed it's missing component observations. For example, the Wellness Encounters module records Blood Pressure, a `MultiObservation` with systolic and diastolic blood pressure, and a Metabolic Panel, a `DiagnosticReport` with a number of component observations, but the codes for all of those observations are missing from the concepts list. This PR adds those in.

Resulting concept list (899 concepts) is attached: 
[concepts.csv.txt](https://github.com/synthetichealth/synthea/files/3402437/concepts.csv.txt)

