### PR TITLE
Removed transition to Initial state from opioid module.

### DIFF
--- a/src/main/resources/modules/opioid_addiction.json
+++ b/src/main/resources/modules/opioid_addiction.json
@@ -149,10 +149,6 @@
         {
           "distribution": 0.334,
           "transition": "Enter_Directed_Use_Condition3"
-        },
-        {
-          "transition": "Initial",
-          "distribution": 1
         }
       ]
     },


### PR DESCRIPTION
This pull request removes an unfortunate transition back to the `Initial` state that seems to have been added in error. Even if it was intentional, it should have had no effect on the module performance, since it was the last in a list of distributed transitions.
