### PR TITLE
Support running from a JAR file

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -58,9 +58,9 @@ public class Module {
     retVal.put("Weight Loss", new ModuleSupplier(new WeightLossModule()));
 
     try {
-      URI baseFolder = ClassLoader.getSystemClassLoader().getResource("modules").toURI();
-      fixPathFromJar(baseFolder);
-      Path modulesPath = Paths.get(baseFolder);
+      URI modulesURI = ClassLoader.getSystemClassLoader().getResource("modules").toURI();
+      fixPathFromJar(modulesURI);
+      Path modulesPath = Paths.get(modulesURI);
       Path basePath = modulesPath.getParent();
       Files.walk(modulesPath, Integer.MAX_VALUE).filter(Files::isReadable).filter(Files::isRegularFile)
           .filter(p -> p.toString().endsWith(".json")).forEach(t -> {

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -17,7 +17,7 @@ public abstract class TestHelper {
    * @throws Exception On errors.
    */
   public static Module getFixture(String filename) throws Exception {
-    Path modulesFolder = Paths.get("src/test/resources/generic");
+    Path modulesFolder = Paths.get("generic");
     Path module = modulesFolder.resolve(filename);
     return Module.loadFile(module, modulesFolder);
   }


### PR DESCRIPTION
Updates the module loading process to support running Synthea from a JAR file (for instance, eclipse IDE supports exporting a project and re-packaging all dependencies into a single JAR). All other resources seem to load fine, only modules needed to be handled differently.  Without these changes, if you try to package synthea into a JAR and run it, you get various exceptions trying to load the files.

This is especially useful for running Synthea in a cluster environment; gradle lockfiles prevent multiple instances from running against the same copy at once, and running the classes directly requires a lot of separate libraries and classpath setup.