### PR TITLE
Enhanced Imaging Studies - Random number of Series and Instances

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -3,7 +3,9 @@ package org.mitre.synthea.engine;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.mitre.synthea.engine.Components.Exact;
@@ -1267,17 +1269,28 @@ public abstract class State implements Cloneable {
     private Code procedureCode;
     /** The Series of Instances that represent this ImagingStudy. */
     private List<HealthRecord.ImagingStudy.Series> series;
+    /** Minimum and maximum number of series in this study.
+     * Actual number is picked uniformly randomly from this range, copying series data from
+     * the first series provided. */
+    public int minNumberSeries = 0;
+    public int maxNumberSeries = 0;
 
     @Override
     public ImagingStudy clone() {
       ImagingStudy clone = (ImagingStudy) super.clone();
       clone.procedureCode = procedureCode;
       clone.series = series;
+      clone.minNumberSeries = minNumberSeries;
+      clone.maxNumberSeries = maxNumberSeries;
       return clone;
     }
 
     @Override
     public boolean process(Person person, long time) {
+      // Randomly pick number of series and instances if bounds were provided
+      duplicateSeries();
+      duplicateInstances();
+
       // The modality code of the first series is a good approximation
       // of the type of ImagingStudy this is
       String primaryModality = series.get(0).modality.code;
@@ -1290,6 +1303,54 @@ public abstract class State implements Cloneable {
       procedure.codes.add(procedureCode);
       procedure.stop = procedure.start + TimeUnit.MINUTES.toMillis(30);
       return true;
+    }
+
+    private void duplicateSeries() {
+      if (minNumberSeries > 0 && maxNumberSeries >= minNumberSeries
+          && series.size() > 0) {
+
+        // Randomly pick the number of series in this study
+        int numberOfSeries = ThreadLocalRandom.current().nextInt(minNumberSeries, maxNumberSeries + 1);
+        HealthRecord.ImagingStudy.Series referenceSeries = series.get(0);
+        series = new ArrayList<HealthRecord.ImagingStudy.Series>();
+
+        // Create the new series with random series UID
+        for (int i = 0; i < numberOfSeries; i++) {
+          HealthRecord.ImagingStudy.Series newSeries = referenceSeries.clone();
+          newSeries.dicomUid = Utilities.randomDicomUid(i + 1, 0);
+          series.add(newSeries);
+        }
+      } else {
+        // Ensure series references are distinct (required if no. of instances is picked randomly)
+        List<HealthRecord.ImagingStudy.Series> oldSeries = series;
+        series = new ArrayList<HealthRecord.ImagingStudy.Series>();
+        for (int i = 0; i < oldSeries.size(); i++) {
+          HealthRecord.ImagingStudy.Series newSeries = oldSeries.get(i).clone();
+          series.add(newSeries);
+        }
+      }
+    }
+
+    private void duplicateInstances() {
+      for (int i = 0; i < series.size(); i++) {
+        HealthRecord.ImagingStudy.Series s = series.get(i);
+        if (s.minNumberInstances > 0 && s.maxNumberInstances >= s.minNumberInstances
+            && s.instances.size() > 0) {
+
+          // Randomly pick the number of instances in this series
+          int numberOfInstances = ThreadLocalRandom.current()
+              .nextInt(s.minNumberInstances, s.maxNumberInstances + 1);
+          HealthRecord.ImagingStudy.Instance referenceInstance = s.instances.get(0);
+          s.instances = new ArrayList<HealthRecord.ImagingStudy.Instance>();
+
+          // Create the new instances with random instance UIDs
+          for (int j = 0; j < numberOfInstances; j++) {
+            HealthRecord.ImagingStudy.Instance newInstance = referenceInstance.clone();
+            newInstance.dicomUid = Utilities.randomDicomUid(i + 1, j + 1);
+            s.instances.add(newInstance);
+          }
+        }
+      }
     }
   }
 

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -253,7 +253,7 @@ public class HealthRecord {
      * ImagingStudy.Series represents a series of images that were taken of a
      * specific part of the body.
      */
-    public class Series {
+    public class Series implements Cloneable {
       /** A randomly assigned DICOM UID. */
       public transient String dicomUid;
       /** A SNOMED-CT body structures code. */
@@ -267,13 +267,30 @@ public class HealthRecord {
       public Code modality;
       /** One or more imaging Instances that belong to this Series. */
       public List<Instance> instances;
+      /** Minimum and maximum number of instances in this series.
+       * Actual number is picked uniformly randomly from this range, copying instance data from
+       * the first instance provided. */
+      public int minNumberInstances = 0;
+      public int maxNumberInstances = 0;
+
+      @Override
+      public Series clone() {
+        Series clone = new Series();
+        clone.dicomUid = dicomUid;
+        clone.bodySite = bodySite;
+        clone.modality = modality;
+        clone.instances = instances;
+        clone.minNumberInstances = minNumberInstances;
+        clone.maxNumberInstances = maxNumberInstances;
+        return clone;
+      }
     }
 
     /**
      * ImagingStudy.Instance represents a single imaging Instance taken as part of a
      * Series of images.
      */
-    public class Instance {
+    public class Instance implements Cloneable {
       /** A randomly assigned DICOM UID. */
       public transient String dicomUid;
       /** A title for this image. */
@@ -284,6 +301,15 @@ public class HealthRecord {
        * @see <a href="https://www.dicomlibrary.com/dicom/sop/">DICOM SOP codes</a>
        */
       public Code sopClass;
+
+      @Override
+      public Instance clone() {
+        Instance clone = new Instance();
+        clone.dicomUid = dicomUid;
+        clone.title = title;
+        clone.sopClass = sopClass;
+        return clone;
+      }
     }
   }
 

--- a/src/main/resources/modules/lung_cancer.json
+++ b/src/main/resources/modules/lung_cancer.json
@@ -1516,6 +1516,8 @@
             "code": "CT",
             "display": "Computed Tomography"
           },
+          "min_number_instances": 300,
+          "max_number_instances": 500,
           "instances": [
             {
               "title": "CT Image Storage",
@@ -1549,6 +1551,8 @@
             "code": "CT",
             "display": "Computed Tomography"
           },
+          "min_number_instances": 300,
+          "max_number_instances": 500,
           "instances": [
             {
               "title": "CT Image Storage",


### PR DESCRIPTION
This PR enhances Synthea's Imaging Study outputs through the following changes:
1. Adds options to uniformly randomly pick the number of series and instances within an ImagingStudy. Random DICOM UIDs will also be added to them.
2. Provides an example of this by modifying the Lung Cancer module.

In more detail:
1. Within the ImagingStudy state inside modules, you can provide the minimum and maximum (inclusive) number of series the ImagingStudy may contain. For this you need to provide at least one series as a reference which will then be duplicated.
Similarily within a series you may provide the minimum and maximum number of instances the series may contain, along with a reference instance.
For example, a ImagingStudy state in JSON format:
```
"State Name": {
  "type": "ImagingStudy",
  "procedure_code": { ... },
  "min_number_series": 1,
  "max_number_series": 3,
  "series": [
    {
      "body_site": { ... },
      "modality": { ... },
      "min_number_instances": 300,
      "max_number_instances": 500,
      "instances": [
        {
          "title": "CT Image Storage",
          "sop_class": { ... }
        }
      ]
    }
  ],
  "direct_transition": "Next State Name"
}
```
When processing the state, the number of series/instances is uniformly randomly picked within the range, and the reference series/instance is duplicated with new UIDs being assigned.

Note: This is backwards compatible. If the new fields are not included in the state, or have invalid values, the provided series/instances will be exported without any changes.

2. In this PR only the Lung Cancer module has been changed. A generated CT ImagingStudy will contain a single series with between 300-500 instances. Most other modules containing imaging studies are for scans producing a single instance (e.g. 2D X-Ray), so they do not need to be changed.