### PR TITLE
Module overrides

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,22 @@ task attributes(type: JavaExec) {
   main = "org.mitre.synthea.helpers.Attributes"
 }
 
+task overrides(type: JavaExec) {
+  group 'Application'
+  description 'Create a list of modules parameters in module override format'
+  classpath sourceSets.main.runtimeClasspath
+  main = "org.mitre.synthea.helpers.ModuleOverrides"
+  doFirst {
+    // TODO: is there a way to make this cleaner?
+    String includeFields = project.hasProperty('includeFields') ? project.getProperty('includeFields') : ""
+    String includeModules = project.hasProperty('includeModules') ? project.getProperty('includeModules') : ""
+    String excludeFields = project.hasProperty('excludeFields') ? project.getProperty('excludeFields') : ""
+    String excludeModules = project.hasProperty('excludeModules') ? project.getProperty('excludeModules') : ""
+
+    args(includeFields, includeModules, excludeFields, excludeModules)
+  }
+}
+
 task physiology(type: JavaExec) {
     group 'Application'
     description 'Test a physiology simulation'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ checkstyle {
 dependencies {
   // This dependency is found on compile classpath of this component and consumers.
   compile 'com.google.code.gson:gson:2.8.0'
+  compile 'com.jayway.jsonpath:json-path:2.4.0'
   compile 'ca.uhn.hapi.fhir:hapi-fhir-base:4.1.0'
   compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:4.1.0'
   compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:4.1.0'

--- a/src/main/java/Graphviz.java
+++ b/src/main/java/Graphviz.java
@@ -20,7 +20,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -31,6 +30,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 
 import org.mitre.synthea.export.Exporter;
+import org.mitre.synthea.helpers.Utilities;
 
 
 public class Graphviz {
@@ -65,9 +65,7 @@ public class Graphviz {
   private static void generateJsonModuleGraphs(Path inputPath, File outputFolder) {
     // adapted from Module.loadModules()
     try {
-      Files.walk(inputPath, Integer.MAX_VALUE)
-          .filter(Files::isReadable).filter(Files::isRegularFile)
-          .filter(p -> p.toString().endsWith(".json")).parallel().forEach(t -> {
+      Utilities.walkAllModules(inputPath, t -> {
             try {
               JsonObject module = loadFile(t, inputPath);
               String relativePath = relativePath(t, inputPath);

--- a/src/main/java/Graphviz.java
+++ b/src/main/java/Graphviz.java
@@ -66,14 +66,14 @@ public class Graphviz {
     // adapted from Module.loadModules()
     try {
       Utilities.walkAllModules(inputPath, t -> {
-            try {
-              JsonObject module = loadFile(t, inputPath);
-              String relativePath = relativePath(t, inputPath);
-              generateJsonModuleGraph(module, outputFolder, relativePath);
-            } catch (IOException e) {
-              e.printStackTrace();
-            }
-          });
+        try {
+          JsonObject module = loadFile(t, inputPath);
+          String relativePath = relativePath(t, inputPath);
+          generateJsonModuleGraph(module, outputFolder, relativePath);
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+      });
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -110,15 +110,15 @@ public class Module {
     AtomicInteger submoduleCount = new AtomicInteger();
     Path basePath = modulesPath.getParent();
     Utilities.walkAllModules(modulesPath, t -> {
-              String relativePath = relativePath(t, modulesPath);
-              boolean submodule = !t.getParent().equals(modulesPath);
-              if (submodule) {
-                submoduleCount.getAndIncrement();
-              }
-              retVal.put(relativePath, new ModuleSupplier(submodule,
-                  relativePath,
-                  () -> loadFile(basePath.relativize(t), submodule, overrides)));
-            });
+      String relativePath = relativePath(t, modulesPath);
+      boolean submodule = !t.getParent().equals(modulesPath);
+      if (submodule) {
+        submoduleCount.getAndIncrement();
+      }
+      retVal.put(relativePath, new ModuleSupplier(submodule,
+          relativePath,
+          () -> loadFile(basePath.relativize(t), submodule, overrides)));
+    });
     return submoduleCount.get();
   }
 

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -3,8 +3,14 @@ package org.mitre.synthea.engine;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.json.GsonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.GsonMappingProvider;
 
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.FileSystemNotFoundException;
@@ -20,12 +26,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.modules.CardiovascularDiseaseModule;
 import org.mitre.synthea.modules.EncounterModule;
@@ -44,6 +52,11 @@ import org.mitre.synthea.world.agents.Person;
  */
 public class Module {
 
+  private static final Configuration JSON_PATH_CONFIG = Configuration.builder()
+      .jsonProvider(new GsonJsonProvider())
+      .mappingProvider(new GsonMappingProvider())
+      .build();
+
   private static final Map<String, ModuleSupplier> modules = loadModules();
   
   private static Map<String, ModuleSupplier> loadModules() {
@@ -56,11 +69,13 @@ public class Module {
     retVal.put("Quality Of Life", new ModuleSupplier(new QualityOfLifeModule()));
     retVal.put("Weight Loss", new ModuleSupplier(new WeightLossModule()));
 
+    Properties moduleOverrides = getModuleOverrides();
+
     try {
       URI modulesURI = Module.class.getClassLoader().getResource("modules").toURI();
       fixPathFromJar(modulesURI);
       Path modulesPath = Paths.get(modulesURI);
-      submoduleCount = walkModuleTree(modulesPath, retVal);
+      submoduleCount = walkModuleTree(modulesPath, retVal, moduleOverrides);
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -72,7 +87,25 @@ public class Module {
     return retVal;
   }
 
-  private static int walkModuleTree(Path modulesPath, Map<String, ModuleSupplier> retVal)
+  private static Properties getModuleOverrides() {
+    String moduleOverrideFile = Config.get("module_override");
+    Properties overrides = null;
+    if (moduleOverrideFile != null && !moduleOverrideFile.trim().equals("")) {
+      try {
+        overrides = new Properties();
+        overrides.load(new FileReader(moduleOverrideFile));
+      } catch (IOException e) {
+        // TODO Auto-generated catch block
+        e.printStackTrace();
+      }
+    }
+    return overrides;
+  }
+
+  private static int walkModuleTree(
+          Path modulesPath, Map<String, 
+          ModuleSupplier> retVal, 
+          Properties overrides)
           throws IOException {
     AtomicInteger submoduleCount = new AtomicInteger();
     Path basePath = modulesPath.getParent();
@@ -87,7 +120,7 @@ public class Module {
               }
               retVal.put(relativePath, new ModuleSupplier(submodule,
                   relativePath,
-                  () -> loadFile(basePath.relativize(t), submodule)));
+                  () -> loadFile(basePath.relativize(t), submodule, overrides)));
             });
     return submoduleCount.get();
   }
@@ -102,8 +135,9 @@ public class Module {
   public static void addModules(File dir) {
     int submoduleCount = 0;
     int originalModuleCount = modules.size();
+    Properties moduleOverrides = getModuleOverrides();
     try {
-      walkModuleTree(dir.toPath(), modules);
+      walkModuleTree(dir.toPath(), modules, moduleOverrides);
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -136,17 +170,38 @@ public class Module {
     return relativeFilePath;
   }
 
-  public static Module loadFile(Path path, Path modulesFolder) throws Exception {
+  public static Module loadFile(Path path, Path modulesFolder, Properties overrides)
+         throws Exception {
     boolean submodule = !path.getParent().equals(modulesFolder);
-    return loadFile(path, submodule);
+    return loadFile(path, submodule, overrides);
   }
 
-  private static Module loadFile(Path path, boolean submodule) throws Exception {
+  private static Module loadFile(Path path, boolean submodule, Properties overrides)
+          throws Exception {
     System.out.format("Loading %s %s\n", submodule ? "submodule" : "module", path.toString());
     String jsonString = Utilities.readResource(path.toString());
+    if (overrides != null) {
+      jsonString = applyOverrides(jsonString, overrides, path.getFileName().toString());
+    }
     JsonParser parser = new JsonParser();
     JsonObject object = parser.parse(jsonString).getAsJsonObject();
     return new Module(object, submodule);
+  }
+
+  private static String applyOverrides(String jsonString, Properties overrides,
+          String moduleFileName) {
+    DocumentContext ctx = JsonPath.using(JSON_PATH_CONFIG).parse(jsonString);
+    overrides.forEach((key, value) -> {
+      // use :: for the separator because filenames cannot contain :
+      String[] parts = ((String)key).split("::");
+      String module = parts[0];
+      if (module.equals(moduleFileName)) {
+        String jsonPath = parts[1];
+        Double numberValue = Double.parseDouble((String)value);
+        ctx.set(jsonPath, numberValue);
+      }
+    });
+    return ctx.jsonString();
   }
 
   public static String[] getModuleNames() {

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -106,13 +106,10 @@ public class Module {
           Path modulesPath, Map<String, 
           ModuleSupplier> retVal, 
           Properties overrides)
-          throws IOException {
+          throws Exception {
     AtomicInteger submoduleCount = new AtomicInteger();
     Path basePath = modulesPath.getParent();
-    Files.walk(modulesPath, Integer.MAX_VALUE)
-            .filter(Files::isReadable)
-            .filter(Files::isRegularFile)
-            .filter(p -> p.toString().endsWith(".json")).forEach(t -> {
+    Utilities.walkAllModules(modulesPath, t -> {
               String relativePath = relativePath(t, modulesPath);
               boolean submodule = !t.getParent().equals(modulesPath);
               if (submodule) {

--- a/src/main/java/org/mitre/synthea/helpers/Attributes.java
+++ b/src/main/java/org/mitre/synthea/helpers/Attributes.java
@@ -24,10 +24,6 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -137,10 +133,7 @@ public class Attributes {
   public static Map<String,Inventory> getAttributeInventory() throws Exception {
     Map<String,Inventory> attributes = new TreeMap<String,Inventory>();
 
-    URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
-    Path path = Paths.get(modulesFolder.toURI());
-    Files.walk(path).filter(Files::isReadable).filter(Files::isRegularFile)
-        .filter(f -> f.toString().endsWith(".json")).forEach(modulePath -> {
+    Utilities.walkAllModules((basePath, modulePath) -> {
           try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
             JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
             inventoryModule(attributes, module);

--- a/src/main/java/org/mitre/synthea/helpers/Attributes.java
+++ b/src/main/java/org/mitre/synthea/helpers/Attributes.java
@@ -134,13 +134,13 @@ public class Attributes {
     Map<String,Inventory> attributes = new TreeMap<String,Inventory>();
 
     Utilities.walkAllModules((basePath, modulePath) -> {
-          try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
-            JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
-            inventoryModule(attributes, module);
-          } catch (IOException e) {
-            throw new RuntimeException("Unable to read modules", e);
-          }
-        });
+      try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
+        JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
+        inventoryModule(attributes, module);
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to read modules", e);
+      }
+    });
 
     CardiovascularDiseaseModule.inventoryAttributes(attributes);
     DeathModule.inventoryAttributes(attributes);

--- a/src/main/java/org/mitre/synthea/helpers/Concepts.java
+++ b/src/main/java/org/mitre/synthea/helpers/Concepts.java
@@ -9,10 +9,8 @@ import com.google.gson.stream.JsonReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -64,10 +62,7 @@ public class Concepts {
   public static List<String> getConceptInventory() throws Exception {
     Map<Code,Set<String>> concepts = new TreeMap<Code,Set<String>>();
 
-    URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
-    Path path = Paths.get(modulesFolder.toURI());
-    Files.walk(path).filter(Files::isReadable).filter(Files::isRegularFile)
-        .filter(f -> f.toString().endsWith(".json")).forEach(modulePath -> {
+    Utilities.walkAllModules((modulesPath, modulePath) -> {
           try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
             JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
             inventoryModule(concepts, module);

--- a/src/main/java/org/mitre/synthea/helpers/Concepts.java
+++ b/src/main/java/org/mitre/synthea/helpers/Concepts.java
@@ -63,13 +63,13 @@ public class Concepts {
     Map<Code,Set<String>> concepts = new TreeMap<Code,Set<String>>();
 
     Utilities.walkAllModules((modulesPath, modulePath) -> {
-          try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
-            JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
-            inventoryModule(concepts, module);
-          } catch (IOException e) {
-            throw new RuntimeException("Unable to read modules", e);
-          }
-        });
+      try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
+        JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
+        inventoryModule(concepts, module);
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to read modules", e);
+      }
+    });
 
     inventoryCodes(concepts, CardiovascularDiseaseModule.getAllCodes(),
         CardiovascularDiseaseModule.class.getSimpleName());

--- a/src/main/java/org/mitre/synthea/helpers/ModuleOverrides.java
+++ b/src/main/java/org/mitre/synthea/helpers/ModuleOverrides.java
@@ -4,10 +4,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -102,13 +100,7 @@ public class ModuleOverrides {
 	public List<String> generateOverrides() throws Exception {
 		List<String> lines = new LinkedList<>();
 		
-		URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
-	    Path modulesPath = Paths.get(modulesFolder.toURI());
-	    Files.walk(modulesPath)
-	    	.filter(Files::isReadable)
-	    	.filter(Files::isRegularFile)
-	        .filter(f -> f.toString().endsWith(".json"))
-	        .forEach(modulePath -> processModule(modulesPath, modulePath, lines));
+		Utilities.walkAllModules((basePath, modulePath) -> processModule(basePath, modulePath, lines));
 	    
 	    return lines;
 	}

--- a/src/main/java/org/mitre/synthea/helpers/ModuleOverrides.java
+++ b/src/main/java/org/mitre/synthea/helpers/ModuleOverrides.java
@@ -1,0 +1,166 @@
+package org.mitre.synthea.helpers;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.io.IOCase;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.stream.JsonReader;
+
+public class ModuleOverrides {
+
+	// sample line osteoporosis.json\:\:$['states']['Male']['distributed_transition'][1]['distribution'] = 0.02
+	
+	
+	private List<String> includeFields;
+	private List<String> excludeFields;
+	private FilenameFilter includeModules;
+	private FilenameFilter excludeModules;
+	
+	/**
+	 * 
+	 * @param args -- format is [includeFields,includeModules,excludeFields,excludeModules]
+	 * @throws Exception
+	 */
+	public static void main(String[] args) throws Exception {
+		String includeFieldsArg = args[0];
+		String includeModulesArg = args[1];
+		String excludeFieldsArg = args[2];
+		String excludeModulesArg = args[3];
+	
+		List<String> excludeFields = argToList(excludeFieldsArg, null);
+		List<String> includeFields;
+		if (excludeFields == null) {
+			includeFields = argToList(includeFieldsArg, Arrays.asList("distribution"));
+		} else {
+			includeFields = null; // if they exclude something, don't do anything with includes
+		}
+		
+		List<String> includeModules = argToList(includeModulesArg, null);
+		List<String> excludeModules = argToList(excludeModulesArg, null);
+		
+		System.out.println("Included fields: " + includeFields);
+		System.out.println("Excluded fields: " + excludeFields);
+		System.out.println("Included modules: " + includeModules);
+		System.out.println("Excluded modules: " + excludeModules);
+		
+		ModuleOverrides mo = new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
+		
+		List<String> lines = mo.generateOverrides();
+		
+	    Path outFilePath = new File("./output/overrides.properties").toPath();
+	    
+	    Files.write(outFilePath, lines);
+	    
+	    System.out.println("Catalogued " + lines.size() + " parameters.");
+	    System.out.println("Done.");
+	}
+	
+	private static List<String> argToList(String arg, List<String> defaults) {
+		if (arg == null || arg.isEmpty()) {
+			return defaults;
+		}
+		
+		List<String> list = new LinkedList<>();
+		
+		list.addAll( Arrays.asList(arg.split(",")) );
+		list.replaceAll(s -> s.trim());
+		
+		return list;
+	}
+	
+	public ModuleOverrides(List<String> includeFields, 
+			List<String> includeModulesList, 
+			List<String> excludeFields,
+			List<String> excludeModulesList) {
+		this.includeFields = includeFields;
+		this.excludeFields = excludeFields;
+		
+		if (includeModules != null) {
+			this.includeModules = new WildcardFileFilter(includeModulesList, IOCase.INSENSITIVE);
+		}
+		if (excludeModules != null) {
+			this.excludeModules = new WildcardFileFilter(excludeModulesList, IOCase.INSENSITIVE);
+		}
+	}
+	
+	public List<String> generateOverrides() throws Exception {
+		List<String> lines = new LinkedList<>();
+		
+		URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
+	    Path modulesPath = Paths.get(modulesFolder.toURI());
+	    Files.walk(modulesPath)
+	    	.filter(Files::isReadable)
+	    	.filter(Files::isRegularFile)
+	        .filter(f -> f.toString().endsWith(".json"))
+	        .forEach(modulePath -> processModule(modulesPath, modulePath, lines));
+	    
+	    return lines;
+	}
+	
+	private void processModule(Path modulesPath, Path modulePath, List<String> lines) {
+		String moduleFilename = modulesPath.relativize(modulePath).toString();
+
+		if ((includeModules != null && !includeModules.accept(null, moduleFilename))
+				|| (excludeModules != null && excludeModules.accept(null, moduleFilename))) {
+			return;
+		}
+		
+		try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
+			JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
+
+			String lineStart = moduleFilename + "\\:\\:$";
+			lines.addAll(handleElement(lineStart, "$", module));
+		} catch (IOException e) {
+			throw new RuntimeException("Unable to read modules", e);
+		}
+	}
+	
+	private List<String> handleElement(String path, String currentElementName, JsonElement element) {
+		// do a depth-first search, add things that are numbers
+		List<String> parameters = new LinkedList<>();
+		
+		if (element.isJsonArray()) {
+			JsonArray ja = element.getAsJsonArray();
+			for (int i = 0 ; i < ja.size() ; i++) {
+				JsonElement fieldValue = ja.get(i);
+				parameters.addAll( handleElement(path + "[" + i + "]", currentElementName, fieldValue) );
+			}
+		} else if (element.isJsonObject()) {
+			JsonObject jo = element.getAsJsonObject();
+			
+			for (String field : jo.keySet()) {
+				String safeFieldName = field.replace(" ", "\\ "); // have to escape spaces in properties file
+				JsonElement fieldValue = jo.get(field);
+				parameters.addAll( handleElement(path + "['" + safeFieldName + "']", field, fieldValue) );
+			}
+			
+		} else if (element.isJsonPrimitive()) {
+			JsonPrimitive jp = element.getAsJsonPrimitive();
+			if (jp.isNumber()) {
+				if ((includeFields != null && includeFields.contains(currentElementName))
+						|| (excludeFields != null && !excludeFields.contains(currentElementName))) {
+					String newParam = path + " = " + jp.getAsString();
+					parameters.add(newParam);	
+				}
+			}
+		}
+		
+		return parameters;
+	}
+}

--- a/src/main/java/org/mitre/synthea/helpers/ModuleOverrides.java
+++ b/src/main/java/org/mitre/synthea/helpers/ModuleOverrides.java
@@ -9,10 +9,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-
 import org.apache.commons.io.IOCase;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -22,137 +20,141 @@ import com.google.gson.stream.JsonReader;
 
 public class ModuleOverrides {
 
-	// sample line osteoporosis.json\:\:$['states']['Male']['distributed_transition'][1]['distribution'] = 0.02
-	
-	
-	private List<String> includeFields;
-	private List<String> excludeFields;
-	private FilenameFilter includeModules;
-	private FilenameFilter excludeModules;
-	
-	/**
-	 * 
-	 * @param args -- format is [includeFields,includeModules,excludeFields,excludeModules]
-	 * @throws Exception
-	 */
-	public static void main(String[] args) throws Exception {
-		String includeFieldsArg = args[0];
-		String includeModulesArg = args[1];
-		String excludeFieldsArg = args[2];
-		String excludeModulesArg = args[3];
-	
-		List<String> excludeFields = argToList(excludeFieldsArg, null);
-		List<String> includeFields;
-		if (excludeFields == null) {
-			includeFields = argToList(includeFieldsArg, Arrays.asList("distribution"));
-		} else {
-			includeFields = null; // if they exclude something, don't do anything with includes
-		}
-		
-		List<String> includeModules = argToList(includeModulesArg, null);
-		List<String> excludeModules = argToList(excludeModulesArg, null);
-		
-		System.out.println("Included fields: " + includeFields);
-		System.out.println("Excluded fields: " + excludeFields);
-		System.out.println("Included modules: " + includeModules);
-		System.out.println("Excluded modules: " + excludeModules);
-		
-		ModuleOverrides mo = new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
-		
-		List<String> lines = mo.generateOverrides();
-		
-	    Path outFilePath = new File("./output/overrides.properties").toPath();
-	    
-	    Files.write(outFilePath, lines);
-	    
-	    System.out.println("Catalogued " + lines.size() + " parameters.");
-	    System.out.println("Done.");
-	}
-	
-	private static List<String> argToList(String arg, List<String> defaults) {
-		if (arg == null || arg.isEmpty()) {
-			return defaults;
-		}
-		
-		List<String> list = new LinkedList<>();
-		
-		list.addAll( Arrays.asList(arg.split(",")) );
-		list.replaceAll(s -> s.trim());
-		
-		return list;
-	}
-	
-	public ModuleOverrides(List<String> includeFields, 
-			List<String> includeModulesList, 
-			List<String> excludeFields,
-			List<String> excludeModulesList) {
-		this.includeFields = includeFields;
-		this.excludeFields = excludeFields;
-		
-		if (includeModules != null) {
-			this.includeModules = new WildcardFileFilter(includeModulesList, IOCase.INSENSITIVE);
-		}
-		if (excludeModules != null) {
-			this.excludeModules = new WildcardFileFilter(excludeModulesList, IOCase.INSENSITIVE);
-		}
-	}
-	
-	public List<String> generateOverrides() throws Exception {
-		List<String> lines = new LinkedList<>();
-		
-		Utilities.walkAllModules((basePath, modulePath) -> processModule(basePath, modulePath, lines));
-	    
-	    return lines;
-	}
-	
-	private void processModule(Path modulesPath, Path modulePath, List<String> lines) {
-		String moduleFilename = modulesPath.relativize(modulePath).toString();
+  // sample line
+  // osteoporosis.json\:\:$['states']['Male']['distributed_transition'][1]['distribution'] = 0.02
 
-		if ((includeModules != null && !includeModules.accept(null, moduleFilename))
-				|| (excludeModules != null && excludeModules.accept(null, moduleFilename))) {
-			return;
-		}
-		
-		try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
-			JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
 
-			String lineStart = moduleFilename + "\\:\\:$";
-			lines.addAll(handleElement(lineStart, "$", module));
-		} catch (IOException e) {
-			throw new RuntimeException("Unable to read modules", e);
-		}
-	}
-	
-	private List<String> handleElement(String path, String currentElementName, JsonElement element) {
-		// do a depth-first search, add things that are numbers
-		List<String> parameters = new LinkedList<>();
-		
-		if (element.isJsonArray()) {
-			JsonArray ja = element.getAsJsonArray();
-			for (int i = 0 ; i < ja.size() ; i++) {
-				JsonElement fieldValue = ja.get(i);
-				parameters.addAll( handleElement(path + "[" + i + "]", currentElementName, fieldValue) );
-			}
-		} else if (element.isJsonObject()) {
-			JsonObject jo = element.getAsJsonObject();
-			
-			for (String field : jo.keySet()) {
-				String safeFieldName = field.replace(" ", "\\ "); // have to escape spaces in properties file
-				JsonElement fieldValue = jo.get(field);
-				parameters.addAll( handleElement(path + "['" + safeFieldName + "']", field, fieldValue) );
-			}
-			
-		} else if (element.isJsonPrimitive()) {
-			JsonPrimitive jp = element.getAsJsonPrimitive();
-			if (jp.isNumber()) {
-				if ((includeFields != null && includeFields.contains(currentElementName))
-						|| (excludeFields != null && !excludeFields.contains(currentElementName))) {
-					String newParam = path + " = " + jp.getAsString();
-					parameters.add(newParam);	
-				}
-			}
-		}
-		
-		return parameters;
-	}
+  private List<String> includeFields;
+  private List<String> excludeFields;
+  private FilenameFilter includeModules;
+  private FilenameFilter excludeModules;
+
+  /**
+   * 
+   * @param args -- format is [includeFields,includeModules,excludeFields,excludeModules]
+   * @throws Exception
+   */
+  public static void main(String[] args) throws Exception {
+    String includeFieldsArg = args[0];
+    String includeModulesArg = args[1];
+    String excludeFieldsArg = args[2];
+    String excludeModulesArg = args[3];
+
+    List<String> excludeFields = argToList(excludeFieldsArg);
+    List<String> includeFields;
+    if (excludeFields == null) {
+      includeFields = argToList(includeFieldsArg);
+      if (includeFields == null) {
+        includeFields = Arrays.asList("distribution");
+      }
+    } else {
+      includeFields = null; // if they exclude something, don't do anything with includes
+    }
+
+    List<String> includeModules = argToList(includeModulesArg);
+    List<String> excludeModules = argToList(excludeModulesArg);
+
+    System.out.println("Included fields: " + includeFields);
+    System.out.println("Excluded fields: " + excludeFields);
+    System.out.println("Included modules: " + includeModules);
+    System.out.println("Excluded modules: " + excludeModules);
+
+    ModuleOverrides mo =
+        new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
+
+    List<String> lines = mo.generateOverrides();
+
+    Path outFilePath = new File("./output/overrides.properties").toPath();
+
+    Files.write(outFilePath, lines);
+
+    System.out.println("Catalogued " + lines.size() + " parameters.");
+    System.out.println("Done.");
+  }
+
+  private static List<String> argToList(String arg) {
+    if (arg == null || arg.isEmpty()) {
+      return null;
+    }
+
+    List<String> list = new LinkedList<>();
+
+    list.addAll(Arrays.asList(arg.split(",")));
+    list.replaceAll(s -> s.trim());
+
+    return list;
+  }
+
+  public ModuleOverrides(List<String> includeFields, List<String> includeModulesList,
+      List<String> excludeFields, List<String> excludeModulesList) {
+    this.includeFields = includeFields;
+    this.excludeFields = excludeFields;
+
+    if (includeModulesList != null) {
+      this.includeModules = new WildcardFileFilter(includeModulesList, IOCase.INSENSITIVE);
+    }
+    if (excludeModulesList != null) {
+      this.excludeModules = new WildcardFileFilter(excludeModulesList, IOCase.INSENSITIVE);
+    }
+  }
+
+  public List<String> generateOverrides() throws Exception {
+    List<String> lines = new LinkedList<>();
+
+    Utilities.walkAllModules((basePath, modulePath) -> processModule(basePath, modulePath, lines));
+
+    return lines;
+  }
+
+  private void processModule(Path modulesPath, Path modulePath, List<String> lines) {
+    String moduleFilename = modulesPath.relativize(modulePath).toString();
+
+    if ((includeModules != null && !includeModules.accept(null, moduleFilename))
+        || (excludeModules != null && excludeModules.accept(null, moduleFilename))) {
+      return;
+    }
+
+    try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
+      JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
+
+      String lineStart = moduleFilename + "\\:\\:$";
+      lines.addAll(handleElement(lineStart, "$", module));
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to read modules", e);
+    }
+  }
+
+  private List<String> handleElement(String path, String currentElementName, JsonElement element) {
+    // do a depth-first search, add things that are numbers
+    List<String> parameters = new LinkedList<>();
+
+    if (element.isJsonArray()) {
+      JsonArray ja = element.getAsJsonArray();
+      for (int i = 0; i < ja.size(); i++) {
+        JsonElement fieldValue = ja.get(i);
+        parameters.addAll(handleElement(path + "[" + i + "]", currentElementName, fieldValue));
+      }
+    } else if (element.isJsonObject()) {
+      JsonObject jo = element.getAsJsonObject();
+
+      for (String field : jo.keySet()) {
+        // note: spaces have to be escaped in properties file key
+        String safeFieldName = field.replace(" ", "\\ "); 
+        JsonElement fieldValue = jo.get(field);
+        parameters.addAll(handleElement(path + "['" + safeFieldName + "']", field, fieldValue));
+      }
+
+    } else if (element.isJsonPrimitive()) {
+      JsonPrimitive jp = element.getAsJsonPrimitive();
+      if (jp.isNumber()) {
+        if ((includeFields != null && includeFields.contains(currentElementName))
+            || (excludeFields != null && !excludeFields.contains(currentElementName))) {
+          String newParam = path + " = " + jp.getAsString();
+          parameters.add(newParam);
+        }
+      }
+    }
+
+    return parameters;
+  }
 }

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -351,32 +351,34 @@ public class Utilities {
     }
     throw new IllegalArgumentException("Cannot parse value for class " + clazz);
   }
-  
+
   /**
-   * Walk the directory structure of the modules, and apply the given function for every module. 
+   * Walk the directory structure of the modules, and apply the given function for every module.
    * 
-   * @param action Action to apply for every module. Function signature is (topLevelModulesPath, currentModulePath) -> {...}
+   * @param action Action to apply for every module. Function signature is 
+   *        (topLevelModulesFolderPath, currentModulePath) -> {...}
    * @throws Exception
    */
-  public static void walkAllModules(BiConsumer<Path,Path> action) throws Exception {
-		URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
-	    Path modulesPath = Paths.get(modulesFolder.toURI());
-	    
-	    walkAllModules(modulesPath, p -> action.accept(modulesPath, p));
+  public static void walkAllModules(BiConsumer<Path, Path> action) throws Exception {
+    URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
+    Path modulesPath = Paths.get(modulesFolder.toURI());
+
+    walkAllModules(modulesPath, p -> action.accept(modulesPath, p));
   }
-  
+
   /**
-   * Walk the directory structure of the modules starting at the given location, and apply the given function for every module underneath.
+   * Walk the directory structure of the modules starting at the given location, and apply the given
+   * function for every module underneath.
    * 
-   * @param action Action to apply for every module. Function signature is (currentModulePath) -> {...}
+   * @param action Action to apply for every module. Function signature is 
+   *        (currentModulePath) -> {...}
    * @throws Exception
    */
   public static void walkAllModules(Path modulesPath, Consumer<Path> action) throws Exception {
-	    Files.walk(modulesPath, Integer.MAX_VALUE)
-	        .filter(Files::isReadable)
-	        .filter(Files::isRegularFile)
-	        .filter(p -> p.toString().endsWith(".json"))
-	        .forEach(p -> action.accept(p));
-  }
-  
+    Files.walk(modulesPath, Integer.MAX_VALUE)
+        .filter(Files::isReadable)
+        .filter(Files::isRegularFile)
+        .filter(p -> p.toString().endsWith(".json"))
+        .forEach(p -> action.accept(p));
+  } 
 }

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -357,7 +357,6 @@ public class Utilities {
    * 
    * @param action Action to apply for every module. Function signature is 
    *        (topLevelModulesFolderPath, currentModulePath) -> {...}
-   * @throws Exception
    */
   public static void walkAllModules(BiConsumer<Path, Path> action) throws Exception {
     URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
@@ -372,7 +371,6 @@ public class Utilities {
    * 
    * @param action Action to apply for every module. Function signature is 
    *        (currentModulePath) -> {...}
-   * @throws Exception
    */
   public static void walkAllModules(Path modulesPath, Consumer<Path> action) throws Exception {
     Files.walk(modulesPath, Integer.MAX_VALUE)

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -9,10 +9,15 @@ import com.google.gson.JsonPrimitive;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Calendar;
 import java.util.Random;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import org.mitre.synthea.engine.Logic;
 import org.mitre.synthea.engine.State;
@@ -346,4 +351,32 @@ public class Utilities {
     }
     throw new IllegalArgumentException("Cannot parse value for class " + clazz);
   }
+  
+  /**
+   * Walk the directory structure of the modules, and apply the given function for every module. 
+   * 
+   * @param action Action to apply for every module. Function signature is (topLevelModulesPath, currentModulePath) -> {...}
+   * @throws Exception
+   */
+  public static void walkAllModules(BiConsumer<Path,Path> action) throws Exception {
+		URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
+	    Path modulesPath = Paths.get(modulesFolder.toURI());
+	    
+	    walkAllModules(modulesPath, p -> action.accept(modulesPath, p));
+  }
+  
+  /**
+   * Walk the directory structure of the modules starting at the given location, and apply the given function for every module underneath.
+   * 
+   * @param action Action to apply for every module. Function signature is (currentModulePath) -> {...}
+   * @throws Exception
+   */
+  public static void walkAllModules(Path modulesPath, Consumer<Path> action) throws Exception {
+	    Files.walk(modulesPath, Integer.MAX_VALUE)
+	        .filter(Files::isReadable)
+	        .filter(Files::isRegularFile)
+	        .filter(p -> p.toString().endsWith(".json"))
+	        .forEach(p -> action.accept(p));
+  }
+  
 }

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -19,7 +19,7 @@ public abstract class TestHelper {
   public static Module getFixture(String filename) throws Exception {
     Path modulesFolder = Paths.get("generic");
     Path module = modulesFolder.resolve(filename);
-    return Module.loadFile(module, modulesFolder);
+    return Module.loadFile(module, modulesFolder, null);
   }
 
   /**

--- a/src/test/java/org/mitre/synthea/engine/ModuleTest.java
+++ b/src/test/java/org/mitre/synthea/engine/ModuleTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 import org.junit.Test;
+import org.mitre.synthea.helpers.Utilities;
 import org.powermock.reflect.Whitebox;
 
 public class ModuleTest {
@@ -134,14 +135,7 @@ public class ModuleTest {
    */
   @Test
   public void targetEncounters() throws Exception {
-    URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
-    Path path = Paths.get(modulesFolder.toURI());
-
-    Files.walk(path, Integer.MAX_VALUE)
-        .filter(Files::isReadable)
-        .filter(Files::isRegularFile)
-        .filter(p -> p.toString().endsWith(".json"))
-        .forEach(t -> {
+    Utilities.walkAllModules((modulesFolder, t) -> {
           try {
             FileReader fileReader = new FileReader(t.toString());
             JsonReader reader = new JsonReader(fileReader);

--- a/src/test/java/org/mitre/synthea/engine/ModuleTest.java
+++ b/src/test/java/org/mitre/synthea/engine/ModuleTest.java
@@ -16,10 +16,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -136,25 +132,25 @@ public class ModuleTest {
   @Test
   public void targetEncounters() throws Exception {
     Utilities.walkAllModules((modulesFolder, t) -> {
-          try {
-            FileReader fileReader = new FileReader(t.toString());
-            JsonReader reader = new JsonReader(fileReader);
-            JsonParser parser = new JsonParser();
-            JsonObject object = parser.parse(reader).getAsJsonObject();
-            JsonObject states = object.getAsJsonObject("states");
-            for (String stateName : states.keySet()) {
-              JsonObject state = states.getAsJsonObject(stateName);
-              if (state.has("target_encounter")) {
-                String type = state.get("type").getAsString();
-                if (!type.endsWith("Onset")) {
-                  System.err.println(t.toString() + " => " + stateName + "(" + type + ")");
-                }
-                assertTrue(type.endsWith("Onset"));
-              }
+      try {
+        FileReader fileReader = new FileReader(t.toString());
+        JsonReader reader = new JsonReader(fileReader);
+        JsonParser parser = new JsonParser();
+        JsonObject object = parser.parse(reader).getAsJsonObject();
+        JsonObject states = object.getAsJsonObject("states");
+        for (String stateName : states.keySet()) {
+          JsonObject state = states.getAsJsonObject(stateName);
+          if (state.has("target_encounter")) {
+            String type = state.get("type").getAsString();
+            if (!type.endsWith("Onset")) {
+              System.err.println(t.toString() + " => " + stateName + "(" + type + ")");
             }
-          } catch (Exception e) {
-            fail(e.getMessage());
+            assertTrue(type.endsWith("Onset"));
           }
-        });
+        }
+      } catch (Exception e) {
+        fail(e.getMessage());
+      }
+    });
   }
 }

--- a/src/test/java/org/mitre/synthea/helpers/ModuleOverridesTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/ModuleOverridesTest.java
@@ -1,0 +1,155 @@
+package org.mitre.synthea.helpers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import com.jayway.jsonpath.internal.Path;
+import com.jayway.jsonpath.internal.path.PathCompiler;
+  
+public class ModuleOverridesTest {
+
+  @Test
+  public void testOverridesAllNulls() throws Exception {
+    List<String> includeFields = null;
+    List<String> includeModules = null;
+    List<String> excludeFields = null;
+    List<String> excludeModules = null;
+    ModuleOverrides mo = new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
+    List<String> overrides = mo.generateOverrides();
+    assertNotNull(overrides);
+    assertTrue(overrides.size() == 0);
+  }
+  
+  @Test
+  public void testOverridesDistributions() throws Exception {
+    List<String> includeFields = Arrays.asList("distribution");
+    List<String> includeModules = null;
+    List<String> excludeFields = null;
+    List<String> excludeModules = null;
+    ModuleOverrides mo = new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
+    List<String> overrides = mo.generateOverrides();
+    assertNotNull(overrides);
+    assertTrue(overrides.size() > 0);
+    String fullFileContent = String.join(System.lineSeparator(), overrides);
+    Properties props = new Properties();
+    props.load( IOUtils.toInputStream(fullFileContent, StandardCharsets.UTF_8) );
+    
+    props.forEach((k,v) -> {
+      String key = k.toString();
+      String value = v.toString();
+      assertStringEndsWith(key, "['distribution']");
+      assertCorrectFormat(key, value);
+    });
+  }
+  
+  @Test
+  public void testOverridesIncludeModule() throws Exception {
+    List<String> includeFields = Arrays.asList("distribution");
+    List<String> includeModules = Arrays.asList("med_rec*");
+    List<String> excludeFields = null;
+    List<String> excludeModules = null;
+    ModuleOverrides mo = new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
+    List<String> overrides = mo.generateOverrides();
+    assertNotNull(overrides);
+    assertTrue(overrides.size() > 0); // it should == 1 but i don't want to tie it too tightly to the module
+    String fullFileContent = String.join(System.lineSeparator(), overrides);
+    Properties props = new Properties();
+    props.load( IOUtils.toInputStream(fullFileContent, StandardCharsets.UTF_8) );
+    
+    props.forEach((k,v) -> {
+      String key = k.toString();
+      String value = v.toString();
+      assertStringContains(key, "med_rec.json");
+      assertStringEndsWith(key, "['distribution']");
+      assertCorrectFormat(key, value);
+    });
+  }
+  
+  @Test
+  public void testOverridesExcludeFields() throws Exception {
+    List<String> includeFields = null;
+    List<String> includeModules = null;
+    List<String> excludeFields = Arrays.asList("distribution");
+    List<String> excludeModules = null;
+    ModuleOverrides mo = new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
+    List<String> overrides = mo.generateOverrides();
+    assertNotNull(overrides);
+    assertTrue(overrides.size() > 0);
+    String fullFileContent = String.join(System.lineSeparator(), overrides);
+    Properties props = new Properties();
+    props.load( IOUtils.toInputStream(fullFileContent, StandardCharsets.UTF_8) );
+    
+    props.forEach((k,v) -> {
+      String key = k.toString();
+      String value = v.toString();
+      assertStringDoesNotEndWith(key, "['distribution']");
+      assertCorrectFormat(key, value);
+    });
+  }
+  
+  @Test
+  public void testOverridesExcludeModule() throws Exception {
+    List<String> includeFields = Arrays.asList("distribution");
+    List<String> includeModules = null;
+    List<String> excludeFields = null;
+    List<String> excludeModules = Arrays.asList("med_rec*");
+    ModuleOverrides mo = new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
+    List<String> overrides = mo.generateOverrides();
+    assertNotNull(overrides);
+    assertTrue(overrides.size() > 0);
+    String fullFileContent = String.join(System.lineSeparator(), overrides);
+    Properties props = new Properties();
+    props.load( IOUtils.toInputStream(fullFileContent, StandardCharsets.UTF_8) );
+    
+    props.forEach((k,v) -> {
+      String key = k.toString();
+      String value = v.toString();
+      assertStringDoesNotContain(key, "med_rec.json");
+      assertStringEndsWith(key, "['distribution']");
+      assertCorrectFormat(key, value);
+    });
+  }
+  
+  private static void assertCorrectFormat(String key, String value) {
+    assertTrue(key.contains("::"));
+    String[] keyParts = key.split("::");
+    String filePart = keyParts[0];
+    assertStringEndsWith(filePart, ".json");
+    String jsonPathPart = keyParts[1];
+    Path jsonPath = PathCompiler.compile(jsonPathPart);
+    assertNotNull(jsonPath); // confirm the key is valid JSONPath
+    assertTrue(isNumeric(value));
+  }
+  
+  private static void assertStringContains(String str, String shouldContain) {
+    assertTrue("Expected '" + str + "' to contain '" + shouldContain + "'", str.contains(shouldContain));
+  }
+  
+  private static void assertStringDoesNotContain(String str, String shouldContain) {
+    assertFalse("Expected '" + str + "' to not contain '" + shouldContain + "'", str.contains(shouldContain));
+  }
+  
+  private static void assertStringEndsWith(String str, String shouldContain) {
+    assertTrue("Expected '" + str + "' to end with '" + shouldContain + "'", str.endsWith(shouldContain));
+  }
+  
+  private static void assertStringDoesNotEndWith(String str, String shouldContain) {
+    assertFalse("Expected '" + str + "' to not end with '" + shouldContain + "'", str.endsWith(shouldContain));
+  }
+  
+  private static boolean isNumeric(String str) { 
+    try {  
+      Double.parseDouble(str);  
+      return true;
+    } catch(NumberFormatException e){  
+      return false;  
+    }  
+  }
+  
+}

--- a/src/test/java/org/mitre/synthea/helpers/ModuleOverridesTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/ModuleOverridesTest.java
@@ -3,15 +3,18 @@ package org.mitre.synthea.helpers;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import com.jayway.jsonpath.internal.Path;
+import com.jayway.jsonpath.internal.path.PathCompiler;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
-import com.jayway.jsonpath.internal.Path;
-import com.jayway.jsonpath.internal.path.PathCompiler;
-  
+
 public class ModuleOverridesTest {
 
   @Test
@@ -20,49 +23,54 @@ public class ModuleOverridesTest {
     List<String> includeModules = null;
     List<String> excludeFields = null;
     List<String> excludeModules = null;
-    ModuleOverrides mo = new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
+    ModuleOverrides mo =
+        new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
     List<String> overrides = mo.generateOverrides();
     assertNotNull(overrides);
     assertTrue(overrides.size() == 0);
   }
-  
+
   @Test
   public void testOverridesDistributions() throws Exception {
     List<String> includeFields = Arrays.asList("distribution");
     List<String> includeModules = null;
     List<String> excludeFields = null;
     List<String> excludeModules = null;
-    ModuleOverrides mo = new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
+    ModuleOverrides mo =
+        new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
     List<String> overrides = mo.generateOverrides();
     assertNotNull(overrides);
     assertTrue(overrides.size() > 0);
     String fullFileContent = String.join(System.lineSeparator(), overrides);
     Properties props = new Properties();
-    props.load( IOUtils.toInputStream(fullFileContent, StandardCharsets.UTF_8) );
-    
-    props.forEach((k,v) -> {
+    props.load(IOUtils.toInputStream(fullFileContent, StandardCharsets.UTF_8));
+
+    props.forEach((k, v) -> {
       String key = k.toString();
       String value = v.toString();
       assertStringEndsWith(key, "['distribution']");
       assertCorrectFormat(key, value);
     });
   }
-  
+
   @Test
   public void testOverridesIncludeModule() throws Exception {
     List<String> includeFields = Arrays.asList("distribution");
     List<String> includeModules = Arrays.asList("med_rec*");
     List<String> excludeFields = null;
     List<String> excludeModules = null;
-    ModuleOverrides mo = new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
+    ModuleOverrides mo =
+        new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
     List<String> overrides = mo.generateOverrides();
     assertNotNull(overrides);
-    assertTrue(overrides.size() > 0); // it should == 1 but i don't want to tie it too tightly to the module
+    assertTrue(overrides.size() > 0);
+    // note: this is an easy example module, should == 1, 
+    // but i don't want to tie the test too tightly to a real module that may change
     String fullFileContent = String.join(System.lineSeparator(), overrides);
     Properties props = new Properties();
-    props.load( IOUtils.toInputStream(fullFileContent, StandardCharsets.UTF_8) );
-    
-    props.forEach((k,v) -> {
+    props.load(IOUtils.toInputStream(fullFileContent, StandardCharsets.UTF_8));
+
+    props.forEach((k, v) -> {
       String key = k.toString();
       String value = v.toString();
       assertStringContains(key, "med_rec.json");
@@ -70,44 +78,46 @@ public class ModuleOverridesTest {
       assertCorrectFormat(key, value);
     });
   }
-  
+
   @Test
   public void testOverridesExcludeFields() throws Exception {
     List<String> includeFields = null;
     List<String> includeModules = null;
     List<String> excludeFields = Arrays.asList("distribution");
     List<String> excludeModules = null;
-    ModuleOverrides mo = new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
+    ModuleOverrides mo =
+        new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
     List<String> overrides = mo.generateOverrides();
     assertNotNull(overrides);
     assertTrue(overrides.size() > 0);
     String fullFileContent = String.join(System.lineSeparator(), overrides);
     Properties props = new Properties();
-    props.load( IOUtils.toInputStream(fullFileContent, StandardCharsets.UTF_8) );
-    
-    props.forEach((k,v) -> {
+    props.load(IOUtils.toInputStream(fullFileContent, StandardCharsets.UTF_8));
+
+    props.forEach((k, v) -> {
       String key = k.toString();
       String value = v.toString();
       assertStringDoesNotEndWith(key, "['distribution']");
       assertCorrectFormat(key, value);
     });
   }
-  
+
   @Test
   public void testOverridesExcludeModule() throws Exception {
     List<String> includeFields = Arrays.asList("distribution");
     List<String> includeModules = null;
     List<String> excludeFields = null;
     List<String> excludeModules = Arrays.asList("med_rec*");
-    ModuleOverrides mo = new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
+    ModuleOverrides mo =
+        new ModuleOverrides(includeFields, includeModules, excludeFields, excludeModules);
     List<String> overrides = mo.generateOverrides();
     assertNotNull(overrides);
     assertTrue(overrides.size() > 0);
     String fullFileContent = String.join(System.lineSeparator(), overrides);
     Properties props = new Properties();
-    props.load( IOUtils.toInputStream(fullFileContent, StandardCharsets.UTF_8) );
-    
-    props.forEach((k,v) -> {
+    props.load(IOUtils.toInputStream(fullFileContent, StandardCharsets.UTF_8));
+
+    props.forEach((k, v) -> {
       String key = k.toString();
       String value = v.toString();
       assertStringDoesNotContain(key, "med_rec.json");
@@ -115,7 +125,7 @@ public class ModuleOverridesTest {
       assertCorrectFormat(key, value);
     });
   }
-  
+
   private static void assertCorrectFormat(String key, String value) {
     assertTrue(key.contains("::"));
     String[] keyParts = key.split("::");
@@ -126,30 +136,33 @@ public class ModuleOverridesTest {
     assertNotNull(jsonPath); // confirm the key is valid JSONPath
     assertTrue(isNumeric(value));
   }
-  
+
   private static void assertStringContains(String str, String shouldContain) {
-    assertTrue("Expected '" + str + "' to contain '" + shouldContain + "'", str.contains(shouldContain));
+    assertTrue("Expected '" + str + "' to contain '" + shouldContain + "'",
+        str.contains(shouldContain));
   }
-  
+
   private static void assertStringDoesNotContain(String str, String shouldContain) {
-    assertFalse("Expected '" + str + "' to not contain '" + shouldContain + "'", str.contains(shouldContain));
+    assertFalse("Expected '" + str + "' to not contain '" + shouldContain + "'",
+        str.contains(shouldContain));
   }
-  
+
   private static void assertStringEndsWith(String str, String shouldContain) {
-    assertTrue("Expected '" + str + "' to end with '" + shouldContain + "'", str.endsWith(shouldContain));
+    assertTrue("Expected '" + str + "' to end with '" + shouldContain + "'",
+        str.endsWith(shouldContain));
   }
-  
+
   private static void assertStringDoesNotEndWith(String str, String shouldContain) {
-    assertFalse("Expected '" + str + "' to not end with '" + shouldContain + "'", str.endsWith(shouldContain));
+    assertFalse("Expected '" + str + "' to not end with '" + shouldContain + "'",
+        str.endsWith(shouldContain));
   }
-  
-  private static boolean isNumeric(String str) { 
-    try {  
-      Double.parseDouble(str);  
+
+  private static boolean isNumeric(String str) {
+    try {
+      Double.parseDouble(str);
       return true;
-    } catch(NumberFormatException e){  
-      return false;  
-    }  
+    } catch (NumberFormatException e) {
+      return false;
+    }
   }
-  
 }


### PR DESCRIPTION
Starting point for "module overrides". The idea here is that we can provide a module override file at runtime that defines parameters that override parts of the generic modules. There are a number of possible use cases for this, for example pre-defining alternative populations (think "internationalization", such as "run with this override file to produce a population matching all condition prevalence rates in Germany"). Also includes a task that can generate a base set of override files with some configurability.

The format of the overrides file is a java properties file, with format:
```
(module file path)::(jsonpath to value) = (new value)
```

example:
```
congestive_heart_failure.json\:\:$['states']['Age_70-79-Chance\ of\ CHF']['distributed_transition'][0]['distribution'] = 0.024
congestive_heart_failure.json\:\:$['states']['Age_80-Chance\ of\ CHF']['distributed_transition'][0]['distribution'] = 0.045
atopy.json\:\:$['states']['Initial']['complex_transition'][0]['distributions'][0]['distribution'] = 0.917
atopy.json\:\:$['states']['Initial']['complex_transition'][1]['distributions'][0]['distribution'] = 0.033
```

The way that this feature is used is by setting a config property:
```shell
run_synthea --module_override=path_to_properties_file
```

Note that I also extracted the common "for each module" logic into a new utility method since the exact same boilerplate was used in 5+ places. Apologies for the extra diffs but if you view it in "ignore whitespace mode" it's more obvious what the actual change to those files was.