### PR TITLE
Fix incorrect RxNorm codes in Synthea

### DIFF
--- a/src/main/resources/costs/medications.csv
+++ b/src/main/resources/costs/medications.csv
@@ -2,7 +2,7 @@ CODE,MIN,MODE,MAX,COMMENTS
 312617,2,7,25,predniSONE 5 MG Oral Tablet
 1870230,150,350,530,NDA020800 0.3 ML Epinephrine 1 MG/ML Auto-Injector
 895994,6,20,60,120 ACTUAT Fluticasone propionate 0.044 MG/ACTUAT Metered Dose Inhaler -- note that brand name Flovent HFA ranges from 130 - 500
-745679,5,65,300,200 ACTUAT Albuterol 0.09 MG/ACTUAT Metered Dose Inhaler
+2123111,0.72,62.31,1174.83,NDA020503 200 ACTUAT Albuterol 0.09 MG/ACTUAT Metered Dose Inhale
 1091392,20,90,250,"Methylphenidate Hydrochloride 20 MG Oral Tablet -- note high variability on this one, I see 20-250, avg is ~90"
 608139,100,300,700,atomoxetine 100 MG Oral Capsule
 1043400,4,8,12,Acetaminophen 21.7 MG/ML / Dextromethorphan Hydrobromide 1 MG/ML / doxylamine succinate 0.417 MG/ML Oral Solution - OTC cough syrup
@@ -12,7 +12,6 @@ CODE,MIN,MODE,MAX,COMMENTS
 1366343,300,600,800,Levonorgestrel 0.00354 MG/HR Drug Implant -- using 365 from https://www.washingtonpost.com/archive/lifestyle/wellness/1993/11/16/the-price-of-norplant/fc4fb471-7b53-4b87-9abb-bad368b88042/ adjusted to 2018 dollars
 389221,300,600,800, Etonogestrel 68 MG Drug Implant-- assuming the same cost for all 3 implants
 1000126,20,55,715,1 ML medroxyprogesterone acetate 150 MG/ML Injection - est https://clearhealthcosts.com/blog/2014/05/much-depo-provera-cost-draft/
-1000156,20,55,715,0.65 ML medroxyprogesterone acetate 160 MG/ML Prefilled Syringe
 807283,800,1000,1494,"Mirena 52 MG Intrauterine System -- all 3 IUDs estimated at 1000, based on http://time.com/4985605/iud-birth-control-health-insurance/"
 1605257,800,1000,1494,Liletta 52 MG Intrauterine System
 1856546,800,1000,1494,Kyleena 19.5 MG Intrauterine System
@@ -36,24 +35,24 @@ CODE,MIN,MODE,MAX,COMMENTS
 313185,1280,1350,1447,Tacrine 10 MG Oral Capsule -- using yearly cost from https://webcache.googleusercontent.com/search?q=cache:tEYxPDcg0UoJ:https://www.thepharmaletter.com/article/cognex-approved-for-alzheimer-s-in-usa+&cd=12&hl=en&ct=clnk&gl=us&client=firefox-b-1
 1599803,400,450,600,24 HR Donepezil hydrochloride 10 MG / Memantine hydrochloride 28 MG Extended Release Oral Capsule -- https://www.drugs.com/price-guide/namzaric
 996740,33,275,900,Memantine hydrochloride 2 MG/ML Oral Solution
-998582,2,250,630,"Donepezil hydrochloride 23 MG [Aricept] -- note aricept expensive, generic only ~10"
+1100184,1.19,19.76,1417.21,Donepezil hydrochloride 23 MG Oral Tablet
 106258,3,7,12,Hydrocortisone 10 MG/ML Topical Cream - OTC
 308971,2,35,500,Carbamazepine[Tegretol] -- note fairly high variability
-563026,0.66,6,200,Diazepam [Valium]
-1153378,1.5,8,150,Clonazepam [Klonopin]
+197591,0.24,9.77,3120.45,Diazepam 5 MG Oral Tablet
+204892,0.11,9.36,1097.62,clonazePAM 0.25 MG Oral Tablet
 198014,3,8,30,Naproxen 500 MG Oral Tablet
 483438,40,300,1200,pregabalin 100 MG Oral Capsule
 596926,32,200,750,duloxetine 20 MG Delayed Release Oral Capsule
-833137,80,225,415,Milnacipran hydrochloride 100 MG [Savella]
-1049636,3,50,1300,Acetaminophen 325 MG / oxyCODONE Hydrochloride 2.5 MG [Percocet]
-858069,20,250,550,Colchicine 0.6 MG [Colcrys]
+833135,36.12,306.20,930.26,Milnacipran hydrochloride 100 MG Oral Tablet
+1049635,1.39,45.37,5767.86,Acetaminophen 325 MG / oxyCODONE Hydrochloride 2.5 MG Oral Tablet
+197541,7,219.82,1186.61,Colchicine 0.6 MG Oral Tablet
 197319,2,10,35,Allopurinol 100 MG Oral Tablet
 1736854,400,445,500,Cisplatin 50 MG Injection -- https://www.mskcc.org/sites/default/files/node/25097/documents/drug-prices-table-bach-center-health-policy-and-outcomes-v2.pdf
 1734340,150,200,250,Etoposide 100 MG Injection -- https://www.drugs.com/price-guide/etoposide
 583214,6000,6500,6800,PACLitaxel 100 MG Injection -- few instances in data set
 849574,6,8,11,Naproxen sodium 220 MG Oral Tablet - OTC
-567645,2,7,25,predniSONE 2.5 MG [Deltasone]
-835900,50,200,650,cycloSPORINE  modified 100 MG [Neoral]
+312615,0.74,8.12,6882.55,predniSONE 20 MG Oral Tablet
+241834,17.05,177.41,913.68,cycloSPORIN modified 100 MG Oral Capsule
 105078,0.01,7,43,Penicillin G 375 MG/ML Injectable Solution
 789980,11,175,350,Ampicillin 100 MG/ML Injectable Solution
 1652673,8.8,60,733,Doxycycline Monohydrate 50 MG Oral Tablet
@@ -78,7 +77,7 @@ CODE,MIN,MODE,MAX,COMMENTS
 1014676,15,19,25,cetirizine hydrochloride 5 MG Oral Tablet - OTC [zyrtec]
 1014678,15,19,25,cetirizine hydrochloride 10 MG Oral Tablet - OTC [zyrtec]
 243670,4,6.5,12,Aspirin 81 MG Oral Tablet - OTC
-282464,3,4,8,Acetaminophen 160 MG Oral Tablet - OTC
+313820,3,4,8,Acetaminophen 160 MG Chewable Tablet - OTC
 313782,4,5,10,Acetaminophen 325 MG Oral Tablet - OTC
 198405,1.11,7,45,Ibuprofen 100 MG Oral Tablet
 310965,1.11,8,45,Ibuprofen 200 MG Oral Tablet
@@ -90,11 +89,11 @@ CODE,MIN,MODE,MAX,COMMENTS
 1373463,75,400,885,canagliflozin 100 MG Oral Tablet
 106892,25,250,1000,insulin human  isophane 70 UNT/ML / Regular Insulin  Human 30 UNT/ML Injectable Suspension [Humulin]
 865098,75,350,1800,Insulin Lispro 100 UNT/ML Injectable Solution [Humalog]
-1310197,2.36,50,500,Acetaminophen 300 MG / HYDROcodone Bitartrate 5 MG [Vicodin]
+856987,1.11,21.28,2424.04,Acetaminophen 300 MG / HYDROcodone Bitartrate 5 MG Oral Tablet
 1860154,3,200,2700,Abuse-Deterrent 12 HR Oxycodone Hydrochloride 15 MG Extended Release Oral Tablet
 1049221,2.83,800,2258,Acetaminophen 325 MG / Oxycodone Hydrochloride 5 MG Oral Tablet -- see other percocet above
 904419,2.55,110,303,Alendronic acid 10 MG Oral Tablet -- SEE ALENDRONATE SODIUM
-105586,5.5,70,180,Methotrexate 10 MG Oral Tablet
+105585,1.13,51.66,539.60,Methotrexate 2.5 MG Oral Tablet
 562251,3,16,153,Amoxicillin 250 MG / Clavulanate 125 MG Oral Tablet -- see AMOX TR-POTASSIUM CLAVULANATE
 834061,0.01,7,43,Penicillin V Potassium 250 MG Oral Tablet
 834102,0.01,7,43,Penicillin V Potassium 500 MG Oral Tablet

--- a/src/main/resources/modules/asthma.json
+++ b/src/main/resources/modules/asthma.json
@@ -254,8 +254,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "745679",
-          "display": "200 ACTUAT Albuterol 0.09 MG/ACTUAT Metered Dose Inhaler"
+          "code": "2123111",
+          "display": "NDA020503 200 ACTUAT Albuterol 0.09 MG/ACTUAT Metered Dose Inhaler"
         }
       ],
       "prescription": {

--- a/src/main/resources/modules/breast_cancer.json
+++ b/src/main/resources/modules/breast_cancer.json
@@ -1009,8 +1009,8 @@
                 "codes": [
                   {
                     "system": "RxNorm",
-                    "code": 10324,
-                    "display": "Tamoxifen"
+                    "code": "198240",
+                    "display": "Tamoxifen 10 MG Oral Tablet"
                   }
                 ]
               },
@@ -1019,8 +1019,8 @@
                 "codes": [
                   {
                     "system": "RxNorm",
-                    "code": 38409,
-                    "display": "Toremifene"
+                    "code": "313428",
+                    "display": "Toremifene 60 MG Oral Tablet"
                   }
                 ]
               }
@@ -1082,8 +1082,8 @@
                 "codes": [
                   {
                     "system": "RxNorm",
-                    "code": 258494,
-                    "display": "exemestane"
+                    "code": "310261",
+                    "display": "exemestane 25 MG Oral Tablet"
                   }
                 ]
               },
@@ -1095,8 +1095,8 @@
                     "codes": [
                       {
                         "system": "RxNorm",
-                        "code": 84857,
-                        "display": "anastrozole"
+                        "code": "199224",
+                        "display": "anastrozole 1 MG Oral Tablet"
                       }
                     ]
                   },
@@ -1105,8 +1105,8 @@
                     "codes": [
                       {
                         "system": "RxNorm",
-                        "code": 72965,
-                        "display": "letrozole"
+                        "code": "200064",
+                        "display": "letrozole 2.5 MG Oral Tablet"
                       }
                     ]
                   }

--- a/src/main/resources/modules/breast_cancer/hormonetherapy_breast.json
+++ b/src/main/resources/modules/breast_cancer/hormonetherapy_breast.json
@@ -343,8 +343,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 1946831,
-          "display": "abemaciclib 100 MG Oral Tablet"
+          "code": 1946840,
+          "display": "Verzenio 100 MG Oral Tablet"
         }
       ],
       "direct_transition": "ER_PR_medication_end",

--- a/src/main/resources/modules/congestive_heart_failure.json
+++ b/src/main/resources/modules/congestive_heart_failure.json
@@ -292,8 +292,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 315971,
-          "display": "Lasix 40mg"
+          "code": "313988",
+          "display": "Furosemide 40 MG Oral Tablet"
         }
       ],
       "direct_transition": "Assign CHF care plan",

--- a/src/main/resources/modules/contraceptives/injectable_contraceptive.json
+++ b/src/main/resources/modules/contraceptives/injectable_contraceptive.json
@@ -124,8 +124,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "1000156",
-          "display": "0.65 ML medroxyprogesterone acetate 160 MG/ML Prefilled Syringe"
+          "code": "1000126",
+          "display": "1 ML medroxyPROGESTERone acetate 150 MG/ML Injection"
         }
       ],
       "direct_transition": "Initial_Injection_By_Physician"

--- a/src/main/resources/modules/cystic_fibrosis.json
+++ b/src/main/resources/modules/cystic_fibrosis.json
@@ -479,8 +479,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 210856,
-          "display": "Pancreatin 4X 600 MG Oral Tablet"
+          "code": "198767",
+          "display": "Pancreatin 600 MG Oral Tablet"
         }
       ],
       "direct_transition": "CF_CarePlan",
@@ -1210,8 +1210,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 998755,
-          "display": "Ciprofloxacin 10MG/ML"
+          "code": 1665227,
+          "display": "20 ML Ciprofloxacin 10 MG/ML Injection"
         }
       ],
       "direct_transition": "Pulmonary_Function_Test",

--- a/src/main/resources/modules/cystic_fibrosis.json
+++ b/src/main/resources/modules/cystic_fibrosis.json
@@ -686,8 +686,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 1655927,
-          "display": "Ivacaftor"
+          "code": 1243052,
+          "display": "Kalydeco 150 MG Oral Tablet"
         }
       ],
       "direct_transition": "Prescribe_Mucus_Thinner",
@@ -1225,8 +1225,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 1160499,
-          "display": "IV antibiotic Vancomycin"
+          "code": 313572,
+          "display": "Vancomycin 50 MG/ML Injectable Solution"
         }
       ],
       "direct_transition": "Pulmonary_Function_Test",

--- a/src/main/resources/modules/dementia.json
+++ b/src/main/resources/modules/dementia.json
@@ -543,8 +543,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "998582",
-          "display": "Donepezil hydrochloride 23 MG [Aricept]"
+          "code": "1100184",
+          "display": "Donepezil hydrochloride 23 MG Oral Tablet"
         }
       ],
       "direct_transition": "End_ModeratelySevere_Encounter"

--- a/src/main/resources/modules/dermatitis.json
+++ b/src/main/resources/modules/dermatitis.json
@@ -560,8 +560,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "835900",
-          "display": "cycloSPORINE 50 MG Oral Capsule"
+          "code": "241834",
+          "display": "cycloSPORINE, modified 100 MG Oral Capsule"
         }
       ],
       "prescription": {
@@ -607,8 +607,8 @@
             "codes": [
               {
                 "system": "RxNorm",
-                "code": "835900",
-                "display": "cycloSPORINE 50 MG Oral Capsule"
+                "code": "241834",
+                "display": "cycloSPORINE, modified 100 MG Oral Capsule"
               }
             ]
           },

--- a/src/main/resources/modules/epilepsy.json
+++ b/src/main/resources/modules/epilepsy.json
@@ -301,8 +301,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "563026",
-          "display": "Diazepam [Valium]"
+          "code": "197591",
+          "display": "Diazepam 5 MG Oral Tablet"
         }
       ],
       "assign_to_attribute": "seizure_meds",

--- a/src/main/resources/modules/epilepsy.json
+++ b/src/main/resources/modules/epilepsy.json
@@ -324,8 +324,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "1153378",
-          "display": "Clonazepam [Klonopin]"
+          "code": "204892",
+          "display": "clonazePAM 0.25 MG Oral Tablet"
         }
       ],
       "assign_to_attribute": "seizure_meds",

--- a/src/main/resources/modules/fibromyalgia.json
+++ b/src/main/resources/modules/fibromyalgia.json
@@ -343,8 +343,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "1049636",
-          "display": "Acetaminophen 325 MG / oxyCODONE Hydrochloride 2.5 MG [Percocet]"
+          "code": "1049635",
+          "display": "Acetaminophen 325 MG / oxyCODONE Hydrochloride 2.5 MG Oral Tablet"
         }
       ],
       "direct_transition": "End_Episode_Encounter"

--- a/src/main/resources/modules/fibromyalgia.json
+++ b/src/main/resources/modules/fibromyalgia.json
@@ -327,8 +327,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "833137",
-          "display": "Milnacipran hydrochloride 100 MG [Savella]"
+          "code": "833135",
+          "display": "Milnacipran hydrochloride 100 MG Oral Tablet"
         }
       ],
       "direct_transition": "End_Episode_Encounter"

--- a/src/main/resources/modules/gallstones.json
+++ b/src/main/resources/modules/gallstones.json
@@ -1233,8 +1233,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 314659,
-          "display": "heparin sodium, porcine"
+          "code": "1659263",
+          "display": "1 ML heparin sodium, porcine 5000 UNT/ML Injection"
         }
       ],
       "direct_transition": "Heparin_End"

--- a/src/main/resources/modules/gout.json
+++ b/src/main/resources/modules/gout.json
@@ -204,8 +204,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "858069",
-          "display": "Colchicine 0.6 MG [Colcrys]"
+          "code": "197541",
+          "display": "Colchicine 0.6 MG Oral Tablet"
         }
       ],
       "direct_transition": "Uric_Acid_Reducer"

--- a/src/main/resources/modules/hypertension.json
+++ b/src/main/resources/modules/hypertension.json
@@ -54,8 +54,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 316049,
-          "display": "Hydrochlorothiazide 25 MG"
+          "code": 310798,
+          "display": "Hydrochlorothiazide 25 MG Oral Tablet"
         }
       ],
       "prescription": {
@@ -143,8 +143,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 999969,
-          "display": "Amlodipine 5 MG / Hydrochlorothiazide 12.5 MG / Olmesartan medoxomil 20 MG"
+          "code": 999967,
+          "display": "amLODIPine 5 MG / Hydrochlorothiazide 12.5 MG / Olmesartan medoxomil 20 MG Oral Tablet"
         }
       ],
       "prescription": {

--- a/src/main/resources/modules/lupus.json
+++ b/src/main/resources/modules/lupus.json
@@ -181,8 +181,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "567645",
-          "display": "predniSONE 2.5 MG [Deltasone]"
+          "code": "312615",
+          "display": "predniSONE 20 MG Oral Tablet"
         }
       ],
       "direct_transition": "End_Diagnosis_Encounter"
@@ -272,8 +272,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "835900",
-          "display": "cycloSPORINE, modified 100 MG [Neoral]"
+          "code": "241834",
+          "display": "cycloSPORINE, modified 100 MG Oral Capsule"
         }
       ],
       "direct_transition": "Flareup_Corticosteroid"
@@ -290,8 +290,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "567645",
-          "display": "predniSONE 2.5 MG [Deltasone]"
+          "code": "312615",
+          "display": "predniSONE 20 MG Oral Tablet"
         }
       ],
       "direct_transition": "End_Flareup_Encounter"

--- a/src/main/resources/modules/medications/otc_pain_reliever.json
+++ b/src/main/resources/modules/medications/otc_pain_reliever.json
@@ -171,8 +171,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "282464",
-          "display": "Acetaminophen 160 MG Oral Tablet"
+          "code": "313820",
+          "display": "Acetaminophen 160 MG Chewable Tablet"
         }
       ],
       "prescription": {

--- a/src/main/resources/modules/opioid_addiction.json
+++ b/src/main/resources/modules/opioid_addiction.json
@@ -194,8 +194,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "1310197",
-          "display": "Acetaminophen 300 MG / HYDROcodone Bitartrate 5 MG [Vicodin]"
+          "code": "856987",
+          "display": "Acetaminophen 300 MG / HYDROcodone Bitartrate 5 MG Oral Tablet"
         }
       ],
       "direct_transition": "End_Directed_Use_Encounter"

--- a/src/main/resources/modules/rheumatoid_arthritis.json
+++ b/src/main/resources/modules/rheumatoid_arthritis.json
@@ -236,8 +236,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "567645",
-          "display": "predniSONE 2.5 MG [Deltasone]"
+          "code": "312615",
+          "display": "predniSONE 20 MG Oral Tablet"
         }
       ],
       "direct_transition": "Encounter_Ends_After_Corticosteroids"

--- a/src/main/resources/modules/rheumatoid_arthritis.json
+++ b/src/main/resources/modules/rheumatoid_arthritis.json
@@ -189,8 +189,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "105586",
-          "display": "Methotrexate 10 MG Oral Tablet"
+          "code": "105585",
+          "display": "Methotrexate 2.5 MG Oral Tablet"
         }
       ],
       "direct_transition": "Encounter_Ends_After_DMARD"

--- a/src/main/resources/modules/surgery/general_anesthesia.json
+++ b/src/main/resources/modules/surgery/general_anesthesia.json
@@ -152,8 +152,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 4337,
-          "display": "Fentanyl"
+          "code": "1735006",
+          "display": "10 ML Fentanyl 0.05 MG/ML Injection"
         }
       ],
       "direct_transition": "Fentanyl_End",
@@ -189,8 +189,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 73032,
-          "display": "Remifentanil"
+          "code": "1729584",
+          "display": "remifentanil 2 MG Injection"
         }
       ],
       "direct_transition": "Remifentanil_End",
@@ -201,8 +201,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 480,
-          "display": "Alfentanil"
+          "code": "1723208",
+          "display": "10 ML Alfentanil 0.5 MG/ML Injection"
         }
       ],
       "direct_transition": "Alfentanil_End",
@@ -213,8 +213,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 56795,
-          "display": "Sufentanil"
+          "code": "1809104",
+          "display": "5 ML SUFentanil 0.05 MG/ML Injection"
         }
       ],
       "direct_transition": "Sufentanil_End",

--- a/src/main/resources/modules/surgery/general_anesthesia.json
+++ b/src/main/resources/modules/surgery/general_anesthesia.json
@@ -260,8 +260,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 200252,
-          "display": "desflurane 990 MG/ML Inhalant Solution"
+          "code": "562366",
+          "display": "desflurane 1000 MG/ML Inhalation Solution"
         }
       ],
       "direct_transition": "Desflurane_End",

--- a/src/main/resources/modules/veteran_hyperlipidemia.json
+++ b/src/main/resources/modules/veteran_hyperlipidemia.json
@@ -210,8 +210,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 316672,
-          "display": "Simvistatin 10 MG"
+          "code": 314231,
+          "display": "Simvastatin 10 MG Oral Tablet"
         }
       ],
       "direct_transition": "followup encounter end",
@@ -815,8 +815,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 316672,
-          "display": "Simvistatin 10 MG"
+          "code": 314231,
+          "display": "Simvastatin 10 MG Oral Tablet"
         }
       ],
       "reason": "hyperlipidemia",

--- a/src/main/resources/modules/veteran_mdd.json
+++ b/src/main/resources/modules/veteran_mdd.json
@@ -532,8 +532,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 406022,
-          "display": "Fluoxetine 25MG"
+          "code": 310385,
+          "display": "FLUoxetine 20 MG Oral Capsule"
         }
       ],
       "assign_to_attribute": "ssri",

--- a/src/main/resources/modules/veteran_ptsd.json
+++ b/src/main/resources/modules/veteran_ptsd.json
@@ -468,8 +468,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 328670,
-          "display": "Sertraline 100MG"
+          "code": 312938,
+          "display": "Sertraline 100 MG Oral Tablet"
         }
       ],
       "assign_to_attribute": "SSRI",


### PR DESCRIPTION
Reasoning for all changes is in the commit messages. Addresses #469.