### PR TITLE
Fixing lat/lon randomization

### DIFF
--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -270,8 +270,8 @@ public class Location {
       // Precision within 0.001 degree is more or less a neighborhood or street.
       // Precision within 0.01 is a village or town
       // Precision within 0.1 is a large city
-      double dx = person.rand(0.001, 0.1);
-      double dy = person.rand(0.001, 0.1);
+      double dx = person.rand(-0.05, 0.05);
+      double dy = person.rand(-0.001, 0.05);
       coordinate.setLocation(coordinate.x + dx, coordinate.y + dy);
       person.attributes.put(Person.COORDINATE, coordinate);
     }

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -271,7 +271,7 @@ public class Location {
       // Precision within 0.01 is a village or town
       // Precision within 0.1 is a large city
       double dx = person.rand(-0.05, 0.05);
-      double dy = person.rand(-0.001, 0.05);
+      double dy = person.rand(-0.05, 0.05);
       coordinate.setLocation(coordinate.x + dx, coordinate.y + dy);
       person.attributes.put(Person.COORDINATE, coordinate);
     }


### PR DESCRIPTION
Previous settings always added a value to the lat/lon. This will shift
the generated population to the north and east of the desired point.

This change will now allow the generation of negative values for the
random offset. This will generate a population in a circle around the
desired point.