### PR TITLE
Maven Repo Publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,8 @@ apply plugin: 'application'
 apply plugin: 'eclipse'
 apply plugin: 'checkstyle'
 apply plugin: 'jacoco'
+apply plugin: "maven-publish"
+
 
 // In this section you declare where to find the dependencies of your project
 repositories {
@@ -190,4 +192,37 @@ run {
   if (project.hasProperty("arams")) {
     args Eval.me(arams)
   }
+}
+
+task sourceJar(type: Jar) {
+    classifier "sources"
+    from sourceSets.main.allJava
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier "javadoc"
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives jar
+    archives sourceJar
+    archives javadocJar
+}
+
+publishing {
+    publications {
+        synthea(MavenPublication) {
+            groupId 'org.mitre'
+            version '2.4.1-SNAPSHOT'
+            from components.java
+            
+            artifact(sourceJar) {
+                classifier = 'sources'
+            }
+            artifact(javadocJar) {
+                classifier = 'javadoc'
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -211,11 +211,14 @@ artifacts {
     archives javadocJar
 }
 
+def mavenGroup = 'org.mitre.synthea'
+def mavenVersion = '2.5.0-SNAPSHOT'
+
 publishing {
     publications {
         synthea(MavenPublication) {
-            groupId 'org.mitre.synthea'
-            version '2.5.0-SNAPSHOT'
+            groupId mavenGroup
+            version mavenVersion
             from components.java
             
             artifact(sourceJar) {
@@ -252,8 +255,9 @@ publishing {
     }
     repositories {
         maven {
-            url 'https://oss.sonatype.org/content/repositories/snapshots'
-//            url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            def snapshotUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
+            def releaseUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            url mavenVersion.endsWith('SNAPSHOT') ? snapshotUrl : releaseUrl
             credentials {
                 def user = project.hasProperty('sonatypeUsername') ? sonatypeUsername : ''
                 def pw = project.hasProperty('sonatypePassword') ? sonatypePassword : ''

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,8 @@ apply plugin: 'application'
 apply plugin: 'eclipse'
 apply plugin: 'checkstyle'
 apply plugin: 'jacoco'
-apply plugin: "maven-publish"
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 
 // In this section you declare where to find the dependencies of your project
@@ -213,8 +214,8 @@ artifacts {
 publishing {
     publications {
         synthea(MavenPublication) {
-            groupId 'org.mitre'
-            version '2.4.1-SNAPSHOT'
+            groupId 'org.mitre.synthea'
+            version '2.5.0-SNAPSHOT'
             from components.java
             
             artifact(sourceJar) {
@@ -223,6 +224,44 @@ publishing {
             artifact(javadocJar) {
                 classifier = 'javadoc'
             }
+            pom {
+                name = 'Synthea'
+                description = 'Synthetic Patient Population Simulator'
+                url = 'https://github.com/synthetichealth/synthea'
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/synthetichealth/synthea.git'
+                    developerConnection = 'scm:git:ssh://github.com:synthetichealth/synthea.git'
+                    url = 'http://github.com/synthetichealth/synthea/tree/master'
+                }
+                developers {
+                    developer {
+                        name = 'Jason Walonoski'
+                        email = 'jwalonoski@mitre.org'
+                        organization = 'The MITRE Corporation'
+                        organizationUrl = 'http://www.mitre.org/'
+                    }
+                }
+            }
         }
     }
+    repositories {
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots'
+//            url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            credentials {
+                username sonatypeUsername
+                password sonatypePassword
+            }
+        }
+    }
+}
+
+signing {
+  sign publishing.publications.synthea
 }

--- a/build.gradle
+++ b/build.gradle
@@ -255,13 +255,16 @@ publishing {
             url 'https://oss.sonatype.org/content/repositories/snapshots'
 //            url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
             credentials {
-                username sonatypeUsername
-                password sonatypePassword
+                def user = project.hasProperty('sonatypeUsername') ? sonatypeUsername : ''
+                def pw = project.hasProperty('sonatypePassword') ? sonatypePassword : ''
+                username user
+                password pw 
             }
         }
     }
 }
 
 signing {
+  required { project.hasProperty('signing.keyId') }
   sign publishing.publications.synthea
 }

--- a/src/main/java/org/mitre/synthea/engine/Components.java
+++ b/src/main/java/org/mitre/synthea/engine/Components.java
@@ -62,7 +62,7 @@ public abstract class Components {
    * Defining this in a separate class makes it easier to define
    * where units are and are not required.
    * 
-   * @param <T >Type of quantity
+   * @param <T> Type of quantity
    */
   public static class ExactWithUnit<T> extends Exact<T> {
     /**

--- a/src/main/java/org/mitre/synthea/export/CDWExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CDWExporter.java
@@ -38,7 +38,7 @@ import org.mitre.synthea.world.geography.Location;
  * This exporter attempts to export synthetic patient data into 
  * comma-separated value (CSV) files that align with the Veteran's 
  * Health Administration (VHA) Corporate Data Warehouse (CDW).
- * <p/>
+ * <p></p>
  * https://www.data.va.gov/dataset/corporate-data-warehouse-cdw
  */
 public class CDWExporter {

--- a/src/main/java/org/mitre/synthea/modules/BloodPressureValueGenerator.java
+++ b/src/main/java/org/mitre/synthea/modules/BloodPressureValueGenerator.java
@@ -9,7 +9,8 @@ import org.mitre.synthea.world.concepts.BiometricsConfig;
  * Generate realistic blood pressure vital signs. 
  * Can reproducibly look a few days into the past and future.
  * 
- * @see "https://raywinstead.com/bp/thrice.htm" for desired result
+ * See <a href="https://raywinstead.com/bp/thrice.htm">https://raywinstead.com/bp/thrice.htm</a>
+ * for desired result
  */
 public class BloodPressureValueGenerator extends ValueGenerator {
   public enum SysDias {

--- a/src/main/java/org/mitre/synthea/world/concepts/BirthStatistics.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/BirthStatistics.java
@@ -82,7 +82,7 @@ public class BirthStatistics {
   /**
    * Sets attributes on the mother on when her baby will be born,
    * the baby sex, and the birth height and weight.
-   * <p/>
+   * <p></p>
    * These attributes will be overridden on subsequent pregnancies.
    * @param mother The baby's mother.
    * @param time The time.

--- a/src/main/java/org/mitre/synthea/world/concepts/ClinicianSpecialty.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/ClinicianSpecialty.java
@@ -5,9 +5,9 @@ package org.mitre.synthea.world.concepts;
  * Clinician can possess. Each of the values (e.g. "ADDICTION MEDICINE")
  * corresponds to a column header in the primary care facilities file
  * identified by the Synthea property:
- * <p/>
+ * <p></p>
  * generate.providers.primarycare.default_file = "providers/primary_care_facilities.csv"
- * <p/>The numeric value in each cell identifies how many of clinicians should be
+ * <p></p>The numeric value in each cell identifies how many of clinicians should be
  * generated with each specialty. These specialties can then be used to select
  * an appropriate clinician for any encounter.
  */

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -410,9 +410,9 @@ public class Location {
 
   /**
    * Load a resource which contains foreign places of birth based on ethnicity in json format:
-   * <p/>
+   * <p></p>
    * {"ethnicity":["city1,state1,country1", "city2,state2,country2"..., "cityN,stateN,countryN"]}
-   * <p/>
+   * <p></p>
    * see src/main/resources/foreign_birthplace.json for a working example
    * package protected for testing
    * @param resource A json file listing foreign places of birth by ethnicity.


### PR DESCRIPTION
Add support for pushing synthea.jar to Maven repositories.

Running the new Gradle tasks to publish the jar requires additional local set-up, in particular a Sonatype Jira account and a GnuPGP key pair. Regular builds are unaffected.