### PR TITLE
Fix zipcode selection

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -185,7 +185,7 @@ public final class LifecycleModule extends Module {
     if (location != null) {
       // should never happen in practice, but can happen in unit tests
       location.assignPoint(person, city);
-      person.attributes.put(Person.ZIP, location.getZipCode(city));
+      person.attributes.put(Person.ZIP, location.getZipCode(city, person));
       String[] birthPlace;
       if ("english".equalsIgnoreCase((String) attributes.get(Person.FIRST_LANGUAGE))) {
         birthPlace = location.randomBirthPlace(person.random);

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -113,9 +113,11 @@ public class Location {
    * If a city has more than one zip code, this picks a random one.
    * 
    * @param cityName Name of the city
+   * @param person Used for a source of repeatable randomness when selecting a zipcode when multiple
+   *               exist for a location
    * @return a zip code for the given city
    */
-  public String getZipCode(String cityName) {
+  public String getZipCode(String cityName, Person person) {
     List<Place> zipsForCity = zipCodes.get(cityName);
     
     if (zipsForCity == null) {
@@ -125,7 +127,8 @@ public class Location {
     if (zipsForCity == null || zipsForCity.isEmpty()) {
       return "00000"; // if we don't have the city, just use a dummy
     } else if (zipsForCity.size() >= 1) {
-      return zipsForCity.get(0).postalCode;
+      int randomChoice = person.randInt(zipsForCity.size());
+      return zipsForCity.get(randomChoice).postalCode;
     }
     return "00000";
   }

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -246,7 +246,7 @@ public class Location {
    * @param cityName Name of the city, or null to choose one randomly
    */
   public void assignPoint(Person person, String cityName) {
-    List<Place> zipsForCity = null;
+    List<Place> zipsForCity;
 
     if (cityName == null) {
       int size = zipCodes.keySet().size();
@@ -258,12 +258,19 @@ public class Location {
       zipsForCity = zipCodes.get(cityName + " Town");
     }
     
-    Place place = null;
+    Place place;
     if (zipsForCity.size() == 1) {
       place = zipsForCity.get(0);
     } else {
-      // pick a random one
-      place = zipsForCity.get(person.randInt(zipsForCity.size()));
+      String personZip = (String) person.attributes.get(Person.ZIP);
+      if (personZip == null) {
+        place = zipsForCity.get(person.randInt(zipsForCity.size()));
+      } else {
+        place = zipsForCity.stream()
+            .filter(c -> personZip.equals(c.postalCode))
+            .findFirst()
+            .orElse(zipsForCity.get(person.randInt(zipsForCity.size())));
+      }
     }
     
     if (place != null) {

--- a/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
+++ b/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
+import org.mitre.synthea.world.agents.Person;
 
 public class LocationTest {
 
@@ -41,7 +42,7 @@ public class LocationTest {
   @Test
   public void testLocation() {
     Assert.assertTrue(location.getPopulation("Bedford") > 0);
-    Assert.assertTrue(location.getZipCode("Bedford").equals("01730"));
+    Assert.assertTrue(location.getZipCode("Bedford", new Person(1)).equals("01730"));
   }
 
   @Test

--- a/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
+++ b/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+
+import org.apache.sis.geometry.DirectPosition2D;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -86,6 +88,16 @@ public class LocationTest {
     }
     String message = mismatches.toString();
     Assert.assertEquals(message, 0, mismatches.size());
+  }
+
+  @Test
+  public void testAssignPointInMultiZipCodeCity() {
+    Person p = new Person(1);
+    p.attributes.put(Person.ZIP, "02151");
+    location.assignPoint(p, "Boston");
+    DirectPosition2D coord = (DirectPosition2D) p.attributes.get(Person.COORDINATE);
+    Assert.assertEquals(-71.001251, coord.x, 0.05);
+    Assert.assertEquals(42.41829, coord.y, 0.05);
   }
 
   @Test


### PR DESCRIPTION
Randomizing zip code selection, fixing placement

Previously, when a person was generated in a city with multiple zip
codes, Synthea would select the first zip code for the city.

This change causes it to randomly choose a zip code.

This also fixes the assignment of the lat / lon to the person. Previously, it would randomly chose a place in a city if multiples existed. Now, if a person has a zip code in a city with multiple zip codes, it will start with the lat / lon of the proper zip code.
