### PR TITLE
Accelerate geographic searches.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,6 @@ dependencies {
   compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:4.0.3'
   // C-CDA export uses Apache FreeMarker templates
   compile 'org.freemarker:freemarker:2.3.26-incubating'
-  // location processing
-  compile group: 'org.apache.sis.core', name: 'sis-referencing', version: '0.8'
-  compile group: 'org.apache.sis.storage', name: 'sis-storage', version: '0.8'
   compile group: 'com.h2database', name: 'h2', version: '1.4.196'
   // google guava for some data structures
   compile 'com.google.guava:guava:23.0'

--- a/src/main/java/org/mitre/synthea/export/CDWExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CDWExporter.java
@@ -4,6 +4,7 @@ import static org.mitre.synthea.export.ExportHelper.iso8601Timestamp;
 
 import com.google.gson.JsonObject;
 
+import java.awt.geom.Point2D;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -14,7 +15,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.sis.geometry.DirectPosition2D;
 import org.mitre.synthea.helpers.FactTable;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.modules.DeathModule;
@@ -690,7 +690,7 @@ public class CDWExporter {
     s.append(person.attributes.get(Person.ZIP)).append(',');
     s.append(person.attributes.get(Person.ZIP)).append(",USA,,,");
 
-    DirectPosition2D coord = (DirectPosition2D) person.attributes.get(Person.COORDINATE);
+    Point2D.Double coord = person.getLonLat();
     if (coord != null) {
       s.append(coord.x).append(',').append(coord.y).append(',');
     } else {

--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -84,6 +84,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import java.awt.geom.Point2D;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
@@ -94,7 +95,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.sis.geometry.DirectPosition2D;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Clinician;
@@ -408,7 +408,7 @@ public class FhirDstu2 {
       addrResource.setCountry(COUNTRY_CODE);
     }
 
-    DirectPosition2D coord = person.getLatLon();
+    Point2D.Double coord = person.getLonLat();
     if (coord != null) {
       ExtensionDt geolocationExtension = new ExtensionDt();
       geolocationExtension.setUrl("http://hl7.org/fhir/StructureDefinition/geolocation");

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -6,6 +6,8 @@ import com.google.common.collect.Table;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
+import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -19,7 +21,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.sis.geometry.DirectPosition2D;
 import org.hl7.fhir.r4.model.Address;
 import org.hl7.fhir.r4.model.AllergyIntolerance;
 import org.hl7.fhir.r4.model.AllergyIntolerance.AllergyIntoleranceCategory;
@@ -570,7 +571,7 @@ public class FhirR4 {
               "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus"));
     }
 
-    DirectPosition2D coord = person.getLatLon();
+    Point2D.Double coord = person.getLonLat();
     if (coord != null) {
       Extension geolocation = addrResource.addExtension();
       geolocation.setUrl("http://hl7.org/fhir/StructureDefinition/geolocation");

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -8,6 +8,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -21,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.sis.geometry.DirectPosition2D;
 import org.hl7.fhir.dstu3.model.Address;
 import org.hl7.fhir.dstu3.model.AllergyIntolerance;
 import org.hl7.fhir.dstu3.model.AllergyIntolerance.AllergyIntoleranceCategory;
@@ -517,7 +517,7 @@ public class FhirStu3 {
           mapCodeToCodeableConcept(maritalStatusCode, "http://hl7.org/fhir/v3/MaritalStatus"));
     }
 
-    DirectPosition2D coord = person.getLatLon();
+    Point2D.Double coord = person.getLonLat();
     if (coord != null) {
       Extension geolocation = addrResource.addExtension();
       geolocation.setUrl("http://hl7.org/fhir/StructureDefinition/geolocation");
@@ -2187,7 +2187,7 @@ public class FhirStu3 {
     }
     organizationResource.addAddress(address);
 
-    DirectPosition2D coord = provider.getLatLon();
+    Point2D.Double coord = provider.getLonLat();
     if (coord != null) {
       Extension geolocation = address.addExtension();
       geolocation.setUrl("http://hl7.org/fhir/StructureDefinition/geolocation");

--- a/src/main/java/org/mitre/synthea/world/agents/Clinician.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Clinician.java
@@ -1,5 +1,6 @@
 package org.mitre.synthea.world.agents;
 
+import java.awt.geom.Point2D;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Map;
@@ -7,10 +8,9 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.sis.geometry.DirectPosition2D;
-import org.apache.sis.index.tree.QuadTreeData;
+import org.mitre.synthea.world.geography.quadtree.QuadTreeElement;
 
-public class Clinician implements Serializable, QuadTreeData {
+public class Clinician implements Serializable, QuadTreeElement {
   private static final long serialVersionUID = 1370111157423846567L;
 
   public static final String WELLNESS = "wellness";
@@ -123,40 +123,20 @@ public class Clinician implements Serializable, QuadTreeData {
   public int randInt(int bound) {
     return random.nextInt(bound);
   }
-  
-  /*
-   * (non-Javadoc)
-   * @see org.apache.sis.index.tree.QuadTreeData#getX()
-   */
+
   @Override
   public double getX() {
-    return getLatLon().getX();
+    // TODO Auto-generated method stub
+    return getLonLat().getX();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see org.apache.sis.index.tree.QuadTreeData#getY()
-   */
   @Override
   public double getY() {
-    return getLatLon().getY();
+    // TODO Auto-generated method stub
+    return getLonLat().getY();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see org.apache.sis.index.tree.QuadTreeData#getLatLon()
-   */
-  @Override
-  public DirectPosition2D getLatLon() {
-    return (DirectPosition2D) attributes.get(Person.COORDINATE);
-  }
-
-  /*
-   * (non-Javadoc)
-   * @see org.apache.sis.index.tree.QuadTreeData#getFileName()
-   */
-  @Override
-  public String getFileName() {
-    return null;
+  public Point2D.Double getLonLat() {
+    return (Point2D.Double) attributes.get(Person.COORDINATE);
   }
 }

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -1,5 +1,6 @@
 package org.mitre.synthea.world.agents;
 
+import java.awt.geom.Point2D;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -16,8 +17,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.sis.geometry.DirectPosition2D;
-import org.apache.sis.index.tree.QuadTreeData;
 import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.engine.State;
 import org.mitre.synthea.helpers.Config;
@@ -30,8 +29,9 @@ import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
 import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
 import org.mitre.synthea.world.concepts.HealthRecord.Entry;
 import org.mitre.synthea.world.concepts.VitalSign;
+import org.mitre.synthea.world.geography.quadtree.QuadTreeElement;
 
-public class Person implements Serializable, QuadTreeData {
+public class Person implements Serializable, QuadTreeElement {
   private static final long serialVersionUID = 4322116644425686379L;
   private static final ZoneId timeZone = ZoneId.systemDefault();
 
@@ -743,43 +743,17 @@ public class Person implements Serializable, QuadTreeData {
     return ((Map<Integer, Double>) this.attributes.get("QOL")).get(year);
   }
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.sis.index.tree.QuadTreeData#getX()
-   */
   @Override
   public double getX() {
-    return getLatLon().getX();
+    return getLonLat().getX();
   }
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.sis.index.tree.QuadTreeData#getY()
-   */
   @Override
   public double getY() {
-    return getLatLon().getY();
+    return getLonLat().getY();
   }
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.sis.index.tree.QuadTreeData#getLatLon()
-   */
-  @Override
-  public DirectPosition2D getLatLon() {
-    return (DirectPosition2D) attributes.get(Person.COORDINATE);
-  }
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.sis.index.tree.QuadTreeData#getFileName()
-   */
-  @Override
-  public String getFileName() {
-    return null;
+  public Point2D.Double getLonLat() {
+    return (Point2D.Double) attributes.get(Person.COORDINATE);
   }
 }

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -4,6 +4,7 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import com.google.gson.internal.LinkedTreeMap;
 
+import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -16,9 +17,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.sis.geometry.DirectPosition2D;
-import org.apache.sis.index.tree.QuadTree;
-import org.apache.sis.index.tree.QuadTreeData;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
@@ -31,8 +29,10 @@ import org.mitre.synthea.world.concepts.ClinicianSpecialty;
 import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
 import org.mitre.synthea.world.geography.Demographics;
 import org.mitre.synthea.world.geography.Location;
+import org.mitre.synthea.world.geography.quadtree.QuadTree;
+import org.mitre.synthea.world.geography.quadtree.QuadTreeElement;
 
-public class Provider implements QuadTreeData {
+public class Provider implements QuadTreeElement {
 
   public static final String ENCOUNTERS = "encounters";
   public static final String PROCEDURES = "procedures";
@@ -52,7 +52,7 @@ public class Provider implements QuadTreeData {
   private static int loaded = 0;
 
   private static final double MAX_PROVIDER_SEARCH_DISTANCE =
-      Double.parseDouble(Config.get("generate.providers.maximum_search_distance", "500"));
+      Double.parseDouble(Config.get("generate.providers.maximum_search_distance", "2"));
   public static final String PROVIDER_SELECTION_BEHAVIOR =
       Config.get("generate.providers.selection_behavior", "nearest").toLowerCase();
   private static IProviderFinder providerFinder = buildProviderFinder();
@@ -71,7 +71,7 @@ public class Provider implements QuadTreeData {
   public String ownership;
   public int quality;
   private double revenue;
-  private DirectPosition2D coordinates;
+  private Point2D.Double coordinates;
   public ArrayList<EncounterType> servicesProvided;
   public Map<String, ArrayList<Clinician>> clinicianMap;
   // row: year, column: type, value: count
@@ -87,7 +87,7 @@ public class Provider implements QuadTreeData {
     utilization = HashBasedTable.create();
     servicesProvided = new ArrayList<EncounterType>();
     clinicianMap = new HashMap<String, ArrayList<Clinician>>();
-    coordinates = new DirectPosition2D();
+    coordinates = new Point2D.Double();
   }
 
   private static IProviderFinder buildProviderFinder() {
@@ -204,17 +204,16 @@ public class Provider implements QuadTreeData {
    */
   public static Provider findService(Person person, EncounterType service, long time) {
     double maxDistance = MAX_PROVIDER_SEARCH_DISTANCE;
-    double distance = 100;
-    double step = 100;
+    double degrees = 0.125;
     List<Provider> options = null;
     Provider provider = null;
-    while (distance <= maxDistance) {
-      options = findProvidersByLocation(person, distance);
+    while (degrees <= maxDistance) {
+      options = findProvidersByLocation(person, degrees);
       provider = providerFinder.find(options, person, service, time);
       if (provider != null) {
         return provider;
       }
-      distance += step;
+      degrees *= 2.0;
     }
     return null;
   }
@@ -222,14 +221,13 @@ public class Provider implements QuadTreeData {
   /**
    * Find a service around a given point.
    * @param person The patient who requires the service.
-   * @param distance in kilometers
+   * @param distance in degrees
    * @return List of providers within the given distance.
    */
   private static List<Provider> findProvidersByLocation(Person person, double distance) {
-    DirectPosition2D coord = person.getLatLon();
-    List<QuadTreeData> results = providerMap.queryByPointRadius(coord, distance);
+    List<QuadTreeElement> results = providerMap.query(person, distance);
     List<Provider> providers = new ArrayList<Provider>();
-    for (QuadTreeData item : results) {
+    for (QuadTreeElement item : results) {
       providers.add((Provider) item);
     }
     return providers;
@@ -251,7 +249,7 @@ public class Provider implements QuadTreeData {
    * @return QuadTree.
    */
   private static QuadTree generateQuadTree() {
-    return new QuadTree(7500, 25); // capacity, depth
+    return new QuadTree();
   }
   
   /**
@@ -424,7 +422,7 @@ public class Provider implements QuadTreeData {
       clinician.attributes.put(Person.CITY, provider.city);
       clinician.attributes.put(Person.STATE, provider.state);
       clinician.attributes.put(Person.ZIP, provider.zip);
-      clinician.attributes.put(Person.COORDINATE, provider.getLatLon());
+      clinician.attributes.put(Person.COORDINATE, provider.coordinates);
 
       String firstName = LifecycleModule.fakeFirstName(gender, language, clinician.random);
       String lastName = LifecycleModule.fakeLastName(language, clinician.random);
@@ -501,39 +499,17 @@ public class Provider implements QuadTreeData {
     return providerList;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see org.apache.sis.index.tree.QuadTreeData#getX()
-   */
   @Override
   public double getX() {
     return coordinates.getX();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see org.apache.sis.index.tree.QuadTreeData#getY()
-   */
   @Override
   public double getY() {
     return coordinates.getY();
   }
 
-  /*
-   * (non-Javadoc)
-   * @see org.apache.sis.index.tree.QuadTreeData#getLatLon()
-   */
-  @Override
-  public DirectPosition2D getLatLon() {
+  public Point2D.Double getLonLat() {
     return coordinates;
-  }
-
-  /*
-   * (non-Javadoc)
-   * @see org.apache.sis.index.tree.QuadTreeData#getFileName()
-   */
-  @Override
-  public String getFileName() {
-    return null;
   }
 }

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderNearest.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderNearest.java
@@ -18,7 +18,7 @@ public class ProviderFinderNearest implements IProviderFinder {
     for (Provider provider : providers) {
       if (provider.accepts(person, time)
           && (provider.hasService(service) || service == null)) {
-        distance = provider.getLatLon().distance(person.getLatLon());
+        distance = provider.getLonLat().distance(person.getLonLat());
         if (distance < minDistance) {
           options.clear();
           options.add(provider);

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -3,6 +3,7 @@ package org.mitre.synthea.world.geography;
 import com.google.common.collect.Table;
 import com.google.gson.Gson;
 
+import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -11,7 +12,6 @@ import java.util.Map;
 import java.util.Random;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.sis.geometry.DirectPosition2D;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
@@ -265,7 +265,8 @@ public class Location {
     
     if (place != null) {
       // Get the coordinate of the city/town
-      DirectPosition2D coordinate = place.getLatLon().clone();
+      Point2D.Double coordinate = new Point2D.Double();
+      coordinate.setLocation(place.coordinate);
       // And now perturbate it slightly.
       // Precision within 0.001 degree is more or less a neighborhood or street.
       // Precision within 0.01 is a village or town
@@ -308,13 +309,14 @@ public class Location {
     
     if (place != null) {
       // Get the coordinate of the city/town
-      DirectPosition2D coordinate = place.getLatLon().clone();
+      Point2D.Double coordinate = new Point2D.Double();
+      coordinate.setLocation(place.coordinate);
       // And now perturbate it slightly.
       // Precision within 0.001 degree is more or less a neighborhood or street.
       // Precision within 0.01 is a village or town
       // Precision within 0.1 is a large city
-      double dx = clinician.rand() / 10.0;
-      double dy = clinician.rand() / 10.0;
+      double dx = (clinician.rand() * 0.1) - 0.05;
+      double dy = (clinician.rand() * 0.1) - 0.05;
       coordinate.setLocation(coordinate.x + dx, coordinate.y + dy);
       clinician.attributes.put(Person.COORDINATE, coordinate);
     }

--- a/src/main/java/org/mitre/synthea/world/geography/Place.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Place.java
@@ -1,14 +1,14 @@
 package org.mitre.synthea.world.geography;
 
+import java.awt.geom.Point2D;
 import java.util.Map;
 
-import org.apache.sis.geometry.DirectPosition2D;
-import org.apache.sis.index.tree.QuadTreeData;
+import org.mitre.synthea.world.geography.quadtree.QuadTreeElement;
 
 /**
  * Place represents a named place with a postal code and coordinate.
  */
-public class Place implements QuadTreeData {
+public class Place implements QuadTreeElement {
   /** The name of the state. For example, Ohio */
   public String state;
   /** The state abbreviation. For example, OH */
@@ -18,7 +18,7 @@ public class Place implements QuadTreeData {
   /** The postal code. For example, 01001 */
   public String postalCode;
   /** Coordinate of the place. */
-  public DirectPosition2D coordinate;
+  public Point2D.Double coordinate;
   
   /**
    * Create a new row from a CSV row.
@@ -31,7 +31,7 @@ public class Place implements QuadTreeData {
     this.postalCode = row.get("ZCTA5");
     double lat = Double.parseDouble(row.get("LAT"));
     double lon = Double.parseDouble(row.get("LON"));
-    this.coordinate = new DirectPosition2D(lon, lat);
+    this.coordinate = new Point2D.Double(lon, lat);
   }
   
   /**
@@ -52,15 +52,5 @@ public class Place implements QuadTreeData {
   @Override
   public double getY() {
     return coordinate.getY();
-  }
-
-  @Override
-  public DirectPosition2D getLatLon() {
-    return coordinate;
-  }
-
-  @Override
-  public String getFileName() {
-    return null;
   }
 }

--- a/src/main/java/org/mitre/synthea/world/geography/quadtree/QuadTree.java
+++ b/src/main/java/org/mitre/synthea/world/geography/quadtree/QuadTree.java
@@ -1,0 +1,168 @@
+package org.mitre.synthea.world.geography.quadtree;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simple QuadTree class that is optimized for query speed.
+ * The query is simplified, because it only takes into account
+ * Euclidean distance and does not take into account the
+ * elevation, altitude, curvature of the Earth, or features
+ * such as roads, mountains, or bodies of water.
+ */
+public class QuadTree {
+
+  protected boolean isLeaf = true;
+  /** maximum amount of data at this node before it splits. */
+  private int maxLeafSize = 50;
+
+  /** local data before split. */
+  protected List<QuadTreeElement> data = new ArrayList<QuadTreeElement>();
+
+  /* bounding box */
+  private double xcoord;
+  private double ycoord;
+  private double radius;
+
+  /* branch data after split. */
+  protected QuadTree[] branches;
+
+  /**
+   * Default constructor creates a QuadTree centered around (0, 0)
+   * with bounds around the center point of 180.
+   */
+  public QuadTree() {
+    xcoord = 0.0;
+    ycoord = 0.0;
+    radius = 180.0;
+  }
+
+  /**
+   * Create a QuadTree centered around (x, y) with a bounds of r.
+   * @param x The x-coordinate of the center point.
+   * @param y The y-coordinate of the center point.
+   * @param r The distance of the bounds around the center point.
+   */
+  private QuadTree(double x, double y, double r) {
+    this.xcoord = x;
+    this.ycoord = y;
+    this.radius = r;
+  }
+
+  /**
+   * Check if this QuadTree should contain this item.
+   * @param item The item to check.
+   * @return True if the item should be within the QuadTree, otherwise false.
+   */
+  public boolean hasBoundsAround(QuadTreeElement item) {
+    return hasBoundsAround(item, 0.0);
+  }
+
+  /**
+   * Check if this QuadTree should contain this item, given some error
+   * (in distance) around the item location.
+   * @param item The item to check.
+   * @param error The error around the item in distance.
+   * @return True if the item should be within the QuadTree, otherwise false.
+   */
+  public boolean hasBoundsAround(QuadTreeElement item, double error) {
+    return ((xcoord + radius) >= (item.getX() - error)) 
+        && ((xcoord - radius) <= (item.getX() + error))
+        && ((ycoord + radius) >= (item.getY() - error))
+        && ((ycoord - radius) <= (item.getY() + error));
+  }
+
+  /**
+   * Insert an item into this tree.
+   * @param item The item to insert.
+   * @return True if the item was inserted, false otherwise.
+   */
+  public boolean insert(QuadTreeElement item) {
+    boolean inserted = false;
+    if (isLeaf) {
+      // this is a leaf node
+      if (data.size() < maxLeafSize) {
+        // the leaf node is still small, add the item here
+        inserted = data.add(item);
+      } else {
+        // the leaf node is too big, split the leaf here
+        isLeaf = false;
+        double d = (radius / 2.0);
+        branches = new QuadTree[4];
+        branches[0] = new QuadTree(xcoord + d, ycoord + d, d);
+        branches[1] = new QuadTree(xcoord - d, ycoord + d, d);
+        branches[2] = new QuadTree(xcoord + d, ycoord - d, d);
+        branches[3] = new QuadTree(xcoord - d, ycoord - d, d);
+        inserted = this.insert(item);
+      }
+    } else {
+      // this is a branch node
+      for (QuadTree branch : branches) {
+        if (branch.hasBoundsAround(item)) {
+          inserted = branch.insert(item);
+          if (inserted) {
+            break;
+          }
+        }
+      }
+      // this item does not really fit into the branches,
+      // so we might as well store it here. This might happen
+      // if the item is exactly on the split point.
+      if (!inserted) {
+        inserted = data.add(item);
+      }
+    }
+    return inserted;
+  }
+
+  /**
+   * Query this QuadTree for elements around a given point.
+   * @param queryPoint The query point to search around.
+   * @param radius The radius to search.
+   * @return A non-null list of elements within the radius around the queryPoint.
+   */
+  public List<QuadTreeElement> query(QuadTreeElement queryPoint, double radius) {
+    List<QuadTreeElement> results = new ArrayList<QuadTreeElement>();
+    for (QuadTreeElement localItem : data) {
+      if (queryPoint.distance(localItem) <= radius) {
+        results.add(localItem);
+      }
+    }
+    // if this node has split...
+    if (!isLeaf) {
+      for (QuadTree branch : branches) {
+        if (branch.hasBoundsAround(queryPoint, radius)) {
+          results.addAll(branch.query(queryPoint, radius));
+        }
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Get the count of elements within this QuadTree including all branches.
+   * @return The count of elements within this QuadTree including all branches.
+   */
+  public int size() {
+    int count = data.size();
+    if (!isLeaf) {
+      for (QuadTree branch : branches) {
+        count += branch.size();
+      }
+    }
+    return count;
+  }
+
+  @Override
+  public String toString() {
+    String value;
+    if (isLeaf) {
+      value = "Leaf @ (";
+    } else {
+      value = "Branch @ (";
+    }
+    value += xcoord + ", " + ycoord + ", " + radius + ") = ";
+    value += size();
+    return value;
+  }
+}

--- a/src/main/java/org/mitre/synthea/world/geography/quadtree/QuadTreeElement.java
+++ b/src/main/java/org/mitre/synthea/world/geography/quadtree/QuadTreeElement.java
@@ -1,0 +1,20 @@
+package org.mitre.synthea.world.geography.quadtree;
+
+public interface QuadTreeElement {
+  /** Get the x-coordinate of this element. */
+  public double getX();
+
+  /** Get the y-coordinate of this element. */
+  public double getY();
+
+  /**
+   * Return the distance between this element and another.
+   * @param element The element to measure the distance towards.
+   * @return The distance.
+   */
+  public default double distance(QuadTreeElement element) {
+    double dx = this.getX() - element.getX();
+    double dy = this.getY() - element.getY();
+    return Math.sqrt((dx * dx) + (dy * dy));
+  }
+}

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -152,8 +152,8 @@ generate.providers.primarycare.default_file = providers/primary_care_facilities.
 generate.providers.selection_behavior = nearest
 
 # maximum distance to look for a provider for a given patient, in km
-# set to 2000km to support the model that veterans only seek care at VA facilities
-generate.providers.maximum_search_distance = 2000
+# set to 10 degrees lat/lon to support the model that veterans only seek care at VA facilities
+generate.providers.maximum_search_distance = 32
 
 # Payers
 generate.payers.insurance_companies.default_file = payers/insurance_companies.csv

--- a/src/test/java/org/mitre/synthea/helpers/ConfigTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/ConfigTest.java
@@ -8,7 +8,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Paths;
 import java.util.Set;
 
 import org.junit.Test;

--- a/src/test/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderTest.java
@@ -1,9 +1,9 @@
 package org.mitre.synthea.world.agents.behaviors;
 
+import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.sis.geometry.DirectPosition2D;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -23,14 +23,14 @@ public class ProviderFinderTest {
   @BeforeClass
   public static void setup() {
     person = new Person(0L);
-    DirectPosition2D coordinate = new DirectPosition2D(0, 0);
+    Point2D.Double coordinate = new Point2D.Double(0, 0);
     person.attributes.put(Person.COORDINATE, coordinate);
     
     providers = new ArrayList<Provider>();
     for (int i = 1; i <= 3; i += 1) {
       Provider provider = new Provider();
       provider.id = i + "";
-      provider.getLatLon().setLocation(i, i);
+      provider.getLonLat().setLocation(i, i);
       provider.quality = i;
       provider.servicesProvided.add(EncounterType.WELLNESS);
       providers.add(provider);

--- a/src/test/java/org/mitre/synthea/world/geography/quadtree/QuadTreeTest.java
+++ b/src/test/java/org/mitre/synthea/world/geography/quadtree/QuadTreeTest.java
@@ -1,0 +1,133 @@
+package org.mitre.synthea.world.geography.quadtree;
+
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QuadTreeTest {
+
+  @Test
+  public void testInsertOneMillionElements() {
+    Random random = new Random();
+    QuadTree tree = new QuadTree();
+    int amount = 1000000;
+    for (int i = 0; i < amount; i++) {
+      double x = (random.nextDouble() * 360.0) - 180.0;
+      double y = (random.nextDouble() * 360.0) - 180.0;
+      TestElement data = new TestElement(x, y);
+      Assert.assertTrue(tree.insert(data));
+    }
+    Assert.assertFalse(tree.isLeaf);
+    Assert.assertEquals(amount, tree.size());
+  }
+
+  @Test
+  public void testInsertNE() {
+    Random random = new Random();
+    QuadTree tree = new QuadTree();
+    int amount = 1000000;
+    for (int i = 0; i < amount; i++) {
+      double x = (random.nextDouble() * 180.0);
+      double y = (random.nextDouble() * 180.0);
+      TestElement data = new TestElement(x, y);
+      Assert.assertTrue(tree.insert(data));
+    }
+    Assert.assertFalse(tree.isLeaf);
+    Assert.assertEquals(amount, tree.size());
+    Assert.assertEquals(amount, tree.data.size() + tree.branches[0].size());
+    Assert.assertTrue(tree.branches[1].isLeaf);
+    Assert.assertTrue(tree.branches[2].isLeaf);
+    Assert.assertTrue(tree.branches[3].isLeaf);
+  }
+
+  @Test
+  public void testInsertNW() {
+    Random random = new Random();
+    QuadTree tree = new QuadTree();
+    int amount = 1000000;
+    for (int i = 0; i < amount; i++) {
+      double x = (random.nextDouble() * -180.0);
+      double y = (random.nextDouble() * 180.0);
+      TestElement data = new TestElement(x, y);
+      Assert.assertTrue(tree.insert(data));
+    }
+    Assert.assertFalse(tree.isLeaf);
+    Assert.assertEquals(amount, tree.size());
+    Assert.assertEquals(amount, tree.data.size() + tree.branches[1].size());
+    Assert.assertTrue(tree.branches[0].isLeaf);
+    Assert.assertTrue(tree.branches[2].isLeaf);
+    Assert.assertTrue(tree.branches[3].isLeaf);
+  }
+
+  @Test
+  public void testInsertSE() {
+    Random random = new Random();
+    QuadTree tree = new QuadTree();
+    int amount = 1000000;
+    for (int i = 0; i < amount; i++) {
+      double x = (random.nextDouble() * 180.0);
+      double y = (random.nextDouble() * -180.0);
+      TestElement data = new TestElement(x, y);
+      Assert.assertTrue(tree.insert(data));
+    }
+    Assert.assertFalse(tree.isLeaf);
+    Assert.assertEquals(amount, tree.size());
+    Assert.assertEquals(amount, tree.data.size() + tree.branches[2].size());
+    Assert.assertTrue(tree.branches[0].isLeaf);
+    Assert.assertTrue(tree.branches[1].isLeaf);
+    Assert.assertTrue(tree.branches[3].isLeaf);
+  }
+
+  @Test
+  public void testInsertSW() {
+    Random random = new Random();
+    QuadTree tree = new QuadTree();
+    int amount = 1000000;
+    for (int i = 0; i < amount; i++) {
+      double x = (random.nextDouble() * -180.0);
+      double y = (random.nextDouble() * -180.0);
+      TestElement data = new TestElement(x, y);
+      Assert.assertTrue(tree.insert(data));
+    }
+    Assert.assertFalse(tree.isLeaf);
+    Assert.assertEquals(amount, tree.size());
+    Assert.assertEquals(amount, tree.data.size() + tree.branches[3].size());
+    Assert.assertTrue(tree.branches[0].isLeaf);
+    Assert.assertTrue(tree.branches[1].isLeaf);
+    Assert.assertTrue(tree.branches[2].isLeaf);
+  }
+
+  @Test
+  public void testQueryAgainstOneMillionTightlyPackedElements() {
+    // Insert all the data
+    Random random = new Random();
+    QuadTree tree = new QuadTree();
+    int amount = 1000000;
+    for (int i = 0; i < amount; i++) {
+      double x = (random.nextDouble() * 10.0) - 5.0;
+      double y = (random.nextDouble() * 10.0) - 5.0;
+      TestElement data = new TestElement(x, y);
+      Assert.assertTrue(tree.insert(data));
+    }
+    Assert.assertFalse(tree.isLeaf);
+    Assert.assertEquals(amount, tree.size());
+
+    // Query the data
+    QuadTreeElement queryPoint = new TestElement(0, 0);
+    double queryRadius = 0.125; // 0.125, 0.25, 0.5, 1.0, 2.0
+    List<QuadTreeElement> results;
+    while (queryRadius <= 2.0) {
+      results = tree.query(queryPoint, queryRadius);
+      Assert.assertNotNull(results);
+      Assert.assertFalse(results.isEmpty());
+      // check the distance
+      for (QuadTreeElement resultItem : results) {
+        Assert.assertTrue(queryPoint.distance(resultItem) <= queryRadius);
+      }
+      // progressively widen the query
+      queryRadius *= 2.0;
+    }
+  }
+}

--- a/src/test/java/org/mitre/synthea/world/geography/quadtree/TestElement.java
+++ b/src/test/java/org/mitre/synthea/world/geography/quadtree/TestElement.java
@@ -1,0 +1,26 @@
+package org.mitre.synthea.world.geography.quadtree;
+
+public class TestElement implements QuadTreeElement {
+
+  public double xCoordinate;
+  public double yCoordinate;
+
+  public TestElement(double x, double y) {
+    this.xCoordinate = x;
+    this.yCoordinate = y;
+  }
+  
+  @Override
+  public double getX() {
+    return xCoordinate;
+  }
+
+  @Override
+  public double getY() {
+    return yCoordinate;
+  }
+
+  public String toString() {
+    return "(" + xCoordinate + ", " + yCoordinate + ")";
+  }
+}


### PR DESCRIPTION
## What?
This pull request removes the `org.apache.sis` library dependency and replaces it with a very simple and fast QuadTree class.

## Why?
While reviewing Pull Request #589 I have been conducting a lot of profiling using `jvisualvm`.

The single largest consumption of CPU time has been calls to `java.lang.Math.acos()` required to compute the Haversine distance while querying the QuadTree from the Apache SIS library. These are queries such as the "find nearest provider" query. According to the profiler, this was taking 28 - 30% of the computation time for each entire run of Synthea.

As an experiment, I replaced the Apache SIS QuadTree which uses Haversine distance calculations (which take into account the curvature of the Earth) with a very simple QuadTree that merely considers Euclidean distance on a flat 2D plane.

Considering the required degree of accuracy of this simulation, Euclidean distance is sufficient.

## Test and Results
I ran `./run_synthea -s 0 -p 10000` for `California`, `Alaska`, and `Texas` (large locations) and saw an average of a 30% reduction in overall time. `Alaska` saw the biggest improvement, which went from 10 minutes down to 4.5 minutes on my machine. This is probably because Alaska, and especially the Aleutian Islands, are so spread out and benefited the most from the simplification.

I also ran some seeded runs in Massachusetts before and after the change to determine if the change altered the locations that patients visited for their encounters. I conducted several spot checks and did not find any discrepancies.