### PR TITLE
Extracting GrowthChart from LifecycleModule

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -1,7 +1,5 @@
 package org.mitre.synthea.modules;
 
-import com.google.gson.Gson;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -13,8 +11,6 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.math3.distribution.NormalDistribution;
-import org.apache.commons.math3.special.Erf;
 import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.helpers.Attributes;
 import org.mitre.synthea.helpers.Attributes.Inventory;
@@ -27,13 +23,16 @@ import org.mitre.synthea.modules.BloodPressureValueGenerator.SysDias;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.BiometricsConfig;
 import org.mitre.synthea.world.concepts.BirthStatistics;
+import org.mitre.synthea.world.concepts.GrowthChart;
+import org.mitre.synthea.world.concepts.GrowthChartEntry;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 import org.mitre.synthea.world.concepts.VitalSign;
 import org.mitre.synthea.world.geography.Location;
 
 public final class LifecycleModule extends Module {
   @SuppressWarnings("rawtypes")
-  private static final Map growthChart = loadGrowthChart();
+  private static final Map<GrowthChart.ChartType, GrowthChart> growthChart =
+      GrowthChart.loadCharts();
   private static final List<LinkedHashMap<String, String>> weightForLengthChart =
       loadWeightForLengthChart();
   private static final String AGE = "AGE";
@@ -53,20 +52,6 @@ public final class LifecycleModule extends Module {
   
   public LifecycleModule() {
     this.name = "Lifecycle";
-  }
-
-  @SuppressWarnings("rawtypes")
-  private static Map loadGrowthChart() {
-    String filename = "cdc_growth_charts.json";
-    try {
-      String json = Utilities.readResource(filename);
-      Gson g = new Gson();
-      return g.fromJson(json, HashMap.class);
-    } catch (Exception e) {
-      System.err.println("ERROR: unable to load json: " + filename);
-      e.printStackTrace();
-      throw new ExceptionInInitializerError(e);
-    }
   }
 
   private static List<LinkedHashMap<String, String>> loadWeightForLengthChart() {
@@ -512,22 +497,19 @@ public final class LifecycleModule extends Module {
    * @param percentile 0.0 - 1.0
    * @return The height (cm) or weight (kg)
    */
-  @SuppressWarnings("rawtypes")
   public static double lookupGrowthChart(String heightWeightOrBMI, String gender, int ageInMonths,
       double percentile) {
-    Map chart = (Map) growthChart.get(heightWeightOrBMI);
-    Map byGender = (Map) chart.get(gender);
-    Map byAge = (Map) byGender.get(Integer.toString(ageInMonths));
-
-    double l = Double.parseDouble((String) byAge.get("l"));
-    double m = Double.parseDouble((String) byAge.get("m"));
-    double s = Double.parseDouble((String) byAge.get("s"));
-    double z = calculateZScore(percentile);
-
-    if (l == 0) {
-      return m * Math.exp((s * z));
-    } else {
-      return m * Math.pow((1 + (l * s * z)), (1.0 / l));
+    switch (heightWeightOrBMI) {
+      case "height":
+        return growthChart.get(GrowthChart.ChartType.HEIGHT).lookUp(ageInMonths,
+            gender, percentile);
+      case "weight":
+        return growthChart.get(GrowthChart.ChartType.WEIGHT).lookUp(ageInMonths,
+            gender, percentile);
+      case "bmi":
+        return growthChart.get(GrowthChart.ChartType.BMI).lookUp(ageInMonths, gender, percentile);
+      default:
+        throw new IllegalArgumentException("Unknown chart type: " + heightWeightOrBMI);
     }
   }
 
@@ -539,72 +521,7 @@ public final class LifecycleModule extends Module {
    * @return 0 - 1.0
    */
   public static double percentileForBMI(double bmi, String gender, int ageInMonths) {
-    Map chart = (Map) growthChart.get("bmi");
-    Map byGender = (Map) chart.get(gender);
-    Map byAge = (Map) byGender.get(Integer.toString(ageInMonths));
-
-    double l = Double.parseDouble((String) byAge.get("l"));
-    double m = Double.parseDouble((String) byAge.get("m"));
-    double s = Double.parseDouble((String) byAge.get("s"));
-    double z = zscoreForValue(bmi, l, m, s);
-    return zscoreToPercentile(z);
-  }
-
-  /**
-   * Z is the z-score that corresponds to the percentile.
-   * z-scores correspond exactly to percentiles, e.g.,
-   * z-scores of:
-   * -1.881, // 3rd
-   * -1.645, // 5th
-   * -1.282, // 10th
-   * -0.674, // 25th
-   *  0,     // 50th
-   *  0.674, // 75th
-   *  1.036, // 85th
-   *  1.282, // 90th
-   *  1.645, // 95th
-   *  1.881  // 97th
-   * @param percentile 0.0 - 1.0
-   * @return z-score that corresponds to the percentile.
-   */
-  protected static double calculateZScore(double percentile) {
-    // Set percentile gt0 and lt1, otherwise the error
-    // function will return Infinity.
-    if (percentile >= 1.0) {
-      percentile = 0.999;
-    } else if (percentile <= 0.0) {
-      percentile = 0.001;
-    }
-    return -1 * Math.sqrt(2) * Erf.erfcInv(2 * percentile);
-  }
-
-  /**
-   * Compute the z-score given a value and the LMS parameters.
-   * @param value the actual value, for example a weight, height or BMI
-   * @param l distribution's L parameter
-   * @param m distribution's M parameter
-   * @param s distribution's S parameter
-   * @return z-score
-   */
-  protected static double zscoreForValue(double value, double l, double m, double s) {
-    if (l == 0) {
-      return Math.log(value / m) / s;
-    } else {
-      return (Math.pow((value / m), l) - 1) / (l * s);
-    }
-  }
-
-  /**
-   * Convert a z-score into a percentile.
-   * @param zscore The ZScore to find the percentile for
-   * @return percentile - 0.0 - 1.0
-   */
-  protected static double zscoreToPercentile(double zscore) {
-    double percentile = 0;
-
-    NormalDistribution dist = new NormalDistribution();
-    percentile = dist.cumulativeProbability(zscore);
-    return percentile;
+    return growthChart.get(GrowthChart.ChartType.BMI).percentileFor(ageInMonths, gender, bmi);
   }
 
   public static double bmi(double heightCM, double weightKG) {
@@ -637,8 +554,8 @@ public final class LifecycleModule extends Module {
         double l = Double.parseDouble(entry.get("L"));
         double m = Double.parseDouble(entry.get("M"));
         double s = Double.parseDouble(entry.get("S"));
-        double z = zscoreForValue(weight, l, m, s);
-        double percentile = zscoreToPercentile(z) * 100.0;
+        double z = new GrowthChartEntry(l, m, s).zscoreForValue(weight);
+        double percentile = GrowthChart.zscoreToPercentile(z) * 100.0;
         person.attributes.put(Person.CURRENT_WEIGHT_LENGTH_PERCENTILE, percentile);
       }
     }

--- a/src/main/java/org/mitre/synthea/world/concepts/GrowthChart.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/GrowthChart.java
@@ -1,0 +1,154 @@
+package org.mitre.synthea.world.concepts;
+
+import com.google.gson.Gson;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.apache.commons.math3.special.Erf;
+import org.mitre.synthea.helpers.Utilities;
+
+/**
+ * Represents a growth chart for a particular measure.
+ */
+public class GrowthChart {
+  public enum ChartType {
+    HEIGHT, WEIGHT, BMI
+  }
+
+  private ChartType chartType;
+  private HashMap<Integer, GrowthChartEntry> maleEntries;
+  private HashMap<Integer, GrowthChartEntry> femaleEntries;
+
+  /**
+   * Construct a new GrowthChart.
+   * @param chartType What kind of chart it is.
+   * @param rawChart One of the raw HashMaps pulled from the JSON file.
+   */
+  public GrowthChart(ChartType chartType, Map<String, Map<String, Map<String, String>>> rawChart) {
+    this.chartType = chartType;
+    this.maleEntries = new HashMap();
+    this.femaleEntries = new HashMap();
+    Map<String, Map<String, String>> maleValues = rawChart.get("M");
+    maleValues.keySet().forEach(ageMonth -> {
+      Map<String, String> percentileInfo = maleValues.get(ageMonth);
+      GrowthChartEntry entry = new GrowthChartEntry(Double.parseDouble(percentileInfo.get("l")),
+          Double.parseDouble(percentileInfo.get("m")),
+          Double.parseDouble(percentileInfo.get("s")));
+      maleEntries.put(Integer.parseInt(ageMonth), entry);
+    });
+    this.chartType = chartType;
+    Map<String, Map<String, String>> femaleValues = rawChart.get("M");
+    femaleValues.keySet().forEach(ageMonth -> {
+      Map<String, String> percentileInfo = femaleValues.get(ageMonth);
+      GrowthChartEntry entry = new GrowthChartEntry(Double.parseDouble(percentileInfo.get("l")),
+          Double.parseDouble(percentileInfo.get("m")),
+          Double.parseDouble(percentileInfo.get("s")));
+      femaleEntries.put(Integer.parseInt(ageMonth), entry);
+    });
+  }
+
+  /**
+   * Lookup and calculate values from the CDC growth charts, using the LMS
+   * values to calculate the intermediate values.
+   * Reference : https://www.cdc.gov/growthcharts/percentile_data_files.htm
+   *
+   * @param gender "M" | "F"
+   * @param ageInMonths 0 - 240
+   * @param percentile 0.0 - 1.0
+   * @return The height (cm) or weight (kg) or BMI
+   */
+  public double lookUp(int ageInMonths, String gender, double percentile) {
+    GrowthChartEntry entry;
+    if (gender.equals("M")) {
+      entry = maleEntries.get(ageInMonths);
+    } else {
+      entry = femaleEntries.get(ageInMonths);
+    }
+    return entry.lookUp(percentile);
+  }
+
+  /**
+   * Given a value, find the percentile of the individual based on sex and age in months.
+   *
+   * @param gender "M" | "F"
+   * @param ageInMonths 0 - 240
+   * @param value the weight, height or BMI
+   * @return 0 - 1.0
+   */
+  public double percentileFor(int ageInMonths, String gender, double value) {
+    GrowthChartEntry entry;
+    if (gender.equals("M")) {
+      entry = maleEntries.get(ageInMonths);
+    } else {
+      entry = femaleEntries.get(ageInMonths);
+    }
+    return entry.percentileForValue(value);
+  }
+
+  /**
+   * Z is the z-score that corresponds to the percentile.
+   * z-scores correspond exactly to percentiles, e.g.,
+   * z-scores of:
+   * -1.881, // 3rd
+   * -1.645, // 5th
+   * -1.282, // 10th
+   * -0.674, // 25th
+   *  0,     // 50th
+   *  0.674, // 75th
+   *  1.036, // 85th
+   *  1.282, // 90th
+   *  1.645, // 95th
+   *  1.881  // 97th
+   * @param percentile 0.0 - 1.0
+   * @return z-score that corresponds to the percentile.
+   */
+  public static double calculateZScore(double percentile) {
+    // Set percentile gt0 and lt1, otherwise the error
+    // function will return Infinity.
+    if (percentile >= 1.0) {
+      percentile = 0.999;
+    } else if (percentile <= 0.0) {
+      percentile = 0.001;
+    }
+    return -1 * Math.sqrt(2) * Erf.erfcInv(2 * percentile);
+  }
+
+  /**
+   * Convert a z-score into a percentile.
+   * @param zscore The ZScore to find the percentile for
+   * @return percentile - 0.0 - 1.0
+   */
+  public static double zscoreToPercentile(double zscore) {
+    double percentile = 0;
+
+    NormalDistribution dist = new NormalDistribution();
+    percentile = dist.cumulativeProbability(zscore);
+    return percentile;
+  }
+
+  /**
+   * Load all of the charts in the cdc_growth_charts.json file
+   * @return a map of chart type to growth chart
+   */
+  public static Map<ChartType, GrowthChart> loadCharts() {
+    String filename = "cdc_growth_charts.json";
+    try {
+      String json = Utilities.readResource(filename);
+      Gson g = new Gson();
+      HashMap allCharts = g.fromJson(json, HashMap.class);
+      HashMap<ChartType, GrowthChart> returnMap = new HashMap();
+      returnMap.put(ChartType.HEIGHT,
+          new GrowthChart(ChartType.HEIGHT, (Map) allCharts.get("height")));
+      returnMap.put(ChartType.WEIGHT,
+          new GrowthChart(ChartType.WEIGHT, (Map) allCharts.get("weight")));
+      returnMap.put(ChartType.BMI, new GrowthChart(ChartType.BMI, (Map) allCharts.get("bmi")));
+      return returnMap;
+    } catch (Exception e) {
+      System.err.println("ERROR: unable to load json: " + filename);
+      e.printStackTrace();
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+}

--- a/src/main/java/org/mitre/synthea/world/concepts/GrowthChartEntry.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/GrowthChartEntry.java
@@ -1,0 +1,59 @@
+package org.mitre.synthea.world.concepts;
+
+/**
+ * Represents the LMS parameters on the CDC growth chart for a particular sex and age in months.
+ */
+public class GrowthChartEntry {
+  private double lboxCox;
+  private double median;
+  private double scov;
+
+  /**
+   * Create a new growth chart entry based on LMS values.
+   * @param l the power in the Box-Cox transformation
+   * @param m median
+   * @param s the generalized coefficient of variation
+   */
+  public GrowthChartEntry(double l, double m, double s) {
+    this.lboxCox = l;
+    this.median = m;
+    this.scov = s;
+  }
+
+  /**
+   * Compute the z-score given a value and the LMS parameters.
+   * @param value the actual value, for example a weight, height or BMI
+   * @return z-score
+   */
+  public double zscoreForValue(double value) {
+    if (this.lboxCox == 0) {
+      return Math.log(value / this.median) / this.scov;
+    } else {
+      return (Math.pow((value / this.median), this.lboxCox) - 1)
+          / (this.lboxCox * this.scov);
+    }
+  }
+
+  /**
+   * Look up the percentile that a given value falls into.
+   * @param value the value to find the percentile for
+   * @return 0 - 1.0
+   */
+  public double percentileForValue(double value) {
+    return GrowthChart.zscoreToPercentile(zscoreForValue(value));
+  }
+
+  /**
+   * Look up the value for a particular percentile.
+   * @param percentile 0 - 1.0
+   * @return The value for the given percentile
+   */
+  public double lookUp(double percentile) {
+    double z = GrowthChart.calculateZScore(percentile);
+    if (this.lboxCox == 0) {
+      return this.median * Math.exp((this.scov * z));
+    } else {
+      return this.median * Math.pow((1 + (this.lboxCox * this.scov * z)), (1.0 / this.lboxCox));
+    }
+  }
+}

--- a/src/test/java/org/mitre/synthea/modules/GrowthChartTest.java
+++ b/src/test/java/org/mitre/synthea/modules/GrowthChartTest.java
@@ -3,6 +3,7 @@ package org.mitre.synthea.modules;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import org.mitre.synthea.world.concepts.GrowthChart;
 
 public class GrowthChartTest {
   @Test
@@ -24,7 +25,7 @@ public class GrowthChartTest {
     double[] zscores = {-1.881, -1.645, -1.282, -0.674,  0.0, 0.674, 1.036, 1.282, 1.645, 1.881};
     double[] percent = { 0.03, 0.05, 0.10, 0.25, 0.50, 0.75, 0.85, 0.90, 0.95, 0.97};
     for (int i = 0; i < percent.length; i++) {
-      double z = LifecycleModule.calculateZScore(percent[i]);
+      double z = GrowthChart.calculateZScore(percent[i]);
       assertEquals(zscores[i], z, 0.01);
     }
   }

--- a/src/test/java/org/mitre/synthea/modules/LifecycleModuleTest.java
+++ b/src/test/java/org/mitre/synthea/modules/LifecycleModuleTest.java
@@ -63,4 +63,16 @@ public class LifecycleModuleTest {
     double percentile = LifecycleModule.percentileForBMI(18.37736191, "M", 26);
     Assert.assertEquals(0.9, percentile, 0.01);
   }
+
+  @Test
+  public void lookupGrowthChart() {
+//    Uncomment to check performance.
+//    long start = System.currentTimeMillis();
+//    for (int i = 0; i < 1000000; i++) {
+    double height = LifecycleModule.lookupGrowthChart("height", "M", 24, 0.5);
+    Assert.assertEquals(86.86160934, height, 0.01);
+//    }
+//    long end = System.currentTimeMillis();
+//    System.out.println("Time to complete: " + (end - start));
+  }
 }


### PR DESCRIPTION
Extract growth chart related items from `LifecycleModule`. This makes the `LifecycleModule` a little smaller with fewer unrelated functions.

This change also parses age in months as well as the LMS values from
strings into ints or doubles on startup as opposed to every time a value
is needed. Rough performance test appears to show a 2x performance
improvement when looking up values in growth charts. On my machine, running `LifecycleModule.lookupGrowthChart` on my laptop 1,000,000 times took ~580ms originally. After the changes, it's down to ~265ms. 