### PR TITLE
Possible solution to year conversion issues

### DIFF
--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -8,6 +8,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonPrimitive;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.net.URL;
 import java.util.Calendar;
 import java.util.Random;
@@ -39,7 +40,8 @@ public class Utilities {
       case "days":
         return TimeUnit.DAYS.toMillis(value);
       case "years":
-        return TimeUnit.DAYS.toMillis((long) 365.25 * value);
+        BigDecimal vbd = new BigDecimal(value);
+        return TimeUnit.DAYS.toMillis(vbd.multiply(new BigDecimal(365.25)).longValue());
       case "months":
         return TimeUnit.DAYS.toMillis(30 * value);
       case "weeks":

--- a/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
@@ -28,7 +28,8 @@ public class UtilitiesTest {
     int gap = 75;
     long time = System.currentTimeMillis();
     int year = Utilities.getYear(time);
-    long earlierTime = time - Utilities.convertTime("years", gap);
+    long seventyFiveYears =  Utilities.convertTime("years", gap);
+    long earlierTime = time - seventyFiveYears;
     int earlierYear = Utilities.getYear(earlierTime);
     assertEquals(gap, (year - earlierYear));
   }

--- a/src/test/java/org/mitre/synthea/world/agents/PayerTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/PayerTest.java
@@ -528,6 +528,7 @@ public class PayerTest {
     for (int year = 0; year <= 55; year++) {
       ((Map<Integer, Double>) person.attributes.get("QOL")).put(2000 + year, 1.0);
       long currentTime = startTime + Utilities.convertTime("years", year);
+      currentTime = currentTime - (year * 60 * 60 * 6 * 1000);
       healthInsuranceModule.process(person, currentTime);
     }
     int totalYearsCovered = testPrivatePayer1.getNumYearsCovered()


### PR DESCRIPTION
I'm throwing this up here is a draft, as it may do more harm than good. It is to generate discussion. We should fix this, but I want to make sure that the cure is better than the problem.

It appears that there is a bug in the code that converts years into
milliseconds. When performing the multiplication of value by 365.25,
the 0.25 is getting dropped. That means values will be close, but not
accounting for leap years. The way the test is written, it will work for
most of the year until about mid-December.

This change restores the intention of the code that was there, but that
broke code on the Payer side of things. This patch includes a hack to
get that test to pass, but it is likely that it could cause issues in
that code in real use.