### PR TITLE
Fix #608 providers with duplicate UUIDs.

### DIFF
--- a/src/main/java/org/mitre/synthea/world/agents/Clinician.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Clinician.java
@@ -54,7 +54,9 @@ public class Clinician implements Serializable, QuadTreeElement {
    */
   public Clinician(long clinicianSeed, Random clinicianRand,
       long identifier, Provider organization) {
-    this.uuid =  new UUID(clinicianSeed, identifier).toString();    
+    String base = clinicianSeed + ":" + identifier + ":" +
+      organization.id + ":" + clinicianRand.nextLong();
+    this.uuid = UUID.nameUUIDFromBytes(base.getBytes()).toString();
     this.random = clinicianRand;
     this.identifier = identifier;
     this.organization = organization;


### PR DESCRIPTION
Fixes #608 providers with duplicate UUIDs.

Through a twist of fate, the `providers.csv` file actually contains `Clinicians`. `Providers` are written into the `organizations.csv` file.

Therefore, the fix to #608 is to increase the variation in the code that assigns UUIDs to `Clinicians`.