### PR TITLE
Fix build on Java 13

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 org.gradle.jvmargs=-Xmx2048m

--- a/src/main/java/org/mitre/synthea/helpers/InnerClassTypeAdapterFactory.java
+++ b/src/main/java/org/mitre/synthea/helpers/InnerClassTypeAdapterFactory.java
@@ -97,7 +97,7 @@ import org.apache.commons.lang3.NotImplementedException;
  * Both the type field name ({@code "type"}) and the type labels ({@code
  * "Rectangle"}) are configurable.
  *
- * <h3>Registering Types</h3>
+ * <h2>Registering Types</h2>
  * Create an {@code InnerClassTypeAdapterFactory} by passing the base type and type field
  * name to the {@link #of} factory method. If you don't supply an explicit type
  * field name, {@code "type"} will be used. <pre>   {@code

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -356,7 +356,7 @@ public class Utilities {
    * Walk the directory structure of the modules, and apply the given function for every module.
    * 
    * @param action Action to apply for every module. Function signature is 
-   *        (topLevelModulesFolderPath, currentModulePath) -> {...}
+   *        (topLevelModulesFolderPath, currentModulePath) -&gt; {...}
    */
   public static void walkAllModules(BiConsumer<Path, Path> action) throws Exception {
     URL modulesFolder = ClassLoader.getSystemClassLoader().getResource("modules");
@@ -370,7 +370,7 @@ public class Utilities {
    * function for every module underneath.
    * 
    * @param action Action to apply for every module. Function signature is 
-   *        (currentModulePath) -> {...}
+   *        (currentModulePath) -&gt; {...}
    */
   public static void walkAllModules(Path modulesPath, Consumer<Path> action) throws Exception {
     Files.walk(modulesPath, Integer.MAX_VALUE)


### PR DESCRIPTION
Use newer Gradle distribution and modify Javadoc to get the build running on Java 13.

"gradlew build check test" is running successfully after these changes.

Disclaimer: I'm neither a Java, Gradle or Javadoc expert. This was a simple, naive try to get the build working.