### PR TITLE
There is now an option to generate only alive patients (Solves #624)

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -51,6 +51,7 @@ public class Generator {
   public Location location;
   private AtomicInteger totalGeneratedPopulation;
   private String logLevel;
+  private boolean onlyAlivePatients;
   private boolean onlyDeadPatients;
   private boolean onlyVeterans;
   public TransitionMetrics metrics;
@@ -188,7 +189,15 @@ public class Generator {
     this.location = new Location(options.state, options.city);
 
     this.logLevel = Config.get("generate.log_patients.detail", "simple");
+
     this.onlyDeadPatients = Boolean.parseBoolean(Config.get("generate.only_dead_patients"));
+    this.onlyAlivePatients = Boolean.parseBoolean(Config.get("generate.only_alive_patients"));
+    //If both values are set to true, then they are both set back to the default
+    if(this.onlyDeadPatients && this.onlyAlivePatients){
+      this.onlyDeadPatients = false;
+      this.onlyAlivePatients = false;
+    }
+
     this.onlyVeterans = Boolean.parseBoolean(Config.get("generate.veteran_population_override"));
     this.totalGeneratedPopulation = new AtomicInteger(0);
     this.stats = Collections.synchronizedMap(new HashMap<String, AtomicInteger>());
@@ -365,6 +374,14 @@ public class Generator {
           personSeed = new Random(personSeed).nextLong();
           continue;
           // skip the other stuff if the patient is alive and we only want dead patients
+          // note that this skips ahead to the while check and doesn't automatically re-loop
+        }
+
+        if(!isAlive && onlyAlivePatients){
+          // rotate the seed so the next attempt gets a consistent but different one
+          personSeed = new Random(personSeed).nextLong();
+          continue;
+          // skip the other stuff if the patient is dead and we only want alive patients
           // note that this skips ahead to the while check and doesn't automatically re-loop
         }
 

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -194,6 +194,8 @@ public class Generator {
     this.onlyAlivePatients = Boolean.parseBoolean(Config.get("generate.only_alive_patients"));
     //If both values are set to true, then they are both set back to the default
     if(this.onlyDeadPatients && this.onlyAlivePatients){
+      Config.set("generate.only_dead_patients", "false");
+      Config.set("generate.only_alive_patients", "false");
       this.onlyDeadPatients = false;
       this.onlyAlivePatients = false;
     }

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -74,6 +74,10 @@ generate.lookup_tables = modules/lookup_tables/
 
 # Set to true if you want every patient to be dead.
 generate.only_dead_patients = false
+# Set to true if you want every patient to be alive.
+generate.only_alive_patients = false
+# If both only_dead_patients and only_alive_patients are set to true,
+# It they will both default back to false
 
 # if true, tracks and prints out details of transition tables for each module upon completion
 # note that this may significantly slow down processing, and is intended primarily for debugging

--- a/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
+++ b/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
@@ -85,7 +85,18 @@ public class GeneratorTest {
     assertEquals(0, generator.stats.get("dead").longValue());
     assertEquals(numberOfPeople, generator.stats.get("alive").longValue());
   }
-  
+
+  @Test
+  public void testOnlyAliveAndDead() throws Exception {
+    Config.set("generate.only_alive_patients", "true");
+    Config.set("generate.only_dead_patients", "true");
+    int numberOfPeople = 2;
+    Generator generator = new Generator(numberOfPeople);
+    generator.run();
+    assertEquals("false", Config.get("generate.only_alive_patients"));
+    assertEquals("false", Config.get("generate.only_dead_patients"));
+  }
+
   @Test
   public void testGeneratePeopleDefaultLocation() throws Exception {
     int numberOfPeople = 2;

--- a/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
+++ b/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
@@ -75,6 +75,16 @@ public class GeneratorTest {
     assertEquals(0, generator.stats.get("alive").longValue());
     assertEquals(numberOfPeople, generator.stats.get("dead").longValue());
   }
+
+  @Test
+  public void testGenerateOnlyAlivePatients() throws Exception {
+    Config.set("generate.only_alive_patients", "true");
+    int numberOfPeople = 2;
+    Generator generator = new Generator(numberOfPeople);
+    generator.run();
+    assertEquals(0, generator.stats.get("dead").longValue());
+    assertEquals(numberOfPeople, generator.stats.get("alive").longValue());
+  }
   
   @Test
   public void testGeneratePeopleDefaultLocation() throws Exception {


### PR DESCRIPTION
Allows users to specify that only alive patients are generated.

This new property conflicts with only_dead_patients, and I couldn't really find a place to do a check for the conflict, so I thought it better to default them both to false if the user sets them both to true.

Solves #624 