### PR TITLE
Fix adjustBMIVectorForSuccessfulManagement to only append once

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/WeightLossModule.java
+++ b/src/main/java/org/mitre/synthea/modules/WeightLossModule.java
@@ -300,8 +300,14 @@ public final class WeightLossModule extends Module {
     double percentileChange = (double) person.attributes.get(WEIGHT_LOSS_BMI_PERCENTILE_CHANGE);
     double bmiAtStart = pgt.currentBMI(person, start, person.random);
     double startPercentile = bmiChart.percentileFor(startAgeInMonths, gender, bmiAtStart);
-    double targetPercentile = startPercentile - percentileChange;
     int currentTailAge = pgt.tail().ageInMonths;
+    double currentTailBMI = pgt.tail().ageInMonths;
+    double currentTailPercentile = bmiChart.percentileFor(currentTailAge, gender, currentTailBMI);
+    if (currentTailPercentile <= startPercentile) {
+      // Vector has been adjusted, exit early to not run again.
+      return;
+    }
+    double targetPercentile = startPercentile - percentileChange;
     long currentTailTimeInSim = pgt.tail().timeInSimulation;
     int monthsInTheFuture = 12;
     if (currentTailAge + monthsInTheFuture > TWENTY_YEARS_IN_MONTHS) {
@@ -329,7 +335,7 @@ public final class WeightLossModule extends Module {
       String gender = (String) person.attributes.get(Person.GENDER);
       int monthsInTheFuture = 12;
       if (tail.ageInMonths + monthsInTheFuture > TWENTY_YEARS_IN_MONTHS) {
-        monthsInTheFuture = tail.ageInMonths + monthsInTheFuture - TWENTY_YEARS_IN_MONTHS;
+        monthsInTheFuture = TWENTY_YEARS_IN_MONTHS - tail.ageInMonths;
       }
 
       double percentile = bmiChart.percentileFor(tail.ageInMonths, gender, tail.bmi);


### PR DESCRIPTION
Addresses #660 

Since adjustBMIVectorForSuccessfulManagement gets called multiple times, it kept adding values to the end of the growth trajectory. This code makes sure that even when called multiple times, it will only append a single point.

Also, make sure that we properly limit running over 20 years when
maintaining BMI