### PR TITLE
Add amount field to Counter state

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -542,11 +542,16 @@ public abstract class State implements Cloneable {
     private String attribute;
     private String action;
     private boolean increment;
+    private int amount;
 
     @Override
     protected void initialize(Module module, String name, JsonObject definition) {
       super.initialize(module, name, definition);
       increment = action.equals("increment");
+      if (amount == 0) {
+        // default to 1 for legacy compatibility
+        amount = 1;
+      }
     }
 
     @Override
@@ -554,6 +559,7 @@ public abstract class State implements Cloneable {
       Counter clone = (Counter) super.clone();
       clone.attribute = attribute;
       clone.increment = increment;
+      clone.amount = amount;
       return clone;
     }
 
@@ -565,9 +571,9 @@ public abstract class State implements Cloneable {
       }
 
       if (increment) {
-        counter++;
+        counter = counter + amount;
       } else {
-        counter--;
+        counter = counter - amount;
       }
       person.attributes.put(attribute, counter);
       return true;

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -135,12 +135,12 @@ public class StateTest {
     assertTrue(counter.process(person, time));
     assertEquals(3, person.attributes.get("loop_index"));
 
-    State decrement = module.getState("Counter_Decrement");
-    assertTrue(decrement.process(person, time));
-    assertEquals(2, person.attributes.get("loop_index"));
-
+    State decrement = module.getState("Counter_Decrement_by_2");
     assertTrue(decrement.process(person, time));
     assertEquals(1, person.attributes.get("loop_index"));
+
+    assertTrue(decrement.process(person, time));
+    assertEquals(-1, person.attributes.get("loop_index"));
   }
 
   @Test

--- a/src/test/resources/generic/counter.json
+++ b/src/test/resources/generic/counter.json
@@ -30,9 +30,10 @@
       ]
     },
 
-    "Counter_Decrement" : {
+    "Counter_Decrement_by_2" : {
       "type" : "Counter",
       "action" : "decrement",
+      "amount" : 2,
       "attribute" : "loop_index",
       "direct_transition" : "Terminal"
     },


### PR DESCRIPTION
Adds an `amount` field to the Counter state, so that counters can count 2 by 2, or 17 by 17, or whatever number you like. Defaults to 1 if the field is not present, so all current usage of the Counter state will work without explicitly adding the field.