### PR TITLE
Fix attribute logic. See #529.

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Logic.java
+++ b/src/main/java/org/mitre/synthea/engine/Logic.java
@@ -274,10 +274,12 @@ public abstract class Logic {
 
     @Override
     public boolean test(Person person, long time) {
-      if (value instanceof String) {
-        return value.equals(person.attributes.get(attribute));
-      } else {
+      try {
         return Utilities.compare(person.attributes.get(attribute), value, operator);
+      } catch (Exception e) {
+        String message = "Attribute Logic error: " + attribute + " " + operator + " " + value;
+        message += ": " + e.getMessage();
+        throw new RuntimeException(message, e);
       }
     }
   }

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -178,13 +178,13 @@ public class Utilities {
       case "<=":
         return lhs.compareTo(rhs) <= 0;
       case "==":
-        return lhs == rhs;
+        return lhs.equals(rhs);
       case ">=":
         return lhs.compareTo(rhs) >= 0;
       case ">":
         return lhs.compareTo(rhs) > 0;
       case "!=":
-        return lhs != rhs;
+        return !lhs.equals(rhs);
       case "is nil":
         return lhs == null;
       case "is not nil":

--- a/src/main/resources/modules/veteran_ptsd.json
+++ b/src/main/resources/modules/veteran_ptsd.json
@@ -452,10 +452,19 @@
         {
           "transition": "Evaluation Gate delay",
           "condition": {
-            "condition_type": "Attribute",
-            "attribute": "ptsd_careplan",
-            "operator": "==",
-            "value": "PTSD_Careplan_Rx_ONLY"
+            "condition_type": "And",
+            "conditions": [
+              {
+                "condition_type": "PriorState",
+                "name": "PTSD_Careplan_Rx_ONLY",
+                "since": "PTSD_Re_evaluation Encounter"
+              },
+              {
+                "condition_type": "Attribute",
+                "attribute": "SSRI",
+                "operator": "is not nil"
+              }
+            ]
           }
         },
         {
@@ -817,19 +826,17 @@
         {
           "transition": "Therapy_Visit_Telehealth",
           "condition": {
-            "condition_type": "Attribute",
-            "attribute": "ptsd_careplan",
-            "operator": "==",
-            "value": "PTSD_Careplan_Telehealth_Psych"
+            "condition_type": "PriorState",
+            "name": "PTSD_Careplan_Telehealth_Psych",
+            "since": "PTSD_Re_evaluation Encounter"
           }
         },
         {
           "transition": "Therapy_Visit_Telehealth",
           "condition": {
-            "condition_type": "Attribute",
-            "attribute": "ptsd_careplan",
-            "operator": "==",
-            "value": "PTSD_Careplan_Telehealth_Psych_and_Rx"
+            "condition_type": "PriorState",
+            "name": "PTSD_Careplan_Telehealth_Psych_and_Rx",
+            "since": "PTSD_Re_evaluation Encounter"
           }
         },
         {

--- a/src/test/java/org/mitre/synthea/engine/LogicTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LogicTest.java
@@ -199,24 +199,40 @@ public class LogicTest {
 
     person.attributes.remove(attribute);
     assertFalse(doTest("attributeEqualTo_TestValue_Test"));
+    assertFalse(doTest("attributeLt_String_Test"));
     assertTrue(doTest("attributeNilTest"));
     assertFalse(doTest("attributeNotNilTest"));
 
     person.attributes.put(attribute, "Wrong Value");
     assertFalse(doTest("attributeEqualTo_TestValue_Test"));
+    assertFalse(doTest("attributeLt_String_Test"));
     assertFalse(doTest("attributeNilTest"));
     assertTrue(doTest("attributeNotNilTest"));
 
     person.attributes.put(attribute, "TestValue");
     assertTrue(doTest("attributeEqualTo_TestValue_Test"));
+    assertTrue(doTest("attributeLt_String_Test"));
     assertFalse(doTest("attributeNilTest"));
     assertTrue(doTest("attributeNotNilTest"));
 
     person.attributes.put(attribute, 120);
-    assertFalse(doTest("attributeEqualTo_TestValue_Test"));
     assertTrue(doTest("attributeGt100Test"));
     assertFalse(doTest("attributeNilTest"));
     assertTrue(doTest("attributeNotNilTest"));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void test_attribute_expected_numeric_exception() {
+    String attribute = "Test_Attribute_Key";
+    person.attributes.put(attribute, "TestValue");
+    doTest("attributeGt100Test");
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void test_attribute_expected_string_exception() {
+    String attribute = "Test_Attribute_Key";
+    person.attributes.put(attribute, 120);
+    doTest("attributeEqualTo_TestValue_Test");
   }
 
   @Test

--- a/src/test/resources/generic/logic.json
+++ b/src/test/resources/generic/logic.json
@@ -135,6 +135,12 @@
     "operator" : "==",
     "value" : "TestValue"
   },
+  "attributeLt_String_Test" : {
+    "condition_type" : "Attribute",
+    "attribute" : "Test_Attribute_Key",
+    "operator" : "<=",
+    "value" : "UComesAfterTandBeforeW"
+  },
   "attributeGt100Test" : {
     "condition_type" : "Attribute",
     "attribute" : "Test_Attribute_Key",


### PR DESCRIPTION
Fixes attribute logic and a bug in the `veteran_ptsd` module that was silently effected by it.

See #529.