### PR TITLE
Add openjdk13 to Travis Build Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
 - openjdk8
+- openjdk13
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
 - rm -fr $HOME/.gradle/caches/*/plugin-resolution/


### PR DESCRIPTION
As a follow up on #654 this PR runs the travis-ci jobs on OpenJDK 13 as well, so future code changes are checked for Java 13 compatibility.

I ran the CI tests with the new changes. The first job failed, but the next job (https://travis-ci.org/bugspencor/synthea/builds/656615725) succeeded without any changes in synthea code. So hopefully the errors in the first build were only random, temporary errors (https://travis-ci.org/bugspencor/synthea/builds/656161105). Building locally (build check test) on my setup with Java 13 worked as well.