### PR TITLE
Physiology State Enable/Disable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
   compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
   compile group: 'org.apache.commons', name: 'commons-text', version: '1.2'
 
-  compile group: 'org.opencds.cqf', name: 'cql-engine', version: '1.3.10-SNAPSHOT'
+  compile group: 'org.opencds.cqf', name: 'cql-engine', version: '1.3.12'
   compile group: 'info.cqframework', name: 'cql', version: '1.3.17'
   compile group: 'info.cqframework', name: 'model', version: '1.3.17'
   compile group: 'info.cqframework', name: 'cql-to-elm', version: '1.3.17'

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
   compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
   compile group: 'org.apache.commons', name: 'commons-text', version: '1.2'
 
-  compile group: 'org.opencds.cqf', name: 'cql-engine', version: '1.3.12' 
+  compile group: 'org.opencds.cqf', name: 'cql-engine', version: '1.3.10-SNAPSHOT'
   compile group: 'info.cqframework', name: 'cql', version: '1.3.17'
   compile group: 'info.cqframework', name: 'model', version: '1.3.17'
   compile group: 'info.cqframework', name: 'cql-to-elm', version: '1.3.17'

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
   compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
   compile group: 'org.apache.commons', name: 'commons-text', version: '1.2'
 
-  compile group: 'org.opencds.cqf', name: 'cql-engine', version: '1.3.12'
+  compile group: 'org.opencds.cqf', name: 'cql-engine', version: '1.3.12' 
   compile group: 'info.cqframework', name: 'cql', version: '1.3.17'
   compile group: 'info.cqframework', name: 'model', version: '1.3.17'
   compile group: 'info.cqframework', name: 'cql-to-elm', version: '1.3.17'

--- a/src/main/java/org/mitre/synthea/engine/Components.java
+++ b/src/main/java/org/mitre/synthea/engine/Components.java
@@ -95,7 +95,7 @@ public abstract class Components {
     public int millisecond;
   }
   
-  public static class SampledData {
+  public static class SampledData implements Serializable {
     public double originValue; // Zero value
     public Double factor; // Multiply data by this before adding to origin
     public Double lowerLimit; // Lower limit of detection
@@ -161,7 +161,7 @@ public abstract class Components {
    * Attachment class to support inline image file generation,
    * raw base64 data, or URLs of image attachments for Observations.
    */
-  public static class Attachment {
+  public static class Attachment implements Serializable {
     public String contentType; // Code for the MIME type of the content, with charset etc.
     public String language; // Human language of the content (BCP-47)
     public String data; // Data inline, base64ed

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -69,7 +69,7 @@ public abstract class State implements Cloneable, Serializable {
   private List<LookupTableTransitionOption> lookupTableTransition;
   public List<String> remarks;
   
-  protected static boolean ENABLE_PHYSIOLOGY_STATE =
+  public static boolean ENABLE_PHYSIOLOGY_STATE =
       Boolean.parseBoolean(Config.get("physiology.state.enabled", "false"));
 
   protected void initialize(Module module, String name, JsonObject definition) {

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -31,8 +31,6 @@ import org.mitre.synthea.engine.Transition.DistributedTransition;
 import org.mitre.synthea.engine.Transition.DistributedTransitionOption;
 import org.mitre.synthea.engine.Transition.LookupTableTransition;
 import org.mitre.synthea.engine.Transition.LookupTableTransitionOption;
-import org.mitre.synthea.helpers.ChartRenderer;
-import org.mitre.synthea.helpers.ChartRenderer.PersonChartConfig;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.ConstantValueGenerator;
 import org.mitre.synthea.helpers.ExpressionProcessor;
@@ -1539,7 +1537,7 @@ public abstract class State implements Cloneable, Serializable {
       } else if (valueCode != null) {
         value = valueCode;
       } else if (threadExpProcessor != null
-    		  && threadExpProcessor.get() != null) {
+          && threadExpProcessor.get() != null) {
         value = threadExpProcessor.get().evaluate(person, time);
       } else if (sampledData != null) {
         // Capture the data lists from person attributes

--- a/src/main/java/org/mitre/synthea/helpers/ChartRenderer.java
+++ b/src/main/java/org/mitre/synthea/helpers/ChartRenderer.java
@@ -420,7 +420,7 @@ public class ChartRenderer {
       valuesX = (List<Double>) attrValueX;
     } else {
       throw new RuntimeException("Invalid Person attribute \""
-          + config.getAxisAttributeX() + "\"provided for chart X Axis: "
+          + config.getAxisAttributeX() + "\" provided for chart X Axis: "
           + attrValueX + ". Attribute must either be \"time\" or refer to a TimeSeriesData or"
           + "List<Double> Object.");
     }
@@ -460,7 +460,7 @@ public class ChartRenderer {
         seriesValues = (List<Double>) seriesObject;
       } else {
         throw new RuntimeException("Invalid Person attribute \""
-            + seriesConfig.getAttribute() + "\"provided for chart series: "
+            + seriesConfig.getAttribute() + "\" provided for chart series: "
             + seriesObject + ". Attribute value must be a TimeSeriesData or List<Double> Object.");
       }
       

--- a/src/main/java/org/mitre/synthea/helpers/ChartRenderer.java
+++ b/src/main/java/org/mitre/synthea/helpers/ChartRenderer.java
@@ -3,6 +3,7 @@ package org.mitre.synthea.helpers;
 import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -33,7 +34,7 @@ public class ChartRenderer {
   /**
    * POJO configuration for a chart.
    **/
-  public abstract static class ChartConfig {
+  public abstract static class ChartConfig implements Serializable {
     /** Name of the image file to export. **/
     private String filename;
     /** User input for the type of chart to render. **/
@@ -129,7 +130,7 @@ public class ChartRenderer {
   /**
    * POJO configuration for a chart with data from a MultiTable.
    **/
-  public static class MultiTableChartConfig extends ChartConfig {
+  public static class MultiTableChartConfig extends ChartConfig implements Serializable {
     /** Parameter to render on the x axis. **/
     private String axisParamX;
     /** Simulation time in seconds to start charting points. **/
@@ -176,7 +177,7 @@ public class ChartRenderer {
   /**
    * POJO configuration for a chart with data from a Person object.
    **/
-  public static class PersonChartConfig extends ChartConfig {
+  public static class PersonChartConfig extends ChartConfig implements Serializable {
     /** Person attribute to render on the x axis. **/
     private String axisAttributeX;
     /** List of series configurations for this chart. **/
@@ -203,7 +204,7 @@ public class ChartRenderer {
   /**
    * POJO configuration for a chart series.
    */
-  private abstract static class SeriesConfig {
+  private abstract static class SeriesConfig implements Serializable {
     /** Series label in the legend. **/
     private String label;
 
@@ -220,7 +221,7 @@ public class ChartRenderer {
   /**
    * POJO configuration for a chart series with data from a MultiTable.
    */
-  public static class MultiTableSeriesConfig extends SeriesConfig {
+  public static class MultiTableSeriesConfig extends SeriesConfig implements Serializable {
     /** Which parameter to plot on this series. (if providing a MultiTable) **/
     private String param;
 
@@ -237,7 +238,7 @@ public class ChartRenderer {
   /**
    * POJO configuration for a chart series with data from a Person object.
    */
-  public static class PersonSeriesConfig extends SeriesConfig {
+  public static class PersonSeriesConfig extends SeriesConfig implements Serializable {
     /** Which attribute to plot on this series. (if providing a Person) **/
     private String attribute;
 

--- a/src/main/java/org/mitre/synthea/helpers/physiology/PreGenerator.java
+++ b/src/main/java/org/mitre/synthea/helpers/physiology/PreGenerator.java
@@ -1,5 +1,6 @@
 package org.mitre.synthea.helpers.physiology;
 
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
@@ -10,7 +11,7 @@ import org.mitre.synthea.helpers.ValueGenerator;
 import org.mitre.synthea.world.agents.Person;
 
 /** Class for handling pre-simulation outputs. **/
-public class PreGenerator {
+public class PreGenerator implements Serializable {
   private String className;
   private List<PreGeneratorArg> args;
   

--- a/src/main/resources/modules/gallstones.json
+++ b/src/main/resources/modules/gallstones.json
@@ -1226,6 +1226,64 @@
         "high": 10,
         "unit": "minutes"
       },
+      "direct_transition": "ECG_Sim"
+    },
+    "ECG_Sim": {
+      "type": "Physiology",
+      "model": "circulation/McSharry2003_Synthetic_ECG.xml",
+      "solver": "runge_kutta",
+      "step_size": 0.01,
+      "sim_duration": 4.0,
+      "lead_time": 0.0,
+      "inputs": [
+        {"from_exp": "#{BMI} * 0.497 + 56.15", "to": "hrmean"}
+      ],
+      "outputs": [
+        {
+          "from_list": "zf",
+          "to": "ecg_result",
+          "type": "Attribute"
+        }
+      ],
+      "direct_transition": "ECG_Data",
+      "alt_direct_transition": "Gall_Bladder_Imaging"
+    },
+    "ECG_Data": {
+      "type": "Observation",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": 29303009,
+        "display": "Electrocardiographic procedure"
+      }],
+      "sampled_data": {
+        "attributes": ["ecg_result"]
+      },
+      "direct_transition": "ECG_Chart"
+    },
+    "ECG_Chart": {
+      "type": "Observation",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": 29303009,
+        "display": "Electrocardiographic procedure"
+      }],
+      "attachment": {
+        "chart": {
+        	"type": "line",
+        	"title": "Electrocardiogram",
+        	"axis_attribute_x": "time",
+        	"width": 400,
+        	"height": 200,
+        	"series": [
+        		{"attribute": "ecg_result"}
+        	]
+        }
+      },
+      "direct_transition": "Clear_ECG_result"
+    },
+    "Clear_ECG_result": {
+      "type": "SetAttribute",
+      "attribute" : "ecg_result",
       "direct_transition": "Gall_Bladder_Imaging"
     },
     "Heparin": {

--- a/src/main/resources/physiology/models/circulation/McSharry2003_Synthetic_ECG.xml
+++ b/src/main/resources/physiology/models/circulation/McSharry2003_Synthetic_ECG.xml
@@ -388,8 +388,8 @@ to compute clinical statistics from the ECG.      </p>
       <parameter id="arr_t1" name="arr_t1" value="0" constant="false"/>
       <parameter id="noise_amp" name="noise_amp" value="0.005" constant="false"/>
       
-      <parameter metaid="_685797" id="vfib_start" name="vfib_start" value="0" constant="false"/>
-      <parameter metaid="_685797" id="vfib_end" name="vfib_end" value="0" constant="false"/>
+      <parameter id="vfib_start" name="vfib_start" value="0" constant="false"/>
+      <parameter id="vfib_end" name="vfib_end" value="0" constant="false"/>
       
   </listOfParameters>
   <listOfRules>

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -219,7 +219,11 @@ lifecycle.death_by_loss_of_care = false
 # Use physiology simulations to generate some VitalSigns
 physiology.generators.enabled = false
 
+# Allow physiology module states to be executed
+# If false, all Physiology state objects will immediately redirect to the state defined in
+# the alt_direct_transition field
+physiology.state.enabled = false
+
 # set to true to introduce errors in height, weight and BMI observations for people
 # under 20 years old
 growtherrors = false
-

--- a/src/test/java/org/mitre/synthea/export/FHIRDSTU2ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRDSTU2ExporterTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import org.apache.commons.codec.binary.Base64;
 import org.hl7.fhir.dstu3.model.DiagnosticReport;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -44,11 +46,31 @@ import org.mockito.Mockito;
  * Uses HAPI FHIR project to validate FHIR export. http://hapifhir.io/doc_validation.html
  */
 public class FHIRDSTU2ExporterTest {
+  private boolean physStateEnabled;
+  
   /**
    * Temporary folder for any exported files, guaranteed to be deleted at the end of the test.
    */
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();
+  
+  /**
+   * Setup state for exporter test.
+   */
+  @Before
+  public void setup() {
+    // Ensure Physiology state is enabled
+    physStateEnabled = State.ENABLE_PHYSIOLOGY_STATE;
+    State.ENABLE_PHYSIOLOGY_STATE = true;
+  }
+  
+  /**
+   * Reset state after exporter test.
+   */
+  @After
+  public void tearDown() {
+    State.ENABLE_PHYSIOLOGY_STATE = physStateEnabled;
+  }
 
   @Test
   public void testDecimalRounding() {

--- a/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
@@ -9,6 +9,7 @@ import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.validation.SingleValidationMessage;
 import ca.uhn.fhir.validation.ValidationResult;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -22,6 +23,8 @@ import org.hl7.fhir.r4.model.Media;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.SampledData;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -42,11 +45,31 @@ import org.mockito.Mockito;
  * Uses HAPI FHIR project to validate FHIR export. http://hapifhir.io/doc_validation.html
  */
 public class FHIRR4ExporterTest {
+  private boolean physStateEnabled;
+  
   /**
    * Temporary folder for any exported files, guaranteed to be deleted at the end of the test.
    */
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();
+  
+  /**
+   * Setup state for exporter test.
+   */
+  @Before
+  public void setup() {
+    // Ensure Physiology state is enabled
+    physStateEnabled = State.ENABLE_PHYSIOLOGY_STATE;
+    State.ENABLE_PHYSIOLOGY_STATE = true;
+  }
+  
+  /**
+   * Reset state after exporter test.
+   */
+  @After
+  public void tearDown() {
+    State.ENABLE_PHYSIOLOGY_STATE = physStateEnabled;
+  }
   
   @Test
   public void testDecimalRounding() {

--- a/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
@@ -24,7 +24,9 @@ import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Quantity;
 import org.hl7.fhir.dstu3.model.SampledData;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -45,11 +47,31 @@ import org.mockito.Mockito;
  * Uses HAPI FHIR project to validate FHIR export. http://hapifhir.io/doc_validation.html
  */
 public class FHIRSTU3ExporterTest {
+  private boolean physStateEnabled;
+  
   /**
    * Temporary folder for any exported files, guaranteed to be deleted at the end of the test.
    */
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();
+  
+  /**
+   * Setup state for exporter test.
+   */
+  @Before
+  public void setup() {
+    // Ensure Physiology state is enabled
+    physStateEnabled = State.ENABLE_PHYSIOLOGY_STATE;
+    State.ENABLE_PHYSIOLOGY_STATE = true;
+  }
+  
+  /**
+   * Reset state after exporter test.
+   */
+  @After
+  public void tearDown() {
+    State.ENABLE_PHYSIOLOGY_STATE = physStateEnabled;
+  }
 
   @Test
   public void testDecimalRounding() {

--- a/src/test/java/org/mitre/synthea/helpers/TimeSeriesDataTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/TimeSeriesDataTest.java
@@ -1,0 +1,5 @@
+package org.mitre.synthea.helpers;
+
+public class TimeSeriesDataTest {
+
+}

--- a/src/test/resources/generic/observation.json
+++ b/src/test/resources/generic/observation.json
@@ -15,32 +15,55 @@
         },
         
         "Simulate_CVS": {
-	      "type": "Physiology",
-	      "model": "circulation/Smith2004_CVS_human.xml",
-	      "solver": "runge_kutta",
-	      "step_size": 0.01,
-	      "sim_duration": 4.0,
-	      "lead_time": 2.0,
-	      "inputs": [],
-	      "outputs": [
-	        {
-	          "from_list": "P_ao",
-	          "to": "P_ao",
-	          "type": "Attribute"
-	        },
-	        {
-	          "from_list": "P_lv",
-	          "to": "P_lv",
-	          "type": "Attribute"
-	        },
-	        {
-	          "from_list": "P_rv",
-	          "to": "P_rv",
-	          "type": "Attribute"
-	        }
-	      ],
-	      "direct_transition": "SomeEncounter"
+  			"type": "Physiology",
+		  	"model": "circulation/Smith2004_CVS_human.xml",
+		  	"solver": "runge_kutta",
+		  	"step_size": 0.01,
+		  	"sim_duration": 4.0,
+		  	"lead_time": 2.0,
+		  	"inputs": [],
+		  	"outputs": [
+		    	{
+		      		"from_list": "P_ao",
+		      		"to": "P_ao",
+		      		"type": "Attribute"
+		    	},
+		    	{
+		      		"from_list": "P_lv",
+		      		"to": "P_lv",
+		      		"type": "Attribute"
+		    	},
+		    	{
+		      		"from_list": "P_rv",
+		      		"to": "P_rv",
+		      		"type": "Attribute"
+		    	}
+		  	],
+		  	"direct_transition": "SomeEncounter",
+		  	"alt_direct_transition": "ContrivedPAO"
 	    },
+	    
+	    "ContrivedPAO" : {
+            "type" : "SetAttribute",
+            "attribute": "P_ao",
+            "seriesData": "128 116 103 91 78 126 113 101",
+            "period": 0.25,
+            "direct_transition" : "ContrivedPLV"
+        },
+        "ContrivedPLV" : {
+            "type" : "SetAttribute",
+            "attribute": "P_lv",
+            "seriesData": "130 30 2 4 26 129 21 1",
+            "period": 0.25,
+            "direct_transition" : "ContrivedPRV"
+        },
+        "ContrivedPRV" : {
+            "type" : "SetAttribute",
+            "attribute": "P_rv",
+            "seriesData": "25 5 -1 2 3 27 5 -2",
+            "period": 0.25,
+            "direct_transition" : "SomeEncounter"
+        },
 
         "SomeEncounter" : {
             "type" : "Encounter",

--- a/src/test/resources/generic/smith_physiology.json
+++ b/src/test/resources/generic/smith_physiology.json
@@ -14,7 +14,7 @@
       "type": "SetAttribute",
       "attribute" : "cvs_systemic_resistance",
       "value" : 1.814,
-      "direct_transition": "Simulate_CVS"
+      "direct_transition": "SomeEncounter"
     },
     
     "SomeEncounter" : {
@@ -66,9 +66,83 @@
           "type": "Attribute"
         }
       ],
-      "direct_transition": "Chart"
+      "direct_transition": "Media",
+      "alt_direct_transition": "ContrivedLVEF"
     },
     
+	"ContrivedLVEF" : {
+        "type" : "SetAttribute",
+        "attribute": "LVEF",
+        "value": 55.5,
+        "direct_transition": "ContrivedSBP"
+    },
+    
+    "ContrivedSBP" : {
+        "type" : "SetAttribute",
+        "attribute": "SBP",
+        "value": 140.5,
+        "direct_transition": "ContrivedDBP"
+    },
+    
+    "ContrivedDBP" : {
+        "type" : "SetAttribute",
+        "attribute": "DBP",
+        "value": 90.5,
+        "direct_transition" : "Media"
+    },
+    
+    "Media": {
+      "type": "Media",
+      "media_type": "image",
+      "reason_code": [{
+      	"system": "SNOMED-CT",
+      	"code": "386532001",
+      	"display": "Invasive arterial pressure"
+      }],
+      "body_site": {
+      	"system": "SNOMED-CT",
+      	"code": "360543005",
+      	"display": "Branch of bracial artery"
+      },
+      "modality": {
+      	"system": "MediaModality",
+      	"code": "diagram",
+      	"display": "Diagram"
+      },
+      "device_name": "Arterial line",
+      "language": "en",
+      "chart": {
+      	"type": "line",
+      	"title": "Media Test",
+      	"axis_attribute_x": "time",
+      	"width": 400,
+      	"height": 200,
+      	"series": [
+      		{"attribute": "Arterial Pressure Values"}
+      	]
+      },
+      "direct_transition": "Media2"
+    },
+    
+    "Media2": {
+      "type": "Media",
+      "media_type": "video",
+      "url": "https://example.com/video/12498596132",
+      "size": 242323456,
+      "duration": 14.56234423,
+      "language": "en",
+      "direct_transition": "Media3"
+    },
+    
+    "Media3": {
+      "type": "Media",
+      "media_type": "audio",
+      "url": "https://example.com/audio/12498596132",
+      "size": 1947648,
+      "duration": 16.13,
+      "language": "en",
+      "direct_transition": "Main_Terminal"
+    },
     "Main_Terminal": {
       "type": "Terminal"
     }

--- a/src/test/resources/generic/smith_physiology.json
+++ b/src/test/resources/generic/smith_physiology.json
@@ -66,7 +66,7 @@
           "type": "Attribute"
         }
       ],
-      "direct_transition": "Media",
+      "direct_transition": "ChartObservation",
       "alt_direct_transition": "ContrivedLVEF"
     },
     
@@ -88,59 +88,28 @@
         "type" : "SetAttribute",
         "attribute": "DBP",
         "value": 90.5,
-        "direct_transition" : "Media"
+        "direct_transition" : "ChartObservation"
     },
     
-    "Media": {
-      "type": "Media",
-      "media_type": "image",
-      "reason_code": [{
+    "ChartObservation": {
+      "type": "Observation",
+      "codes": [{
       	"system": "SNOMED-CT",
       	"code": "386532001",
       	"display": "Invasive arterial pressure"
       }],
-      "body_site": {
-      	"system": "SNOMED-CT",
-      	"code": "360543005",
-      	"display": "Branch of bracial artery"
+      "attachment": {
+        "chart": {
+        	"type": "line",
+        	"title": "Media Test",
+        	"axis_attribute_x": "time",
+        	"width": 400,
+        	"height": 200,
+        	"series": [
+        		{"attribute": "Arterial Pressure Values"}
+        	]
+        }
       },
-      "modality": {
-      	"system": "MediaModality",
-      	"code": "diagram",
-      	"display": "Diagram"
-      },
-      "device_name": "Arterial line",
-      "language": "en",
-      "chart": {
-      	"type": "line",
-      	"title": "Media Test",
-      	"axis_attribute_x": "time",
-      	"width": 400,
-      	"height": 200,
-      	"series": [
-      		{"attribute": "Arterial Pressure Values"}
-      	]
-      },
-      "direct_transition": "Media2"
-    },
-    
-    "Media2": {
-      "type": "Media",
-      "media_type": "video",
-      "url": "https://example.com/video/12498596132",
-      "size": 242323456,
-      "duration": 14.56234423,
-      "language": "en",
-      "direct_transition": "Media3"
-    },
-    
-    "Media3": {
-      "type": "Media",
-      "media_type": "audio",
-      "url": "https://example.com/audio/12498596132",
-      "size": 1947648,
-      "duration": 16.13,
-      "language": "en",
       "direct_transition": "Main_Terminal"
     },
     "Main_Terminal": {


### PR DESCRIPTION
Added ability to disable Physiology State simulations in the `synthea.properties` file (and they are now disabled by default). This also involved adding an `alt_direct_transition` field to Physiology state definitions to indicate where the Module should flow in the event Physiology States are disabled.

Note that this also includes updates from the (yet unmerged) `observation_media` branch.