### PR TITLE
Clone the initial state

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -333,7 +333,7 @@ public class Module {
   }
 
   private State initialState() {
-    return states.get("Initial"); // all Initial states have name Initial
+    return states.get("Initial").clone(); // all Initial states have name Initial
   }
 
   /**


### PR DESCRIPTION
This was created to deal with #673. I think this will fix the issue, but I find that it is sometimes hard to reproduce.

`Module` keeps a map of `States`. When running, most of these get cloned before they are run. The exception to this is the initial state. `Module` has a function that will return a single instance of the initial state.

Some problems with this, I think we avoid via luck. Others come back to get us via multi-threading.

After the first person has gone through a module, in `Module.process` when adding the initial state to the person's history, `State.exited` will be set to whenever the last time it was used. This can be a value before someone was born in the simulation. It probably doesn't matter, because it gets reset when `State.run` gets called.

What I believe to be the larger issue is that since initial state is shared, another thread can exit the initial state while someone is in the middle of `Module.process`. If the exit value is prior to the current time, Synthea has logic to rewind the clock, assuming that a `Delay` state happened. However, if this value was overwritten on another thread to a time before birth, this can throw off the logic. Since process is called recursively, it can use the wrong `exited` value through a number of `State`s.

With this minor change, I'm no longer able to replicate the case where encounters are happening before birth. 