### PR TITLE
Add Device & SupplyList to GMF

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1688,7 +1688,50 @@ public abstract class State implements Cloneable, Serializable {
       return true;
     }
   }
-
+  
+  public static class Device extends State {
+    public Code code;
+    public String manufacturer;
+    public String model;
+    
+    @Override
+    public Device clone() {
+      Device clone = (Device) super.clone();
+      clone.code = code;
+      clone.manufacturer = manufacturer;
+      clone.model = model;
+      return clone;
+    }
+    
+	@Override
+	public boolean process(Person person, long time) {
+		HealthRecord.Device device = person.record.deviceImplant(time, code.code);
+		device.codes.add(code);
+		device.manufacturer = manufacturer;
+		device.model = model;
+		
+		return true;
+	}
+  }
+  
+  public static class SupplyList extends State {
+	  public List<JsonObject> supplies; // TODO: make a class for these, when needed
+	  
+	  @Override
+	  public SupplyList clone() {
+		  SupplyList clone = (SupplyList) super.clone();
+		  clone.supplies = supplies;
+		  return clone;
+	  }
+	  
+	  @Override
+		public boolean process(Person person, long time) {
+		  HealthRecord.Encounter encounter = person.getCurrentEncounter(module);
+		  encounter.supplies.addAll(supplies);
+		  return false;
+		}
+  }
+  
   /**
    * The Death state type indicates a point in the module at which the patient dies or the patient
    * is given a terminal diagnosis (e.g. "you have 3 months to live"). When the Death state is

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1689,11 +1689,18 @@ public abstract class State implements Cloneable, Serializable {
     }
   }
   
+  /**
+   * The Device state indicates the point that a permanent or semi-permanent device
+   * (for example, a prosthetic, or pacemaker) is associated to a person.
+   * The actual procedure in which the device is implanted is not automatically generated
+   * and should be added separately. A Device may have a manufacturer or model listed
+   * for cases where there is generally only one choice.
+   */
   public static class Device extends State {
     public Code code;
     public String manufacturer;
     public String model;
-    
+
     @Override
     public Device clone() {
       Device clone = (Device) super.clone();
@@ -1702,34 +1709,40 @@ public abstract class State implements Cloneable, Serializable {
       clone.model = model;
       return clone;
     }
-    
-	@Override
-	public boolean process(Person person, long time) {
-		HealthRecord.Device device = person.record.deviceImplant(time, code.code);
-		device.codes.add(code);
-		device.manufacturer = manufacturer;
-		device.model = model;
-		
-		return true;
-	}
+
+    @Override
+    public boolean process(Person person, long time) {
+      HealthRecord.Device device = person.record.deviceImplant(time, code.code);
+      device.codes.add(code);
+      device.manufacturer = manufacturer;
+      device.model = model;
+
+      return true;
+    }
   }
   
+  /**
+   * The SupplyList state includes a list of supplies that are needed for the current encounter.
+   * Supplies may include things like PPE for the physician, or other resources and machines.
+   *
+   */
   public static class SupplyList extends State {
-	  public List<JsonObject> supplies; // TODO: make a class for these, when needed
-	  
-	  @Override
-	  public SupplyList clone() {
-		  SupplyList clone = (SupplyList) super.clone();
-		  clone.supplies = supplies;
-		  return clone;
-	  }
-	  
-	  @Override
-		public boolean process(Person person, long time) {
-		  HealthRecord.Encounter encounter = person.getCurrentEncounter(module);
-		  encounter.supplies.addAll(supplies);
-		  return false;
-		}
+    // TODO: make a class for these, when needed beyond just exporting
+    public List<JsonObject> supplies;
+
+    @Override
+    public SupplyList clone() {
+      SupplyList clone = (SupplyList) super.clone();
+      clone.supplies = supplies;
+      return clone;
+    }
+
+    @Override
+    public boolean process(Person person, long time) {
+      HealthRecord.Encounter encounter = person.getCurrentEncounter(module);
+      encounter.supplies.addAll(supplies);
+      return true;
+    }
   }
   
   /**

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -382,6 +382,8 @@ public class HealthRecord implements Serializable {
    * or hip, heart pacemaker, or implantable defibrillator.
    */
   public class Device extends Entry {
+    public String manufacturer;
+    public String model;
     /** UDI == Unique Device Identifier. */
     public String udi;
     public long manufactureTime;
@@ -479,6 +481,7 @@ public class HealthRecord implements Serializable {
     public List<CarePlan> careplans;
     public List<ImagingStudy> imagingStudies;
     public List<Device> devices;
+    public List<JsonObject> supplies;
     public Claim claim; // for now assume 1 claim per encounter
     public Code reason;
     public Code discharge;
@@ -513,6 +516,7 @@ public class HealthRecord implements Serializable {
       careplans = new ArrayList<CarePlan>();
       imagingStudies = new ArrayList<ImagingStudy>();
       devices = new ArrayList<Device>();
+      supplies = new ArrayList<JsonObject>();
       this.claim = new Claim(this, person);
     }
 

--- a/src/test/resources/generic/artificial_heart_device.json
+++ b/src/test/resources/generic/artificial_heart_device.json
@@ -1,0 +1,87 @@
+{
+  "name": "artificial_heart_device",
+  "remarks": [
+    "1. give a baby an artificial heart",
+    "2. ???",
+    "3. profit"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Encounter"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Encounter": {
+      "type": "Encounter",
+      "encounter_class": "ambulatory",
+      "reason": "",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 440068009,
+          "display": "Home visit for newborn care and assessment (procedure)"
+        }
+      ],
+      "direct_transition": "Necessary_Supplies"
+    },
+    "End_Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
+    },
+    "Necessary_Supplies": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "category": "device",
+          "quantity": 10000,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 52291003,
+            "display": "Glove, device (physical object)"
+          }
+        },
+        {
+          "category": "device",
+          "quantity": 3000,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 468159004,
+            "display": "Cotton ball (physical object)"
+          }
+        },
+        {
+          "category": "device",
+          "quantity": 98765,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 39802000,
+            "display": "Tongue blade, device (physical object)"
+          }
+        },
+        {
+          "category": "device",
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 788177008,
+            "display": "Examination gown, single-use (physical object)"
+          }
+        }
+      ],
+      "direct_transition": "Artificial_Heart"
+    },
+    "Artificial_Heart": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 13459008,
+        "display": "Temporary artificial heart prosthesis, device (physical object)"
+      },
+      "direct_transition": "End_Encounter",
+      "manufacturer": "SynCardia",
+      "model": "Total Artificial Heart"
+    }
+  }
+}


### PR DESCRIPTION
Adds new state types Device and SupplyList, which get added to the HealthRecord data model but are not (yet) written out to any exported records.
A Device represents a permanent or semi-permanent device such as a prosthetic or a pacemaker. SupplyList represents the generic supplies needed to perform the encounter, like gloves, mask, other PPE, etc

IMPORTANT: I discovered that the new serialization feature doesn't work when the patient's record contains `JsonObject`s. Here I was using one for supplies since we aren't doing anything but exporting yet, but we're also using one already for CarePlan goals, so we should address both of those. I can do that here but wanted to get this PR up asap.