### PR TITLE
Make available only one binding for SLF4J on classpath (fixes #659)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,9 @@ dependencies {
   
   // Physiology simulation dependencies
   compile files('lib/sbscl/SimulationCoreLibrary_v1.5_slim.jar')
-  compile group: 'org.sbml.jsbml', name: 'jsbml', version: '1.4'
+  compile group: 'org.sbml.jsbml', name: 'jsbml', version: '1.4', {
+      exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
+  }
   compile group: 'org.apache.commons', name: 'commons-math', version: '2.2'
   
   // JfreeChart for drawing physiology charts


### PR DESCRIPTION
Hello people,
This pull request excludes a dependency from the project's `build.gradle` in order to have a single binding for SLF4J on classpath.

Thanks,
Jafer