### PR TITLE
Export Device and SupplyDelivery resources in FHIR and CSV

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1728,7 +1728,7 @@ public abstract class State implements Cloneable, Serializable {
    */
   public static class SupplyList extends State {
     // TODO: make a class for these, when needed beyond just exporting
-    public List<JsonObject> supplies;
+    public List<HealthRecord.Supply> supplies;
 
     @Override
     public SupplyList clone() {

--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -39,6 +39,8 @@ import org.mitre.synthea.world.concepts.HealthRecord.ImagingStudy;
 import org.mitre.synthea.world.concepts.HealthRecord.Medication;
 import org.mitre.synthea.world.concepts.HealthRecord.Observation;
 import org.mitre.synthea.world.concepts.HealthRecord.Procedure;
+import org.mitre.synthea.world.concepts.HealthRecord.Supply;
+
 
 /**
  * Researchers have requested a simple table-based format that could easily be
@@ -408,7 +410,7 @@ public class CSVExporter {
         device(personID, encounterID, device);
       }
       
-      for (JsonObject supply : encounter.supplies) {
+      for (Supply supply : encounter.supplies) {
         supply(personID, encounterID, encounter, supply);
       }
     }
@@ -986,7 +988,7 @@ public class CSVExporter {
    * @param supply       The supply itself
    * @throws IOException if any IO error occurs
    */
-  private void supply(String personID, String encounterID, Encounter encounter, JsonObject supply)
+  private void supply(String personID, String encounterID, Encounter encounter, Supply supply)
     throws IOException {
     // DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,QUANTITY
     StringBuilder s = new StringBuilder();
@@ -994,13 +996,12 @@ public class CSVExporter {
     s.append(dateFromTimestamp(encounter.start)).append(',');
     s.append(personID).append(',');
     s.append(encounterID).append(',');
-    
-    JsonObject code = supply.get("code").getAsJsonObject();
-    s.append(code.get("code").getAsString()).append(',');
-    s.append(clean(code.get("display").getAsString())).append(',');
-    
-    s.append(supply.get("quantity").getAsLong());
-    
+
+    s.append(supply.code.code).append(',');
+    s.append(clean(supply.code.display)).append(',');
+
+    s.append(supply.quantity);
+
     s.append(NEWLINE);
     
     write(s.toString(), supplies);

--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -1420,7 +1420,7 @@ public class FhirDstu2 {
     type.addCoding()
       .setCode("device")
       .setDisplay("Device")
-      .setSystem(SNOMED_URI);
+      .setSystem("http://hl7.org/fhir/supply-item-type");
     supplyResource.setType(type);
 
     // super hackish -- there's no "code" field available here, just a reference to a Device

--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -227,7 +227,7 @@ public class FhirDstu2 {
         device(personEntry, bundle, device);
       }
       
-      for (JsonObject supply : encounter.supplies) {
+      for (HealthRecord.Supply supply : encounter.supplies) {
         supplyDelivery(personEntry, bundle, supply, encounter);
       }
 
@@ -1410,7 +1410,7 @@ public class FhirDstu2 {
    * @return The added Entry.
    */
   private static Entry supplyDelivery(Entry personEntry, Bundle bundle,
-      JsonObject supply, Encounter encounter) {
+      HealthRecord.Supply supply, Encounter encounter) {
    
     SupplyDelivery supplyResource = new SupplyDelivery();
     supplyResource.setStatus(SupplyDeliveryStatusEnum.DELIVERED);
@@ -1423,17 +1423,14 @@ public class FhirDstu2 {
       .setSystem(SNOMED_URI);
     supplyResource.setType(type);
 
-    JsonObject jsonCode = supply.get("code").getAsJsonObject();
-    String code = jsonCode.get("code").getAsString();
-    String display = jsonCode.get("display").getAsString();
     // super hackish -- there's no "code" field available here, just a reference to a Device
     // so for now just put some text in the reference
     ResourceReferenceDt suppliedItem = new ResourceReferenceDt();
-    suppliedItem.setDisplay("SNOMED[" + code + "]: " + display);
+    suppliedItem.setDisplay("SNOMED[" + supply.code.code + "]: " + supply.code.display);
 
     supplyResource.setSuppliedItem(suppliedItem);
 
-    supplyResource.setQuantity(new SimpleQuantityDt(supply.get("quantity").getAsLong()));
+    supplyResource.setQuantity(new SimpleQuantityDt(supply.quantity));
 
     supplyResource.setTime((DateTimeDt) convertFhirDateTime(encounter.start, true));
     

--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -1429,7 +1429,7 @@ public class FhirDstu2 {
     // super hackish -- there's no "code" field available here, just a reference to a Device
     // so for now just put some text in the reference
     ResourceReferenceDt suppliedItem = new ResourceReferenceDt();
-    suppliedItem.setDisplay("SNOMED-CT[" + code + "]: " + display);
+    suppliedItem.setDisplay("SNOMED[" + code + "]: " + display);
 
     supplyResource.setSuppliedItem(suppliedItem);
 

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -1680,7 +1680,7 @@ public class FhirR4 {
     type.addCoding()
       .setCode("device")
       .setDisplay("Device")
-      .setSystem(SNOMED_URI);
+      .setSystem("http://terminology.hl7.org/CodeSystem/supply-item-type");
     supplyResource.setType(type);
     
     SupplyDeliverySuppliedItemComponent suppliedItem = new SupplyDeliverySuppliedItemComponent();

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -270,7 +270,7 @@ public class FhirR4 {
         device(personEntry, bundle, device);
       }
       
-      for (JsonObject supply : encounter.supplies) {
+      for (HealthRecord.Supply supply : encounter.supplies) {
         supplyDelivery(personEntry, bundle, supply, encounter);
       }
 
@@ -1670,7 +1670,7 @@ public class FhirR4 {
    * @return The added Entry.
    */
   private static BundleEntryComponent supplyDelivery(BundleEntryComponent personEntry, Bundle bundle,
-      JsonObject supply, Encounter encounter) {
+      HealthRecord.Supply supply, Encounter encounter) {
    
     SupplyDelivery supplyResource = new SupplyDelivery();
     supplyResource.setStatus(SupplyDeliveryStatus.COMPLETED);
@@ -1684,14 +1684,8 @@ public class FhirR4 {
     supplyResource.setType(type);
     
     SupplyDeliverySuppliedItemComponent suppliedItem = new SupplyDeliverySuppliedItemComponent();
-    CodeableConcept itemCC = new CodeableConcept();
-    JsonObject jsonCode = supply.get("code").getAsJsonObject();
-    itemCC.addCoding()
-      .setCode(jsonCode.get("code").getAsString())
-      .setDisplay(jsonCode.get("display").getAsString())
-      .setSystem(SNOMED_URI);
-    suppliedItem.setItem(itemCC);
-    suppliedItem.setQuantity(new Quantity(supply.get("quantity").getAsLong()));
+    suppliedItem.setItem(mapCodeToCodeableConcept(supply.code, SNOMED_URI));
+    suppliedItem.setQuantity(new Quantity(supply.quantity));
     
     supplyResource.setSuppliedItem(suppliedItem);
     

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -9,9 +9,6 @@ import com.google.gson.JsonObject;
 
 import java.awt.geom.Point2D;
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.MathContext;
-import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -1638,6 +1635,12 @@ public class FhirR4 {
         .setCarrierHRF(device.udi);
     deviceResource.setStatus(FHIRDeviceStatus.ACTIVE);
     deviceResource.setDistinctIdentifier(device.deviceIdentifier);
+    if (device.manufacturer != null) {
+      deviceResource.setManufacturer(device.manufacturer);
+    }
+    if (device.model != null) {
+      deviceResource.setModelNumber(device.model);
+    }
     deviceResource.setManufactureDate(new Date(device.manufactureTime));
     deviceResource.setExpirationDate(new Date(device.expirationTime));
     deviceResource.setLotNumber(device.lotNumber);

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -2206,7 +2206,7 @@ public class FhirStu3 {
     type.addCoding()
       .setCode("device")
       .setDisplay("Device")
-      .setSystem(SNOMED_URI);
+      .setSystem("http://hl7.org/fhir/supply-item-type");
     supplyResource.setType(type);
     
     SupplyDeliverySuppliedItemComponent suppliedItem = new SupplyDeliverySuppliedItemComponent();

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -273,7 +273,7 @@ public class FhirStu3 {
         device(personEntry, bundle, device);
       }
       
-      for (JsonObject supply : encounter.supplies) {
+      for (HealthRecord.Supply supply : encounter.supplies) {
         supplyDelivery(personEntry, bundle, supply, encounter);
       }
       
@@ -2196,7 +2196,7 @@ public class FhirStu3 {
    * @return The added Entry.
    */
   private static BundleEntryComponent supplyDelivery(BundleEntryComponent personEntry, Bundle bundle,
-      JsonObject supply, Encounter encounter) {
+      HealthRecord.Supply supply, Encounter encounter) {
    
     SupplyDelivery supplyResource = new SupplyDelivery();
     supplyResource.setStatus(SupplyDeliveryStatus.COMPLETED);
@@ -2210,16 +2210,10 @@ public class FhirStu3 {
     supplyResource.setType(type);
     
     SupplyDeliverySuppliedItemComponent suppliedItem = new SupplyDeliverySuppliedItemComponent();
-    CodeableConcept itemCC = new CodeableConcept();
-    JsonObject jsonCode = supply.get("code").getAsJsonObject();
-    itemCC.addCoding()
-      .setCode(jsonCode.get("code").getAsString())
-      .setDisplay(jsonCode.get("display").getAsString())
-      .setSystem(SNOMED_URI);
-    suppliedItem.setItem(itemCC);
+    suppliedItem.setItem( mapCodeToCodeableConcept(supply.code, SNOMED_URI));
     
     SimpleQuantity quantity = new SimpleQuantity();
-    quantity.setValue(supply.get("quantity").getAsLong());
+    quantity.setValue(supply.quantity);
     suppliedItem.setQuantity(quantity);
     
     supplyResource.setSuppliedItem(suppliedItem);

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -430,6 +430,11 @@ public class HealthRecord implements Serializable {
       return retVal;
     }
   }
+  
+  public class Supply implements Serializable {
+    public int quantity;
+    public Code code;
+  }
 
   public enum EncounterType {
     WELLNESS("AMB"), AMBULATORY("AMB"), OUTPATIENT("AMB"),
@@ -481,7 +486,7 @@ public class HealthRecord implements Serializable {
     public List<CarePlan> careplans;
     public List<ImagingStudy> imagingStudies;
     public List<Device> devices;
-    public List<JsonObject> supplies;
+    public List<Supply> supplies;
     public Claim claim; // for now assume 1 claim per encounter
     public Code reason;
     public Code discharge;
@@ -516,7 +521,7 @@ public class HealthRecord implements Serializable {
       careplans = new ArrayList<CarePlan>();
       imagingStudies = new ArrayList<ImagingStudy>();
       devices = new ArrayList<Device>();
-      supplies = new ArrayList<JsonObject>();
+      supplies = new ArrayList<Supply>();
       this.claim = new Claim(this, person);
     }
 

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -1749,7 +1749,7 @@ public class StateTest {
     assertTrue(supplyListState.process(person, time));
     
     Encounter encounter = person.getCurrentEncounter(module);
-    List<JsonObject> supplies = encounter.supplies;
+    List<HealthRecord.Supply> supplies = encounter.supplies;
     assertNotNull(supplies);
     assertEquals(4, supplies.size());
     
@@ -1760,11 +1760,10 @@ public class StateTest {
     int[] expectedQuantities = { 10_000, 3_000, 98765, 1 };
     
     for (int i = 0; i < 4; i++) {
-      JsonObject supply = supplies.get(i);
-      JsonObject supplyCode = supply.get("code").getAsJsonObject();
-      assertEquals(expectedCodes[i], supplyCode.get("code").getAsString());
-      assertEquals(expectedDisplays[i], supplyCode.get("display").getAsString());
-      assertEquals(expectedQuantities[i], supply.get("quantity").getAsInt());
+      HealthRecord.Supply supply = supplies.get(i);
+      assertEquals(expectedCodes[i], supply.code.code);
+      assertEquals(expectedDisplays[i], supply.code.display);
+      assertEquals(expectedQuantities[i], supply.quantity);
     }
   }
 }

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -81,6 +81,6 @@ public class CSVExporterTest {
       count++;
     }
 
-    assertEquals("Expected 14 CSV files in the output directory, found " + count, 14, count);
+    assertEquals("Expected 16 CSV files in the output directory, found " + count, 16, count);
   }
 }

--- a/src/test/resources/generic/artificial_heart_device.json
+++ b/src/test/resources/generic/artificial_heart_device.json
@@ -34,7 +34,6 @@
       "type": "SupplyList",
       "supplies": [
         {
-          "category": "device",
           "quantity": 10000,
           "code": {
             "system": "SNOMED-CT",
@@ -43,7 +42,6 @@
           }
         },
         {
-          "category": "device",
           "quantity": 3000,
           "code": {
             "system": "SNOMED-CT",
@@ -52,7 +50,6 @@
           }
         },
         {
-          "category": "device",
           "quantity": 98765,
           "code": {
             "system": "SNOMED-CT",
@@ -61,7 +58,6 @@
           }
         },
         {
-          "category": "device",
           "quantity": 1,
           "code": {
             "system": "SNOMED-CT",


### PR DESCRIPTION
In support of the new Device and SupplyList fields recently added to the GMF, this adds Device and SupplyDelivery resources to FHIR exporters (R4, STU3, and DSTU2) and creates new devices.csv and supplies.csv in the CSV exporter.

Travis is failing right now because of issues with the oss.sonatype.org repo, but if you already have all the libraries loaded it works.

Samples containing the new output:

FHIR R4: [Shannon293_Schumm995_r4.json.txt](https://github.com/synthetichealth/synthea/files/4402447/Shannon293_Schumm995_r4.json.txt)

STU3: [Shannon293_Schumm995_stu3.json.txt](https://github.com/synthetichealth/synthea/files/4402451/Shannon293_Schumm995_stu3.json.txt)

DSTU2:  [Shannon293_Schumm995_dstu2.json.txt](https://github.com/synthetichealth/synthea/files/4402453/Shannon293_Schumm995_dstu2.json.txt)

CSV:
[devices.csv.txt](https://github.com/synthetichealth/synthea/files/4402434/devices.csv.txt)
[supplies.csv.txt](https://github.com/synthetichealth/synthea/files/4402435/supplies.csv.txt)
