### PR TITLE
Allow time as a property in LookupTableTransitions

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Transition.java
+++ b/src/main/java/org/mitre/synthea/engine/Transition.java
@@ -188,7 +188,8 @@ public abstract class Transition implements Serializable {
       // Retrieve CSV column headers.
       List<String> columnHeaders = new ArrayList<String>(lookupTable.get(0).keySet());
       // Parse the list of attributes.
-      this.attributes = columnHeaders.subList(0, columnHeaders.size() - this.transitions.size());
+      this.attributes = new ArrayList(columnHeaders.subList(0,
+          columnHeaders.size() - this.transitions.size()));
       // Parse the list of states to transition to.
       List<String> transitionStates = columnHeaders.subList((columnHeaders.size()
           - this.transitions.size()), columnHeaders.size());
@@ -200,6 +201,7 @@ public abstract class Transition implements Serializable {
         rowAttributes = rowAttributes.subList(0, this.attributes.size());
         // Create age range for lookup table key if age is an attribute.
         Range<Integer> ageRange = null;
+        Range<Long> timeRange = null;
         if (this.attributes.contains("age")) {
           Integer ageIndex = this.attributes.indexOf("age");
           // Remove and parse the age range.
@@ -216,9 +218,25 @@ public abstract class Transition implements Serializable {
               Integer.parseInt(value.substring(0, value.indexOf("-"))),
               Integer.parseInt(value.substring(value.indexOf("-") + 1)));
         }
+        if (this.attributes.contains("time")) {
+          Integer timeIndex = this.attributes.indexOf("time");
+          // Remove and parse the age range.
+          String value = rowAttributes.remove(timeIndex.intValue());
+          if (!value.contains("-")
+              || value.substring(0, value.indexOf("-")).length() < 1
+              || value.substring(value.indexOf("-") + 1).length() < 1) {
+            throw new RuntimeException(
+                "LOOKUP TABLE '" + fileName
+                    + "' ERROR: Time Range must be in the form: 'timeLow-timeHigh'. Found '"
+                    + value + "'");
+          }
+          timeRange = Range.between(
+              Long.parseLong(value.substring(0, value.indexOf("-"))),
+              Long.parseLong(value.substring(value.indexOf("-") + 1)));
+        }
         // Attributes key to inert into lookup table.
         LookupTableKey attributesLookupKey =
-            new LookupTableKey(rowAttributes, ageRange);
+            new LookupTableKey(rowAttributes, ageRange, timeRange);
         // Transition probabilities to insert into lookup table.
         List<DistributedTransitionOption> transitionProbabilities
             = createDistributedTransitionOptions(currentRow, transitionStates);
@@ -263,6 +281,8 @@ public abstract class Transition implements Serializable {
       for (String currentAttribute : this.attributes) {
         if (currentAttribute.equalsIgnoreCase("age")) {
           age = person.ageInYears(time);
+        } else if (currentAttribute.equalsIgnoreCase("time")) {
+          // do nothing, we already have it
         } else {
           String personsAttribute
               = (String) person.attributes.get(currentAttribute.toLowerCase());
@@ -275,7 +295,7 @@ public abstract class Transition implements Serializable {
         }
       }
       // Create key from person's attributes to get distributions
-      LookupTableKey personsAttributesLookupKey = new LookupTableKey(personsAttributes, age);
+      LookupTableKey personsAttributesLookupKey = new LookupTableKey(personsAttributes, age, time);
       if (lookupTables.get(lookupTableName).containsKey(personsAttributesLookupKey)) {
         // Person matches, use their attribute's list of distributedtransitionoptions
         return pickDistributedTransition(
@@ -287,22 +307,27 @@ public abstract class Transition implements Serializable {
     }
   }
 
-  public final class LookupTableKey {
+  public final class LookupTableKey implements Serializable {
     private final List<String> attributes;
     /** Age for this patient. May be null if lookup table does not use age. */
     private final Integer age;
     /** Age range for this row. Null if this is a person. */
     private final Range<Integer> ageRange;
 
+    private final Long time;
+    private final Range<Long> timeRange;
+
     /**
      * Create a symbolic lookup key for a given row that contains actual patient values.
      * @param attributes Patient attribute values.
      * @param age Patient age.
      */
-    public LookupTableKey(List<String> attributes, Integer age) {
+    public LookupTableKey(List<String> attributes, Integer age, Long time) {
       this.attributes = attributes;
       this.age = age;
       this.ageRange = null;
+      this.time = time;
+      this.timeRange = null;
     }
 
     /**
@@ -311,10 +336,12 @@ public abstract class Transition implements Serializable {
      * @param range If the table contains an age column, range contains the age range
      *     information for this key.
      */
-    public LookupTableKey(List<String> attributes, Range<Integer> range) {
+    public LookupTableKey(List<String> attributes, Range<Integer> range, Range<Long> timeRange) {
       this.attributes = attributes;
       this.age = null;
       this.ageRange = range;
+      this.time = null;
+      this.timeRange = timeRange;
     }
 
     /**
@@ -341,6 +368,7 @@ public abstract class Transition implements Serializable {
       LookupTableKey that = (LookupTableKey) obj;
 
       boolean agesMatch = true;
+      boolean timesMatch = true;
 
       if (this.age != null) {
         if (that.age != null) {
@@ -369,7 +397,34 @@ public abstract class Transition implements Serializable {
         agesMatch = false;
       }
 
-      return agesMatch && this.attributes.equals(that.attributes);
+      if (this.time != null) {
+        if (that.time != null) {
+          timesMatch = (this.time == that.time);
+        } else if (that.timeRange != null) {
+          timesMatch = (that.timeRange.contains(this.time));
+        } else {
+          // that.age == null && that.ageRange == null
+          // do nothing. Time will always be populated in one of them
+        }
+      } else if (that.time != null) {
+        if (this.timeRange != null) {
+          timesMatch = (this.timeRange.contains(that.time));
+        } else {
+          // this.age == null && this.ageRange == null
+          timesMatch = false;
+        }
+      } else if (this.timeRange != null) {
+        // this.age == null && that.age == null
+        if (that.timeRange != null) {
+          timesMatch = this.timeRange.containsRange(that.timeRange);
+        } else {
+          timesMatch = false;
+        }
+      } else if (that.timeRange != null) {
+        timesMatch = false;
+      }
+
+      return agesMatch && timesMatch && this.attributes.equals(that.attributes);
     }
 
     /**
@@ -377,8 +432,14 @@ public abstract class Transition implements Serializable {
      */
     @Override
     public String toString() {
-      String age = (this.age == null ? ageRange.toString() : this.age.toString());
-      return attributes.toString() + " : " + age;
+      String ending = "";
+      if (this.age != null || this.ageRange != null) {
+        ending = (this.age == null ? ageRange.toString() : this.age.toString());
+      }
+      if (this.time != null || this.timeRange != null) {
+        ending = (this.time == null ? timeRange.toString() : this.time.toString());
+      }
+      return attributes.toString() + " : " + ending;
     }
   }
 

--- a/src/test/java/org/mitre/synthea/engine/LookupTableTransitionTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LookupTableTransitionTest.java
@@ -85,13 +85,13 @@ public class LookupTableTransitionTest {
     attributes.add("foo");
     attributes.add("bar");
     Integer age = 20;
-    LookupTableKey silver = test.new LookupTableKey(attributes, age);
+    LookupTableKey silver = test.new LookupTableKey(attributes, age, null);
 
     List<String> others = new ArrayList<String>();
     others.add("foo");
     others.add("bar");
     Range<Integer> range = Range.between(0, 30);
-    LookupTableKey gold = test.new LookupTableKey(others, range);
+    LookupTableKey gold = test.new LookupTableKey(others, range, null);
 
     Assert.assertEquals(silver, gold);
     Assert.assertEquals(gold, silver);
@@ -109,13 +109,13 @@ public class LookupTableTransitionTest {
     attributes.add("foo");
     attributes.add("bar");
     Integer age = 30;
-    LookupTableKey silver = test.new LookupTableKey(attributes, age);
+    LookupTableKey silver = test.new LookupTableKey(attributes, age, null);
 
     List<String> others = new ArrayList<String>();
     others.add("foo");
     others.add("bar");
     Range<Integer> range = Range.between(0, 30);
-    LookupTableKey gold = test.new LookupTableKey(others, range);
+    LookupTableKey gold = test.new LookupTableKey(others, range, null);
 
     Assert.assertEquals(silver, gold);
     Assert.assertEquals(gold, silver);
@@ -133,13 +133,13 @@ public class LookupTableTransitionTest {
     attributes.add("foo");
     attributes.add("bar");
     Integer age = 0;
-    LookupTableKey silver = test.new LookupTableKey(attributes, age);
+    LookupTableKey silver = test.new LookupTableKey(attributes, age, null);
 
     List<String> others = new ArrayList<String>();
     others.add("foo");
     others.add("bar");
     Range<Integer> range = Range.between(0, 30);
-    LookupTableKey gold = test.new LookupTableKey(others, range);
+    LookupTableKey gold = test.new LookupTableKey(others, range, null);
 
     Assert.assertEquals(silver, gold);
     Assert.assertEquals(gold, silver);
@@ -157,18 +157,18 @@ public class LookupTableTransitionTest {
     attributes.add("foo");
     attributes.add("bar");
     Integer age = 20;
-    LookupTableKey yellow = test.new LookupTableKey(attributes, age);
+    LookupTableKey yellow = test.new LookupTableKey(attributes, age, null);
     age = 50;
-    LookupTableKey grey = test.new LookupTableKey(attributes, age);
+    LookupTableKey grey = test.new LookupTableKey(attributes, age, null);
 
     List<String> others = new ArrayList<String>();
     others.add("foo");
     others.add("bar");
     Range<Integer> range = Range.between(0, 30);
-    LookupTableKey gold = test.new LookupTableKey(others, range);
+    LookupTableKey gold = test.new LookupTableKey(others, range, null);
 
     Range<Integer> anotherRange = Range.between(31, 60);
-    LookupTableKey platinum = test.new LookupTableKey(others, anotherRange);
+    LookupTableKey platinum = test.new LookupTableKey(others, anotherRange, null);
 
     Assert.assertEquals(yellow, gold);
     Assert.assertEquals(gold, yellow);
@@ -197,13 +197,13 @@ public class LookupTableTransitionTest {
     attributes.add("foo");
     attributes.add("bar");
     Integer age = 40;
-    LookupTableKey silver = test.new LookupTableKey(attributes, age);
+    LookupTableKey silver = test.new LookupTableKey(attributes, age, null);
 
     List<String> others = new ArrayList<String>();
     others.add("foo");
     others.add("bar");
     Range<Integer> range = Range.between(0, 30);
-    LookupTableKey gold = test.new LookupTableKey(others, range);
+    LookupTableKey gold = test.new LookupTableKey(others, range, null);
 
     Assert.assertNotEquals(silver, gold);
     Assert.assertNotEquals(gold, silver);
@@ -221,13 +221,13 @@ public class LookupTableTransitionTest {
     attributes.add("foo");
     attributes.add("bar");
     Integer age = 20;
-    LookupTableKey silver = test.new LookupTableKey(attributes, age);
+    LookupTableKey silver = test.new LookupTableKey(attributes, age, null);
 
     List<String> others = new ArrayList<String>();
     others.add("foo");
     others.add("baz");
     Range<Integer> range = Range.between(0, 30);
-    LookupTableKey gold = test.new LookupTableKey(others, range);
+    LookupTableKey gold = test.new LookupTableKey(others, range, null);
 
     Assert.assertNotEquals(silver, gold);
     Assert.assertNotEquals(gold, silver);
@@ -245,13 +245,13 @@ public class LookupTableTransitionTest {
     attributes.add("foo");
     attributes.add("bar");
     Integer age = null;
-    LookupTableKey silver = test.new LookupTableKey(attributes, age);
+    LookupTableKey silver = test.new LookupTableKey(attributes, age, null);
 
     List<String> others = new ArrayList<String>();
     others.add("foo");
     others.add("bar");
     Range<Integer> range = null;
-    LookupTableKey gold = test.new LookupTableKey(others, range);
+    LookupTableKey gold = test.new LookupTableKey(others, range, null);
 
     Assert.assertEquals(silver, gold);
     Assert.assertEquals(gold, silver);
@@ -269,13 +269,13 @@ public class LookupTableTransitionTest {
     attributes.add("foo");
     attributes.add("bar");
     Integer age = null;
-    LookupTableKey silver = test.new LookupTableKey(attributes, age);
+    LookupTableKey silver = test.new LookupTableKey(attributes, age, null);
 
     List<String> others = new ArrayList<String>();
     others.add("foo");
     others.add("baz");
     Range<Integer> range = null;
-    LookupTableKey gold = test.new LookupTableKey(others, range);
+    LookupTableKey gold = test.new LookupTableKey(others, range, null);
 
     Assert.assertNotEquals(silver, gold);
     Assert.assertNotEquals(gold, silver);

--- a/src/test/java/org/mitre/synthea/engine/LookupTableTransitionTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LookupTableTransitionTest.java
@@ -48,6 +48,8 @@ public class LookupTableTransitionTest {
     // hack to load these test modules so they can be called by the CallSubmodule state
     Module lookuptabletestModule = TestHelper.getFixture("lookuptable_test.json");
     modules.put("lookuptable_test", new Module.ModuleSupplier(lookuptabletestModule));
+    Module lookuptabletesttimerangeModule = TestHelper.getFixture("lookuptable_timerangetest.json");
+    modules.put("lookuptable_timerangetest", new Module.ModuleSupplier(lookuptabletesttimerangeModule));
 
     /* Create Mild Lookuptablitis Condition */
     mildLookuptablitis = new ActiveCondition();
@@ -75,6 +77,7 @@ public class LookupTableTransitionTest {
     Config.set("generic.lookuptables", "modules/lookup_tables");
     // Remove the lookuptable_test.json module
     modules.remove("lookuptable_test");
+    modules.remove("lookuptable_timerangetest");
   }
 
   @Test
@@ -505,6 +508,116 @@ public class LookupTableTransitionTest {
     assertFalse(mildLookuptablitis.test(person, conditionTime + 100));
     assertFalse(moderateLookuptablitis.test(person, conditionTime + 100));
     assertTrue(extremeLookuptablitis.test(person, conditionTime + 100));
+  }
+
+  @Test
+  public void firstTimeRangeMaleMA() {
+    long birthTime = 0L;
+    // Under Fifty
+    long conditionTime = 500L;
+
+    // Create the person with the preset attributes.
+    Person person = new Person(0L);
+    person.attributes.put(Person.BIRTHDATE, 0L);
+    person.attributes.put(Person.GENDER, "M");
+    person.attributes.put(Person.STATE, "Massachusetts");
+
+    // Process the lookuptable_test Module.
+    Module lookuptableTestModule = modules.get("lookuptable_timerangetest").get();
+    lookuptableTestModule.process(person, conditionTime);
+
+    // Make sure this person has the correct lookuptablitis.
+    assertFalse(mildLookuptablitis.test(person, conditionTime + 100));
+    assertTrue(moderateLookuptablitis.test(person, conditionTime + 100));
+    assertFalse(extremeLookuptablitis.test(person, conditionTime + 100));
+  }
+
+  @Test
+  public void firstTimeRangeFemaleMA() {
+    long birthTime = 0L;
+    // Under Fifty
+    long conditionTime = 500L;
+
+    // Create the person with the preset attributes.
+    Person person = new Person(0L);
+    person.attributes.put(Person.BIRTHDATE, 0L);
+    person.attributes.put(Person.GENDER, "F");
+    person.attributes.put(Person.STATE, "Massachusetts");
+
+    // Process the lookuptable_test Module.
+    Module lookuptableTestModule = modules.get("lookuptable_timerangetest").get();
+    lookuptableTestModule.process(person, conditionTime);
+
+    // Make sure this person has the correct lookuptablitis.
+    assertTrue(mildLookuptablitis.test(person, conditionTime + 100));
+    assertFalse(moderateLookuptablitis.test(person, conditionTime + 100));
+    assertFalse(extremeLookuptablitis.test(person, conditionTime + 100));
+  }
+
+  @Test
+  public void firstTimeRangeMaleOutOfState() {
+    long birthTime = 0L;
+    // Under Fifty
+    long conditionTime = 500L;
+
+    // Create the person with the preset attributes.
+    Person person = new Person(0L);
+    person.attributes.put(Person.BIRTHDATE, 0L);
+    person.attributes.put(Person.GENDER, "M");
+    person.attributes.put(Person.STATE, "New Hampshire");
+
+    // Process the lookuptable_test Module.
+    Module lookuptableTestModule = modules.get("lookuptable_timerangetest").get();
+    lookuptableTestModule.process(person, conditionTime);
+
+    // Make sure this person has the correct lookuptablitis.
+    assertFalse(mildLookuptablitis.test(person, conditionTime + 100));
+    assertFalse(moderateLookuptablitis.test(person, conditionTime + 100));
+    assertTrue(extremeLookuptablitis.test(person, conditionTime + 100));
+  }
+
+  @Test
+  public void secondTimeRangeMaleMA() {
+    long birthTime = 0L;
+    // Under Fifty
+    long conditionTime = 1500L;
+
+    // Create the person with the preset attributes.
+    Person person = new Person(0L);
+    person.attributes.put(Person.BIRTHDATE, 0L);
+    person.attributes.put(Person.GENDER, "M");
+    person.attributes.put(Person.STATE, "Massachusetts");
+
+    // Process the lookuptable_test Module.
+    Module lookuptableTestModule = modules.get("lookuptable_timerangetest").get();
+    lookuptableTestModule.process(person, conditionTime);
+
+    // Make sure this person has the correct lookuptablitis.
+    assertFalse(mildLookuptablitis.test(person, conditionTime + 100));
+    assertFalse(moderateLookuptablitis.test(person, conditionTime + 100));
+    assertTrue(extremeLookuptablitis.test(person, conditionTime + 100));
+  }
+
+  @Test
+  public void secondTimeRangeFemaleMA() {
+    long birthTime = 0L;
+    // Under Fifty
+    long conditionTime = 1500L;
+
+    // Create the person with the preset attributes.
+    Person person = new Person(0L);
+    person.attributes.put(Person.BIRTHDATE, 0L);
+    person.attributes.put(Person.GENDER, "F");
+    person.attributes.put(Person.STATE, "Massachusetts");
+
+    // Process the lookuptable_test Module.
+    Module lookuptableTestModule = modules.get("lookuptable_timerangetest").get();
+    lookuptableTestModule.process(person, conditionTime);
+
+    // Make sure this person has the correct lookuptablitis.
+    assertFalse(mildLookuptablitis.test(person, conditionTime + 100));
+    assertTrue(moderateLookuptablitis.test(person, conditionTime + 100));
+    assertFalse(extremeLookuptablitis.test(person, conditionTime + 100));
   }
 
   @Test

--- a/src/test/resources/generic/lookup_tables/lookuptable_timerangetest.csv
+++ b/src/test/resources/generic/lookup_tables/lookuptable_timerangetest.csv
@@ -1,0 +1,5 @@
+time,gender,state,Mild_Lookuptablitis,Moderate_Lookuptablitis,Extreme_Lookuptablitis
+0-999,M,Massachusetts,0,1,0
+0-999,F,Massachusetts,1,0,0
+1000-1999,M,Massachusetts,0,0,1
+1000-1999,F,Massachusetts,0,1,0

--- a/src/test/resources/generic/lookuptable_timerangetest.json
+++ b/src/test/resources/generic/lookuptable_timerangetest.json
@@ -1,0 +1,74 @@
+{
+  "name": "lookuptable_agerangetest",
+  "remarks": [
+    "A test for Lookup Table Transitions where ageLow >  ageHigh."
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Determine_Condition",
+      "name": "Initial"
+    },
+    "Terminal": {
+      "type": "Terminal",
+      "name": "Terminal"
+    },
+    "Determine_Condition": {
+      "type": "Simple",
+      "name": "Determine_Condition",
+      "lookup_table_transition": [
+        {
+          "transition": "Mild_Lookuptablitis",
+          "default_probability": "0",
+          "lookup_table_name": "lookuptable_timerangetest.csv"
+        },
+        {
+          "transition": "Extreme_Lookuptablitis",
+          "default_probability": "1",
+          "lookup_table_name": "lookuptable_timerangetest.csv"
+        },
+        {
+          "transition": "Moderate_Lookuptablitis",
+          "default_probability": "0",
+          "lookup_table_name": "lookuptable_timerangetest.csv"
+        }
+      ]
+    },
+    "Mild_Lookuptablitis": {
+      "type": "ConditionOnset",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 23502007,
+          "display": "Mild_Lookuptablitis"
+        }
+      ],
+      "direct_transition": "Terminal",
+      "name": "Mild_Lookuptablitis"
+    },
+    "Moderate_Lookuptablitis": {
+      "type": "ConditionOnset",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 23502008,
+          "display": "Moderate_Lookuptablitis"
+        }
+      ],
+      "direct_transition": "Terminal",
+      "name": "Moderate_Lookuptablitis"
+    },
+    "Extreme_Lookuptablitis": {
+      "type": "ConditionOnset",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 23502009,
+          "display": "Extreme_Lookuptablitis"
+        }
+      ],
+      "direct_transition": "Terminal",
+      "name": "Extreme_Lookuptablitis"
+    }
+  }
+}


### PR DESCRIPTION
This change allows time to be used a a property in
LookupTableTransitions. It only supports time ranges, as exact times are
unlikely to be useful. Time refers to the time in the simulation. Time
ranges can be combined with any other attributes that would be valid for
a LookupTableTransition.

This was extracted from the `covid19lookuptable` branch. This will allow us to get the capability into Synthea without needing to worry about getting the COVID-19 probabilities correct.