### PR TITLE
Covid19 Supplies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,9 @@ dependencies {
   
   // Physiology simulation dependencies
   compile files('lib/sbscl/SimulationCoreLibrary_v1.5_slim.jar')
-  compile group: 'org.sbml.jsbml', name: 'jsbml', version: '1.4'
+  compile group: 'org.sbml.jsbml', name: 'jsbml', version: '1.4', {
+      exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
+  }
   compile group: 'org.apache.commons', name: 'commons-math', version: '2.2'
   
   // JfreeChart for drawing physiology charts

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1734,7 +1734,7 @@ public abstract class State implements Cloneable, Serializable {
    */
   public static class SupplyList extends State {
     // TODO: make a class for these, when needed beyond just exporting
-    public List<JsonObject> supplies;
+    public List<HealthRecord.Supply> supplies;
 
     @Override
     public SupplyList clone() {

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1695,11 +1695,18 @@ public abstract class State implements Cloneable, Serializable {
     }
   }
   
+  /**
+   * The Device state indicates the point that a permanent or semi-permanent device
+   * (for example, a prosthetic, or pacemaker) is associated to a person.
+   * The actual procedure in which the device is implanted is not automatically generated
+   * and should be added separately. A Device may have a manufacturer or model listed
+   * for cases where there is generally only one choice.
+   */
   public static class Device extends State {
     public Code code;
     public String manufacturer;
     public String model;
-    
+
     @Override
     public Device clone() {
       Device clone = (Device) super.clone();
@@ -1708,34 +1715,40 @@ public abstract class State implements Cloneable, Serializable {
       clone.model = model;
       return clone;
     }
-    
-	@Override
-	public boolean process(Person person, long time) {
-		HealthRecord.Device device = person.record.deviceImplant(time, code.code);
-		device.codes.add(code);
-		device.manufacturer = manufacturer;
-		device.model = model;
-		
-		return true;
-	}
+
+    @Override
+    public boolean process(Person person, long time) {
+      HealthRecord.Device device = person.record.deviceImplant(time, code.code);
+      device.codes.add(code);
+      device.manufacturer = manufacturer;
+      device.model = model;
+
+      return true;
+    }
   }
   
+  /**
+   * The SupplyList state includes a list of supplies that are needed for the current encounter.
+   * Supplies may include things like PPE for the physician, or other resources and machines.
+   *
+   */
   public static class SupplyList extends State {
-	  public List<JsonObject> supplies; // TODO: make a class for these, when needed
-	  
-	  @Override
-	  public SupplyList clone() {
-		  SupplyList clone = (SupplyList) super.clone();
-		  clone.supplies = supplies;
-		  return clone;
-	  }
-	  
-	  @Override
-		public boolean process(Person person, long time) {
-		  HealthRecord.Encounter encounter = person.getCurrentEncounter(module);
-		  encounter.supplies.addAll(supplies);
-		  return false;
-		}
+    // TODO: make a class for these, when needed beyond just exporting
+    public List<JsonObject> supplies;
+
+    @Override
+    public SupplyList clone() {
+      SupplyList clone = (SupplyList) super.clone();
+      clone.supplies = supplies;
+      return clone;
+    }
+
+    @Override
+    public boolean process(Person person, long time) {
+      HealthRecord.Encounter encounter = person.getCurrentEncounter(module);
+      encounter.supplies.addAll(supplies);
+      return true;
+    }
   }
   
   /**

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1694,7 +1694,50 @@ public abstract class State implements Cloneable, Serializable {
       return true;
     }
   }
-
+  
+  public static class Device extends State {
+    public Code code;
+    public String manufacturer;
+    public String model;
+    
+    @Override
+    public Device clone() {
+      Device clone = (Device) super.clone();
+      clone.code = code;
+      clone.manufacturer = manufacturer;
+      clone.model = model;
+      return clone;
+    }
+    
+	@Override
+	public boolean process(Person person, long time) {
+		HealthRecord.Device device = person.record.deviceImplant(time, code.code);
+		device.codes.add(code);
+		device.manufacturer = manufacturer;
+		device.model = model;
+		
+		return true;
+	}
+  }
+  
+  public static class SupplyList extends State {
+	  public List<JsonObject> supplies; // TODO: make a class for these, when needed
+	  
+	  @Override
+	  public SupplyList clone() {
+		  SupplyList clone = (SupplyList) super.clone();
+		  clone.supplies = supplies;
+		  return clone;
+	  }
+	  
+	  @Override
+		public boolean process(Person person, long time) {
+		  HealthRecord.Encounter encounter = person.getCurrentEncounter(module);
+		  encounter.supplies.addAll(supplies);
+		  return false;
+		}
+  }
+  
   /**
    * The Death state type indicates a point in the module at which the patient dies or the patient
    * is given a terminal diagnosis (e.g. "you have 3 months to live"). When the Death state is

--- a/src/main/java/org/mitre/synthea/engine/Transition.java
+++ b/src/main/java/org/mitre/synthea/engine/Transition.java
@@ -188,7 +188,8 @@ public abstract class Transition implements Serializable {
       // Retrieve CSV column headers.
       List<String> columnHeaders = new ArrayList<String>(lookupTable.get(0).keySet());
       // Parse the list of attributes.
-      this.attributes = new ArrayList(columnHeaders.subList(0, columnHeaders.size() - this.transitions.size()));
+      this.attributes = new ArrayList(columnHeaders.subList(0,
+          columnHeaders.size() - this.transitions.size()));
       // Parse the list of states to transition to.
       List<String> transitionStates = columnHeaders.subList((columnHeaders.size()
           - this.transitions.size()), columnHeaders.size());

--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -39,6 +39,8 @@ import org.mitre.synthea.world.concepts.HealthRecord.ImagingStudy;
 import org.mitre.synthea.world.concepts.HealthRecord.Medication;
 import org.mitre.synthea.world.concepts.HealthRecord.Observation;
 import org.mitre.synthea.world.concepts.HealthRecord.Procedure;
+import org.mitre.synthea.world.concepts.HealthRecord.Supply;
+
 
 /**
  * Researchers have requested a simple table-based format that could easily be
@@ -408,7 +410,7 @@ public class CSVExporter {
         device(personID, encounterID, device);
       }
       
-      for (JsonObject supply : encounter.supplies) {
+      for (Supply supply : encounter.supplies) {
         supply(personID, encounterID, encounter, supply);
       }
     }
@@ -986,7 +988,7 @@ public class CSVExporter {
    * @param supply       The supply itself
    * @throws IOException if any IO error occurs
    */
-  private void supply(String personID, String encounterID, Encounter encounter, JsonObject supply)
+  private void supply(String personID, String encounterID, Encounter encounter, Supply supply)
     throws IOException {
     // DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,QUANTITY
     StringBuilder s = new StringBuilder();
@@ -994,13 +996,12 @@ public class CSVExporter {
     s.append(dateFromTimestamp(encounter.start)).append(',');
     s.append(personID).append(',');
     s.append(encounterID).append(',');
-    
-    JsonObject code = supply.get("code").getAsJsonObject();
-    s.append(code.get("code").getAsString()).append(',');
-    s.append(clean(code.get("display").getAsString())).append(',');
-    
-    s.append(supply.get("quantity").getAsLong());
-    
+
+    s.append(supply.code.code).append(',');
+    s.append(clean(supply.code.display)).append(',');
+
+    s.append(supply.quantity);
+
     s.append(NEWLINE);
     
     write(s.toString(), supplies);

--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -1420,7 +1420,7 @@ public class FhirDstu2 {
     type.addCoding()
       .setCode("device")
       .setDisplay("Device")
-      .setSystem(SNOMED_URI);
+      .setSystem("http://hl7.org/fhir/supply-item-type");
     supplyResource.setType(type);
 
     // super hackish -- there's no "code" field available here, just a reference to a Device

--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -227,7 +227,7 @@ public class FhirDstu2 {
         device(personEntry, bundle, device);
       }
       
-      for (JsonObject supply : encounter.supplies) {
+      for (HealthRecord.Supply supply : encounter.supplies) {
         supplyDelivery(personEntry, bundle, supply, encounter);
       }
 
@@ -1410,7 +1410,7 @@ public class FhirDstu2 {
    * @return The added Entry.
    */
   private static Entry supplyDelivery(Entry personEntry, Bundle bundle,
-      JsonObject supply, Encounter encounter) {
+      HealthRecord.Supply supply, Encounter encounter) {
    
     SupplyDelivery supplyResource = new SupplyDelivery();
     supplyResource.setStatus(SupplyDeliveryStatusEnum.DELIVERED);
@@ -1423,17 +1423,14 @@ public class FhirDstu2 {
       .setSystem(SNOMED_URI);
     supplyResource.setType(type);
 
-    JsonObject jsonCode = supply.get("code").getAsJsonObject();
-    String code = jsonCode.get("code").getAsString();
-    String display = jsonCode.get("display").getAsString();
     // super hackish -- there's no "code" field available here, just a reference to a Device
     // so for now just put some text in the reference
     ResourceReferenceDt suppliedItem = new ResourceReferenceDt();
-    suppliedItem.setDisplay("SNOMED[" + code + "]: " + display);
+    suppliedItem.setDisplay("SNOMED[" + supply.code.code + "]: " + supply.code.display);
 
     supplyResource.setSuppliedItem(suppliedItem);
 
-    supplyResource.setQuantity(new SimpleQuantityDt(supply.get("quantity").getAsLong()));
+    supplyResource.setQuantity(new SimpleQuantityDt(supply.quantity));
 
     supplyResource.setTime((DateTimeDt) convertFhirDateTime(encounter.start, true));
     

--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -1429,7 +1429,7 @@ public class FhirDstu2 {
     // super hackish -- there's no "code" field available here, just a reference to a Device
     // so for now just put some text in the reference
     ResourceReferenceDt suppliedItem = new ResourceReferenceDt();
-    suppliedItem.setDisplay("SNOMED-CT[" + code + "]: " + display);
+    suppliedItem.setDisplay("SNOMED[" + code + "]: " + display);
 
     supplyResource.setSuppliedItem(suppliedItem);
 

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -1680,7 +1680,7 @@ public class FhirR4 {
     type.addCoding()
       .setCode("device")
       .setDisplay("Device")
-      .setSystem(SNOMED_URI);
+      .setSystem("http://terminology.hl7.org/CodeSystem/supply-item-type");
     supplyResource.setType(type);
     
     SupplyDeliverySuppliedItemComponent suppliedItem = new SupplyDeliverySuppliedItemComponent();

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -270,7 +270,7 @@ public class FhirR4 {
         device(personEntry, bundle, device);
       }
       
-      for (JsonObject supply : encounter.supplies) {
+      for (HealthRecord.Supply supply : encounter.supplies) {
         supplyDelivery(personEntry, bundle, supply, encounter);
       }
 
@@ -1670,7 +1670,7 @@ public class FhirR4 {
    * @return The added Entry.
    */
   private static BundleEntryComponent supplyDelivery(BundleEntryComponent personEntry, Bundle bundle,
-      JsonObject supply, Encounter encounter) {
+      HealthRecord.Supply supply, Encounter encounter) {
    
     SupplyDelivery supplyResource = new SupplyDelivery();
     supplyResource.setStatus(SupplyDeliveryStatus.COMPLETED);
@@ -1684,14 +1684,8 @@ public class FhirR4 {
     supplyResource.setType(type);
     
     SupplyDeliverySuppliedItemComponent suppliedItem = new SupplyDeliverySuppliedItemComponent();
-    CodeableConcept itemCC = new CodeableConcept();
-    JsonObject jsonCode = supply.get("code").getAsJsonObject();
-    itemCC.addCoding()
-      .setCode(jsonCode.get("code").getAsString())
-      .setDisplay(jsonCode.get("display").getAsString())
-      .setSystem(SNOMED_URI);
-    suppliedItem.setItem(itemCC);
-    suppliedItem.setQuantity(new Quantity(supply.get("quantity").getAsLong()));
+    suppliedItem.setItem(mapCodeToCodeableConcept(supply.code, SNOMED_URI));
+    suppliedItem.setQuantity(new Quantity(supply.quantity));
     
     supplyResource.setSuppliedItem(suppliedItem);
     

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -9,9 +9,6 @@ import com.google.gson.JsonObject;
 
 import java.awt.geom.Point2D;
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.MathContext;
-import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -1638,6 +1635,12 @@ public class FhirR4 {
         .setCarrierHRF(device.udi);
     deviceResource.setStatus(FHIRDeviceStatus.ACTIVE);
     deviceResource.setDistinctIdentifier(device.deviceIdentifier);
+    if (device.manufacturer != null) {
+      deviceResource.setManufacturer(device.manufacturer);
+    }
+    if (device.model != null) {
+      deviceResource.setModelNumber(device.model);
+    }
     deviceResource.setManufactureDate(new Date(device.manufactureTime));
     deviceResource.setExpirationDate(new Date(device.expirationTime));
     deviceResource.setLotNumber(device.lotNumber);

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -2206,7 +2206,7 @@ public class FhirStu3 {
     type.addCoding()
       .setCode("device")
       .setDisplay("Device")
-      .setSystem(SNOMED_URI);
+      .setSystem("http://hl7.org/fhir/supply-item-type");
     supplyResource.setType(type);
     
     SupplyDeliverySuppliedItemComponent suppliedItem = new SupplyDeliverySuppliedItemComponent();

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -273,7 +273,7 @@ public class FhirStu3 {
         device(personEntry, bundle, device);
       }
       
-      for (JsonObject supply : encounter.supplies) {
+      for (HealthRecord.Supply supply : encounter.supplies) {
         supplyDelivery(personEntry, bundle, supply, encounter);
       }
       
@@ -2196,7 +2196,7 @@ public class FhirStu3 {
    * @return The added Entry.
    */
   private static BundleEntryComponent supplyDelivery(BundleEntryComponent personEntry, Bundle bundle,
-      JsonObject supply, Encounter encounter) {
+      HealthRecord.Supply supply, Encounter encounter) {
    
     SupplyDelivery supplyResource = new SupplyDelivery();
     supplyResource.setStatus(SupplyDeliveryStatus.COMPLETED);
@@ -2210,16 +2210,10 @@ public class FhirStu3 {
     supplyResource.setType(type);
     
     SupplyDeliverySuppliedItemComponent suppliedItem = new SupplyDeliverySuppliedItemComponent();
-    CodeableConcept itemCC = new CodeableConcept();
-    JsonObject jsonCode = supply.get("code").getAsJsonObject();
-    itemCC.addCoding()
-      .setCode(jsonCode.get("code").getAsString())
-      .setDisplay(jsonCode.get("display").getAsString())
-      .setSystem(SNOMED_URI);
-    suppliedItem.setItem(itemCC);
+    suppliedItem.setItem( mapCodeToCodeableConcept(supply.code, SNOMED_URI));
     
     SimpleQuantity quantity = new SimpleQuantity();
-    quantity.setValue(supply.get("quantity").getAsLong());
+    quantity.setValue(supply.quantity);
     suppliedItem.setQuantity(quantity);
     
     supplyResource.setSuppliedItem(suppliedItem);

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -382,6 +382,8 @@ public class HealthRecord implements Serializable {
    * or hip, heart pacemaker, or implantable defibrillator.
    */
   public class Device extends Entry {
+    public String manufacturer;
+    public String model;
     /** UDI == Unique Device Identifier. */
     public String udi;
     public long manufactureTime;
@@ -479,6 +481,7 @@ public class HealthRecord implements Serializable {
     public List<CarePlan> careplans;
     public List<ImagingStudy> imagingStudies;
     public List<Device> devices;
+    public List<JsonObject> supplies;
     public Claim claim; // for now assume 1 claim per encounter
     public Code reason;
     public Code discharge;
@@ -513,6 +516,7 @@ public class HealthRecord implements Serializable {
       careplans = new ArrayList<CarePlan>();
       imagingStudies = new ArrayList<ImagingStudy>();
       devices = new ArrayList<Device>();
+      supplies = new ArrayList<JsonObject>();
       this.claim = new Claim(this, person);
     }
 

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -430,6 +430,11 @@ public class HealthRecord implements Serializable {
       return retVal;
     }
   }
+  
+  public class Supply implements Serializable {
+    public int quantity;
+    public Code code;
+  }
 
   public enum EncounterType {
     WELLNESS("AMB"), AMBULATORY("AMB"), OUTPATIENT("AMB"),
@@ -481,7 +486,7 @@ public class HealthRecord implements Serializable {
     public List<CarePlan> careplans;
     public List<ImagingStudy> imagingStudies;
     public List<Device> devices;
-    public List<JsonObject> supplies;
+    public List<Supply> supplies;
     public Claim claim; // for now assume 1 claim per encounter
     public Code reason;
     public Code discharge;
@@ -516,7 +521,7 @@ public class HealthRecord implements Serializable {
       careplans = new ArrayList<CarePlan>();
       imagingStudies = new ArrayList<ImagingStudy>();
       devices = new ArrayList<Device>();
-      supplies = new ArrayList<JsonObject>();
+      supplies = new ArrayList<Supply>();
       this.claim = new Claim(this, person);
     }
 

--- a/src/main/resources/modules/covid19/admission.json
+++ b/src/main/resources/modules/covid19/admission.json
@@ -266,7 +266,8 @@
       "direct_transition": "Metered_Dose_Inhaler"
     },
     "Hospitalization Supplies": {
-      "type": "Simple",
+      "type": "CallSubmodule",
+      "submodule": "covid19/supplies_hospitalization",
       "direct_transition": "Hospitalization Day End"
     },
     "Hospitalization Next Day": {
@@ -343,7 +344,8 @@
       ]
     },
     "ICU Supplies": {
-      "type": "Simple",
+      "type": "CallSubmodule",
+      "submodule": "covid19/supplies_icu",
       "direct_transition": "ICU Day End"
     },
     "Metered_Dose_Inhaler": {
@@ -466,7 +468,7 @@
       },
       "conditional_transition": [
         {
-          "transition": "Intubation",
+          "transition": "Intubation Supplies",
           "condition": {
             "condition_type": "Active Condition",
             "codes": [
@@ -482,6 +484,11 @@
           "transition": "ICU Day Begin"
         }
       ]
+    },
+    "Intubation Supplies": {
+      "type": "CallSubmodule",
+      "submodule": "covid19/supplies_intubation",
+      "direct_transition": "Intubation"
     },
     "Intubation": {
       "type": "Procedure",

--- a/src/main/resources/modules/covid19/supplies_hospitalization.json
+++ b/src/main/resources/modules/covid19/supplies_hospitalization.json
@@ -1,0 +1,72 @@
+{
+  "name": "Supplies - Hospitalization",
+  "remarks": [
+    "This module includes the supplies needed during daily treatment of COVID-19 in a basic hospital inpatient setting, not the ICU. This includes the PPE needed for 1 patient, 1 doctor, 1 nurse for 1 day.",
+    "",
+    "Patient",
+    "- 1 surgical mask",
+    "- patient gown not tracked as these are completely washable",
+    "",
+    "Doctor/Nurse",
+    "- 2 gloves each",
+    "- surgical gown each",
+    "- surgical mask each",
+    "- glasses/goggles/face shield",
+    "- hand sanitizer"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Precautions_Baseline"
+    },
+    "Precautions_Baseline": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "quantity": 3,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "465635009",
+            "display": "Surgical face mask, single-use (physical object)"
+          }
+        },
+        {
+          "quantity": 4,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "713779008",
+            "display": "Nitrile examination/treatment glove, non-powdered, sterile (physical object)"
+          }
+        },
+        {
+          "quantity": 2,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "469673003",
+            "display": "Isolation gown, single-use (physical object)"
+          }
+        },
+        {
+          "quantity": 2,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "38126007",
+            "display": "Protective glasses, device (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "419343004",
+            "display": "Alcohol disinfectant (substance)"
+          }
+        }
+      ],
+      "direct_transition": "Terminal"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/src/main/resources/modules/covid19/supplies_icu.json
+++ b/src/main/resources/modules/covid19/supplies_icu.json
@@ -1,0 +1,71 @@
+{
+  "name": "Supplies - ICU",
+  "remarks": [
+    "This module includes the supplies needed during daily treatment of COVID-19 in an intensive care setting.  These supplies offer a higher level of protection to the health care provider than the general inpatient setting. This includes the PPE needed for 1 patient, 1 doctor, 1 nurse for 1 day.",
+    "",
+    "Patient",
+    "- no additional supplies",
+    "",
+    "Doctor/Nurse",
+    "- 2 gloves each",
+    "- isolation gown each",
+    "- N95 respirator mask each",
+    "- glasses/goggles/face shield",
+    "- hand sanitizer"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Precautions_Aerosol"
+    },
+    "Precautions_Aerosol": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "quantity": 4,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "713779008",
+            "display": "Nitrile examination/treatment glove, non-powdered, sterile (physical object)"
+          }
+        },
+        {
+          "quantity": 2,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "469673003",
+            "display": "Isolation gown, single-use (physical object)"
+          }
+        },
+        {
+          "quantity": 2,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "409534002",
+            "display": "Disposable air-purifying respirator (physical object)"
+          }
+        },
+        {
+          "quantity": 2,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "38126007",
+            "display": "Protective glasses, device (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "419343004",
+            "display": "Alcohol disinfectant (substance)"
+          }
+        }
+      ],
+      "direct_transition": "Terminal"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/src/main/resources/modules/covid19/supplies_intubation.json
+++ b/src/main/resources/modules/covid19/supplies_intubation.json
@@ -1,0 +1,189 @@
+{
+  "name": "Supplies - Intubation",
+  "remarks": [
+    "This module includes the supplies needed during an intubation (i.e, an aerosolizing procedures) in support of the treatment of COVID-19. These are the supplies offering the highest level of protection to the health care provider, as well as the required supplies for the procedure itself. This submodule should be considered additional to the other supplies submodules as it only considers a single procedure, not the entire day. This also considers the inclusion of a respiratory therapist in addition to the 1 doctor and 1 nurse.",
+    "",
+    "Patient",
+    "- no additional supplies",
+    "",
+    "HCP",
+    " - Nurse and RT wear same as ICU PPE:",
+    "  - gloves",
+    "  - isolation gown",
+    "  - glasses/goggles/shield",
+    "- physician:",
+    "  - wears OR gown instead of isolation gown",
+    "  - surgical cap",
+    "  - extra set of gloves",
+    "",
+    ""
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Ventilator"
+    },
+    "Supplies_Intubation": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "quantity": 8,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "713779008",
+            "display": "Nitrile examination/treatment glove, non-powdered, sterile (physical object)"
+          }
+        },
+        {
+          "quantity": 2,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "469673003",
+            "display": "Isolation gown, single-use (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "463983006",
+            "display": "Operating room gown, single-use (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "465668002",
+            "display": "Surgical cap, single-use (physical object)"
+          }
+        },
+        {
+          "quantity": 3,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "409534002",
+            "display": "Disposable air-purifying respirator (physical object)"
+          }
+        },
+        {
+          "quantity": 3,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "38126007",
+            "display": "Protective glasses, device (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "419343004",
+            "display": "Alcohol disinfectant (substance)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "448907002",
+            "display": "Videolaryngoscope (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "470609007",
+            "display": "Laryngoscope blade, single-use (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "467053003",
+            "display": "Basic endotracheal tube, single-use (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "468507004",
+            "display": "Endotracheal tube stylet, single-use (physical object)"
+          }
+        },
+        {
+          "quantity": 2,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "61968008",
+            "display": "Syringe, device (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "706092000",
+            "display": "Suction system (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "706774004",
+            "display": "Lubricant (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "468601005",
+            "display": "Endotracheal tube holder (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "701434005",
+            "display": "Viral filter (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "827149008",
+            "display": "Carbon dioxide breath analyzer (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": "17102003",
+            "display": "Nasogastric tube, device (physical object)"
+          }
+        }
+      ],
+      "direct_transition": "Terminal"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Ventilator": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 449071006,
+        "display": "Mechanical ventilator (physical object)"
+      },
+      "direct_transition": "Supplies_Intubation"
+    }
+  }
+}

--- a/src/test/java/org/mitre/synthea/engine/LookupTableTransitionTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LookupTableTransitionTest.java
@@ -48,6 +48,8 @@ public class LookupTableTransitionTest {
     // hack to load these test modules so they can be called by the CallSubmodule state
     Module lookuptabletestModule = TestHelper.getFixture("lookuptable_test.json");
     modules.put("lookuptable_test", new Module.ModuleSupplier(lookuptabletestModule));
+    Module lookuptabletesttimerangeModule = TestHelper.getFixture("lookuptable_timerangetest.json");
+    modules.put("lookuptable_timerangetest", new Module.ModuleSupplier(lookuptabletesttimerangeModule));
 
     /* Create Mild Lookuptablitis Condition */
     mildLookuptablitis = new ActiveCondition();
@@ -75,6 +77,7 @@ public class LookupTableTransitionTest {
     Config.set("generic.lookuptables", "modules/lookup_tables");
     // Remove the lookuptable_test.json module
     modules.remove("lookuptable_test");
+    modules.remove("lookuptable_timerangetest");
   }
 
   @Test
@@ -505,6 +508,116 @@ public class LookupTableTransitionTest {
     assertFalse(mildLookuptablitis.test(person, conditionTime + 100));
     assertFalse(moderateLookuptablitis.test(person, conditionTime + 100));
     assertTrue(extremeLookuptablitis.test(person, conditionTime + 100));
+  }
+
+  @Test
+  public void firstTimeRangeMaleMA() {
+    long birthTime = 0L;
+    // Under Fifty
+    long conditionTime = 500L;
+
+    // Create the person with the preset attributes.
+    Person person = new Person(0L);
+    person.attributes.put(Person.BIRTHDATE, 0L);
+    person.attributes.put(Person.GENDER, "M");
+    person.attributes.put(Person.STATE, "Massachusetts");
+
+    // Process the lookuptable_test Module.
+    Module lookuptableTestModule = modules.get("lookuptable_timerangetest").get();
+    lookuptableTestModule.process(person, conditionTime);
+
+    // Make sure this person has the correct lookuptablitis.
+    assertFalse(mildLookuptablitis.test(person, conditionTime + 100));
+    assertTrue(moderateLookuptablitis.test(person, conditionTime + 100));
+    assertFalse(extremeLookuptablitis.test(person, conditionTime + 100));
+  }
+
+  @Test
+  public void firstTimeRangeFemaleMA() {
+    long birthTime = 0L;
+    // Under Fifty
+    long conditionTime = 500L;
+
+    // Create the person with the preset attributes.
+    Person person = new Person(0L);
+    person.attributes.put(Person.BIRTHDATE, 0L);
+    person.attributes.put(Person.GENDER, "F");
+    person.attributes.put(Person.STATE, "Massachusetts");
+
+    // Process the lookuptable_test Module.
+    Module lookuptableTestModule = modules.get("lookuptable_timerangetest").get();
+    lookuptableTestModule.process(person, conditionTime);
+
+    // Make sure this person has the correct lookuptablitis.
+    assertTrue(mildLookuptablitis.test(person, conditionTime + 100));
+    assertFalse(moderateLookuptablitis.test(person, conditionTime + 100));
+    assertFalse(extremeLookuptablitis.test(person, conditionTime + 100));
+  }
+
+  @Test
+  public void firstTimeRangeMaleOutOfState() {
+    long birthTime = 0L;
+    // Under Fifty
+    long conditionTime = 500L;
+
+    // Create the person with the preset attributes.
+    Person person = new Person(0L);
+    person.attributes.put(Person.BIRTHDATE, 0L);
+    person.attributes.put(Person.GENDER, "M");
+    person.attributes.put(Person.STATE, "New Hampshire");
+
+    // Process the lookuptable_test Module.
+    Module lookuptableTestModule = modules.get("lookuptable_timerangetest").get();
+    lookuptableTestModule.process(person, conditionTime);
+
+    // Make sure this person has the correct lookuptablitis.
+    assertFalse(mildLookuptablitis.test(person, conditionTime + 100));
+    assertFalse(moderateLookuptablitis.test(person, conditionTime + 100));
+    assertTrue(extremeLookuptablitis.test(person, conditionTime + 100));
+  }
+
+  @Test
+  public void secondTimeRangeMaleMA() {
+    long birthTime = 0L;
+    // Under Fifty
+    long conditionTime = 1500L;
+
+    // Create the person with the preset attributes.
+    Person person = new Person(0L);
+    person.attributes.put(Person.BIRTHDATE, 0L);
+    person.attributes.put(Person.GENDER, "M");
+    person.attributes.put(Person.STATE, "Massachusetts");
+
+    // Process the lookuptable_test Module.
+    Module lookuptableTestModule = modules.get("lookuptable_timerangetest").get();
+    lookuptableTestModule.process(person, conditionTime);
+
+    // Make sure this person has the correct lookuptablitis.
+    assertFalse(mildLookuptablitis.test(person, conditionTime + 100));
+    assertFalse(moderateLookuptablitis.test(person, conditionTime + 100));
+    assertTrue(extremeLookuptablitis.test(person, conditionTime + 100));
+  }
+
+  @Test
+  public void secondTimeRangeFemaleMA() {
+    long birthTime = 0L;
+    // Under Fifty
+    long conditionTime = 1500L;
+
+    // Create the person with the preset attributes.
+    Person person = new Person(0L);
+    person.attributes.put(Person.BIRTHDATE, 0L);
+    person.attributes.put(Person.GENDER, "F");
+    person.attributes.put(Person.STATE, "Massachusetts");
+
+    // Process the lookuptable_test Module.
+    Module lookuptableTestModule = modules.get("lookuptable_timerangetest").get();
+    lookuptableTestModule.process(person, conditionTime);
+
+    // Make sure this person has the correct lookuptablitis.
+    assertFalse(mildLookuptablitis.test(person, conditionTime + 100));
+    assertTrue(moderateLookuptablitis.test(person, conditionTime + 100));
+    assertFalse(extremeLookuptablitis.test(person, conditionTime + 100));
   }
 
   @Test

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -1749,7 +1749,7 @@ public class StateTest {
     assertTrue(supplyListState.process(person, time));
     
     Encounter encounter = person.getCurrentEncounter(module);
-    List<JsonObject> supplies = encounter.supplies;
+    List<HealthRecord.Supply> supplies = encounter.supplies;
     assertNotNull(supplies);
     assertEquals(4, supplies.size());
     
@@ -1760,11 +1760,10 @@ public class StateTest {
     int[] expectedQuantities = { 10_000, 3_000, 98765, 1 };
     
     for (int i = 0; i < 4; i++) {
-      JsonObject supply = supplies.get(i);
-      JsonObject supplyCode = supply.get("code").getAsJsonObject();
-      assertEquals(expectedCodes[i], supplyCode.get("code").getAsString());
-      assertEquals(expectedDisplays[i], supplyCode.get("display").getAsString());
-      assertEquals(expectedQuantities[i], supply.get("quantity").getAsInt());
+      HealthRecord.Supply supply = supplies.get(i);
+      assertEquals(expectedCodes[i], supply.code.code);
+      assertEquals(expectedDisplays[i], supply.code.display);
+      assertEquals(expectedQuantities[i], supply.quantity);
     }
   }
 }

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -81,6 +81,6 @@ public class CSVExporterTest {
       count++;
     }
 
-    assertEquals("Expected 14 CSV files in the output directory, found " + count, 14, count);
+    assertEquals("Expected 16 CSV files in the output directory, found " + count, 16, count);
   }
 }

--- a/src/test/resources/generic/artificial_heart_device.json
+++ b/src/test/resources/generic/artificial_heart_device.json
@@ -34,7 +34,6 @@
       "type": "SupplyList",
       "supplies": [
         {
-          "category": "device",
           "quantity": 10000,
           "code": {
             "system": "SNOMED-CT",
@@ -43,7 +42,6 @@
           }
         },
         {
-          "category": "device",
           "quantity": 3000,
           "code": {
             "system": "SNOMED-CT",
@@ -52,7 +50,6 @@
           }
         },
         {
-          "category": "device",
           "quantity": 98765,
           "code": {
             "system": "SNOMED-CT",
@@ -61,7 +58,6 @@
           }
         },
         {
-          "category": "device",
           "quantity": 1,
           "code": {
             "system": "SNOMED-CT",

--- a/src/test/resources/generic/artificial_heart_device.json
+++ b/src/test/resources/generic/artificial_heart_device.json
@@ -1,0 +1,87 @@
+{
+  "name": "artificial_heart_device",
+  "remarks": [
+    "1. give a baby an artificial heart",
+    "2. ???",
+    "3. profit"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Encounter"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Encounter": {
+      "type": "Encounter",
+      "encounter_class": "ambulatory",
+      "reason": "",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 440068009,
+          "display": "Home visit for newborn care and assessment (procedure)"
+        }
+      ],
+      "direct_transition": "Necessary_Supplies"
+    },
+    "End_Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
+    },
+    "Necessary_Supplies": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "category": "device",
+          "quantity": 10000,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 52291003,
+            "display": "Glove, device (physical object)"
+          }
+        },
+        {
+          "category": "device",
+          "quantity": 3000,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 468159004,
+            "display": "Cotton ball (physical object)"
+          }
+        },
+        {
+          "category": "device",
+          "quantity": 98765,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 39802000,
+            "display": "Tongue blade, device (physical object)"
+          }
+        },
+        {
+          "category": "device",
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 788177008,
+            "display": "Examination gown, single-use (physical object)"
+          }
+        }
+      ],
+      "direct_transition": "Artificial_Heart"
+    },
+    "Artificial_Heart": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 13459008,
+        "display": "Temporary artificial heart prosthesis, device (physical object)"
+      },
+      "direct_transition": "End_Encounter",
+      "manufacturer": "SynCardia",
+      "model": "Total Artificial Heart"
+    }
+  }
+}

--- a/src/test/resources/generic/lookup_tables/lookuptable_timerangetest.csv
+++ b/src/test/resources/generic/lookup_tables/lookuptable_timerangetest.csv
@@ -1,0 +1,5 @@
+time,gender,state,Mild_Lookuptablitis,Moderate_Lookuptablitis,Extreme_Lookuptablitis
+0-999,M,Massachusetts,0,1,0
+0-999,F,Massachusetts,1,0,0
+1000-1999,M,Massachusetts,0,0,1
+1000-1999,F,Massachusetts,0,1,0

--- a/src/test/resources/generic/lookuptable_timerangetest.json
+++ b/src/test/resources/generic/lookuptable_timerangetest.json
@@ -1,0 +1,74 @@
+{
+  "name": "lookuptable_agerangetest",
+  "remarks": [
+    "A test for Lookup Table Transitions where ageLow >  ageHigh."
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Determine_Condition",
+      "name": "Initial"
+    },
+    "Terminal": {
+      "type": "Terminal",
+      "name": "Terminal"
+    },
+    "Determine_Condition": {
+      "type": "Simple",
+      "name": "Determine_Condition",
+      "lookup_table_transition": [
+        {
+          "transition": "Mild_Lookuptablitis",
+          "default_probability": "0",
+          "lookup_table_name": "lookuptable_timerangetest.csv"
+        },
+        {
+          "transition": "Extreme_Lookuptablitis",
+          "default_probability": "1",
+          "lookup_table_name": "lookuptable_timerangetest.csv"
+        },
+        {
+          "transition": "Moderate_Lookuptablitis",
+          "default_probability": "0",
+          "lookup_table_name": "lookuptable_timerangetest.csv"
+        }
+      ]
+    },
+    "Mild_Lookuptablitis": {
+      "type": "ConditionOnset",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 23502007,
+          "display": "Mild_Lookuptablitis"
+        }
+      ],
+      "direct_transition": "Terminal",
+      "name": "Mild_Lookuptablitis"
+    },
+    "Moderate_Lookuptablitis": {
+      "type": "ConditionOnset",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 23502008,
+          "display": "Moderate_Lookuptablitis"
+        }
+      ],
+      "direct_transition": "Terminal",
+      "name": "Moderate_Lookuptablitis"
+    },
+    "Extreme_Lookuptablitis": {
+      "type": "ConditionOnset",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 23502009,
+          "display": "Extreme_Lookuptablitis"
+        }
+      ],
+      "direct_transition": "Terminal",
+      "name": "Extreme_Lookuptablitis"
+    }
+  }
+}


### PR DESCRIPTION
Adds 3 supplies submodules to the COVID19 track - one for daily supplies in general inpatient care, one for daily supplies in intensive care, one for the supplies needed for the intubation process. These 3 submodules are called at appropriate times in the admissions submodule - 2 Simple state placeholders were replaced with CallSubmodules, and 1 was added right before the Intubation Procedure state.


Note that the covid19 branch doesn't currently have the Device and SupplyList states that were recently merged into master, so I merged all the latest from master into this branch. If that makes things too messy I can look into cherry-picking instead.