### PR TITLE
Better ICD-10-CD code for pneumonia due to coronavirus?

### DIFF
--- a/src/main/resources/modules/covid19/outcomes.json
+++ b/src/main/resources/modules/covid19/outcomes.json
@@ -15,9 +15,9 @@
       "type": "ConditionOnset",
       "codes": [
         {
-          "system": "SNOMED-CT",
-          "code": "233604007",
-          "display": "Pneumonia (disorder)"
+          "system": "ICD-10-CM",
+          "code": "J12.89",
+          "display": "Pneumonia due to coronavirus"
         }
       ],
       "direct_transition": "Mild Respiratory Distress",


### PR DESCRIPTION
But I'm not sure ICD-10 is supported yet?