### PR TITLE
Update codes and displays to fix FHIR validator warnings

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -2380,7 +2380,7 @@ public class FhirR4 {
     participant.addRole(mapCodeToCodeableConcept(
         new Code(
             SNOMED_URI,
-            "116153009",
+            "116154003",
             "Patient"),
         SNOMED_URI));
     Patient patient = (Patient) personEntry.getResource();

--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -236,20 +236,20 @@ public final class CardiovascularDiseaseModule extends Module {
     // medications
     LOOKUP.put("clopidogrel", new Code("RxNorm", "309362", "Clopidogrel 75 MG Oral Tablet"));
     LOOKUP.put("simvastatin", new Code("RxNorm", "312961", "Simvastatin 20 MG Oral Tablet"));
-    LOOKUP.put("amlodipine", new Code("RxNorm", "197361", "Amlodipine 5 MG Oral Tablet"));
+    LOOKUP.put("amlodipine", new Code("RxNorm", "197361", "amLODIPine besylate 5 MG Oral Tablet"));
     LOOKUP.put("nitroglycerin",
-        new Code("RxNorm", "705129", "Nitroglycerin 0.4 MG/ACTUAT Mucosal Spray"));
-    LOOKUP.put("atorvastatin", new Code("RxNorm", "259255", "Atorvastatin 80 MG Oral Tablet"));
-    LOOKUP.put("captopril", new Code("RxNorm", "833036", "Captopril 25 MG Oral Tablet"));
+        new Code("RxNorm", "705129", "nitroglycerin 400 MCG/ACTUAT Mucosal Spray"));
+    LOOKUP.put("atorvastatin", new Code("RxNorm", "259255", "atorvastatin calcium 80 MG Oral Tablet"));
+    LOOKUP.put("captopril", new Code("RxNorm", "833036", "HYDROcodone bitartrate 7.5 MG / acetaminophen 750 MG Oral Tablet"));
     LOOKUP.put("warfarin", new Code("RxNorm", "855332", "Warfarin Sodium 5 MG Oral Tablet"));
     LOOKUP.put("verapamil", new Code("RxNorm", "897718", "Verapamil Hydrochloride 40 MG"));
-    LOOKUP.put("digoxin", new Code("RxNorm", "197604", "Digoxin 0.125 MG Oral Tablet"));
+    LOOKUP.put("digoxin", new Code("RxNorm", "197604", "digoxin 125 MCG Oral Tablet"));
     LOOKUP.put("epinephrine",
-        new Code("RxNorm", "1660014", "1 ML Epinephrine 1 MG/ML Injection"));
+        new Code("RxNorm", "1660014", "EPINEPHrine 1 MG per 1 ML Injection"));
     LOOKUP.put("amiodarone",
-        new Code("RxNorm", "834357", "3 ML Amiodarone hydrocholoride 50 MG/ML Prefilled Syringe"));
+        new Code("RxNorm", "834357", "amiodarone HCl 150 MG in 3 ML Prefilled Syringe"));
     LOOKUP.put("atropine",
-        new Code("RxNorm", "1190795", "Atropine Sulfate 1 MG/ML Injectable Solution"));
+        new Code("RxNorm", "1190795", "atropine sulfate 1 MG in 1 ML Injection"));
     LOOKUP.put("alteplase", new Code("RxNorm", "1804799", "Alteplase 100 MG Injection"));
 
     // reasons

--- a/src/main/java/org/mitre/synthea/modules/EncounterModule.java
+++ b/src/main/java/org/mitre/synthea/modules/EncounterModule.java
@@ -36,13 +36,13 @@ public final class EncounterModule extends Module {
   public static final Code ENCOUNTER_CHECKUP = new Code("SNOMED-CT", "185349003",
       "Encounter for check up (procedure)");
   public static final Code ENCOUNTER_EMERGENCY = new Code("SNOMED-CT", "50849002",
-      "Emergency Encounter");
+      "Emergency room admission (procedure)");
   public static final Code WELL_CHILD_VISIT = new Code("SNOMED-CT", "410620009",
       "Well child visit (procedure)");
   public static final Code GENERAL_EXAM = new Code("SNOMED-CT", "162673000",
       "General examination of patient (procedure)");
   public static final Code ENCOUNTER_URGENTCARE = new Code("SNOMED-CT", "702927004",
-      "Urgent care clinic (procedure)");
+      "Urgent care clinic (environment)");
   // NOTE: if new codes are added, be sure to update getAllCodes below
 
   public EncounterModule() {

--- a/src/main/resources/immunization_schedule.json
+++ b/src/main/resources/immunization_schedule.json
@@ -304,7 +304,7 @@
     "code": {
       "system": "http://hl7.org/fhir/sid/cvx",
       "code": "113",
-      "display": "Td (adult) preservative free"
+      "display": "Td (adult), 5 Lf tetanus toxoid, preservative free, adsorbed"
     },
     "remark": "21 years and every 10 years after. This particular combination of tetanus and diphtheria first available 1992.",
     "at_months": [
@@ -323,7 +323,7 @@
     "code": {
       "system": "http://hl7.org/fhir/sid/cvx",
       "code": "121",
-      "display": "zoster"
+      "display": "zoster live"
     },
     "at_months": [
       600,
@@ -335,7 +335,7 @@
     "code": {
       "system": "http://hl7.org/fhir/sid/cvx",
       "code": "33",
-      "display": "pneumococcal polysaccharide vaccine, 23 valent"
+      "display": "pneumococcal polysaccharide PPV23"
     },
     "at_months": [
       792

--- a/src/main/resources/modules/allergic_rhinitis.json
+++ b/src/main/resources/modules/allergic_rhinitis.json
@@ -283,7 +283,7 @@
                 {
                   "system": "SNOMED-CT",
                   "code": "232347008",
-                  "display": "Dander (animal) allergy"
+                  "display": "Allergy to animal dander (finding)"
                 }
               ]
             },
@@ -303,7 +303,7 @@
                 {
                   "system": "SNOMED-CT",
                   "code": "419474003",
-                  "display": "Allergy to mould"
+                  "display": "Allergy to mold (finding)"
                 }
               ]
             }

--- a/src/main/resources/modules/allergies.json
+++ b/src/main/resources/modules/allergies.json
@@ -175,7 +175,7 @@
         {
           "system": "RxNorm",
           "code": "1870230",
-          "display": "NDA020800 0.3 ML Epinephrine 1 MG/ML Auto-Injector"
+          "display": "EPINEPHrine (generic for Adrenaclick) 0.3 MG per 0.3 ML Auto-Injector"
         }
       ],
       "prescription": {

--- a/src/main/resources/modules/allergies/allergy_incidence.json
+++ b/src/main/resources/modules/allergies/allergy_incidence.json
@@ -390,7 +390,7 @@
         {
           "system": "SNOMED-CT",
           "code": "714035009",
-          "display": "Allergy to soya"
+          "display": "Allergy to soy (disorder)"
         }
       ],
       "direct_transition": "Chance_of_Dairy_Allergy"
@@ -607,7 +607,7 @@
         {
           "system": "SNOMED-CT",
           "code": "232347008",
-          "display": "Dander (animal) allergy"
+          "display": "Allergy to animal dander (finding)"
         }
       ],
       "direct_transition": "Chance_of_Dust_Mite_Allergy"
@@ -712,7 +712,7 @@
         {
           "system": "SNOMED-CT",
           "code": "419474003",
-          "display": "Allergy to mould"
+          "display": "Allergy to mold (finding)"
         }
       ],
       "direct_transition": "Chance_of_Bee_Allergy"

--- a/src/main/resources/modules/allergies/allergy_panel.json
+++ b/src/main/resources/modules/allergies/allergy_panel.json
@@ -51,7 +51,7 @@
         {
           "system": "LOINC",
           "code": "6206-7",
-          "display": "Peanut IgE Ab in Serum"
+          "display": "Peanut IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -68,7 +68,7 @@
         {
           "system": "LOINC",
           "code": "6206-7",
-          "display": "Peanut IgE Ab in Serum"
+          "display": "Peanut IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -111,7 +111,7 @@
         {
           "system": "LOINC",
           "code": "6273-7",
-          "display": "Walnut IgE Ab in Serum"
+          "display": "Walnut IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -128,7 +128,7 @@
         {
           "system": "LOINC",
           "code": "6273-7",
-          "display": "Walnut IgE Ab in Serum"
+          "display": "Walnut IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -171,7 +171,7 @@
         {
           "system": "LOINC",
           "code": "6082-2",
-          "display": "Codfish IgE Ab in Serum"
+          "display": "Codfish IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -188,7 +188,7 @@
         {
           "system": "LOINC",
           "code": "6082-2",
-          "display": "Codfish IgE Ab in Serum"
+          "display": "Codfish IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -233,7 +233,7 @@
         {
           "system": "LOINC",
           "code": "6246-3",
-          "display": "Shrimp IgE Ab in Serum"
+          "display": "Shrimp IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -250,7 +250,7 @@
         {
           "system": "LOINC",
           "code": "6246-3",
-          "display": "Shrimp IgE Ab in Serum"
+          "display": "Shrimp IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -293,7 +293,7 @@
         {
           "system": "LOINC",
           "code": "6276-0",
-          "display": "Wheat IgE Ab in Serum"
+          "display": "Wheat IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -310,7 +310,7 @@
         {
           "system": "LOINC",
           "code": "6276-0",
-          "display": "Wheat IgE Ab in Serum"
+          "display": "Wheat IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -353,7 +353,7 @@
         {
           "system": "LOINC",
           "code": "6106-9",
-          "display": "Egg white IgE Ab in Serum"
+          "display": "Egg white IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -370,7 +370,7 @@
         {
           "system": "LOINC",
           "code": "6106-9",
-          "display": "Egg white IgE Ab in Serum"
+          "display": "Egg white IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -395,7 +395,7 @@
               {
                 "system": "SNOMED-CT",
                 "code": "714035009",
-                "display": "Allergy to soya"
+                "display": "Allergy to soy (disorder)"
               }
             ]
           },
@@ -413,7 +413,7 @@
         {
           "system": "LOINC",
           "code": "6248-9",
-          "display": "Soybean IgE Ab in Serum"
+          "display": "Soybean IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -430,7 +430,7 @@
         {
           "system": "LOINC",
           "code": "6248-9",
-          "display": "Soybean IgE Ab in Serum"
+          "display": "Soybean IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -473,7 +473,7 @@
         {
           "system": "LOINC",
           "code": "7258-7",
-          "display": "Cow milk IgE Ab in Serum"
+          "display": "Cow milk IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -490,7 +490,7 @@
         {
           "system": "LOINC",
           "code": "7258-7",
-          "display": "Cow milk IgE Ab in Serum"
+          "display": "Cow milk IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -533,7 +533,7 @@
         {
           "system": "LOINC",
           "code": "6189-5",
-          "display": "White oak IgE Ab in Serum"
+          "display": "White Oak IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -550,7 +550,7 @@
         {
           "system": "LOINC",
           "code": "6189-5",
-          "display": "White oak IgE Ab in Serum"
+          "display": "White Oak IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -593,7 +593,7 @@
         {
           "system": "LOINC",
           "code": "6085-5",
-          "display": "Common Ragweed IgE Ab in Serum"
+          "display": "Common Ragweed IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -610,7 +610,7 @@
         {
           "system": "LOINC",
           "code": "6085-5",
-          "display": "Common Ragweed IgE Ab in Serum"
+          "display": "Common Ragweed IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -635,7 +635,7 @@
               {
                 "system": "SNOMED-CT",
                 "code": "232347008",
-                "display": "Dander (animal) allergy"
+                "display": "Allergy to animal dander (finding)"
               }
             ]
           },
@@ -653,7 +653,7 @@
         {
           "system": "LOINC",
           "code": "6833-8",
-          "display": "Cat dander IgE Ab in Serum"
+          "display": "Cat dander IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -670,7 +670,7 @@
         {
           "system": "LOINC",
           "code": "6833-8",
-          "display": "Cat dander IgE Ab in Serum"
+          "display": "Cat dander IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -713,7 +713,7 @@
         {
           "system": "LOINC",
           "code": "6095-4",
-          "display": "American house dust mite IgE Ab in Serum"
+          "display": "American house dust mite IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -730,7 +730,7 @@
         {
           "system": "LOINC",
           "code": "6095-4",
-          "display": "American house dust mite IgE Ab in Serum"
+          "display": "American house dust mite IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -755,7 +755,7 @@
               {
                 "system": "SNOMED-CT",
                 "code": "419474003",
-                "display": "Allergy to mould"
+                "display": "Allergy to mold (finding)"
               }
             ]
           },
@@ -773,7 +773,7 @@
         {
           "system": "LOINC",
           "code": "6075-6",
-          "display": "Cladosporium herbarum IgE Ab in Serum"
+          "display": "Cladosporium herbarum IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -790,7 +790,7 @@
         {
           "system": "LOINC",
           "code": "6075-6",
-          "display": "Cladosporium herbarum IgE Ab in Serum"
+          "display": "Cladosporium herbarum IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -833,7 +833,7 @@
         {
           "system": "LOINC",
           "code": "6844-5",
-          "display": "Honey bee IgE Ab in Serum"
+          "display": "Honey bee IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -850,7 +850,7 @@
         {
           "system": "LOINC",
           "code": "6844-5",
-          "display": "Honey bee IgE Ab in Serum"
+          "display": "Honey bee IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -893,7 +893,7 @@
         {
           "system": "LOINC",
           "code": "6158-0",
-          "display": "Latex IgE Ab in Serum"
+          "display": "Latex IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",
@@ -910,7 +910,7 @@
         {
           "system": "LOINC",
           "code": "6158-0",
-          "display": "Latex IgE Ab in Serum"
+          "display": "Latex IgE Ab Units/volume in Serum"
         }
       ],
       "unit": "kU/L",

--- a/src/main/resources/modules/allergies/outgrow_env_allergies.json
+++ b/src/main/resources/modules/allergies/outgrow_env_allergies.json
@@ -127,7 +127,7 @@
               {
                 "system": "SNOMED-CT",
                 "code": "419474003",
-                "display": "Allergy to mould"
+                "display": "Allergy to mold (finding)"
               }
             ]
           },
@@ -158,7 +158,7 @@
         {
           "system": "SNOMED-CT",
           "code": "419474003",
-          "display": "Allergy to mould"
+          "display": "Allergy to mold (finding)"
         }
       ],
       "direct_transition": "Pet_Dander_Allergy"
@@ -178,7 +178,7 @@
               {
                 "system": "SNOMED-CT",
                 "code": "232347008",
-                "display": "Dander (animal) allergy"
+                "display": "Allergy to animal dander (finding)"
               }
             ]
           },
@@ -209,7 +209,7 @@
         {
           "system": "SNOMED-CT",
           "code": "232347008",
-          "display": "Dander (animal) allergy"
+          "display": "Allergy to animal dander (finding)"
         }
       ],
       "direct_transition": "Mite_Allergy"

--- a/src/main/resources/modules/allergies/outgrow_food_allergies.json
+++ b/src/main/resources/modules/allergies/outgrow_food_allergies.json
@@ -178,7 +178,7 @@
               {
                 "system": "SNOMED-CT",
                 "code": "714035009",
-                "display": "Allergy to soya"
+                "display": "Allergy to soy (disorder)"
               }
             ]
           },
@@ -209,7 +209,7 @@
         {
           "system": "SNOMED-CT",
           "code": "714035009",
-          "display": "Allergy to soya"
+          "display": "Allergy to soy (disorder)"
         }
       ],
       "direct_transition": "Latex_Allergy"

--- a/src/main/resources/modules/allergies/severe_allergic_reaction.json
+++ b/src/main/resources/modules/allergies/severe_allergic_reaction.json
@@ -43,7 +43,7 @@
         {
           "system": "SNOMED-CT",
           "code": "313191000",
-          "display": "Injection of adrenaline"
+          "display": "Injection of epinephrine (procedure)"
         }
       ],
       "direct_transition": "Observation_Period"

--- a/src/main/resources/modules/anemia/anemia_sub.json
+++ b/src/main/resources/modules/anemia/anemia_sub.json
@@ -73,7 +73,7 @@
                   {
                     "system": "LOINC",
                     "code": "20570-8",
-                    "display": "Hematocrit"
+                    "display": "Hematocrit Volume Fraction of Blood"
                   }
                 ],
                 "operator": "<=",
@@ -101,7 +101,7 @@
                   {
                     "system": "LOINC",
                     "code": "20570-8",
-                    "display": "Hematocrit"
+                    "display": "Hematocrit Volume Fraction of Blood"
                   }
                 ],
                 "operator": "<=",

--- a/src/main/resources/modules/asthma.json
+++ b/src/main/resources/modules/asthma.json
@@ -239,7 +239,7 @@
         {
           "system": "RxNorm",
           "code": "895994",
-          "display": "120 ACTUAT Fluticasone propionate 0.044 MG/ACTUAT Metered Dose Inhaler"
+          "display": "fluticasone propionate 44 MCG/INHAL Metered Dose Inhaler, 120 Actuations"
         }
       ],
       "prescription": {

--- a/src/main/resources/modules/attention_deficit_disorder.json
+++ b/src/main/resources/modules/attention_deficit_disorder.json
@@ -333,7 +333,7 @@
         {
           "system": "RxNorm",
           "code": "1091392",
-          "display": "Methylphenidate Hydrochloride 20 MG Oral Tablet"
+          "display": "methylphenidate HCl 20 MG Oral Tablet"
         }
       ],
       "distributed_transition": [

--- a/src/main/resources/modules/breast_cancer.json
+++ b/src/main/resources/modules/breast_cancer.json
@@ -1010,7 +1010,7 @@
                   {
                     "system": "RxNorm",
                     "code": "198240",
-                    "display": "Tamoxifen 10 MG Oral Tablet"
+                    "display": "tamoxifen citrate 10 MG Oral Tablet"
                   }
                 ]
               },
@@ -1544,7 +1544,7 @@
         {
           "system": "RxNorm",
           "code": 1790099,
-          "display": "10 ML Doxorubicin Hydrochloride 2 MG/ML Injection"
+          "display": "DOXOrubicin hydrochloride 20 MG per 10 ML Injection"
         }
       ],
       "remarks": [
@@ -1562,7 +1562,7 @@
         {
           "system": "RxNorm",
           "code": 1732186,
-          "display": "100 ML Epirubicin Hydrochloride 2 MG/ML Injection"
+          "display": "epirubicin HCl 200 MG in 100 ML Injection"
         }
       ],
       "direct_transition": "Neoadjuvant chemotherapy procedure",
@@ -1937,8 +1937,8 @@
       ],
       "value_code": {
         "system": "SNOMED-CT",
-        "code": 385633008,
-        "display": "Improving (qualifier value)"
+        "code": 268910001,
+        "display": "Patient's condition improved (finding)"
       }
     },
     "Improvement After Surgery/Therapy": {
@@ -1957,8 +1957,8 @@
       ],
       "value_code": {
         "system": "SNOMED-CT",
-        "code": 385633008,
-        "display": "Improving (qualifier value)"
+        "code": 268910001,
+        "display": "Patient's condition improved (finding)"
       },
       "direct_transition": "Post-Treatment Surveillance"
     },
@@ -1978,8 +1978,8 @@
       ],
       "value_code": {
         "system": "SNOMED-CT",
-        "code": 230993007,
-        "display": "Worsening (qualifier value)"
+        "code": 271299001,
+        "display": "Patient's condition worsened (finding)"
       },
       "direct_transition": "Post-Treatment Surveillance"
     },
@@ -2018,8 +2018,8 @@
       ],
       "value_code": {
         "system": "SNOMED-CT",
-        "code": 230993007,
-        "display": "Worsening (qualifier value)"
+        "code": 271299001,
+        "display": "Patient's condition worsened (finding)"
       },
       "direct_transition": "4 Months between Initial Follow-Ups"
     },
@@ -2039,8 +2039,8 @@
       ],
       "value_code": {
         "system": "SNOMED-CT",
-        "code": 385633008,
-        "display": "Improving (qualifier value)"
+        "code": 268910001,
+        "display": "Patient's condition improved (finding)"
       },
       "direct_transition": "4 Months between Initial Follow-Ups"
     },

--- a/src/main/resources/modules/breast_cancer/chemotherapy_breast.json
+++ b/src/main/resources/modules/breast_cancer/chemotherapy_breast.json
@@ -14,7 +14,7 @@
         {
           "system": "RxNorm",
           "code": 1734919,
-          "display": "Cyclophosphamide 1000 MG Injection"
+          "display": "cyclophosphamide 1 GM Injection"
         }
       ],
       "direct_transition": "Adjuvant Chemotherapy Procedure",
@@ -70,7 +70,7 @@
         {
           "system": "RxNorm",
           "code": 1790099,
-          "display": "10 ML Doxorubicin Hydrochloride 2 MG/ML Injection"
+          "display": "DOXOrubicin hydrochloride 20 MG per 10 ML Injection"
         }
       ],
       "direct_transition": "Adjuvant Chemotherapy Procedure",
@@ -88,7 +88,7 @@
         {
           "system": "RxNorm",
           "code": 1732186,
-          "display": "100 ML Epirubicin Hydrochloride 2 MG/ML Injection"
+          "display": "epirubicin HCl 200 MG in 100 ML Injection"
         }
       ],
       "direct_transition": "Adjuvant Chemotherapy Procedure",

--- a/src/main/resources/modules/breast_cancer/hormone_diagnosis.json
+++ b/src/main/resources/modules/breast_cancer/hormone_diagnosis.json
@@ -314,7 +314,7 @@
       "codes": [
         {
           "system": "LOINC",
-          "code": 417181009,
+          "code": "10480-2",
           "display": "Estrogen+Progesterone receptor Ag [Presence] in Tissue by Immune stain"
         }
       ],

--- a/src/main/resources/modules/breast_cancer/hormonetherapy_breast.json
+++ b/src/main/resources/modules/breast_cancer/hormonetherapy_breast.json
@@ -459,7 +459,7 @@
         {
           "system": "RxNorm",
           "code": 198240,
-          "display": "Tamoxifen 10 MG Oral Tablet"
+          "display": "tamoxifen citrate 10 MG Oral Tablet"
         }
       ],
       "direct_transition": "ER_medication_end",

--- a/src/main/resources/modules/bronchitis.json
+++ b/src/main/resources/modules/bronchitis.json
@@ -392,7 +392,7 @@
         {
           "system": "RxNorm",
           "code": "1043400",
-          "display": "Acetaminophen 21.7 MG/ML / Dextromethorphan Hydrobromide 1 MG/ML / doxylamine succinate 0.417 MG/ML Oral Solution"
+          "display": "acetaminophen 650 MG / dextromethorphan HBr 30 MG / doxylamine succinate 12.5 MG in 30 mL Oral Solution"
         }
       ],
       "direct_transition": "End_Doctor_Visit"

--- a/src/main/resources/modules/colorectal_cancer.json
+++ b/src/main/resources/modules/colorectal_cancer.json
@@ -111,7 +111,7 @@
         {
           "system": "SNOMED-CT",
           "code": "185349003",
-          "display": "Encounter for 'check-up'"
+          "display": "Encounter for check up (procedure)"
         }
       ],
       "direct_transition": "Routine_Colonoscopy_Procedure"
@@ -265,7 +265,7 @@
         {
           "system": "LOINC",
           "code": "33756-8",
-          "display": "Polyp size greatest dimension by CAP cancer protocols"
+          "display": "Polyp size greatest dimension"
         }
       ],
       "direct_transition": "Fecal_Test"
@@ -282,7 +282,7 @@
         {
           "system": "LOINC",
           "code": "33756-8",
-          "display": "Polyp size greatest dimension by CAP cancer protocols"
+          "display": "Polyp size greatest dimension"
         }
       ],
       "direct_transition": "Fecal_Test"
@@ -471,7 +471,7 @@
         {
           "system": "SNOMED-CT",
           "code": "185349003",
-          "display": "Encounter for 'check-up'"
+          "display": "Encounter for check up (procedure)"
         }
       ],
       "direct_transition": "Followup_Colonoscopy_Procedure"
@@ -716,7 +716,7 @@
         {
           "system": "SNOMED-CT",
           "code": "185349003",
-          "display": "Encounter for 'check-up'"
+          "display": "Encounter for check up (procedure)"
         }
       ],
       "direct_transition": "Diagnostic_Colonoscopy_Procedure"
@@ -1446,7 +1446,7 @@
         {
           "system": "RxNorm",
           "code": "1736776",
-          "display": "10 ML oxaliplatin 5 MG/ML Injection"
+          "display": "oxaliplatin 50 MG in 10 ML Injection"
         }
       ],
       "direct_transition": "Chemotherapy_Procedure"
@@ -1515,7 +1515,7 @@
         {
           "system": "SNOMED-CT",
           "code": "185349003",
-          "display": "Encounter for 'check-up'"
+          "display": "Encounter for check up (procedure)"
         }
       ],
       "direct_transition": "End_Colorectal_Cancer_CarePlan"
@@ -1594,7 +1594,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -1606,7 +1606,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -1617,7 +1617,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -1633,7 +1633,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -1645,7 +1645,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -1657,7 +1657,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -1669,7 +1669,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -1681,7 +1681,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -1693,7 +1693,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {

--- a/src/main/resources/modules/congestive_heart_failure.json
+++ b/src/main/resources/modules/congestive_heart_failure.json
@@ -97,7 +97,7 @@
         {
           "system": "LOINC",
           "code": "51990-0",
-          "display": "Basic Metabolic Panel"
+          "display": "Basic metabolic panel - Blood"
         }
       ],
       "observations": [
@@ -108,7 +108,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -120,7 +120,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -132,7 +132,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -144,7 +144,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -156,7 +156,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -168,7 +168,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -180,7 +180,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -192,7 +192,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -233,7 +233,7 @@
         {
           "system": "SNOMED-CT",
           "code": 183301007,
-          "display": "physical exercise"
+          "display": "Physical exercises (regime/therapy)"
         }
       ]
     },
@@ -533,7 +533,7 @@
         {
           "system": "RxNorm",
           "code": 1719286,
-          "display": "10 ML Furosemide 10 MG/ML Injection"
+          "display": "furosemide 100 MG in 10 ML Injection"
         }
       ],
       "reason": "chf",
@@ -684,7 +684,7 @@
         {
           "system": "LOINC",
           "code": "51990-0",
-          "display": "Basic Metabolic Panel"
+          "display": "Basic metabolic panel - Blood"
         }
       ],
       "observations": [
@@ -695,7 +695,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -707,7 +707,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -719,7 +719,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -731,7 +731,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -743,7 +743,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -755,7 +755,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -767,7 +767,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -779,7 +779,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -804,7 +804,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -816,7 +816,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -827,7 +827,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -840,7 +840,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -852,7 +852,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -864,7 +864,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -876,7 +876,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -888,7 +888,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -900,7 +900,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {
@@ -1101,7 +1101,7 @@
         {
           "system": "SNOMED-CT",
           "code": 183301007,
-          "display": "physical exercise"
+          "display": "Physical exercises (regime/therapy)"
         },
         {
           "system": "SNOMED-CT",
@@ -1142,7 +1142,7 @@
         {
           "system": "LOINC",
           "code": "55405-5",
-          "display": "Heartfailure Tracking Panel"
+          "display": "Heart failure tracking panel"
         }
       ],
       "observations": [
@@ -1226,7 +1226,7 @@
         {
           "system": "LOINC",
           "code": "33762-6",
-          "display": "NT-proBNP"
+          "display": "Natriuretic peptide.B prohormone N-Terminal Mass/volume in Serum or Plasma"
         }
       ],
       "direct_transition": "Record_MetabolicPanel",
@@ -1355,7 +1355,7 @@
         {
           "system": "LOINC",
           "code": "85354-9",
-          "display": "Blood Pressure"
+          "display": "Blood pressure panel with all children optional"
         }
       ],
       "direct_transition": "End self-measurement",

--- a/src/main/resources/modules/contraceptives/implant_contraceptive.json
+++ b/src/main/resources/modules/contraceptives/implant_contraceptive.json
@@ -144,7 +144,7 @@
         {
           "system": "RxNorm",
           "code": "1366343",
-          "display": "Levonorgestrel 0.00354 MG/HR Drug Implant"
+          "display": "levonorgestrel 36 MG Drug Implant"
         }
       ],
       "direct_transition": "Initial_Implant"
@@ -156,7 +156,7 @@
         {
           "system": "RxNorm",
           "code": "389221",
-          "display": "Etonogestrel 68 MG Drug Implant"
+          "display": "etonogestrel 68 MG Subdermal Drug Implant"
         }
       ],
       "direct_transition": "Initial_Implant"
@@ -168,7 +168,7 @@
         {
           "system": "RxNorm",
           "code": "389221",
-          "display": "Etonogestrel 68 MG Drug Implant"
+          "display": "etonogestrel 68 MG Subdermal Drug Implant"
         }
       ],
       "direct_transition": "Initial_Implant"

--- a/src/main/resources/modules/copd.json
+++ b/src/main/resources/modules/copd.json
@@ -781,7 +781,7 @@
               {
                 "system": "RxNorm",
                 "code": "896209",
-                "display": "60 ACTUAT Fluticasone propionate 0.25 MG/ACTUAT / salmeterol 0.05 MG/ACTUAT Dry Powder Inhaler"
+                "display": "fluticasone propionate/salmeterol 250/50 MCG/INHAL Dry Powder Inhaler, 60 Blisters"
               }
             ]
           },
@@ -799,7 +799,7 @@
         {
           "system": "RxNorm",
           "code": "896209",
-          "display": "60 ACTUAT Fluticasone propionate 0.25 MG/ACTUAT / salmeterol 0.05 MG/ACTUAT Dry Powder Inhaler"
+          "display": "fluticasone propionate/salmeterol 250/50 MCG/INHAL Dry Powder Inhaler, 60 Blisters"
         }
       ],
       "direct_transition": "Consider_Surgery",

--- a/src/main/resources/modules/dementia.json
+++ b/src/main/resources/modules/dementia.json
@@ -266,7 +266,7 @@
         {
           "system": "SNOMED-CT",
           "code": "386257007",
-          "display": "Demential management"
+          "display": "Dementia management (regime/therapy)"
         }
       ],
       "activities": [
@@ -340,7 +340,7 @@
         {
           "system": "RxNorm",
           "code": "310436",
-          "display": "Galantamine 4 MG Oral Tablet"
+          "display": "galantamine HBr 4 MG Oral Tablet"
         }
       ],
       "direct_transition": "ModerateDecline"
@@ -353,7 +353,7 @@
         {
           "system": "RxNorm",
           "code": "997223",
-          "display": "Donepezil hydrochloride 10 MG Oral Tablet"
+          "display": "donepezil HCl 10 MG Oral Tablet"
         }
       ],
       "direct_transition": "ModerateDecline"
@@ -427,8 +427,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "316744009",
-          "display": "Office Visit"
+          "code": "473203000",
+          "display": "Assessment of dementia (procedure)"
         }
       ],
       "direct_transition": "ModeratelySevere_MMSE_Score"
@@ -520,7 +520,7 @@
         {
           "system": "RxNorm",
           "code": "1599803",
-          "display": "24 HR Donepezil hydrochloride 10 MG / Memantine hydrochloride 28 MG Extended Release Oral Capsule"
+          "display": "donepezil HCl 10 MG / memantine HCl 28 MG 24HR Extended Release Oral Capsule"
         }
       ],
       "direct_transition": "End_ModeratelySevere_Encounter"
@@ -532,7 +532,7 @@
         {
           "system": "RxNorm",
           "code": "996740",
-          "display": "Memantine hydrochloride 2 MG/ML Oral Solution"
+          "display": "memantine HCl 2 MG in 1 mL Oral Solution"
         }
       ],
       "direct_transition": "End_ModeratelySevere_Encounter"
@@ -544,7 +544,7 @@
         {
           "system": "RxNorm",
           "code": "1100184",
-          "display": "Donepezil hydrochloride 23 MG Oral Tablet"
+          "display": "donepezil HCl 23 MG Oral Tablet"
         }
       ],
       "direct_transition": "End_ModeratelySevere_Encounter"
@@ -573,8 +573,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "316744009",
-          "display": "Office Visit"
+          "code": "473203000",
+          "display": "Assessment of dementia (procedure)"
         }
       ],
       "direct_transition": "Severe_MMSE_Score"
@@ -624,8 +624,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "316744009",
-          "display": "Office Visit"
+          "code": "473203000",
+          "display": "Assessment of dementia (procedure)"
         }
       ],
       "direct_transition": "VerySevere_MMSE_Score"

--- a/src/main/resources/modules/dermatitis/early_moderate_eczema_obs.json
+++ b/src/main/resources/modules/dermatitis/early_moderate_eczema_obs.json
@@ -19,7 +19,7 @@
         {
           "system": "LOINC",
           "code": "66519-0",
-          "display": "Percentage area affected by eczema Head and Neck"
+          "display": "Percentage area affected by eczema Head and Neck PhenX"
         }
       ],
       "range": {
@@ -36,7 +36,7 @@
         {
           "system": "LOINC",
           "code": "66529-9",
-          "display": "Percentage area affected by eczema Trunk"
+          "display": "Percentage area affected by eczema Trunk PhenX"
         }
       ],
       "range": {
@@ -53,7 +53,7 @@
         {
           "system": "LOINC",
           "code": "66524-0",
-          "display": "Percentage area affected by eczema Upper extremitiy - bilateral"
+          "display": "Percentage area affected by eczema Upper extremity - bilateral PhenX"
         }
       ],
       "range": {
@@ -70,7 +70,7 @@
         {
           "system": "LOINC",
           "code": "66534-9",
-          "display": "Percentage area affected by eczema Lower extremitiy - bilateral"
+          "display": "Percentage area affected by eczema Lower extremity - bilateral PhenX"
         }
       ],
       "range": {

--- a/src/main/resources/modules/dermatitis/early_severe_eczema_obs.json
+++ b/src/main/resources/modules/dermatitis/early_severe_eczema_obs.json
@@ -19,7 +19,7 @@
         {
           "system": "LOINC",
           "code": "66519-0",
-          "display": "Percentage area affected by eczema Head and Neck"
+          "display": "Percentage area affected by eczema Head and Neck PhenX"
         }
       ],
       "range": {
@@ -36,7 +36,7 @@
         {
           "system": "LOINC",
           "code": "66529-9",
-          "display": "Percentage area affected by eczema Trunk"
+          "display": "Percentage area affected by eczema Trunk PhenX"
         }
       ],
       "range": {
@@ -53,7 +53,7 @@
         {
           "system": "LOINC",
           "code": "66524-0",
-          "display": "Percentage area affected by eczema Upper extremitiy - bilateral"
+          "display": "Percentage area affected by eczema Upper extremity - bilateral PhenX"
         }
       ],
       "range": {
@@ -70,7 +70,7 @@
         {
           "system": "LOINC",
           "code": "66534-9",
-          "display": "Percentage area affected by eczema Lower extremitiy - bilateral"
+          "display": "Percentage area affected by eczema Lower extremity - bilateral PhenX"
         }
       ],
       "range": {

--- a/src/main/resources/modules/dermatitis/mid_moderate_eczema_obs.json
+++ b/src/main/resources/modules/dermatitis/mid_moderate_eczema_obs.json
@@ -19,7 +19,7 @@
         {
           "system": "LOINC",
           "code": "66519-0",
-          "display": "Percentage area affected by eczema Head and Neck"
+          "display": "Percentage area affected by eczema Head and Neck PhenX"
         }
       ],
       "range": {
@@ -36,7 +36,7 @@
         {
           "system": "LOINC",
           "code": "66529-9",
-          "display": "Percentage area affected by eczema Trunk"
+          "display": "Percentage area affected by eczema Trunk PhenX"
         }
       ],
       "range": {
@@ -53,7 +53,7 @@
         {
           "system": "LOINC",
           "code": "66524-0",
-          "display": "Percentage area affected by eczema Upper extremitiy - bilateral"
+          "display": "Percentage area affected by eczema Upper extremity - bilateral PhenX"
         }
       ],
       "range": {
@@ -70,7 +70,7 @@
         {
           "system": "LOINC",
           "code": "66534-9",
-          "display": "Percentage area affected by eczema Lower extremitiy - bilateral"
+          "display": "Percentage area affected by eczema Lower extremity - bilateral PhenX"
         }
       ],
       "range": {

--- a/src/main/resources/modules/dermatitis/mid_severe_eczema_obs.json
+++ b/src/main/resources/modules/dermatitis/mid_severe_eczema_obs.json
@@ -19,7 +19,7 @@
         {
           "system": "LOINC",
           "code": "66519-0",
-          "display": "Percentage area affected by eczema Head and Neck"
+          "display": "Percentage area affected by eczema Head and Neck PhenX"
         }
       ],
       "range": {
@@ -36,7 +36,7 @@
         {
           "system": "LOINC",
           "code": "66529-9",
-          "display": "Percentage area affected by eczema Trunk"
+          "display": "Percentage area affected by eczema Trunk PhenX"
         }
       ],
       "range": {
@@ -53,7 +53,7 @@
         {
           "system": "LOINC",
           "code": "66524-0",
-          "display": "Percentage area affected by eczema Upper extremitiy - bilateral"
+          "display": "Percentage area affected by eczema Upper extremity - bilateral PhenX"
         }
       ],
       "range": {
@@ -70,7 +70,7 @@
         {
           "system": "LOINC",
           "code": "66534-9",
-          "display": "Percentage area affected by eczema Lower extremitiy - bilateral"
+          "display": "Percentage area affected by eczema Lower extremity - bilateral PhenX"
         }
       ],
       "range": {

--- a/src/main/resources/modules/dermatitis/moderate_cd_obs.json
+++ b/src/main/resources/modules/dermatitis/moderate_cd_obs.json
@@ -18,7 +18,7 @@
         {
           "system": "LOINC",
           "code": "66519-0",
-          "display": "Percentage area affected by eczema Head and Neck"
+          "display": "Percentage area affected by eczema Head and Neck PhenX"
         }
       ],
       "exact": {
@@ -34,7 +34,7 @@
         {
           "system": "LOINC",
           "code": "66529-9",
-          "display": "Percentage area affected by eczema Trunk"
+          "display": "Percentage area affected by eczema Trunk PhenX"
         }
       ],
       "exact": {
@@ -50,7 +50,7 @@
         {
           "system": "LOINC",
           "code": "66524-0",
-          "display": "Percentage area affected by eczema Upper extremitiy - bilateral"
+          "display": "Percentage area affected by eczema Upper extremity - bilateral PhenX"
         }
       ],
       "range": {
@@ -67,7 +67,7 @@
         {
           "system": "LOINC",
           "code": "66534-9",
-          "display": "Percentage area affected by eczema Lower extremitiy - bilateral"
+          "display": "Percentage area affected by eczema Lower extremity - bilateral PhenX"
         }
       ],
       "range": {

--- a/src/main/resources/modules/dermatitis/severe_cd_obs.json
+++ b/src/main/resources/modules/dermatitis/severe_cd_obs.json
@@ -18,7 +18,7 @@
         {
           "system": "LOINC",
           "code": "66519-0",
-          "display": "Percentage area affected by eczema Head and Neck"
+          "display": "Percentage area affected by eczema Head and Neck PhenX"
         }
       ],
       "exact": {
@@ -34,7 +34,7 @@
         {
           "system": "LOINC",
           "code": "66529-9",
-          "display": "Percentage area affected by eczema Trunk"
+          "display": "Percentage area affected by eczema Trunk PhenX"
         }
       ],
       "exact": {
@@ -50,7 +50,7 @@
         {
           "system": "LOINC",
           "code": "66524-0",
-          "display": "Percentage area affected by eczema Upper extremitiy - bilateral"
+          "display": "Percentage area affected by eczema Upper extremity - bilateral PhenX"
         }
       ],
       "range": {
@@ -67,7 +67,7 @@
         {
           "system": "LOINC",
           "code": "66534-9",
-          "display": "Percentage area affected by eczema Lower extremitiy - bilateral"
+          "display": "Percentage area affected by eczema Lower extremity - bilateral PhenX"
         }
       ],
       "range": {

--- a/src/main/resources/modules/dialysis.json
+++ b/src/main/resources/modules/dialysis.json
@@ -188,7 +188,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -200,7 +200,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -211,7 +211,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -227,7 +227,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -239,7 +239,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -251,7 +251,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -263,7 +263,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -275,7 +275,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -287,7 +287,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {

--- a/src/main/resources/modules/epilepsy.json
+++ b/src/main/resources/modules/epilepsy.json
@@ -203,7 +203,7 @@
         {
           "system": "SNOMED-CT",
           "code": "54550000",
-          "display": "Seizure Count Cerebral Cortex Electroencephalogram (EEG)"
+          "display": "Electroencephalogram (procedure)"
         }
       ],
       "complex_transition": [

--- a/src/main/resources/modules/fibromyalgia.json
+++ b/src/main/resources/modules/fibromyalgia.json
@@ -328,7 +328,7 @@
         {
           "system": "RxNorm",
           "code": "833135",
-          "display": "Milnacipran hydrochloride 100 MG Oral Tablet"
+          "display": "milnacipran HCl 100 MG Oral Tablet"
         }
       ],
       "direct_transition": "End_Episode_Encounter"

--- a/src/main/resources/modules/gallstones.json
+++ b/src/main/resources/modules/gallstones.json
@@ -352,7 +352,7 @@
         {
           "system": "SNOMED-CT",
           "code": 235919008,
-          "display": "Cholelithiasis"
+          "display": "Gallbladder calculus (disorder)"
         }
       ],
       "remarks": [
@@ -487,7 +487,7 @@
         {
           "system": "SNOMED-CT",
           "code": 45595009,
-          "display": "Laparoscopic Removal of Gall Bladder"
+          "display": "Laparoscopic cholecystectomy (procedure)"
         }
       ],
       "duration": {
@@ -611,7 +611,7 @@
         {
           "system": "SNOMED-CT",
           "code": 185349003,
-          "display": "Encounter for 'check-up'"
+          "display": "Encounter for check up (procedure)"
         }
       ],
       "direct_transition": "End_Postoperative_Follow-up",
@@ -624,7 +624,7 @@
         {
           "system": "SNOMED-CT",
           "code": 185349003,
-          "display": "Encounter for 'check-up'"
+          "display": "Encounter for check up (procedure)"
         }
       ],
       "reason": "Open_Cholecystectomy",
@@ -669,7 +669,7 @@
         {
           "system": "RxNorm",
           "code": 1740467,
-          "display": "2 ML Ondansetron 2 MG/ML Injection"
+          "display": "ondansetron 4 MG in 2 ML Injection"
         }
       ],
       "direct_transition": "Antiemetic_End",
@@ -684,7 +684,7 @@
         {
           "system": "RxNorm",
           "code": 1732136,
-          "display": "1 ML Morphine Sulfate 5 MG/ML Injection"
+          "display": "morphine sulfate 5 MG in 1 ML Injection"
         }
       ],
       "direct_transition": "Delay_for_Surgical_Appointment"
@@ -790,7 +790,7 @@
             {
               "system": "LOINC",
               "code": "42719-5",
-              "display": "Total Bilirubin (Elevated)"
+              "display": "Bilirubin.total Mass/volume in Blood"
             }
           ],
           "range": {
@@ -805,7 +805,7 @@
             {
               "system": "LOINC",
               "code": "1742-6",
-              "display": "ALT (Elevated)"
+              "display": "Alanine aminotransferase Enzymatic activity/volume in Serum or Plasma"
             }
           ],
           "range": {
@@ -820,7 +820,7 @@
             {
               "system": "LOINC",
               "code": "1920-8",
-              "display": "AST (Elevated)"
+              "display": "Aspartate aminotransferase Enzymatic activity/volume in Serum or Plasma"
             }
           ],
           "range": {
@@ -835,7 +835,7 @@
             {
               "system": "LOINC",
               "code": "2345-7",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "vital_sign": "Glucose"
@@ -847,7 +847,7 @@
             {
               "system": "LOINC",
               "code": "3094-0",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "vital_sign": "Urea Nitrogen"
@@ -859,7 +859,7 @@
             {
               "system": "LOINC",
               "code": "2160-0",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "vital_sign": "Creatinine"
@@ -871,7 +871,7 @@
             {
               "system": "LOINC",
               "code": "17861-6",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "vital_sign": "Calcium"
@@ -883,7 +883,7 @@
             {
               "system": "LOINC",
               "code": "2951-2",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "vital_sign": "Sodium"
@@ -895,7 +895,7 @@
             {
               "system": "LOINC",
               "code": "2823-3",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "vital_sign": "Potassium"
@@ -907,7 +907,7 @@
             {
               "system": "LOINC",
               "code": "2075-0",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "vital_sign": "Chloride"
@@ -919,7 +919,7 @@
             {
               "system": "LOINC",
               "code": "2028-9",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "vital_sign": "Carbon Dioxide"
@@ -931,7 +931,7 @@
             {
               "system": "LOINC",
               "code": "33037-3",
-              "display": "Anion Gap"
+              "display": "Anion gap in Serum or Plasma"
             }
           ],
           "range": {
@@ -946,7 +946,7 @@
             {
               "system": "LOINC",
               "code": "2885-2",
-              "display": "Protein"
+              "display": "Protein Mass/volume in Serum or Plasma"
             }
           ],
           "range": {
@@ -961,7 +961,7 @@
             {
               "system": "LOINC",
               "code": "1751-7",
-              "display": "Albumin"
+              "display": "Albumin Mass/volume in Serum or Plasma"
             }
           ],
           "range": {
@@ -976,7 +976,7 @@
             {
               "system": "LOINC",
               "code": "10834-0",
-              "display": "Globulin"
+              "display": "Globulin Mass/volume in Serum by calculation"
             }
           ],
           "range": {
@@ -991,7 +991,7 @@
             {
               "system": "LOINC",
               "code": "6768-6",
-              "display": "Alkaline Phosphatase"
+              "display": "Alkaline phosphatase Enzymatic activity/volume in Serum or Plasma"
             }
           ],
           "range": {
@@ -1025,7 +1025,7 @@
             {
               "system": "LOINC",
               "code": "26464-8",
-              "display": "White Blood Cell (Elevated)"
+              "display": "Leukocytes #/volume in Blood"
             }
           ],
           "range": {
@@ -1040,7 +1040,7 @@
             {
               "system": "LOINC",
               "code": "26453-1",
-              "display": "Red Blood Cell"
+              "display": "Erythrocytes #/volume in Blood"
             }
           ],
           "range": {
@@ -1055,7 +1055,7 @@
             {
               "system": "LOINC",
               "code": "718-7",
-              "display": "Hemoglobin"
+              "display": "Hemoglobin Mass/volume in Blood"
             }
           ],
           "range": {
@@ -1070,7 +1070,7 @@
             {
               "system": "LOINC",
               "code": "20570-8",
-              "display": "Hematocrit"
+              "display": "Hematocrit Volume Fraction of Blood"
             }
           ],
           "range": {
@@ -1085,7 +1085,7 @@
             {
               "system": "LOINC",
               "code": "30428-7",
-              "display": "MCV"
+              "display": "MCV Entitic volume"
             }
           ],
           "range": {
@@ -1100,7 +1100,7 @@
             {
               "system": "LOINC",
               "code": "30385-9",
-              "display": "RBC Distribution Width"
+              "display": "Erythrocyte distribution width Ratio"
             }
           ],
           "range": {
@@ -1115,7 +1115,7 @@
             {
               "system": "LOINC",
               "code": "26515-7",
-              "display": "Platelet Count"
+              "display": "Platelets #/volume in Blood"
             }
           ],
           "range": {
@@ -1145,7 +1145,7 @@
       "value_code": {
         "system": "SNOMED-CT",
         "code": 53566005,
-        "display": "Positive Murphy's Sign"
+        "display": "Murphy's sign (finding)"
       }
     },
     "Chole_Symptom4_Ends": {
@@ -1183,7 +1183,7 @@
         {
           "system": "RxNorm",
           "code": 1659149,
-          "display": "Piperacillin 4000 MG / tazobactam 500 MG Injection"
+          "display": "piperacillin / tazobactam 4.5 GM Injection"
         }
       ],
       "direct_transition": "Penicillin_End",
@@ -1234,7 +1234,7 @@
         {
           "system": "RxNorm",
           "code": "1659263",
-          "display": "1 ML heparin sodium, porcine 5000 UNT/ML Injection"
+          "display": "heparin sodium, porcine 5000 UNT in 1 ML Injection"
         }
       ],
       "direct_transition": "Heparin_End"

--- a/src/main/resources/modules/homelessness.json
+++ b/src/main/resources/modules/homelessness.json
@@ -418,7 +418,7 @@
         {
           "system": "LOINC",
           "code": "46240-8",
-          "display": "History of Hospitalizations+Outpatient visits"
+          "display": "History of Hospitalizations+Outpatient visits Narrative"
         }
       ],
       "range": {

--- a/src/main/resources/modules/hypertension.json
+++ b/src/main/resources/modules/hypertension.json
@@ -21,7 +21,7 @@
         {
           "system": "SNOMED-CT",
           "code": 59621000,
-          "display": "Hypertension"
+          "display": "Essential hypertension (disorder)"
         }
       ],
       "assign_to_attribute": "hypertension_dx",
@@ -33,7 +33,7 @@
         {
           "system": "RxNorm",
           "code": 429503,
-          "display": "Hydrochlorothiazide 12.5 MG"
+          "display": "hydrochlorothiazide 12.5 MG Oral Tablet"
         }
       ],
       "prescription": {
@@ -79,7 +79,7 @@
         {
           "system": "SNOMED-CT",
           "code": 390906007,
-          "display": "Hypertension follow-up encounter"
+          "display": "Follow-up encounter (procedure)"
         }
       ],
       "direct_transition": "Record_BP"
@@ -117,7 +117,7 @@
         {
           "system": "RxNorm",
           "code": 746030,
-          "display": "Atenolol 50 MG / Chlorthalidone 25 MG Oral Tablet"
+          "display": "Tenoretic-50 50 MG / 25 MG Oral Tablet"
         }
       ],
       "prescription": {
@@ -144,7 +144,7 @@
         {
           "system": "RxNorm",
           "code": 999967,
-          "display": "amLODIPine 5 MG / Hydrochlorothiazide 12.5 MG / Olmesartan medoxomil 20 MG Oral Tablet"
+          "display": "olmesartan medoxomil 20 MG / amLODIPine 5 MG / hydrochlorothiazide 12.5 MG Oral Tablet"
         }
       ],
       "prescription": {
@@ -173,7 +173,7 @@
         {
           "system": "SNOMED-CT",
           "code": 390906007,
-          "display": "Hypertension follow-up encounter"
+          "display": "Follow-up encounter (procedure)"
         }
       ],
       "direct_transition": "Record_BP_2"
@@ -186,7 +186,7 @@
         {
           "system": "SNOMED-CT",
           "code": 390906007,
-          "display": "Hypertension follow-up encounter"
+          "display": "Follow-up encounter (procedure)"
         }
       ],
       "direct_transition": "Record_BP_3"
@@ -350,7 +350,7 @@
         {
           "system": "LOINC",
           "code": "85354-9",
-          "display": "Blood Pressure"
+          "display": "Blood pressure panel with all children optional"
         }
       ],
       "observations": [
@@ -401,7 +401,7 @@
         {
           "system": "LOINC",
           "code": "85354-9",
-          "display": "Blood Pressure"
+          "display": "Blood pressure panel with all children optional"
         }
       ],
       "observations": [
@@ -452,7 +452,7 @@
         {
           "system": "LOINC",
           "code": "85354-9",
-          "display": "Blood Pressure"
+          "display": "Blood pressure panel with all children optional"
         }
       ],
       "observations": [

--- a/src/main/resources/modules/injuries.json
+++ b/src/main/resources/modules/injuries.json
@@ -440,7 +440,7 @@
         {
           "system": "SNOMED-CT",
           "code": "1734006",
-          "display": "Fracture of the vertebral column with spinal cord injury"
+          "display": "Fracture of vertebral column with spinal cord injury (disorder)"
         }
       ],
       "distributed_transition": [
@@ -543,7 +543,7 @@
         {
           "system": "SNOMED-CT",
           "code": "185349003",
-          "display": "Encounter for 'check-up'"
+          "display": "Encounter for check up (procedure)"
         }
       ],
       "direct_transition": "End_Spinal_Injury"
@@ -713,7 +713,7 @@
         {
           "system": "SNOMED-CT",
           "code": "185349003",
-          "display": "Encounter for 'check-up'"
+          "display": "Encounter for check up (procedure)"
         }
       ],
       "direct_transition": "Gunshot_Wound_Ends"
@@ -882,7 +882,7 @@
         {
           "system": "SNOMED-CT",
           "code": "185349003",
-          "display": "Encounter for 'check-up'"
+          "display": "Encounter for check up (procedure)"
         }
       ],
       "direct_transition": "End_Concussion_Injury"
@@ -1167,7 +1167,7 @@
           "body_site": {
             "system": "SNOMED-CT",
             "code": "40983000",
-            "display": "Arm"
+            "display": "Upper arm"
           },
           "modality": {
             "system": "DICOM-DCM",
@@ -1206,7 +1206,7 @@
       "procedure_code": {
         "system": "SNOMED-CT",
         "code": "60027007",
-        "display": "X-ray or wrist"
+        "display": "Radiography of wrist (procedure)"
       },
       "series": [
         {
@@ -1634,7 +1634,7 @@
         {
           "system": "SNOMED-CT",
           "code": "185349003",
-          "display": "Encounter for 'check-up'"
+          "display": "Encounter for check up (procedure)"
         }
       ],
       "direct_transition": "End_Broken_Bone_Injury"
@@ -1733,7 +1733,7 @@
         {
           "system": "SNOMED-CT",
           "code": "403190006",
-          "display": "First degree burn"
+          "display": "Epidermal burn of skin (disorder)"
         }
       ],
       "direct_transition": "Burn_CarePlan"
@@ -1800,7 +1800,7 @@
               {
                 "system": "SNOMED-CT",
                 "code": "403190006",
-                "display": "First degree burn"
+                "display": "Epidermal burn of skin (disorder)"
               }
             ]
           },
@@ -1903,7 +1903,7 @@
         {
           "system": "SNOMED-CT",
           "code": "185349003",
-          "display": "Encounter for 'check-up'"
+          "display": "Encounter for check up (procedure)"
         }
       ],
       "direct_transition": "End_Burn_Injury"
@@ -2201,7 +2201,7 @@
         {
           "system": "SNOMED-CT",
           "code": "229586001",
-          "display": "Rest, ice, compression and elevation treatment programme"
+          "display": "Rest, ice, compression and elevation treatment program"
         },
         {
           "system": "SNOMED-CT",
@@ -2330,7 +2330,7 @@
         {
           "system": "SNOMED-CT",
           "code": "229586001",
-          "display": "Rest, ice, compression and elevation treatment programme"
+          "display": "Rest, ice, compression and elevation treatment program"
         },
         {
           "system": "SNOMED-CT",
@@ -2530,7 +2530,7 @@
         {
           "system": "SNOMED-CT",
           "code": "229586001",
-          "display": "Rest, ice, compression and elevation treatment programme"
+          "display": "Rest, ice, compression and elevation treatment program"
         },
         {
           "system": "SNOMED-CT",
@@ -2622,7 +2622,7 @@
         {
           "system": "SNOMED-CT",
           "code": "185349003",
-          "display": "Encounter for 'check-up'"
+          "display": "Encounter for check up (procedure)"
         }
       ],
       "direct_transition": "End_Shoulder_Injury"

--- a/src/main/resources/modules/lung_cancer.json
+++ b/src/main/resources/modules/lung_cancer.json
@@ -1018,7 +1018,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -1030,7 +1030,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -1041,7 +1041,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -1057,7 +1057,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -1069,7 +1069,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -1081,7 +1081,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -1093,7 +1093,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -1105,7 +1105,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -1117,7 +1117,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {
@@ -1250,7 +1250,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -1262,7 +1262,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -1273,7 +1273,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -1289,7 +1289,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -1301,7 +1301,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -1313,7 +1313,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -1325,7 +1325,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -1337,7 +1337,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -1349,7 +1349,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {

--- a/src/main/resources/modules/medications/ear_infection_antibiotic.json
+++ b/src/main/resources/modules/medications/ear_infection_antibiotic.json
@@ -460,7 +460,7 @@
         {
           "system": "RxNorm",
           "code": "309043",
-          "display": "12 HR Cefaclor 500 MG Extended Release Oral Tablet"
+          "display": "cefaclor 500 MG 12HR Extended Release Oral Tablet"
         }
       ],
       "prescription": {
@@ -494,7 +494,7 @@
         {
           "system": "RxNorm",
           "code": "309097",
-          "display": "Cefuroxime 250 MG Oral Tablet"
+          "display": "cefuroxime axetil 250 MG Oral Tablet"
         }
       ],
       "prescription": {

--- a/src/main/resources/modules/medications/moderate_opioid_pain_reliever.json
+++ b/src/main/resources/modules/medications/moderate_opioid_pain_reliever.json
@@ -101,7 +101,7 @@
         {
           "system": "RxNorm",
           "code": "861467",
-          "display": "Meperidine Hydrochloride 50 MG Oral Tablet"
+          "display": "meperidine HCl 50 MG Oral Tablet"
         }
       ],
       "prescription": {
@@ -125,7 +125,7 @@
         {
           "system": "RxNorm",
           "code": "1049221",
-          "display": "Acetaminophen 325 MG / oxyCODONE Hydrochloride 5 MG Oral Tablet"
+          "display": "oxyCODONE 5 MG / acetaminophen 325 MG Oral Tablet"
         }
       ],
       "prescription": {
@@ -149,7 +149,7 @@
         {
           "system": "RxNorm",
           "code": "857005",
-          "display": "Acetaminophen 325 MG / HYDROcodone Bitartrate 7.5 MG Oral Tablet"
+          "display": "HYDROcodone bitartrate 7.5 MG / acetaminophen 325 MG Oral Tablet"
         }
       ],
       "prescription": {

--- a/src/main/resources/modules/medications/otc_antihistamine.json
+++ b/src/main/resources/modules/medications/otc_antihistamine.json
@@ -206,7 +206,7 @@
         {
           "system": "RxNorm",
           "code": "1049630",
-          "display": "diphenhydrAMINE Hydrochloride 25 MG Oral Tablet"
+          "display": "diphenhydrAMINE HCl 25 MG Oral Tablet"
         }
       ],
       "prescription": {
@@ -238,7 +238,7 @@
         {
           "system": "RxNorm",
           "code": "477045",
-          "display": "Chlorpheniramine Maleate 2 MG/ML Oral Solution"
+          "display": "chlorpheniramine maleate 2 MG in 1 mL Oral Solution"
         }
       ],
       "prescription": {
@@ -325,7 +325,7 @@
         {
           "system": "RxNorm",
           "code": "665078",
-          "display": "Loratadine 5 MG Chewable Tablet"
+          "display": "loratadine 5 MG 24HR Chewable Tablet"
         }
       ],
       "prescription": {
@@ -372,7 +372,7 @@
         {
           "system": "RxNorm",
           "code": "997488",
-          "display": "Fexofenadine hydrochloride 30 MG Oral Tablet"
+          "display": "fexofenadine HCl 30 MG Oral Tablet"
         }
       ],
       "prescription": {
@@ -419,7 +419,7 @@
         {
           "system": "RxNorm",
           "code": "1014676",
-          "display": "cetirizine hydrochloride 5 MG Oral Tablet"
+          "display": "cetirizine HCl 5 MG Oral Tablet"
         }
       ],
       "prescription": {

--- a/src/main/resources/modules/metabolic_syndrome_care.json
+++ b/src/main/resources/modules/metabolic_syndrome_care.json
@@ -331,7 +331,7 @@
         {
           "system": "SNOMED-CT",
           "code": "44054006",
-          "display": "Diabetes"
+          "display": "Diabetes mellitus type 2 (disorder)"
         }
       ],
       "assign_to_attribute": "diabetes_stage",
@@ -462,7 +462,7 @@
                     {
                       "system": "RxNorm",
                       "code": "860975",
-                      "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
+                      "display": "metFORMIN HCl 500 MG 24 HR Extended Release Oral Tablet"
                     }
                   ]
                 }
@@ -482,7 +482,7 @@
         {
           "system": "RxNorm",
           "code": "860975",
-          "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
+          "display": "metFORMIN HCl 500 MG 24 HR Extended Release Oral Tablet"
         }
       ],
       "reason": "Diagnose_Diabetes",
@@ -510,7 +510,7 @@
                     {
                       "system": "RxNorm",
                       "code": "897122",
-                      "display": "3 ML liraglutide 6 MG/ML Pen Injector"
+                      "display": "liraglutide 6 MG/ML in 3 ML Pen Injector"
                     }
                   ]
                 }
@@ -535,7 +535,7 @@
                   {
                     "system": "RxNorm",
                     "code": "897122",
-                    "display": "3 ML liraglutide 6 MG/ML Pen Injector"
+                    "display": "liraglutide 6 MG/ML in 3 ML Pen Injector"
                   }
                 ]
               }
@@ -554,7 +554,7 @@
         {
           "system": "RxNorm",
           "code": "897122",
-          "display": "3 ML liraglutide 6 MG/ML Pen Injector"
+          "display": "liraglutide 6 MG/ML in 3 ML Pen Injector"
         }
       ],
       "reason": "Diagnose_Diabetes",
@@ -567,7 +567,7 @@
         {
           "system": "RxNorm",
           "code": "897122",
-          "display": "3 ML liraglutide 6 MG/ML Pen Injector"
+          "display": "liraglutide 6 MG/ML in 3 ML Pen Injector"
         }
       ],
       "direct_transition": "Tritherapy"
@@ -671,7 +671,7 @@
               {
                 "system": "SNOMED-CT",
                 "code": "127013003",
-                "display": "Diabetic renal disease (disorder)"
+                "display": "Disorder of kidney due to diabetes mellitus (disorder)"
               }
             ]
           },
@@ -918,7 +918,7 @@
                     {
                       "system": "SNOMED-CT",
                       "code": "127013003",
-                      "display": "Diabetic renal disease (disorder)"
+                      "display": "Disorder of kidney due to diabetes mellitus (disorder)"
                     }
                   ]
                 }
@@ -942,7 +942,7 @@
                   {
                     "system": "SNOMED-CT",
                     "code": "127013003",
-                    "display": "Diabetic renal disease (disorder)"
+                    "display": "Disorder of kidney due to diabetes mellitus (disorder)"
                   }
                 ]
               }
@@ -961,7 +961,7 @@
         {
           "system": "SNOMED-CT",
           "code": "127013003",
-          "display": "Diabetic renal disease (disorder)"
+          "display": "Disorder of kidney due to diabetes mellitus (disorder)"
         }
       ],
       "direct_transition": "Check_Microalbuminuria"
@@ -972,7 +972,7 @@
         {
           "system": "SNOMED-CT",
           "code": "127013003",
-          "display": "Diabetic renal disease (disorder)"
+          "display": "Disorder of kidney due to diabetes mellitus (disorder)"
         }
       ],
       "direct_transition": "Check_Microalbuminuria"
@@ -1236,7 +1236,7 @@
                     {
                       "system": "SNOMED-CT",
                       "code": "422034002",
-                      "display": "Diabetic retinopathy associated with type II diabetes mellitus (disorder)"
+                      "display": "Retinopathy due to type 2 diabetes mellitus (disorder)"
                     }
                   ]
                 }
@@ -1260,7 +1260,7 @@
                   {
                     "system": "SNOMED-CT",
                     "code": "422034002",
-                    "display": "Diabetic retinopathy associated with type II diabetes mellitus (disorder)"
+                    "display": "Retinopathy due to type 2 diabetes mellitus (disorder)"
                   }
                 ]
               }
@@ -1279,7 +1279,7 @@
         {
           "system": "SNOMED-CT",
           "code": "422034002",
-          "display": "Diabetic retinopathy associated with type II diabetes mellitus (disorder)"
+          "display": "Retinopathy due to type 2 diabetes mellitus (disorder)"
         }
       ],
       "direct_transition": "Check_Nonproliferative_Retinopathy"
@@ -1290,7 +1290,7 @@
         {
           "system": "SNOMED-CT",
           "code": "422034002",
-          "display": "Diabetic retinopathy associated with type II diabetes mellitus (disorder)"
+          "display": "Retinopathy due to type 2 diabetes mellitus (disorder)"
         }
       ],
       "direct_transition": "Check_Nonproliferative_Retinopathy"
@@ -1315,7 +1315,7 @@
                     {
                       "system": "SNOMED-CT",
                       "code": "1551000119108",
-                      "display": "Nonproliferative diabetic retinopathy due to type 2 diabetes mellitus (disorder)"
+                      "display": "Nonproliferative retinopathy due to type 2 diabetes mellitus (disorder)"
                     }
                   ]
                 }
@@ -1339,7 +1339,7 @@
                   {
                     "system": "SNOMED-CT",
                     "code": "1551000119108",
-                    "display": "Nonproliferative diabetic retinopathy due to type 2 diabetes mellitus (disorder)"
+                    "display": "Nonproliferative retinopathy due to type 2 diabetes mellitus (disorder)"
                   }
                 ]
               }
@@ -1358,7 +1358,7 @@
         {
           "system": "SNOMED-CT",
           "code": "1551000119108",
-          "display": "Nonproliferative diabetic retinopathy due to type 2 diabetes mellitus (disorder)"
+          "display": "Nonproliferative retinopathy due to type 2 diabetes mellitus (disorder)"
         }
       ],
       "direct_transition": "Check_Proliferative_Retinopathy"
@@ -1369,7 +1369,7 @@
         {
           "system": "SNOMED-CT",
           "code": "1551000119108",
-          "display": "Nonproliferative diabetic retinopathy due to type 2 diabetes mellitus (disorder)"
+          "display": "Nonproliferative retinopathy due to type 2 diabetes mellitus (disorder)"
         }
       ],
       "direct_transition": "Check_Proliferative_Retinopathy"
@@ -1394,7 +1394,7 @@
                     {
                       "system": "SNOMED-CT",
                       "code": "1501000119109",
-                      "display": "Proliferative diabetic retinopathy due to type II diabetes mellitus (disorder)"
+                      "display": "Proliferative retinopathy due to type 2 diabetes mellitus (disorder)"
                     }
                   ]
                 }
@@ -1418,7 +1418,7 @@
                   {
                     "system": "SNOMED-CT",
                     "code": "1501000119109",
-                    "display": "Proliferative diabetic retinopathy due to type II diabetes mellitus (disorder)"
+                    "display": "Proliferative retinopathy due to type 2 diabetes mellitus (disorder)"
                   }
                 ]
               }
@@ -1437,7 +1437,7 @@
         {
           "system": "SNOMED-CT",
           "code": "1501000119109",
-          "display": "Proliferative diabetic retinopathy due to type II diabetes mellitus (disorder)"
+          "display": "Proliferative retinopathy due to type 2 diabetes mellitus (disorder)"
         }
       ],
       "direct_transition": "Check_Macular_Edema"
@@ -1448,7 +1448,7 @@
         {
           "system": "SNOMED-CT",
           "code": "1501000119109",
-          "display": "Proliferative diabetic retinopathy due to type II diabetes mellitus (disorder)"
+          "display": "Proliferative retinopathy due to type 2 diabetes mellitus (disorder)"
         }
       ],
       "direct_transition": "Check_Macular_Edema"
@@ -1904,7 +1904,7 @@
         {
           "system": "SNOMED-CT",
           "code": "180030006",
-          "display": "Amputation of right foot"
+          "display": "Amputation of the foot (procedure)"
         }
       ],
       "duration": {
@@ -2334,7 +2334,7 @@
         {
           "system": "LOINC",
           "code": "24321-2",
-          "display": "Basic Metabolic 2000 Panel"
+          "display": "Basic metabolic 2000 panel - Serum or Plasma"
         }
       ],
       "observations": [
@@ -2345,7 +2345,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -2357,7 +2357,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -2368,7 +2368,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -2384,7 +2384,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -2396,7 +2396,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -2408,7 +2408,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -2420,7 +2420,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -2432,7 +2432,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -2444,7 +2444,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {
@@ -2461,7 +2461,7 @@
         {
           "system": "LOINC",
           "code": "24321-2",
-          "display": "Basic Metabolic 2000 Panel"
+          "display": "Basic metabolic 2000 panel - Serum or Plasma"
         }
       ],
       "observations": [
@@ -2472,7 +2472,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -2484,7 +2484,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -2495,7 +2495,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -2511,7 +2511,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -2523,7 +2523,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -2535,7 +2535,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -2547,7 +2547,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -2559,7 +2559,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -2571,7 +2571,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {
@@ -2588,7 +2588,7 @@
         {
           "system": "LOINC",
           "code": "24321-2",
-          "display": "Basic Metabolic 2000 Panel"
+          "display": "Basic metabolic 2000 panel - Serum or Plasma"
         }
       ],
       "observations": [
@@ -2599,7 +2599,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -2611,7 +2611,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -2622,7 +2622,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -2638,7 +2638,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -2650,7 +2650,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -2662,7 +2662,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -2674,7 +2674,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -2686,7 +2686,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -2698,7 +2698,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {
@@ -2715,7 +2715,7 @@
         {
           "system": "LOINC",
           "code": "24321-2",
-          "display": "Basic Metabolic 2000 Panel"
+          "display": "Basic metabolic 2000 panel - Serum or Plasma"
         }
       ],
       "observations": [
@@ -2726,7 +2726,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -2738,7 +2738,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -2749,7 +2749,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -2765,7 +2765,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -2777,7 +2777,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -2789,7 +2789,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -2801,7 +2801,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -2813,7 +2813,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -2825,7 +2825,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {
@@ -2842,7 +2842,7 @@
         {
           "system": "LOINC",
           "code": "24321-2",
-          "display": "Basic Metabolic 2000 Panel"
+          "display": "Basic metabolic 2000 panel - Serum or Plasma"
         }
       ],
       "observations": [
@@ -2853,7 +2853,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -2865,7 +2865,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -2876,7 +2876,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -2892,7 +2892,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -2904,7 +2904,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -2916,7 +2916,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -2928,7 +2928,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -2940,7 +2940,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -2952,7 +2952,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {

--- a/src/main/resources/modules/opioid_addiction.json
+++ b/src/main/resources/modules/opioid_addiction.json
@@ -195,7 +195,7 @@
         {
           "system": "RxNorm",
           "code": "856987",
-          "display": "Acetaminophen 300 MG / HYDROcodone Bitartrate 5 MG Oral Tablet"
+          "display": "HYDROcodone bitartrate 5 MG / acetaminophen 300 MG Oral Tablet"
         }
       ],
       "direct_transition": "End_Directed_Use_Encounter"
@@ -232,7 +232,7 @@
         {
           "system": "RxNorm",
           "code": "1860154",
-          "display": "Abuse-Deterrent 12 HR Oxycodone Hydrochloride 15 MG Extended Release Oral Tablet"
+          "display": "oxyCODONE HCl 15 MG 12 HR Extended Release Oral Tablet, Abuse-Deterrent"
         }
       ],
       "direct_transition": "End_Directed_Use_Encounter"
@@ -269,7 +269,7 @@
         {
           "system": "RxNorm",
           "code": "1049221",
-          "display": "Acetaminophen 325 MG / Oxycodone Hydrochloride 5 MG Oral Tablet"
+          "display": "oxyCODONE 5 MG / acetaminophen 325 MG Oral Tablet"
         }
       ],
       "direct_transition": "End_Directed_Use_Encounter"

--- a/src/main/resources/modules/osteoporosis.json
+++ b/src/main/resources/modules/osteoporosis.json
@@ -224,7 +224,7 @@
         {
           "system": "RxNorm",
           "code": "904419",
-          "display": "Alendronic acid 10 MG Oral Tablet"
+          "display": "alendronate sodium 10 MG Oral Tablet"
         }
       ],
       "direct_transition": "Terminal"

--- a/src/main/resources/modules/pregnancy.json
+++ b/src/main/resources/modules/pregnancy.json
@@ -348,7 +348,7 @@
         {
           "system": "SNOMED-CT",
           "code": "44608003",
-          "display": "Blood typing, RH typing"
+          "display": "Blood group typing (procedure)"
         }
       ],
       "direct_transition": "Hemoglobin_Test"
@@ -360,7 +360,7 @@
         {
           "system": "SNOMED-CT",
           "code": "104091002",
-          "display": "Hemoglobin / Hematocrit / Platelet count"
+          "display": "Hemogram, automated, with red blood cells, white blood cells, hemoglobin, hematocrit, indices, platelet count, and manual white blood cell differential (procedure)"
         }
       ],
       "direct_transition": "Hep_B_Surface_Antigen"
@@ -408,7 +408,7 @@
         {
           "system": "SNOMED-CT",
           "code": "165829005",
-          "display": "Gonorrhea infection test"
+          "display": "Gonorrhea infection titer test (procedure)"
         }
       ],
       "direct_transition": "Syphilis_Test"
@@ -420,7 +420,7 @@
         {
           "system": "SNOMED-CT",
           "code": "269828009",
-          "display": "Syphilis infection test"
+          "display": "Syphilis infectious titer test (procedure)"
         }
       ],
       "direct_transition": "Urine_Culture"
@@ -468,7 +468,7 @@
         {
           "system": "SNOMED-CT",
           "code": "104375008",
-          "display": "Hepatitis C antibody test"
+          "display": "Hepatitis C antibody, confirmatory test (procedure)"
         }
       ],
       "direct_transition": "Rubella_Screen"
@@ -504,7 +504,7 @@
         {
           "system": "SNOMED-CT",
           "code": "28163009",
-          "display": "Skin test for tuberculosis"
+          "display": "Skin test for tuberculosis, Tine test (procedure)"
         }
       ],
       "direct_transition": "Urine_Protein_Test"
@@ -631,7 +631,7 @@
         {
           "system": "SNOMED-CT",
           "code": "443529005",
-          "display": "Screening for chromosomal aneuploidy in prenatal amniotic fluid"
+          "display": "Detection of chromosomal aneuploidy in prenatal amniotic fluid specimen using fluorescence in situ hybridization screening technique (procedure)"
         }
       ],
       "direct_transition": "End_Week_12_Visit"
@@ -695,7 +695,7 @@
         {
           "system": "SNOMED-CT",
           "code": "275833003",
-          "display": "Alpha-fetoprotein test"
+          "display": "Alpha-fetoprotein test - antenatal (procedure)"
         }
       ],
       "direct_transition": "Week_16_Fundal_Height"
@@ -879,7 +879,7 @@
         {
           "system": "SNOMED-CT",
           "code": "51116004",
-          "display": "RhD passive immunization"
+          "display": "Passive immunization (procedure)"
         }
       ],
       "direct_transition": "Second_Hemoglobin_Test"
@@ -891,7 +891,7 @@
         {
           "system": "SNOMED-CT",
           "code": "104091002",
-          "display": "Hemoglobin / Hematocrit / Platelet count"
+          "display": "Hemogram, automated, with red blood cells, white blood cells, hemoglobin, hematocrit, indices, platelet count, and manual white blood cell differential (procedure)"
         }
       ],
       "direct_transition": "Tdap_Vaccine"
@@ -1097,7 +1097,7 @@
         {
           "system": "SNOMED-CT",
           "code": "118001005",
-          "display": "Streptococcus pneumoniae group B antigen test"
+          "display": "Streptococcus pneumoniae group B antigen assay (procedure)"
         }
       ],
       "direct_transition": "Week_36_Fundal_Height"
@@ -1723,7 +1723,7 @@
         {
           "system": "SNOMED-CT",
           "code": "156073000",
-          "display": "Fetus with unknown complication"
+          "display": "Complete miscarriage (disorder)"
         }
       ],
       "assign_to_attribute": "fatal_pregnancy_complication",
@@ -1852,7 +1852,7 @@
         {
           "system": "SNOMED-CT",
           "code": "609496007",
-          "display": "Complication occuring during pregnancy"
+          "display": "Complication occurring during pregnancy (disorder)"
         }
       ],
       "direct_transition": "End_Miscarriage_Encounter"
@@ -1903,7 +1903,7 @@
         {
           "system": "SNOMED-CT",
           "code": "51116004",
-          "display": "RhD passive immunization"
+          "display": "Passive immunization (procedure)"
         }
       ],
       "direct_transition": "Physical_Exam_Post_Miscarriage"
@@ -2038,7 +2038,7 @@
         {
           "system": "SNOMED-CT",
           "code": "51116004",
-          "display": "RhD passive immunization"
+          "display": "Passive immunization (procedure)"
         }
       ],
       "direct_transition": "Pregnancy_Termination_Care"
@@ -2209,7 +2209,7 @@
         {
           "system": "SNOMED-CT",
           "code": "51116004",
-          "display": "RhD passive immunization"
+          "display": "Passive immunization (procedure)"
         }
       ],
       "direct_transition": "Physical_Exam_Post_Birth"

--- a/src/main/resources/modules/sinusitis.json
+++ b/src/main/resources/modules/sinusitis.json
@@ -212,7 +212,7 @@
         {
           "system": "RxNorm",
           "code": "562251",
-          "display": "Amoxicillin 250 MG / Clavulanate 125 MG Oral Tablet"
+          "display": "amoxicillin 250 MG / clavulanate potassium 125 MG Oral Tablet"
         }
       ],
       "direct_transition": "End_Encounter"
@@ -239,7 +239,7 @@
                   {
                     "system": "RxNorm",
                     "code": "562251",
-                    "display": "Amoxicillin 250 MG / Clavulanate 125 MG Oral Tablet"
+                    "display": "amoxicillin 250 MG / clavulanate potassium 125 MG Oral Tablet"
                   }
                 ]
               },
@@ -286,7 +286,7 @@
               {
                 "system": "RxNorm",
                 "code": "562251",
-                "display": "Amoxicillin 250 MG / Clavulanate 125 MG Oral Tablet"
+                "display": "amoxicillin 250 MG / clavulanate potassium 125 MG Oral Tablet"
               }
             ]
           },

--- a/src/main/resources/modules/surgery/general_anesthesia.json
+++ b/src/main/resources/modules/surgery/general_anesthesia.json
@@ -27,7 +27,7 @@
         {
           "system": "RxNorm",
           "code": 1808217,
-          "display": "100 ML Propofol 10 MG/ML Injection"
+          "display": "propofol 1000 MG in 100 ML Injection"
         }
       ],
       "direct_transition": "Induction_Medication_End",
@@ -117,7 +117,7 @@
         {
           "system": "RxNorm",
           "code": 1740467,
-          "display": "2 ML Ondansetron 2 MG/ML Injection"
+          "display": "ondansetron 4 MG in 2 ML Injection"
         }
       ],
       "direct_transition": "Antiemetic_End",
@@ -214,7 +214,7 @@
         {
           "system": "RxNorm",
           "code": "1809104",
-          "display": "5 ML SUFentanil 0.05 MG/ML Injection"
+          "display": "SUFentanil 250 MCG per 5 ML Injection"
         }
       ],
       "direct_transition": "Sufentanil_End",
@@ -226,7 +226,7 @@
         {
           "system": "RxNorm",
           "code": 542347,
-          "display": "Isoflurane 999 MG/ML Inhalant Solution"
+          "display": "isoflurane 99.9 % Inhalant Solution"
         }
       ],
       "direct_transition": "Isoflurane_End",
@@ -261,7 +261,7 @@
         {
           "system": "RxNorm",
           "code": "562366",
-          "display": "desflurane 1000 MG/ML Inhalation Solution"
+          "display": "desflurane 100 % Inhalant Solution"
         }
       ],
       "direct_transition": "Desflurane_End",
@@ -273,7 +273,7 @@
         {
           "system": "RxNorm",
           "code": 200243,
-          "display": "sevoflurane 1000 MG/ML Inhalant Solution"
+          "display": "sevoflurane 100 % Inhalant Solution"
         }
       ],
       "direct_transition": "Sevoflurane_End",

--- a/src/main/resources/modules/urinary_tract_infections.json
+++ b/src/main/resources/modules/urinary_tract_infections.json
@@ -257,7 +257,7 @@
         {
           "system": "RxNorm",
           "code": "311989",
-          "display": "Nitrofurantoin 5 MG/ML Oral Suspension"
+          "display": "nitrofurantoin 25 MG in 5 mL Oral Suspension"
         }
       ],
       "direct_transition": "Prescribe_OTC_Painkiller_For_UTIs"
@@ -272,7 +272,7 @@
         {
           "system": "RxNorm",
           "code": "1094107",
-          "display": "Phenazopyridine hydrochloride 100 MG Oral Tablet"
+          "display": "phenazopyridine HCl 100 MG Oral Tablet"
         }
       ],
       "direct_transition": "UTI_CarePlan"

--- a/src/main/resources/modules/veteran_hyperlipidemia.json
+++ b/src/main/resources/modules/veteran_hyperlipidemia.json
@@ -100,7 +100,7 @@
         {
           "system": "LOINC",
           "code": "57698-3",
-          "display": "Lipid Panel"
+          "display": "Lipid panel with direct LDL - Serum or Plasma"
         }
       ],
       "observations": [
@@ -111,7 +111,7 @@
             {
               "system": "LOINC",
               "code": "2093-3",
-              "display": "Total Cholesterol"
+              "display": "Cholesterol Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -126,7 +126,7 @@
             {
               "system": "LOINC",
               "code": "2571-8",
-              "display": "Triglycerides"
+              "display": "Triglyceride Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -141,7 +141,7 @@
             {
               "system": "LOINC",
               "code": "18262-6",
-              "display": "Low Density Lipoprotein Cholesterol"
+              "display": "Cholesterol in LDL Mass/volume in Serum or Plasma by Direct assay"
             }
           ],
           "unit": "mg/dL",
@@ -156,7 +156,7 @@
             {
               "system": "LOINC",
               "code": "2085-9",
-              "display": "High Density Lipoprotein Cholesterol"
+              "display": "Cholesterol in HDL Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -201,7 +201,7 @@
         {
           "system": "SNOMED-CT",
           "code": 183301007,
-          "display": "physical exercise"
+          "display": "Physical exercises (regime/therapy)"
         }
       ]
     },
@@ -248,7 +248,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -260,7 +260,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -271,7 +271,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -287,7 +287,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -299,7 +299,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -311,7 +311,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -323,7 +323,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -335,7 +335,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -347,7 +347,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {
@@ -501,7 +501,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -513,7 +513,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -524,7 +524,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -540,7 +540,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -552,7 +552,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -564,7 +564,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -576,7 +576,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -588,7 +588,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -600,7 +600,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {
@@ -722,7 +722,7 @@
         {
           "system": "LOINC",
           "code": "57698-3",
-          "display": "Lipid Panel"
+          "display": "Lipid panel with direct LDL - Serum or Plasma"
         }
       ],
       "observations": [
@@ -732,7 +732,7 @@
             {
               "system": "LOINC",
               "code": "2093-3",
-              "display": "Total Cholesterol"
+              "display": "Cholesterol Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -747,7 +747,7 @@
             {
               "system": "LOINC",
               "code": "2571-8",
-              "display": "Triglycerides"
+              "display": "Triglyceride Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -762,7 +762,7 @@
             {
               "system": "LOINC",
               "code": "18262-6",
-              "display": "Low Density Lipoprotein Cholesterol"
+              "display": "Cholesterol in LDL Mass/volume in Serum or Plasma by Direct assay"
             }
           ],
           "unit": "mg/dL",
@@ -777,7 +777,7 @@
             {
               "system": "LOINC",
               "code": "2085-9",
-              "display": "High Density Lipoprotein Cholesterol"
+              "display": "Cholesterol in HDL Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",

--- a/src/main/resources/modules/veteran_mdd.json
+++ b/src/main/resources/modules/veteran_mdd.json
@@ -366,7 +366,7 @@
         {
           "system": "SNOMED-CT",
           "code": 79094001,
-          "display": "Initial Psychiatric Interview with mental status evaluation"
+          "display": "Initial psychiatric interview with mental status and evaluation (procedure)"
         }
       ],
       "reason": "mdd",
@@ -389,7 +389,7 @@
         {
           "system": "SNOMED-CT",
           "code": 370143000,
-          "display": "Major depression disorder"
+          "display": "Major depressive disorder (disorder)"
         }
       ],
       "distributed_transition": [
@@ -472,7 +472,7 @@
         {
           "system": "SNOMED-CT",
           "code": 304822001,
-          "display": "Psychodynamic Interpersonal Therapy"
+          "display": "Psychodynamic-interpersonal psychotherapy (regime/therapy)"
         }
       ]
     },
@@ -533,7 +533,7 @@
         {
           "system": "RxNorm",
           "code": 310385,
-          "display": "FLUoxetine 20 MG Oral Capsule"
+          "display": "FLUoxetine 20 MG (as FLUoxetine HCl 22.4 MG) Oral Capsule"
         }
       ],
       "assign_to_attribute": "ssri",
@@ -598,7 +598,7 @@
         {
           "system": "SNOMED-CT",
           "code": 112001000119100,
-          "display": "positive screening for PHQ-9"
+          "display": "Positive screening for depression on Patient Health Questionnaire 9"
         }
       ],
       "direct_transition": "MDD Diagnosis",
@@ -646,7 +646,7 @@
         {
           "system": "SNOMED-CT",
           "code": 112011000119102,
-          "display": "negative screening for depression on phq9"
+          "display": "Negative screening for depression on Patient Health Questionnaire 9"
         }
       ],
       "direct_transition": "Change_Dx_Not_MDD"

--- a/src/main/resources/modules/veteran_prostate_cancer.json
+++ b/src/main/resources/modules/veteran_prostate_cancer.json
@@ -210,7 +210,7 @@
       "value_code": {
         "system": "SNOMED-CT",
         "code": 300531004,
-        "display": "Normal size prostate"
+        "display": "Normal sized prostate (finding)"
       }
     },
     "wellness_visit_time_delay": {
@@ -371,7 +371,7 @@
         {
           "system": "RxNorm",
           "code": 1860480,
-          "display": "1 ML DOCEtaxel 20 MG/ML Injection"
+          "display": "DOCEtaxel 20 MG per 1 ML Injection"
         }
       ],
       "direct_transition": "Chemotherapy_Hormone Order2"
@@ -498,7 +498,7 @@
         {
           "system": "RxNorm",
           "code": 752899,
-          "display": "0.25 ML Leuprolide Acetate 30 MG/ML Prefilled Syringe"
+          "display": "leuprolide acetate 7.5 MG in 0.25 ML (1 month) Prefilled Syringe"
         }
       ],
       "conditional_transition": [
@@ -577,7 +577,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -589,7 +589,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -600,7 +600,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL",
@@ -616,7 +616,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -628,7 +628,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -640,7 +640,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -652,7 +652,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -664,7 +664,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -676,7 +676,7 @@
             {
               "system": "LOINC",
               "code": "33914-3",
-              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+              "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
             }
           ],
           "range": {

--- a/src/main/resources/modules/veteran_ptsd.json
+++ b/src/main/resources/modules/veteran_ptsd.json
@@ -192,7 +192,7 @@
         {
           "system": "SNOMED-CT",
           "code": 79094001,
-          "display": "Initial Psychiatric Interview with mental status evaluation"
+          "display": "Initial psychiatric interview with mental status and evaluation (procedure)"
         }
       ],
       "reason": "ptsd",
@@ -478,7 +478,7 @@
         {
           "system": "RxNorm",
           "code": 312938,
-          "display": "Sertraline 100 MG Oral Tablet"
+          "display": "sertraline HCl 100 MG Oral Tablet"
         }
       ],
       "assign_to_attribute": "SSRI",
@@ -1103,12 +1103,12 @@
         {
           "system": "SNOMED-CT",
           "code": 385724002,
-          "display": "Coping Support Management (Telehealth)"
+          "display": "Coping support management (procedure)"
         },
         {
           "system": "SNOMED-CT",
           "code": 406185000,
-          "display": "Trauma Therapy (Telehealth)"
+          "display": "Trauma therapy (regime/therapy)"
         },
         {
           "system": "SNOMED-CT",
@@ -1123,7 +1123,7 @@
         {
           "system": "SNOMED-CT",
           "code": 76168009,
-          "display": "Group psychotherapy (regime/therapy) (Telehealth)"
+          "display": "Group psychotherapy (regime/therapy)"
         },
         {
           "system": "SNOMED-CT",
@@ -1171,7 +1171,7 @@
         {
           "system": "SNOMED-CT",
           "code": 406185000,
-          "display": "Trauma Therapy (Telehealth)"
+          "display": "Trauma therapy (regime/therapy)"
         },
         {
           "system": "SNOMED-CT",
@@ -1181,7 +1181,7 @@
         {
           "system": "SNOMED-CT",
           "code": 385724002,
-          "display": "Coping Support Management (Telehealth)"
+          "display": "Coping support management (procedure)"
         },
         {
           "system": "SNOMED-CT",
@@ -1191,7 +1191,7 @@
         {
           "system": "SNOMED-CT",
           "code": 76168009,
-          "display": "Group psychotherapy (regime/therapy) (Telehealth)"
+          "display": "Group psychotherapy (regime/therapy)"
         },
         {
           "system": "SNOMED-CT",

--- a/src/main/resources/modules/veteran_substance_abuse_treatment.json
+++ b/src/main/resources/modules/veteran_substance_abuse_treatment.json
@@ -57,7 +57,7 @@
         {
           "system": "RxNorm",
           "code": 198031,
-          "display": "24hr nicotine transdermal patch"
+          "display": "24 HR Nicotine 0.292 MG/HR Transdermal System"
         }
       ],
       "direct_transition": "Alcohol Check",

--- a/src/main/resources/modules/wellness_encounters.json
+++ b/src/main/resources/modules/wellness_encounters.json
@@ -62,7 +62,7 @@
         {
           "system": "LOINC",
           "code": "39156-5",
-          "display": "Body Mass Index"
+          "display": "Body mass index (BMI) Ratio"
         }
       ],
       "unit": "kg/m2",
@@ -99,7 +99,7 @@
         {
           "system": "LOINC",
           "code": "85354-9",
-          "display": "Blood Pressure"
+          "display": "Blood pressure panel with all children optional"
         }
       ],
       "observations": [
@@ -137,7 +137,7 @@
         {
           "system": "LOINC",
           "code": "51990-0",
-          "display": "Basic Metabolic Panel"
+          "display": "Basic metabolic panel - Blood"
         }
       ],
       "observations": [
@@ -148,7 +148,7 @@
             {
               "system": "LOINC",
               "code": "2339-0",
-              "display": "Glucose"
+              "display": "Glucose Mass/volume in Blood"
             }
           ],
           "unit": "mg/dL"
@@ -160,7 +160,7 @@
             {
               "system": "LOINC",
               "code": "6299-2",
-              "display": "Urea Nitrogen"
+              "display": "Urea nitrogen Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -172,7 +172,7 @@
             {
               "system": "LOINC",
               "code": "38483-4",
-              "display": "Creatinine"
+              "display": "Creatinine Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -184,7 +184,7 @@
             {
               "system": "LOINC",
               "code": "49765-1",
-              "display": "Calcium"
+              "display": "Calcium Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -196,7 +196,7 @@
             {
               "system": "LOINC",
               "code": "2947-0",
-              "display": "Sodium"
+              "display": "Sodium Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -208,7 +208,7 @@
             {
               "system": "LOINC",
               "code": "6298-4",
-              "display": "Potassium"
+              "display": "Potassium Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -220,7 +220,7 @@
             {
               "system": "LOINC",
               "code": "2069-3",
-              "display": "Chloride"
+              "display": "Chloride Moles/volume in Blood"
             }
           ],
           "unit": "mmol/L"
@@ -232,7 +232,7 @@
             {
               "system": "LOINC",
               "code": "20565-8",
-              "display": "Carbon Dioxide"
+              "display": "Carbon dioxide, total Moles/volume in Serum or Plasma"
             }
           ],
           "unit": "mmol/L"
@@ -247,7 +247,7 @@
         {
           "system": "LOINC",
           "code": "57698-3",
-          "display": "Lipid Panel"
+          "display": "Lipid panel with direct LDL - Serum or Plasma"
         }
       ],
       "observations": [
@@ -258,7 +258,7 @@
             {
               "system": "LOINC",
               "code": "2093-3",
-              "display": "Total Cholesterol"
+              "display": "Cholesterol Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -270,7 +270,7 @@
             {
               "system": "LOINC",
               "code": "2571-8",
-              "display": "Triglycerides"
+              "display": "Triglyceride Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -282,7 +282,7 @@
             {
               "system": "LOINC",
               "code": "18262-6",
-              "display": "Low Density Lipoprotein Cholesterol"
+              "display": "Cholesterol in LDL Mass/volume in Serum or Plasma by Direct assay"
             }
           ],
           "unit": "mg/dL"
@@ -294,7 +294,7 @@
             {
               "system": "LOINC",
               "code": "2085-9",
-              "display": "High Density Lipoprotein Cholesterol"
+              "display": "Cholesterol in HDL Mass/volume in Serum or Plasma"
             }
           ],
           "unit": "mg/dL"
@@ -310,7 +310,7 @@
         {
           "system": "LOINC",
           "code": "14959-1",
-          "display": "Microalbumin Creatinine Ratio"
+          "display": "Microalbumin/Creatinine Mass Ratio in Urine"
         }
       ],
       "unit": "mg/g",
@@ -324,7 +324,7 @@
         {
           "system": "LOINC",
           "code": "33914-3",
-          "display": "Estimated Glomerular Filtration Rate"
+          "display": "Glomerular filtration rate/1.73 sq M.predicted Volume Rate/Area in Serum or Plasma by Creatinine-based formula (MDRD)"
         }
       ],
       "unit": "mL/min/{1.73_m2}",
@@ -343,7 +343,7 @@
                   {
                     "system": "SNOMED-CT",
                     "code": "44054006",
-                    "display": "Diabetes"
+                    "display": "Diabetes mellitus type 2 (disorder)"
                   }
                 ]
               },
@@ -379,7 +379,7 @@
                   {
                     "system": "SNOMED-CT",
                     "code": "44054006",
-                    "display": "Diabetes"
+                    "display": "Diabetes mellitus type 2 (disorder)"
                   }
                 ]
               },
@@ -424,7 +424,7 @@
               {
                 "system": "SNOMED-CT",
                 "code": "44054006",
-                "display": "Diabetes"
+                "display": "Diabetes mellitus type 2 (disorder)"
               }
             ]
           },
@@ -468,13 +468,13 @@
         {
           "system": "LOINC",
           "code": "72166-2",
-          "display": "Tobacco smoking status NHIS"
+          "display": "Tobacco smoking status"
         }
       ],
       "value_code": {
         "system": "SNOMED-CT",
         "code": 449868002,
-        "display": "Current every day smoker"
+        "display": "Smokes tobacco daily (finding)"
       },
       "direct_transition": "Wellness_Encounter"
     },
@@ -486,14 +486,14 @@
         {
           "system": "LOINC",
           "code": "72166-2",
-          "display": "Tobacco smoking status NHIS"
+          "display": "Tobacco smoking status"
         }
       ],
       "direct_transition": "Wellness_Encounter",
       "value_code": {
         "system": "SNOMED-CT",
         "code": 8517006,
-        "display": "Former smoker"
+        "display": "Ex-smoker (finding)"
       }
     },
     "Record_Never_Smoker": {
@@ -504,14 +504,14 @@
         {
           "system": "LOINC",
           "code": "72166-2",
-          "display": "Tobacco smoking status NHIS"
+          "display": "Tobacco smoking status"
         }
       ],
       "direct_transition": "Wellness_Encounter",
       "value_code": {
         "system": "SNOMED-CT",
         "code": 266919005,
-        "display": "Never smoker"
+        "display": "Never smoked tobacco (finding)"
       }
     },
     "check_CBC": {
@@ -546,7 +546,7 @@
                   {
                     "system": "SNOMED-CT",
                     "code": "44054006",
-                    "display": "Diabetes"
+                    "display": "Diabetes mellitus type 2 (disorder)"
                   }
                 ]
               },
@@ -556,7 +556,7 @@
                   {
                     "system": "SNOMED-CT",
                     "code": "38341003",
-                    "display": "Hypertension"
+                    "display": "Essential hypertension (disorder)"
                   }
                 ]
               }


### PR DESCRIPTION
Updates a bunch of displays, and a few codes that seem to have been wrong, based on running a large set of Synthea patients through the FHIR Validator: https://confluence.hl7.org/display/FHIR/Using+the+FHIR+Validator

The vast majority of these are only display text changes such that we are using a preferred text for the code. There are a only handful of actual codes changed.

Note that this does not address every warning, but some of the other issues identified were not straight 1:1 changes that could be made trivially. I'm not an MD or PharmD but the intent is nothing here represents a material change.