### PR TITLE
Add DeviceEnd state

### DIFF
--- a/src/main/java/Graphviz.java
+++ b/src/main/java/Graphviz.java
@@ -404,6 +404,47 @@ public class Graphviz {
         details.append("SNOMED-CT[").append(bodySiteCode).append("] Body Site: ")
             .append(bodySiteDisplay).append(NEWLINE);
         break;
+      case "Device":
+        JsonObject c = state.get("code").getAsJsonObject();
+        details.append(toCodeString(c, true));
+        
+        if (state.has("manufacturer")) {
+          details.append("Manufacturer: ")
+            .append(state.get("manufacturer").getAsString())
+            .append(NEWLINE);
+        }
+        if (state.has("model")) {
+          details.append("Model: ")
+          .append(state.get("model").getAsString())
+          .append(NEWLINE);
+        }
+        break;
+      case "DeviceEnd":
+        if (state.has("device")) {
+          details.append("Added at: ")
+            .append(state.get("device").getAsString())
+            .append(NEWLINE);
+        }
+        break;
+      case "SupplyList":
+        List<String> supplyQuantity = new ArrayList<String>();
+        supplyQuantity.add("Quantity");
+        List<String> supplyCode = new ArrayList<String>();
+        supplyCode.add("Code");
+
+        state.get("supplies").getAsJsonArray().forEach( (supplyElement) -> {
+          JsonObject supply = supplyElement.getAsJsonObject();
+          supplyQuantity.add(supply.get("quantity").getAsString());
+
+          JsonObject coding = supply.get("code").getAsJsonObject();
+          String codeString = toCodeString(coding, false);
+          supplyCode.add(codeString);
+        });
+
+        details.append("{").append(String.join("|", supplyCode)).append("}|");
+        details.append("{").append(String.join("|", supplyQuantity)).append("}|");
+        break;
+
       default:
         // no special description
     }
@@ -413,11 +454,7 @@ public class Graphviz {
       JsonArray codes = state.get("codes").getAsJsonArray();
       codes.forEach(c -> {
         JsonObject coding = c.getAsJsonObject();
-        String system = coding.get("system").getAsString();
-        String code = coding.get("code").getAsString();
-        String display = coding.get("display").getAsString();
-        details.append(system).append("[").append(code).append("]: ").append(display)
-            .append(NEWLINE);
+        details.append(toCodeString(coding, true));
 
       });
     }
@@ -466,11 +503,7 @@ public class Graphviz {
       details.append(NEWLINE).append("Activities:").append(NEWLINE);
       state.get("activities").getAsJsonArray().forEach(a -> {
         JsonObject coding = a.getAsJsonObject();
-        String system = coding.get("system").getAsString();
-        String code = coding.get("code").getAsString();
-        String display = coding.get("display").getAsString();
-        details.append(system).append("[").append(code).append("]: ").append(display)
-            .append(NEWLINE);
+        details.append(toCodeString(coding, true));
       });
     }
     if (state.has("goals")) {
@@ -481,11 +514,7 @@ public class Graphviz {
           details.append(goal.get("text").getAsString()).append(NEWLINE);
         } else if (goal.has("codes")) {
           JsonObject coding = goal.get("codes").getAsJsonArray().get(0).getAsJsonObject();
-          String system = coding.get("system").getAsString();
-          String code = coding.get("code").getAsString();
-          String display = coding.get("display").getAsString();
-          details.append(system).append("[").append(code).append("]: ").append(display)
-              .append(NEWLINE);
+          details.append(toCodeString(coding, true));
         } else if (goal.has("observation")) {
           JsonObject logic = goal.get("observation").getAsJsonObject();
           String obs = findReferencedType(logic);
@@ -510,6 +539,33 @@ public class Graphviz {
     return details.toString();
   }
 
+  /**
+   * Helper function to turn a a Json "code" type object into a consistent string.
+   * Format: "SYSTEM[CODE]: DISPLAY"
+   * Example: "SNOMED-CT[44054006]: Diabetes"
+   * 
+   * @param coding JSON coding object
+   * @param includeNewLine whether or not to include a newline at the end
+   * @return String to display the code
+   */
+  private static String toCodeString(JsonObject coding, boolean includeNewLine) {
+    StringBuilder sb = new StringBuilder();
+
+    String system = coding.get("system").getAsString();
+    String code = coding.get("code").getAsString();
+    String display = coding.get("display").getAsString();
+    sb.append(system)
+      .append("[").append(code).append("]: ")
+      .append(display)
+      .append(NEWLINE);
+
+    if (includeNewLine) {
+      sb.append(NEWLINE);
+    }
+
+    return sb.toString();
+  }
+  
   private static String logicDetails(JsonObject logic) {
     String conditionType = logic.get("condition_type").getAsString();
 
@@ -593,9 +649,7 @@ public class Graphviz {
           valueString = logic.get("value").getAsString();
         } else if (logic.has("value_code")) {
           JsonObject valueCode = logic.get("value_code").getAsJsonObject();
-          valueString = "'" + valueCode.get("system").getAsString() + " ["
-            + valueCode.get("code").getAsString() + "]: "
-            + valueCode.get("display").getAsString() + "'";
+          valueString = "'" + toCodeString(valueCode, false) + "'";
         }
         return "Observation " + obs + " \\" + logic.get("operator").getAsString() + " "
             + valueString + NEWLINE;
@@ -627,11 +681,7 @@ public class Graphviz {
   private static String findReferencedType(JsonObject logic) {
     if (logic.has("codes")) {
       JsonObject coding = logic.get("codes").getAsJsonArray().get(0).getAsJsonObject();
-      String system = coding.get("system").getAsString();
-      String code = coding.get("code").getAsString();
-      String display = coding.get("display").getAsString();
-
-      return "'" + system + " [" + code + "]: " + display + "'";
+      return toCodeString(coding, false);
     } else if (logic.has("referenced_by_attribute")) {
       return "Referenced By Attribute: '" + logic.get("referenced_by_attribute").getAsString()
           + "'";

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -792,6 +792,27 @@ public class HealthRecord implements Serializable {
       present.remove(type);
     }
   }
+  
+  /**
+   * Remove a device from the patient based on the state where it was assigned.
+   * @param time The time the device is removed.
+   * @param stateName The state where the device was implanted or assigned.
+   */
+  public void deviceRemoveByState(long time, String stateName) {
+    Device device = null;
+    Iterator<Entry> iter = present.values().iterator();
+    while (iter.hasNext()) {
+      Entry e = iter.next();
+      if (e.name != null && e.name.equals(stateName)) {
+        device = (Device)e;
+        break;
+      }
+    }
+    if (device != null) {
+      device.stop = time;
+      present.remove(device.type);
+    }
+  }
 
   public Report report(long time, String type, int numberOfObservations) {
     Encounter encounter = currentEncounter(time);

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -1736,7 +1736,71 @@ public class StateTest {
     assertEquals("13459008", device.type);
     assertEquals("SynCardia", device.manufacturer);
     assertEquals("Total Artificial Heart", device.model);
+    assertEquals(0L, device.stop);
+    
+    HealthRecord.Device attribute = (HealthRecord.Device)person.attributes.get("artificial_heart");
+    assertNotNull(attribute);
+    assertTrue(attribute == device); // we want reference equality, it should be the same object
   }
+  
+  @Test
+  public void testDeviceEndByAttribute() throws Exception {
+    Module module = TestHelper.getFixture("artificial_heart_device.json");
+    
+    State encounterState = module.getState("Encounter");
+    assertTrue(encounterState.process(person, time));
+    
+    State deviceState = module.getState("Artificial_Heart");
+    assertTrue(deviceState.process(person, time));
+
+    State deviceEndState = module.getState("Remove_Device_By_Attribute");
+    assertTrue(deviceEndState.process(person, time));
+    
+    Encounter encounter = person.getCurrentEncounter(module);
+    List<HealthRecord.Device> devices = encounter.devices;    
+    HealthRecord.Device device = devices.get(0);
+    assertEquals(time, device.stop);
+  }
+  
+  @Test
+  public void testDeviceEndByCode() throws Exception {
+    Module module = TestHelper.getFixture("artificial_heart_device.json");
+    
+    State encounterState = module.getState("Encounter");
+    assertTrue(encounterState.process(person, time));
+    
+    State deviceState = module.getState("Artificial_Heart");
+    assertTrue(deviceState.process(person, time));
+
+    State deviceEndState = module.getState("Remove_Device_By_Code");
+    assertTrue(deviceEndState.process(person, time));
+    
+    Encounter encounter = person.getCurrentEncounter(module);
+    List<HealthRecord.Device> devices = encounter.devices;    
+    HealthRecord.Device device = devices.get(0);
+    assertEquals(time, device.stop);
+  }
+  
+  
+  @Test
+  public void testDeviceEndByState() throws Exception {
+    Module module = TestHelper.getFixture("artificial_heart_device.json");
+    
+    State encounterState = module.getState("Encounter");
+    assertTrue(encounterState.process(person, time));
+    
+    State deviceState = module.getState("Artificial_Heart");
+    assertTrue(deviceState.process(person, time));
+
+    State deviceEndState = module.getState("Remove_Device_By_State");
+    assertTrue(deviceEndState.process(person, time));
+    
+    Encounter encounter = person.getCurrentEncounter(module);
+    List<HealthRecord.Device> devices = encounter.devices;    
+    HealthRecord.Device device = devices.get(0);
+    assertEquals(time, device.stop);
+  }
+  
   
   @Test
   public void testSupplyList() throws Exception {

--- a/src/test/resources/generic/artificial_heart_device.json
+++ b/src/test/resources/generic/artificial_heart_device.json
@@ -28,7 +28,7 @@
     },
     "End_Encounter": {
       "type": "EncounterEnd",
-      "direct_transition": "Terminal"
+      "direct_transition": "Delay"
     },
     "Necessary_Supplies": {
       "type": "SupplyList",
@@ -76,8 +76,51 @@
         "display": "Temporary artificial heart prosthesis, device (physical object)"
       },
       "direct_transition": "End_Encounter",
+      "assign_to_attribute": "artificial_heart",
       "manufacturer": "SynCardia",
       "model": "Total Artificial Heart"
+    },
+    "Delay": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 50,
+        "unit": "years"
+      },
+      "distributed_transition": [
+        {
+          "transition": "Remove_Device_By_State",
+          "distribution": 0.4
+        },
+        {
+          "transition": "Remove_Device_By_Code",
+          "distribution": 0.3
+        },
+        {
+          "transition": "Remove_Device_By_Attribute",
+          "distribution": 0.3
+        }
+      ]
+    },
+    "Remove_Device_By_State": {
+      "type": "DeviceEnd",
+      "direct_transition": "Terminal",
+      "device": "Artificial_Heart"
+    },
+    "Remove_Device_By_Code": {
+      "type": "DeviceEnd",
+      "direct_transition": "Terminal",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 13459008,
+          "display": "Temporary artificial heart prosthesis, device (physical object)"
+        }
+      ]
+    },
+    "Remove_Device_By_Attribute": {
+      "type": "DeviceEnd",
+      "direct_transition": "Terminal",
+      "referenced_by_attribute": "artificial_heart"
     }
   }
 }


### PR DESCRIPTION
Adds a DeviceEnd state to support removal of devices associated to patients. The Device to remove can be referenced by an attribute, the name of the state where the Device was added, or by SNOMED code. Assigning Devices to an attribute was not previously supported so that has been added as well.

I also realized I forgot to update Graphviz for the Device and SupplyList states previously so that's now been added as well.