### PR TITLE
Update CQL engine off of snapshot.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
   compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
   compile group: 'org.apache.commons', name: 'commons-text', version: '1.2'
 
-  compile group: 'org.opencds.cqf', name: 'cql-engine', version: '1.3.10-SNAPSHOT'
+  compile group: 'org.opencds.cqf', name: 'cql-engine', version: '1.3.12'
   compile group: 'info.cqframework', name: 'cql', version: '1.3.17'
   compile group: 'info.cqframework', name: 'model', version: '1.3.17'
   compile group: 'info.cqframework', name: 'cql-to-elm', version: '1.3.17'


### PR DESCRIPTION
This pull request only updates a dependency.

The expression processing code uses the CQL engine.

The version in Synthea is `1.3.10-SNAPSHOT` which seems to no longer be available.

This PR updates the dependency to `1.3.12`.