### PR TITLE
Module Encounter Fixes

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -260,6 +260,7 @@ public abstract class State implements Cloneable, Serializable {
         encounter = person.getCurrentEncounter(submod);
         if (encounter != null) {
           person.setCurrentEncounter(module, encounter);
+          person.setCurrentEncounter(submod, null);
         }
         return true;
       } else {
@@ -861,16 +862,17 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public boolean process(Person person, long time) {
       HealthRecord.Encounter encounter = person.getCurrentEncounter(module);
-      EncounterType type = EncounterType.fromString(encounter.type);
-      if (type != EncounterType.WELLNESS) {
-        person.record.encounterEnd(time, type);
+      if (encounter != null) {
+        EncounterType type = EncounterType.fromString(encounter.type);
+        if (type != EncounterType.WELLNESS) {
+          person.record.encounterEnd(time, type);
+        }
+        encounter.discharge = dischargeDisposition;
       }
-      encounter.discharge = dischargeDisposition;
 
       // reset current provider hash
       person.removeCurrentProvider(module.name);
       person.setCurrentEncounter(module, null);
-
       return true;
     }
   }

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -603,6 +603,13 @@ public class Person implements Serializable, QuadTreeElement {
               = (Map<String, Encounter>) attributes.get(CURRENT_ENCOUNTERS);
 
       if (moduleToCurrentEncounter != null && !moduleToCurrentEncounter.isEmpty()) {
+        // Uncomment the following lines to see which module encounters are blocking the start
+        // of wellness encounters in the encounter module.
+        // System.out.println("Pre-wellness Encounter Check Failed:");
+        // for (String module: moduleToCurrentEncounter.keySet()) {
+        //   Encounter encounter = moduleToCurrentEncounter.get(module);
+        //   System.out.printf("%s, %s\n", module, encounter.codes.get(0).code);
+        // }
         return true;
       }
     }

--- a/src/main/resources/modules/allergic_rhinitis.json
+++ b/src/main/resources/modules/allergic_rhinitis.json
@@ -121,7 +121,7 @@
           "display": "Seasonal allergic rhinitis"
         }
       ],
-      "direct_transition": "Allergic_Rhinitis_Diagnosis"
+      "direct_transition": "Allergic_Rhinitis_Symptom1"
     },
     "Has_Perennial_Allergic_Rhinitis": {
       "type": "ConditionOnset",
@@ -134,7 +134,7 @@
           "display": "Perennial allergic rhinitis"
         }
       ],
-      "direct_transition": "Allergic_Rhinitis_Diagnosis"
+      "direct_transition": "Allergic_Rhinitis_Symptom1"
     },
     "Has_Perennial_And_Seasonal_Allergic_Rhinitis": {
       "type": "ConditionOnset",
@@ -147,7 +147,7 @@
           "display": "Perennial allergic rhinitis with seasonal variation"
         }
       ],
-      "direct_transition": "Allergic_Rhinitis_Diagnosis"
+      "direct_transition": "Allergic_Rhinitis_Symptom1"
     },
     "Allergic_Rhinitis_Diagnosis": {
       "type": "Encounter",
@@ -160,7 +160,7 @@
           "display": "Encounter for symptom"
         }
       ],
-      "direct_transition": "Allergic_Rhinitis_Symptom1"
+      "direct_transition": "Prescribe_OTC_Antihistamine"
     },
     "Allergic_Rhinitis_Symptom1": {
       "type": "Symptom",
@@ -214,7 +214,7 @@
         "high": 3,
         "unit": "weeks"
       },
-      "direct_transition": "Prescribe_OTC_Antihistamine"
+      "direct_transition": "Allergic_Rhinitis_Diagnosis"
     },
     "Prescribe_OTC_Antihistamine": {
       "type": "CallSubmodule",

--- a/src/main/resources/modules/asthma.json
+++ b/src/main/resources/modules/asthma.json
@@ -436,7 +436,7 @@
           "display": "Asthma"
         }
       ],
-      "direct_transition": "Maintaining_Asthma"
+      "direct_transition": "End_Wellness_1"
     },
     "Potential_Asthma_Attack": {
       "type": "Simple",
@@ -595,10 +595,18 @@
     "End_Asthma_CarePlan": {
       "type": "CarePlanEnd",
       "referenced_by_attribute": "asthma_careplan",
-      "direct_transition": "Terminal"
+      "direct_transition": "End_Wellness_2"
     },
     "Terminal": {
       "type": "Terminal"
+    },
+    "End_Wellness_1": {
+      "type": "EncounterEnd",
+      "direct_transition": "Maintaining_Asthma"
+    },
+    "End_Wellness_2": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
     }
   }
 }

--- a/src/main/resources/modules/bronchitis.json
+++ b/src/main/resources/modules/bronchitis.json
@@ -98,7 +98,6 @@
       },
       "direct_transition": "Bronchitis_Symptom4"
     },
-
     "Bronchitis_Symptom4": {
       "type": "Symptom",
       "symptom": "Sore Throat",
@@ -108,7 +107,6 @@
       },
       "direct_transition": "Bronchitis_Symptom5"
     },
-
     "Bronchitis_Symptom5": {
       "type": "Symptom",
       "symptom": "Fatigue",
@@ -118,7 +116,6 @@
       },
       "direct_transition": "Bronchitis_Symptom6"
     },
-
     "Bronchitis_Symptom6": {
       "type": "Symptom",
       "symptom": "Fever",
@@ -128,7 +125,6 @@
       },
       "direct_transition": "Bronchitis_Symptom7"
     },
-
     "Bronchitis_Symptom7": {
       "type": "Symptom",
       "symptom": "Body Aches",
@@ -533,6 +529,10 @@
     "End_Bronchitis_CarePlan": {
       "type": "CarePlanEnd",
       "referenced_by_attribute": "bronchitis_careplan",
+      "direct_transition": "End_Wellness_Visit"
+    },
+    "End_Wellness_Visit": {
+      "type": "EncounterEnd",
       "direct_transition": "Potential_Infection"
     }
   }

--- a/src/main/resources/modules/copd.json
+++ b/src/main/resources/modules/copd.json
@@ -712,7 +712,7 @@
           "display": "FEV1/FVC"
         }
       ],
-      "direct_transition": "Loop_back_to_Living_with_COPD"
+      "direct_transition": "End_COPD_Followup_Enc2"
     },
     "Stage2_FEV_Result": {
       "type": "Observation",
@@ -785,7 +785,7 @@
               }
             ]
           },
-          "transition": "Consider_Surgery"
+          "transition": "End_COPD_Followup_Enc1"
         },
         {
           "transition": "Prescribe_Medication"
@@ -802,7 +802,7 @@
           "display": "60 ACTUAT Fluticasone propionate 0.25 MG/ACTUAT / salmeterol 0.05 MG/ACTUAT Dry Powder Inhaler"
         }
       ],
-      "direct_transition": "Consider_Surgery",
+      "direct_transition": "End_COPD_Followup_Enc1",
       "chronic": true
     },
     "Consider_Surgery": {
@@ -997,6 +997,14 @@
           "transition": "Living_with_COPD"
         }
       ]
+    },
+    "End_COPD_Followup_Enc2": {
+      "type": "EncounterEnd",
+      "direct_transition": "Loop_back_to_Living_with_COPD"
+    },
+    "End_COPD_Followup_Enc1": {
+      "type": "EncounterEnd",
+      "direct_transition": "Consider_Surgery"
     }
   }
 }

--- a/src/main/resources/modules/covid19/admission.json
+++ b/src/main/resources/modules/covid19/admission.json
@@ -531,7 +531,7 @@
     "End_Outcomes": {
       "type": "CallSubmodule",
       "submodule": "covid19/end_outcomes",
-      "direct_transition": "Terminal"
+      "direct_transition": "End_Encounter"
     },
     "Transfer": {
       "type": "EncounterEnd",
@@ -1179,6 +1179,10 @@
       "remarks": [
         "Every 6 hours."
       ]
+    },
+    "End_Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
     }
   }
 }

--- a/src/main/resources/modules/dementia.json
+++ b/src/main/resources/modules/dementia.json
@@ -1,4 +1,3 @@
-
 {
   "name": "Dementia",
   "remarks": [
@@ -325,7 +324,7 @@
           ]
         },
         {
-          "transition": "ModerateDecline",
+          "transition": "End_Diagnosis_Encounter",
           "remarks": [
             "before 1993 there were no specific drugs approved for Alzheimer’s by the fda"
           ]
@@ -343,7 +342,7 @@
           "display": "Galantamine 4 MG Oral Tablet"
         }
       ],
-      "direct_transition": "ModerateDecline"
+      "direct_transition": "End_Diagnosis_Encounter"
     },
     "FirstPrescription2": {
       "type": "MedicationOrder",
@@ -356,7 +355,7 @@
           "display": "Donepezil hydrochloride 10 MG Oral Tablet"
         }
       ],
-      "direct_transition": "ModerateDecline"
+      "direct_transition": "End_Diagnosis_Encounter"
     },
     "FirstPrescription3": {
       "type": "MedicationOrder",
@@ -369,7 +368,7 @@
           "display": "Tacrine 10 MG Oral Capsule"
         }
       ],
-      "direct_transition": "ModerateDecline"
+      "direct_transition": "End_Diagnosis_Encounter"
     },
     "ModerateDecline": {
       "type": "Delay",
@@ -727,6 +726,10 @@
     },
     "Terminal": {
       "type": "Terminal"
+    },
+    "End_Diagnosis_Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "ModerateDecline"
     }
   }
 }

--- a/src/main/resources/modules/dermatitis.json
+++ b/src/main/resources/modules/dermatitis.json
@@ -199,7 +199,7 @@
       ],
       "direct_transition": "Dermatitis_Symptom1"
     },
-     "Dermatitis_Symptom1": {
+    "Dermatitis_Symptom1": {
       "type": "Symptom",
       "symptom": "Itchiness",
       "range": {
@@ -591,7 +591,7 @@
       "prescription": {
         "as_needed": true
       },
-      "direct_transition": "Treating_Flare_Up"
+      "direct_transition": "End_Flare_Up_Encounter"
     },
     "Treating_Flare_Up": {
       "type": "Delay",
@@ -660,7 +660,7 @@
       },
       "direct_transition": "Dermatitis_Symptom2_Ends"
     },
-     "Dermatitis_Symptom2_Ends": {
+    "Dermatitis_Symptom2_Ends": {
       "type": "Symptom",
       "symptom": "Red Skin",
       "exact": {
@@ -668,7 +668,7 @@
       },
       "direct_transition": "Dermatitis_Symptom3_Ends"
     },
-     "Dermatitis_Symptom3_Ends": {
+    "Dermatitis_Symptom3_Ends": {
       "type": "Symptom",
       "symptom": "Rash",
       "exact": {
@@ -676,9 +676,12 @@
       },
       "direct_transition": "Terminal"
     },
-  
     "Terminal": {
       "type": "Terminal"
+    },
+    "End_Flare_Up_Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Treating_Flare_Up"
     }
   }
 }

--- a/src/main/resources/modules/ear_infections.json
+++ b/src/main/resources/modules/ear_infections.json
@@ -234,10 +234,10 @@
     "Ear_Infection_End": {
       "type": "ConditionEnd",
       "condition_onset": "Gets_Ear_Infection",
-      "direct_transition": "Loopback_No_Infection"
+      "direct_transition": "End_Wellness_No_Infection"
     },
-    "Loopback_No_Infection": {
-      "type": "Simple",
+    "End_Wellness_No_Infection": {
+      "type": "EncounterEnd",
       "direct_transition": "No_Infection",
       "remarks": [
         "this state only exists to make the graph look nicer"

--- a/src/main/resources/modules/hypertension.json
+++ b/src/main/resources/modules/hypertension.json
@@ -318,7 +318,7 @@
           }
         },
         {
-          "transition": "Wellness_Encounter"
+          "transition": "End_Wellness_No_Action"
         }
       ]
     },
@@ -546,6 +546,10 @@
       "attribute": "blood_pressure_controlled",
       "value": true,
       "direct_transition": "Delay_2_Month_2"
+    },
+    "End_Wellness_No_Action": {
+      "type": "EncounterEnd",
+      "direct_transition": "Wellness_Encounter"
     }
   }
 }

--- a/src/main/resources/modules/med_rec.json
+++ b/src/main/resources/modules/med_rec.json
@@ -22,7 +22,7 @@
         },
         {
           "distribution": 0.55,
-          "transition": "Initial"
+          "transition": "End_Wellness_Encounter"
         }
       ]
     },
@@ -35,6 +35,10 @@
           "display": "Medication Reconciliation (procedure)"
         }
       ],
+      "direct_transition": "End_Wellness_Encounter"
+    },
+    "End_Wellness_Encounter": {
+      "type": "EncounterEnd",
       "direct_transition": "Initial"
     }
   }

--- a/src/main/resources/modules/metabolic_syndrome_care.json
+++ b/src/main/resources/modules/metabolic_syndrome_care.json
@@ -186,7 +186,7 @@
           "remarks": [
             "Normal level"
           ],
-          "transition": "Wellness_Encounter"
+          "transition": "End_Wellness_Encounter"
         },
         {
           "condition": {
@@ -2184,7 +2184,7 @@
     },
     "Living_With_Diabetes": {
       "type": "Simple",
-      "direct_transition": "Wellness_Encounter"
+      "direct_transition": "End_Wellness_Encounter"
     },
     "check CKD": {
       "type": "Simple",
@@ -2298,7 +2298,7 @@
           }
         },
         {
-          "transition": "Wellness_Encounter"
+          "transition": "End_Wellness_Encounter"
         }
       ]
     },
@@ -2312,7 +2312,7 @@
           "display": "Body mass index 30+ - obesity (finding)"
         }
       ],
-      "direct_transition": "Wellness_Encounter",
+      "direct_transition": "End_Wellness_Encounter",
       "assign_to_attribute": "obesity"
     },
     "Severe Obesity": {
@@ -2326,7 +2326,7 @@
           "display": "Body mass index 40+ - severely obese (finding)"
         }
       ],
-      "direct_transition": "Wellness_Encounter"
+      "direct_transition": "End_Wellness_Encounter"
     },
     "Record_MetabolicPanel": {
       "type": "DiagnosticReport",
@@ -4104,6 +4104,10 @@
         "",
         ""
       ]
+    },
+    "End_Wellness_Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Wellness_Encounter"
     }
   }
 }

--- a/src/main/resources/modules/osteoporosis.json
+++ b/src/main/resources/modules/osteoporosis.json
@@ -121,13 +121,13 @@
       },
       "direct_transition": "Onset_Osteoporosis"
     },
-    "Onset_Osteoporosis" : {
-      "type" : "SetAttribute",
-      "attribute" : "osteoporosis",
-      "value" : true,
-      "direct_transition" : "Osteoporosis_Symptom1"
+    "Onset_Osteoporosis": {
+      "type": "SetAttribute",
+      "attribute": "osteoporosis",
+      "value": true,
+      "direct_transition": "Osteoporosis_Symptom1"
     },
-     "Osteoporosis_Symptom1": {
+    "Osteoporosis_Symptom1": {
       "type": "Symptom",
       "symptom": "Decrease in Height",
       "range": {
@@ -213,7 +213,7 @@
           "transition": "Prescribe_Bisphosphate"
         },
         {
-          "transition": "Terminal",
+          "transition": "End_Diagnosis_Encounter",
           "remarks": "bisphosphates are the best medicine for osteoporosis, but not available until ~1995"
         }
       ]
@@ -227,10 +227,14 @@
           "display": "Alendronic acid 10 MG Oral Tablet"
         }
       ],
-      "direct_transition": "Terminal"
+      "direct_transition": "End_Diagnosis_Encounter"
     },
     "Terminal": {
       "type": "Terminal"
+    },
+    "End_Diagnosis_Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
     }
   }
 }

--- a/src/main/resources/modules/urinary_tract_infections.json
+++ b/src/main/resources/modules/urinary_tract_infections.json
@@ -134,7 +134,7 @@
           "display": "Escherichia coli urinary tract infection"
         }
       ],
-      "direct_transition": "UTI_Diagnosis"
+      "direct_transition": "UTI_Symptom1"
     },
     "Cystitis": {
       "type": "ConditionOnset",
@@ -147,7 +147,7 @@
           "display": "Cystitis"
         }
       ],
-      "direct_transition": "UTI_Diagnosis"
+      "direct_transition": "UTI_Symptom1"
     },
     "Pyelonephritis": {
       "type": "ConditionOnset",
@@ -160,7 +160,7 @@
           "display": "Pyelonephritis"
         }
       ],
-      "direct_transition": "UTI_Diagnosis"
+      "direct_transition": "UTI_Symptom1"
     },
     "UTI_Diagnosis": {
       "type": "Encounter",
@@ -173,7 +173,7 @@
           "display": "Encounter for symptom"
         }
       ],
-      "direct_transition": "UTI_Symptom1"
+      "direct_transition": "Prescribe_UTI_Antibiotic"
     },
     "UTI_Symptom1": {
       "type": "Symptom",
@@ -240,12 +240,12 @@
     },
     "Symptom_Period": {
       "type": "Delay",
-      "range" : {
-        "low" : 24,
-        "high" : 48,
-        "unit" : "days"
+      "range": {
+        "low": 24,
+        "high": 48,
+        "unit": "days"
       },
-      "direct_transition" : "Prescribe_UTI_Antibiotic"
+      "direct_transition": "UTI_Diagnosis"
     },
     "Prescribe_UTI_Antibiotic": {
       "type": "MedicationOrder",

--- a/src/main/resources/modules/wellness_encounters.json
+++ b/src/main/resources/modules/wellness_encounters.json
@@ -476,7 +476,7 @@
         "code": 449868002,
         "display": "Current every day smoker"
       },
-      "direct_transition": "Wellness_Encounter"
+      "direct_transition": "End_Of_Wellness_Encounter"
     },
     "Record_Former_Smoker": {
       "type": "Observation",
@@ -489,7 +489,7 @@
           "display": "Tobacco smoking status NHIS"
         }
       ],
-      "direct_transition": "Wellness_Encounter",
+      "direct_transition": "End_Of_Wellness_Encounter",
       "value_code": {
         "system": "SNOMED-CT",
         "code": 8517006,
@@ -507,7 +507,7 @@
           "display": "Tobacco smoking status NHIS"
         }
       ],
-      "direct_transition": "Wellness_Encounter",
+      "direct_transition": "End_Of_Wellness_Encounter",
       "value_code": {
         "system": "SNOMED-CT",
         "code": 266919005,
@@ -848,6 +848,10 @@
       ],
       "direct_transition": "Lab_MetabolicPanel",
       "vital_sign": "Respiration Rate"
+    },
+    "End_Of_Wellness_Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Wellness_Encounter"
     }
   }
 }


### PR DESCRIPTION
This pull request:

1. Adds encounter end states for encounters that were left open in modules
2. Moves symptom delays out of encounters to ensure they run for a more realistic length of time
3. Ensures sub-module encounters are removed from the list of current module encounters

The net result is that wellness encounters that were being blocked by open encounters will now proceed.