### PR TITLE
Fix for encounters that end after death

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -430,6 +430,24 @@ public abstract class State implements Cloneable, Serializable {
     }
   }
 
+  public static abstract class Delayable extends State {
+    // next is "transient" in the sense that it represents object state
+    // as opposed to the other fields which represent object definition
+    // hence it is not set in clone()
+    public Long next;
+
+    public abstract long endOfDelay(long time, Person person);
+
+    @Override
+    public boolean process(Person person, long time) {
+      if (this.next == null) {
+        this.next = this.endOfDelay(time, person);
+      }
+
+      return ((time >= this.next) && person.alive(this.next));
+    }
+  }
+
   /**
    * The Delay state type introduces a pre-configured temporal delay in the module's timeline. As a
    * simple example, a Delay state may indicate a one-month gap in time between an initial encounter
@@ -445,15 +463,9 @@ public abstract class State implements Cloneable, Serializable {
    * state that it can't pass through, it will process it once more using the original (7-day time
    * step) time.
    */
-  public static class Delay extends State {
-    // next is "transient" in the sense that it represents object state
-    // as opposed to the other fields which represent object definition
-    // hence it is not set in clone()
-    public Long next;
-
+  public static class Delay extends Delayable {
     private RangeWithUnit<Long> range;
     private ExactWithUnit<Long> exact;
-
 
     @Override
     public Delay clone() {
@@ -464,22 +476,16 @@ public abstract class State implements Cloneable, Serializable {
     }
 
     @Override
-    public boolean process(Person person, long time) {
-      if (this.next == null) {
-        if (exact != null) {
-          // use an exact quantity
-          this.next = time + Utilities.convertTime(exact.unit, exact.quantity);
-        } else if (range != null) {
-          // use a range
-          this.next =
-              time + Utilities.convertTime(range.unit,
-                  (long) person.rand(range.low, range.high));
-        } else {
-          throw new RuntimeException("Delay state has no exact or range: " + this);
-        }
+    public long endOfDelay(long time, Person person) {
+      if (exact != null) {
+        // use an exact quantity
+        return time + Utilities.convertTime(exact.unit, exact.quantity);
+      } else if (range != null) {
+        // use a range
+        return time + Utilities.convertTime(range.unit, (long) person.rand(range.low, range.high));
+      } else {
+        throw new RuntimeException("Delay state has no exact or range: " + this);
       }
-
-      return ((time >= this.next) && person.alive(this.next));
     }
   }
 
@@ -1333,11 +1339,12 @@ public abstract class State implements Cloneable, Serializable {
    * Optionally, you may define a duration of time that the procedure takes. The Procedure also
    * supports identifying a previous ConditionOnset or an attribute as the reason for the procedure.
    */
-  public static class Procedure extends State {
+  public static class Procedure extends Delayable {
     private List<Code> codes;
     private String reason;
     private RangeWithUnit<Long> duration;
     private String assignToAttribute;
+    private Long stop;
 
     @Override
     public Procedure clone() {
@@ -1347,6 +1354,15 @@ public abstract class State implements Cloneable, Serializable {
       clone.duration = duration;
       clone.assignToAttribute = assignToAttribute;
       return clone;
+    }
+
+    @Override
+    public long endOfDelay(long time, Person person) {
+      if (duration == null) {
+        return time;
+      } else {
+        return this.stop;
+      }
     }
 
     @Override
@@ -1372,10 +1388,10 @@ public abstract class State implements Cloneable, Serializable {
           }
         }
       }
-      if (duration != null) {
+      if (duration != null && this.stop == null) {
         double durationVal = person.rand(duration.low, duration.high);
-        procedure.stop = procedure.start
-            + Utilities.convertTime(duration.unit, (long) durationVal);
+        this.stop = procedure.start + Utilities.convertTime(duration.unit, (long) durationVal);
+        procedure.stop = this.stop;
       }
       // increment number of procedures by respective hospital
       Provider provider;
@@ -1391,7 +1407,7 @@ public abstract class State implements Cloneable, Serializable {
         person.attributes.put(assignToAttribute, procedure);
       }
 
-      return true;
+      return super.process(person, time);
     }
   }
 

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -178,10 +178,10 @@ public abstract class State implements Cloneable, Serializable {
     boolean exit = process(person, time);
 
     if (exit) {
-      // Delay state returns a special value for exited,
-      // to indicate when the delay actually completed.
-      if (this instanceof Delay) {
-        this.exited = ((Delay)this).next;
+      // Delayable states return a special value for exited,
+      // to indicate when the state actually completed.
+      if (this instanceof Delayable) {
+        this.exited = ((Delayable)this).next;
       } else {
         this.exited = time;
       }

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -430,7 +430,7 @@ public abstract class State implements Cloneable, Serializable {
     }
   }
 
-  public static abstract class Delayable extends State {
+  public abstract static class Delayable extends State {
     // next is "transient" in the sense that it represents object state
     // as opposed to the other fields which represent object definition
     // hence it is not set in clone()

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -13,7 +13,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -431,13 +432,19 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
    */
   public void recordDeath(long time, Code cause) {
     if (alive(time)) {
-      attributes.put(Person.DEATHDATE, Long.valueOf(time));
+      Optional<Long> lastEncounterStop =
+          this.record.encounters.stream().map(encounter -> encounter.stop).max(Long::compareTo);
+      long deathTime = time;
+      if (lastEncounterStop.isPresent() && lastEncounterStop.get() > time) {
+        deathTime = lastEncounterStop.get();
+      }
+      attributes.put(Person.DEATHDATE, Long.valueOf(deathTime));
       if (cause == null) {
         attributes.remove(CAUSE_OF_DEATH);
       } else {
         attributes.put(CAUSE_OF_DEATH, cause);
       }
-      record.death = time;
+      record.death = deathTime;
     }
   }
 

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -432,12 +432,7 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
    */
   public void recordDeath(long time, Code cause) {
     if (alive(time)) {
-      Optional<Long> lastEncounterStop =
-          this.record.encounters.stream().map(encounter -> encounter.stop).max(Long::compareTo);
       long deathTime = time;
-      if (lastEncounterStop.isPresent() && lastEncounterStop.get() > time) {
-        deathTime = lastEncounterStop.get();
-      }
       attributes.put(Person.DEATHDATE, Long.valueOf(deathTime));
       if (cause == null) {
         attributes.remove(CAUSE_OF_DEATH);

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -991,14 +991,6 @@ public class HealthRecord implements Serializable {
         if (time > encounter.stop) {
           encounter.stop = time;
         }
-        // Now, add time for each procedure.
-        long procedureTime;
-        for (Procedure p : encounter.procedures) {
-          procedureTime = (p.stop - p.start);
-          if (procedureTime > 0) {
-            encounter.stop += procedureTime;
-          }
-        }
         // Update Costs/Claim infomation.
         encounter.determineCost();
         encounter.claim.assignCosts();

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -188,7 +188,7 @@ public class Location implements Serializable {
   }
 
   /**
-   * Pick the name of a random city from the current "world"?
+   * Pick the name of a random city from the current "world".
    * @param random The source of randomness.
    * @return Demographics of a random city.
    */

--- a/src/test/java/org/mitre/synthea/engine/LogicTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LogicTest.java
@@ -289,6 +289,8 @@ public class LogicTest {
     person.hasMultipleRecords = true;
     person.records = new ConcurrentHashMap<String, HealthRecord>();
     module.process(person, time);
+    long nextStep = time + Utilities.convertTime("days", 7);
+    module.process(person, nextStep);
     assertTrue(person.hasMultipleRecords);
     assertEquals(2, person.records.size());
     assertEquals(0, person.record.currentEncounter(time).conditions.size());
@@ -309,6 +311,8 @@ public class LogicTest {
     person.hasMultipleRecords = true;
     person.records = new ConcurrentHashMap<String, HealthRecord>();
     module.process(person, time);
+    long nextStep = time + Utilities.convertTime("days", 7);
+    module.process(person, nextStep);
     person.record = person.records.get("Mock-Provider");
     assertTrue(person.hasMultipleRecords);
     assertEquals(2, person.records.size());

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -434,17 +434,19 @@ public class StateTest {
 
     // patient dies during the process
     module.process(person, time);
+    long nextStep = time + Utilities.convertTime("days", 7);
+    module.process(person, nextStep);
 
     // patient is dead later...
-    long step = Utilities.convertTime("days", 7);
-    assertFalse(person.alive(time + step));
+    assertFalse(person.alive(nextStep));
 
     // patient has one encounter...
     assertTrue(person.hadPriorState("Encounter 1"));
     assertEquals(1, person.record.encounters.size());
 
-    assertTrue((long) person.attributes.get(Person.DEATHDATE)
-        >= person.record.encounters.get(0).stop);
+    long deathDate = (long) person.attributes.get(Person.DEATHDATE);
+    long encounterStop = person.record.encounters.get(0).stop;
+    assertTrue(deathDate >= encounterStop);
   }
 
   @Test
@@ -610,7 +612,10 @@ public class StateTest {
     // Then have the appendectomy
     State appendectomy = module.getState("Appendectomy");
     appendectomy.entered = time;
-    assertTrue(appendectomy.process(person, time));
+    // Procedure should block
+    assertTrue( !appendectomy.process(person, time));
+    long nextStep = time + Utilities.convertTime("days", 7);
+    assertTrue(appendectomy.process(person, nextStep));
 
     HealthRecord.Procedure proc = person.record.encounters.get(0).procedures.get(0);
     Code code = proc.codes.get(0);

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -426,6 +426,28 @@ public class StateTest {
   }
 
   @Test
+  public void deathAfterProcedureWithDuration() throws Exception {
+    Module module = TestHelper.getFixture("procedure_duration_and_death.json");
+
+    // patient is alive
+    assertTrue(person.alive(time));
+
+    // patient dies during the process
+    module.process(person, time);
+
+    // patient is dead later...
+    long step = Utilities.convertTime("days", 7);
+    assertFalse(person.alive(time + step));
+
+    // patient has one encounter...
+    assertTrue(person.hadPriorState("Encounter 1"));
+    assertEquals(1, person.record.encounters.size());
+
+    assertTrue((long) person.attributes.get(Person.DEATHDATE)
+        >= person.record.encounters.get(0).stop);
+  }
+
+  @Test
   public void vitalsign() throws Exception {
     // Setup a mock to track calls to the patient record
     // In this case, the record shouldn't be called at all

--- a/src/test/resources/generic/procedure_duration_and_death.json
+++ b/src/test/resources/generic/procedure_duration_and_death.json
@@ -1,0 +1,60 @@
+{
+  "name": "Procedure Length and Death",
+  "remarks": [
+    "Unit Test to ensure that procedure length ",
+    "does not cause an encounter end to extend ",
+    "beyond the deathdate"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Encounter 1",
+      "name": "Initial"
+    },
+    "Terminal": {
+      "type": "Terminal",
+      "name": "Terminal"
+    },
+    "Encounter 1": {
+      "type": "Encounter",
+      "encounter_class": "emergency",
+      "reason": "",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "1234",
+          "display": "Encounter 1"
+        }
+      ],
+      "name": "Encounter 1",
+      "direct_transition": "Procedure_With_Duration"
+    },
+    "Death": {
+      "type": "Death",
+      "direct_transition": "Terminal",
+      "name": "Death"
+    },
+    "End Encounter 1": {
+      "type": "EncounterEnd",
+      "direct_transition": "Death",
+      "name": "End Encounter 1"
+    },
+    "Procedure_With_Duration": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "1234",
+          "display": "Does not matter"
+        }
+      ],
+      "duration": {
+        "low": 24,
+        "high": 48,
+        "unit": "hours"
+      },
+      "direct_transition": "End Encounter 1",
+      "name": "Procedure_With_Duration"
+    }
+  }
+}


### PR DESCRIPTION
This change addresses issue #735.

**Edit**
The PR has now been changed.  

Procedure now acts like a Delay state. This PR introduces an abstract Delayable state that is now implemented by Delay and Procedure.

**Old PR**
Procedures with duration add time to the end of an encounter. That pushes the end of the encounter beyond the current time step. If an encounter is ended and followed by a death state, the time of death is set to the current time step. This means that the death will happen before the encounter is closed.

This PR changes the Death state to look at the end time of the last encounter. If that happens, it will push the time back to the end of the encounter. 

