### PR TITLE
Recreation

### DIFF
--- a/src/main/java/App.java
+++ b/src/main/java/App.java
@@ -1,9 +1,11 @@
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.Queue;
+import java.util.TimeZone;
 
 import org.mitre.synthea.engine.Generator;
 import org.mitre.synthea.engine.Module;
@@ -20,6 +22,7 @@ public class App {
   public static void usage() {
     System.out.println("Usage: run_synthea [options] [state [city]]");
     System.out.println("Options: [-s seed] [-cs clinicianSeed] [-p populationSize]");
+    System.out.println("         [-r referenceDate as YYYYMMDD]");
     System.out.println("         [-g gender] [-a minAge-maxAge]");
     System.out.println("         [-o overflowPopulation]");
     System.out.println("         [-m moduleFileWildcardList]");
@@ -69,6 +72,11 @@ public class App {
           } else if (currArg.equalsIgnoreCase("-cs")) {
             String value = argsQ.poll();
             options.clinicianSeed = Long.parseLong(value);
+          } else if (currArg.equalsIgnoreCase("-r")) {
+            String value = argsQ.poll();
+            SimpleDateFormat format = new SimpleDateFormat("YYYYMMDD");
+            format.setTimeZone(TimeZone.getTimeZone("UTC"));
+            options.referenceTime = format.parse(value).getTime();
           } else if (currArg.equalsIgnoreCase("-p")) {
             String value = argsQ.poll();
             options.population = Integer.parseInt(value);

--- a/src/main/java/org/mitre/synthea/editors/GrowthDataErrorsEditor.java
+++ b/src/main/java/org/mitre/synthea/editors/GrowthDataErrorsEditor.java
@@ -3,7 +3,6 @@ package org.mitre.synthea.editors;
 import com.google.gson.Gson;
 
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Collectors;
 
 import org.mitre.synthea.engine.HealthRecordEditor;
@@ -86,34 +85,32 @@ public class GrowthDataErrorsEditor implements HealthRecordEditor {
    * @param person The Synthea person to check on whether the module should be run
    * @param encounters The encounters that took place during the last time step of the simulation
    * @param time The current time in the simulation
-   * @param random Random generator that should be used when randomness is needed
    */
-  public void process(Person person, List<HealthRecord.Encounter> encounters, long time,
-                      Random random) {
+  public void process(Person person, List<HealthRecord.Encounter> encounters, long time) {
     List<HealthRecord.Encounter> encountersWithWeights =
         encountersWithObservationsOfCode(encounters, WEIGHT_LOINC_CODE);
     encountersWithWeights.forEach(e -> {
-      if (random.nextDouble() <= config.weightUnitErrorRate) {
+      if (person.rand() <= config.weightUnitErrorRate) {
         introduceWeightUnitError(e);
         recalculateBMI(e);
       }
-      if (random.nextDouble() <= config.weightTransposeErrorRate) {
+      if (person.rand() <= config.weightTransposeErrorRate) {
         introduceTransposeError(e, "weight");
         recalculateBMI(e);
       }
-      if (random.nextDouble() <= config.weightSwitchErrorRate) {
+      if (person.rand() <= config.weightSwitchErrorRate) {
         introduceWeightSwitchError(e);
         recalculateBMI(e);
       }
-      if (random.nextDouble() <= config.weightExtremeErrorRate) {
+      if (person.rand() <= config.weightExtremeErrorRate) {
         introduceWeightExtremeError(e);
         recalculateBMI(e);
       }
-      if (random.nextDouble() <= config.weightDuplicateErrorRate) {
-        introduceWeightDuplicateError(e, random);
+      if (person.rand() <= config.weightDuplicateErrorRate) {
+        introduceWeightDuplicateError(e, person);
         recalculateBMI(e);
       }
-      if (random.nextDouble() <= config.weightCarriedForwardErrorRate) {
+      if (person.rand() <= config.weightCarriedForwardErrorRate) {
         introduceWeightCarriedForwardError(e);
         recalculateBMI(e);
       }
@@ -122,31 +119,31 @@ public class GrowthDataErrorsEditor implements HealthRecordEditor {
     List<HealthRecord.Encounter> encountersWithHeights =
         encountersWithObservationsOfCode(encounters, HEIGHT_LOINC_CODE);
     encountersWithHeights.forEach(e -> {
-      if (random.nextDouble() <= config.heightUnitErrorRate) {
+      if (person.rand() <= config.heightUnitErrorRate) {
         introduceHeightUnitError(e);
         recalculateBMI(e);
       }
-      if (random.nextDouble() <= config.heightTransposeErrorRate) {
+      if (person.rand() <= config.heightTransposeErrorRate) {
         introduceTransposeError(e, "height");
         recalculateBMI(e);
       }
-      if (random.nextDouble() <= config.heightSwitchErrorRate) {
+      if (person.rand() <= config.heightSwitchErrorRate) {
         introduceHeightSwitchError(e);
         recalculateBMI(e);
       }
-      if (random.nextDouble() <= config.heightExtremeErrorRate) {
+      if (person.rand() <= config.heightExtremeErrorRate) {
         introduceHeightExtremeError(e);
         recalculateBMI(e);
       }
-      if (random.nextDouble() <= config.heightAbsoluteErrorRate) {
-        introduceHeightAbsoluteError(e, random);
+      if (person.rand() <= config.heightAbsoluteErrorRate) {
+        introduceHeightAbsoluteError(e, person);
         recalculateBMI(e);
       }
-      if (random.nextDouble() <= config.heightDuplicateErrorRate) {
-        introduceHeightDuplicateError(e, random);
+      if (person.rand() <= config.heightDuplicateErrorRate) {
+        introduceHeightDuplicateError(e, person);
         recalculateBMI(e);
       }
-      if (random.nextDouble() <= config.heightCarriedForwardErrorRate) {
+      if (person.rand() <= config.heightCarriedForwardErrorRate) {
         introduceHeightCarriedForwardError(e);
         recalculateBMI(e);
       }
@@ -273,10 +270,11 @@ public class GrowthDataErrorsEditor implements HealthRecordEditor {
    * shoes before getting measured.
    * @param encounter The encounter that contains the observation
    */
-  public static void introduceHeightAbsoluteError(HealthRecord.Encounter encounter, Random random) {
+  public static void introduceHeightAbsoluteError(HealthRecord.Encounter encounter,
+                                                  Person person) {
     HealthRecord.Observation htObs = heightObservation(encounter);
     double heightValue = (Double) htObs.value;
-    double additionalAbsolute = random.nextDouble() * 3;
+    double additionalAbsolute = person.rand() * 3;
     htObs.value = heightValue - (3 + additionalAbsolute);
   }
 
@@ -285,10 +283,10 @@ public class GrowthDataErrorsEditor implements HealthRecordEditor {
    * @param encounter The encounter that contains the observation
    */
   public static void introduceWeightDuplicateError(HealthRecord.Encounter encounter,
-                                                   Random random) {
+                                                   Person person) {
     HealthRecord.Observation wtObs = weightObservation(encounter);
     double weightValue = (Double) wtObs.value;
-    double jitter = random.nextDouble() - 0.5;
+    double jitter = person.rand() - 0.5;
     HealthRecord.Observation newObs =
         encounter.addObservation(wtObs.start, wtObs.type, weightValue + jitter, "Body Weight");
     newObs.category = "vital-signs";
@@ -300,10 +298,10 @@ public class GrowthDataErrorsEditor implements HealthRecordEditor {
    * @param encounter The encounter that contains the observation
    */
   public static void introduceHeightDuplicateError(HealthRecord.Encounter encounter,
-                                                   Random random) {
+                                                   Person person) {
     HealthRecord.Observation htObs = heightObservation(encounter);
     double heightValue = (Double) htObs.value;
-    double jitter = random.nextDouble() - 0.5;
+    double jitter = person.rand() - 0.5;
     HealthRecord.Observation newObs = encounter.addObservation(htObs.start, htObs.type,
         heightValue + jitter, "Body Height");
     newObs.category = "vital-signs";

--- a/src/main/java/org/mitre/synthea/editors/GrowthDataErrorsEditor.java
+++ b/src/main/java/org/mitre/synthea/editors/GrowthDataErrorsEditor.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.mitre.synthea.engine.HealthRecordEditor;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.HealthRecord;
@@ -271,10 +272,10 @@ public class GrowthDataErrorsEditor implements HealthRecordEditor {
    * @param encounter The encounter that contains the observation
    */
   public static void introduceHeightAbsoluteError(HealthRecord.Encounter encounter,
-                                                  Person person) {
+                                                  RandomNumberGenerator random) {
     HealthRecord.Observation htObs = heightObservation(encounter);
     double heightValue = (Double) htObs.value;
-    double additionalAbsolute = person.rand() * 3;
+    double additionalAbsolute = random.rand() * 3;
     htObs.value = heightValue - (3 + additionalAbsolute);
   }
 
@@ -283,10 +284,10 @@ public class GrowthDataErrorsEditor implements HealthRecordEditor {
    * @param encounter The encounter that contains the observation
    */
   public static void introduceWeightDuplicateError(HealthRecord.Encounter encounter,
-                                                   Person person) {
+                                                   RandomNumberGenerator random) {
     HealthRecord.Observation wtObs = weightObservation(encounter);
     double weightValue = (Double) wtObs.value;
-    double jitter = person.rand() - 0.5;
+    double jitter = random.rand() - 0.5;
     HealthRecord.Observation newObs =
         encounter.addObservation(wtObs.start, wtObs.type, weightValue + jitter, "Body Weight");
     newObs.category = "vital-signs";
@@ -298,10 +299,10 @@ public class GrowthDataErrorsEditor implements HealthRecordEditor {
    * @param encounter The encounter that contains the observation
    */
   public static void introduceHeightDuplicateError(HealthRecord.Encounter encounter,
-                                                   Person person) {
+                                                   RandomNumberGenerator random) {
     HealthRecord.Observation htObs = heightObservation(encounter);
     double heightValue = (Double) htObs.value;
-    double jitter = person.rand() - 0.5;
+    double jitter = random.rand() - 0.5;
     HealthRecord.Observation newObs = encounter.addObservation(htObs.start, htObs.type,
         heightValue + jitter, "Body Height");
     newObs.category = "vital-signs";

--- a/src/main/java/org/mitre/synthea/engine/HealthRecordEditor.java
+++ b/src/main/java/org/mitre/synthea/engine/HealthRecordEditor.java
@@ -1,7 +1,6 @@
 package org.mitre.synthea.engine;
 
 import java.util.List;
-import java.util.Random;
 
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.HealthRecord;
@@ -45,7 +44,6 @@ public interface HealthRecordEditor {
    * @param person The Synthea person that will have their HealthRecord edited
    * @param encounters The encounters that took place during the last time step of the simulation
    * @param time The current time in the simulation
-   * @param random Random generator that should be used when randomness is needed
    */
-  void process(Person person, List<HealthRecord.Encounter> encounters, long time, Random random);
+  void process(Person person, List<HealthRecord.Encounter> encounters, long time);
 }

--- a/src/main/java/org/mitre/synthea/engine/HealthRecordEditors.java
+++ b/src/main/java/org/mitre/synthea/engine/HealthRecordEditors.java
@@ -2,7 +2,6 @@ package org.mitre.synthea.engine;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Collectors;
 
 import org.mitre.synthea.world.agents.Person;
@@ -45,13 +44,12 @@ public class HealthRecordEditors {
    * <p>
    * It's unlikely that this method should be called by anything outside of Generator.
    * </p>
-   * @param person The Person to run on
+   * @param person The Person to run on, and the source of randomness
    * @param record The HealthRecord to potentially modify
    * @param time The current time in the simulation
    * @param step The time step for the simulation
-   * @param random The source of randomness that modules should use
    */
-  public void executeAll(Person person, HealthRecord record, long time, long step, Random random) {
+  public void executeAll(Person person, HealthRecord record, long time, long step) {
     if (this.registeredEditors.size() > 0) {
       long start = time - step;
       List<HealthRecord.Encounter> encountersThisStep = record.encounters.stream()
@@ -59,7 +57,7 @@ public class HealthRecordEditors {
           .collect(Collectors.toList());
       this.registeredEditors.forEach(m -> {
         if (m.shouldRun(person, record, time)) {
-          m.process(person, encountersThisStep, time, random);
+          m.process(person, encountersThisStep, time);
         }
       });
     }

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -292,8 +292,8 @@ public class Module implements Cloneable, Serializable {
     clone.name = this.name;
     clone.submodule = this.submodule;
     clone.remarks = this.remarks;
-    clone.states = new ConcurrentHashMap<String, State>();
     if (this.states != null) {
+      clone.states = new ConcurrentHashMap<String, State>();
       for (String key : this.states.keySet()) {
         clone.states.put(key, this.states.get(key).clone());
       }

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -52,7 +52,7 @@ import org.mitre.synthea.world.agents.Person;
  * across the population, it is important that States are cloned before they are executed. 
  * This keeps the "master" copy of the module clean.
  */
-public class Module implements Serializable {
+public class Module implements Cloneable, Serializable {
 
   private static final Configuration JSON_PATH_CONFIG = Configuration.builder()
       .jsonProvider(new GsonJsonProvider())
@@ -285,6 +285,23 @@ public class Module implements Serializable {
   }
 
   /**
+   * Clone this module. Never provide the original.
+   */
+  public Module clone() {
+    Module clone = new Module();
+    clone.name = this.name;
+    clone.submodule = this.submodule;
+    clone.remarks = this.remarks;
+    clone.states = new ConcurrentHashMap<String, State>();
+    if (this.states != null) {
+      for (String key : this.states.keySet()) {
+        clone.states.put(key, this.states.get(key).clone());
+      }
+    }
+    return clone;
+  }
+
+  /**
    * Process this Module with the given Person at the specified time within the simulation.
    * 
    * @param person
@@ -423,7 +440,7 @@ public class Module implements Serializable {
       if (fault != null) {
         throw new RuntimeException(fault);
       }
-      return module;
+      return module.clone();
     }
   }
 }

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -34,6 +34,7 @@ import org.mitre.synthea.engine.Transition.LookupTableTransitionOption;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.ConstantValueGenerator;
 import org.mitre.synthea.helpers.ExpressionProcessor;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.RandomValueGenerator;
 import org.mitre.synthea.helpers.TimeSeriesData;
 import org.mitre.synthea.helpers.Utilities;
@@ -1714,19 +1715,19 @@ public abstract class State implements Cloneable, Serializable {
       return true;
     }
 
-    private void duplicateSeries(Person person, long time) {
+    private void duplicateSeries(RandomNumberGenerator random, long time) {
       if (minNumberSeries > 0 && maxNumberSeries >= minNumberSeries
           && series.size() > 0) {
 
         // Randomly pick the number of series in this study
-        int numberOfSeries = (int) person.rand(minNumberSeries, maxNumberSeries + 1);
+        int numberOfSeries = (int) random.rand(minNumberSeries, maxNumberSeries + 1);
         HealthRecord.ImagingStudy.Series referenceSeries = series.get(0);
         series = new ArrayList<HealthRecord.ImagingStudy.Series>();
 
         // Create the new series with random series UID
         for (int i = 0; i < numberOfSeries; i++) {
           HealthRecord.ImagingStudy.Series newSeries = referenceSeries.clone();
-          newSeries.dicomUid = Utilities.randomDicomUid(person, time, i + 1, 0);
+          newSeries.dicomUid = Utilities.randomDicomUid(random, time, i + 1, 0);
           series.add(newSeries);
         }
       } else {
@@ -1740,7 +1741,7 @@ public abstract class State implements Cloneable, Serializable {
       }
     }
 
-    private void duplicateInstances(Person person, long time) {
+    private void duplicateInstances(RandomNumberGenerator random, long time) {
       for (int i = 0; i < series.size(); i++) {
         HealthRecord.ImagingStudy.Series s = series.get(i);
         if (s.minNumberInstances > 0 && s.maxNumberInstances >= s.minNumberInstances
@@ -1748,14 +1749,14 @@ public abstract class State implements Cloneable, Serializable {
 
           // Randomly pick the number of instances in this series
           int numberOfInstances =
-              (int) person.rand(s.minNumberInstances, s.maxNumberInstances + 1);
+              (int) random.rand(s.minNumberInstances, s.maxNumberInstances + 1);
           HealthRecord.ImagingStudy.Instance referenceInstance = s.instances.get(0);
           s.instances = new ArrayList<HealthRecord.ImagingStudy.Instance>();
 
           // Create the new instances with random instance UIDs
           for (int j = 0; j < numberOfInstances; j++) {
             HealthRecord.ImagingStudy.Instance newInstance = referenceInstance.clone();
-            newInstance.dicomUid = Utilities.randomDicomUid(person, time, i + 1, j + 1);
+            newInstance.dicomUid = Utilities.randomDicomUid(random, time, i + 1, j + 1);
             s.instances.add(newInstance);
           }
         }

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -168,7 +168,6 @@ public abstract class State implements Cloneable, Serializable {
    *         should halt for this time step.
    */
   public boolean run(Person person, long time) {
-    // System.out.format("State: %s\n", this.name);
     if (!person.alive(time)) {
       return false;
     }
@@ -337,7 +336,6 @@ public abstract class State implements Cloneable, Serializable {
 
     @Override
     public Physiology clone() {
-      super.clone();
       Physiology clone = (Physiology) super.clone();
       clone.model = model;
       clone.solver = solver;
@@ -345,6 +343,7 @@ public abstract class State implements Cloneable, Serializable {
       clone.simDuration = simDuration;
       clone.leadTime = leadTime;
       clone.altDirectTransition = altDirectTransition;
+      clone.altTransition = altTransition;
       
       List<IoMapper> inputList = new ArrayList<IoMapper>(inputs.size());
       for (IoMapper mapper : inputs) {
@@ -357,9 +356,11 @@ public abstract class State implements Cloneable, Serializable {
         outputList.add(new IoMapper(mapper));
       }
       clone.outputs = outputList;
-      
-      clone.setup();
-      
+
+      if (ENABLE_PHYSIOLOGY_STATE) {
+        clone.setup();
+      }
+
       return clone;
     }
 
@@ -470,7 +471,8 @@ public abstract class State implements Cloneable, Serializable {
         } else if (range != null) {
           // use a range
           this.next =
-              time + Utilities.convertTime(range.unit, (long) person.rand(range.low, range.high));
+              time + Utilities.convertTime(range.unit,
+                  (long) person.rand(range.low, range.high));
         } else {
           throw new RuntimeException("Delay state has no exact or range: " + this);
         }
@@ -570,7 +572,8 @@ public abstract class State implements Cloneable, Serializable {
       clone.value = value;
       clone.range = range;
       clone.expression = expression;
-      clone.threadExpProcessor = threadExpProcessor;
+      // We shouldn't clone thread local objects since the application is multi-threaded.
+      // clone.threadExpProcessor = threadExpProcessor;
       clone.seriesData = seriesData;
       clone.period = period;
       return clone;
@@ -1370,7 +1373,8 @@ public abstract class State implements Cloneable, Serializable {
       }
       if (duration != null) {
         double durationVal = person.rand(duration.low, duration.high);
-        procedure.stop = procedure.start + Utilities.convertTime(duration.unit, (long) durationVal);
+        procedure.stop = procedure.start
+            + Utilities.convertTime(duration.unit, (long) durationVal);
       }
       // increment number of procedures by respective hospital
       Provider provider;
@@ -1433,7 +1437,8 @@ public abstract class State implements Cloneable, Serializable {
       clone.vitalSign = vitalSign;
       clone.unit = unit;
       clone.expression = expression;
-      clone.threadExpProcessor = threadExpProcessor;
+      // We shouldn't clone thread local objects since the application is multi-threaded.
+      // clone.threadExpProcessor = threadExpProcessor;
       return clone;
     }
 
@@ -1533,7 +1538,8 @@ public abstract class State implements Cloneable, Serializable {
       clone.category = category;
       clone.unit = unit;
       clone.expression = expression;
-      clone.threadExpProcessor = threadExpProcessor;
+      // We shouldn't clone thread local objects since the application is multi-threaded.
+      // clone.threadExpProcessor = threadExpProcessor;
       clone.attachment = attachment;
       return clone;
     }
@@ -1691,8 +1697,8 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public boolean process(Person person, long time) {
       // Randomly pick number of series and instances if bounds were provided
-      duplicateSeries(person);
-      duplicateInstances(person);
+      duplicateSeries(person, time);
+      duplicateInstances(person, time);
 
       // The modality code of the first series is a good approximation
       // of the type of ImagingStudy this is
@@ -1708,7 +1714,7 @@ public abstract class State implements Cloneable, Serializable {
       return true;
     }
 
-    private void duplicateSeries(Person person) {
+    private void duplicateSeries(Person person, long time) {
       if (minNumberSeries > 0 && maxNumberSeries >= minNumberSeries
           && series.size() > 0) {
 
@@ -1720,7 +1726,7 @@ public abstract class State implements Cloneable, Serializable {
         // Create the new series with random series UID
         for (int i = 0; i < numberOfSeries; i++) {
           HealthRecord.ImagingStudy.Series newSeries = referenceSeries.clone();
-          newSeries.dicomUid = Utilities.randomDicomUid(i + 1, 0);
+          newSeries.dicomUid = Utilities.randomDicomUid(person, time, i + 1, 0);
           series.add(newSeries);
         }
       } else {
@@ -1734,21 +1740,22 @@ public abstract class State implements Cloneable, Serializable {
       }
     }
 
-    private void duplicateInstances(Person person) {
+    private void duplicateInstances(Person person, long time) {
       for (int i = 0; i < series.size(); i++) {
         HealthRecord.ImagingStudy.Series s = series.get(i);
         if (s.minNumberInstances > 0 && s.maxNumberInstances >= s.minNumberInstances
             && s.instances.size() > 0) {
 
           // Randomly pick the number of instances in this series
-          int numberOfInstances = (int) person.rand(s.minNumberInstances, s.maxNumberInstances + 1);
+          int numberOfInstances =
+              (int) person.rand(s.minNumberInstances, s.maxNumberInstances + 1);
           HealthRecord.ImagingStudy.Instance referenceInstance = s.instances.get(0);
           s.instances = new ArrayList<HealthRecord.ImagingStudy.Instance>();
 
           // Create the new instances with random instance UIDs
           for (int j = 0; j < numberOfInstances; j++) {
             HealthRecord.ImagingStudy.Instance newInstance = referenceInstance.clone();
-            newInstance.dicomUid = Utilities.randomDicomUid(i + 1, j + 1);
+            newInstance.dicomUid = Utilities.randomDicomUid(person, time, i + 1, j + 1);
             s.instances.add(newInstance);
           }
         }

--- a/src/main/java/org/mitre/synthea/export/CDWExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CDWExporter.java
@@ -722,7 +722,7 @@ public class CDWExporter {
     s.append(NEWLINE);
     write(s.toString(), spatientphone);
 
-    if (person.random.nextBoolean()) {
+    if (person.randBoolean()) {
       // Add an email address
       s.setLength(0);
       s.append(getNextKey(spatientphone)).append(',');

--- a/src/main/java/org/mitre/synthea/helpers/RandomCollection.java
+++ b/src/main/java/org/mitre/synthea/helpers/RandomCollection.java
@@ -6,6 +6,8 @@ import java.util.NavigableMap;
 import java.util.Random;
 import java.util.TreeMap;
 
+import org.mitre.synthea.world.agents.Person;
+
 /**
  * Random collection of objects, with weightings. Intended to be an equivalent to the ruby Pickup
  * gem. Adapted from https://stackoverflow.com/a/6409791/630384
@@ -38,7 +40,22 @@ public class RandomCollection<E> implements Serializable {
    * @return a random item from the collection weighted by the item weights.
    */
   public E next(Random random) {
-    double value = random.nextDouble() * total;
+    return next(random.nextDouble() * total);
+  }
+
+  /**
+   * Select an item from the collection at random by the weight of the items.
+   * Selecting an item from one draw, does not remove the item from the collection
+   * for subsequent draws. In other words, an item can be selected repeatedly if
+   * the weights are severely imbalanced.
+   * @param person - person object, and the source of the random number generator.
+   * @return a random item from the collection weighted by the item weights.
+   */
+  public E next(Person person) {
+    return next(person.rand() * total);
+  }
+
+  private E next(double value) {
     Entry<Double, E> entry = map.higherEntry(value);
     if (entry == null) {
       entry = map.lastEntry();

--- a/src/main/java/org/mitre/synthea/helpers/RandomCollection.java
+++ b/src/main/java/org/mitre/synthea/helpers/RandomCollection.java
@@ -6,8 +6,6 @@ import java.util.NavigableMap;
 import java.util.Random;
 import java.util.TreeMap;
 
-import org.mitre.synthea.world.agents.Person;
-
 /**
  * Random collection of objects, with weightings. Intended to be an equivalent to the ruby Pickup
  * gem. Adapted from https://stackoverflow.com/a/6409791/630384
@@ -48,11 +46,11 @@ public class RandomCollection<E> implements Serializable {
    * Selecting an item from one draw, does not remove the item from the collection
    * for subsequent draws. In other words, an item can be selected repeatedly if
    * the weights are severely imbalanced.
-   * @param person - person object, and the source of the random number generator.
+   * @param random the random number generator.
    * @return a random item from the collection weighted by the item weights.
    */
-  public E next(Person person) {
-    return next(person.rand() * total);
+  public E next(RandomNumberGenerator random) {
+    return next(random.rand() * total);
   }
 
   private E next(double value) {

--- a/src/main/java/org/mitre/synthea/helpers/RandomNumberGenerator.java
+++ b/src/main/java/org/mitre/synthea/helpers/RandomNumberGenerator.java
@@ -1,0 +1,100 @@
+package org.mitre.synthea.helpers;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Arrays;
+
+public interface RandomNumberGenerator {
+  /** Returns a double between 0-1 from a uniform distribution. */
+  public double rand();
+
+  /**
+   * Returns a random double in the given range.
+   */
+  public default double rand(double low, double high) {
+    return (low + ((high - low) * rand()));
+  }
+
+  /**
+   * Returns a random double in the given range with no more that the specified
+   * number of decimal places.
+   */
+  public default double rand(double low, double high, Integer decimals) {
+    double value = rand(low, high);
+    if (decimals != null) {
+      value = BigDecimal.valueOf(value).setScale(decimals, RoundingMode.HALF_UP).doubleValue();
+    }
+    return value;
+  }
+
+  /**
+   * Helper function to get a random number based on an array of [min, max]. This
+   * should be used primarily when pulling ranges from YML.
+   * 
+   * @param range array [min, max]
+   * @return random double between min and max
+   */
+  public default double rand(double[] range) {
+    if (range == null || range.length != 2) {
+      throw new IllegalArgumentException(
+          "input range must be of length 2 -- got " + Arrays.toString(range));
+    }
+
+    if (range[0] > range[1]) {
+      throw new IllegalArgumentException(
+          "range must be of the form {low, high} -- got " + Arrays.toString(range));
+    }
+
+    return rand(range[0], range[1]);
+  }
+
+  /**
+   * Return one of the options randomly with uniform distribution.
+   * 
+   * @param choices The options to be returned.
+   * @return One of the options randomly selected.
+   */
+  public default String rand(String[] choices) {
+    int value = randInt(choices.length);
+    return choices[value];
+  }
+
+  /**
+   * Helper function to get a random number based on an integer array of [min,
+   * max]. This should be used primarily when pulling ranges from YML.
+   * 
+   * @param range array [min, max]
+   * @return random double between min and max
+   */
+  public default double rand(int[] range) {
+    if (range == null || range.length != 2) {
+      throw new IllegalArgumentException(
+          "input range must be of length 2 -- got " + Arrays.toString(range));
+    }
+
+    if (range[0] > range[1]) {
+      throw new IllegalArgumentException(
+          "range must be of the form {low, high} -- got " + Arrays.toString(range));
+    }
+
+    return rand(range[0], range[1]);
+  }
+
+  /** Returns a random boolean. */
+  public boolean randBoolean();
+
+  /** 
+   * Returns a double between from a normal distribution
+   * with mean of 0 and standard deviation of 1.
+   */
+  public double randGaussian();
+
+  /** Returns a random integer. */
+  public int randInt();
+
+  /** Returns a random integer in the given bound. */
+  public int randInt(int bound);
+
+  /** Return a random long. */
+  public long randLong();
+}

--- a/src/main/java/org/mitre/synthea/helpers/RandomValueGenerator.java
+++ b/src/main/java/org/mitre/synthea/helpers/RandomValueGenerator.java
@@ -10,7 +10,7 @@ public class RandomValueGenerator extends ValueGenerator {
   private double high;
 
   /**
-   * Createa new RandomValueGenerator.
+   * Create a new RandomValueGenerator.
    * @param person The person to generate data for.
    * @param low The lower bound for the generator.
    * @param high The upper bound for the generator.
@@ -23,8 +23,6 @@ public class RandomValueGenerator extends ValueGenerator {
 
   @Override
   public double getValue(long time) {
-    // TODO: Using the person.random could return a different value for the same timepoint. 
-    // Use the time as seed instead for repeatability?
-    return person.rand(low, high);    
+    return person.rand(low, high);
   }
 }

--- a/src/main/java/org/mitre/synthea/helpers/TrendingValueGenerator.java
+++ b/src/main/java/org/mitre/synthea/helpers/TrendingValueGenerator.java
@@ -92,7 +92,7 @@ public class TrendingValueGenerator extends ValueGenerator {
     double nextValue;
 
     do {
-      nextValue = person.random.nextGaussian() * standardDeviation + mean;
+      nextValue = person.randGaussian() * standardDeviation + mean;
 
       if ((minimumValue == null || nextValue >= minimumValue) && (maximumValue == null
           || nextValue <= maximumValue)) {

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -13,7 +13,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Calendar;
-import java.util.Random;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -21,6 +20,7 @@ import java.util.function.Consumer;
 
 import org.mitre.synthea.engine.Logic;
 import org.mitre.synthea.engine.State;
+import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 
 public class Utilities {
@@ -331,12 +331,12 @@ public class Utilities {
    *
    * @return a String DICOM UID
    */
-  public static String randomDicomUid(int seriesNo, int instanceNo) {
+  public static String randomDicomUid(Person person, long time, int seriesNo, int instanceNo) {
 
     // Add a random salt to increase uniqueness
-    String salt = randomDicomUidSalt();
+    String salt = randomDicomUidSalt(person);
 
-    String now = String.valueOf(System.currentTimeMillis());
+    String now = String.valueOf(time);
     String uid = "1.2.840.99999999";  // 99999999 is an arbitrary organizational identifier
 
     if (seriesNo > 0) {
@@ -354,13 +354,11 @@ public class Utilities {
    * Generates a random string of 8 numbers to use as a salt for DICOM UIDs.
    * @return The 8-digit numeric salt, as a String
    */
-  private static String randomDicomUidSalt() {
-
+  private static String randomDicomUidSalt(Person person) {
     final int MIN = 10000000;
     final int MAX = 99999999;
 
-    Random rand = new Random();
-    int saltInt = rand.nextInt(MAX - MIN + 1) + MIN;
+    int saltInt = person.randInt(MAX - MIN + 1) + MIN;
     return String.valueOf(saltInt);
   }
   

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -20,7 +20,6 @@ import java.util.function.Consumer;
 
 import org.mitre.synthea.engine.Logic;
 import org.mitre.synthea.engine.State;
-import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 
 public class Utilities {
@@ -331,10 +330,11 @@ public class Utilities {
    *
    * @return a String DICOM UID
    */
-  public static String randomDicomUid(Person person, long time, int seriesNo, int instanceNo) {
+  public static String randomDicomUid(RandomNumberGenerator random,
+      long time, int seriesNo, int instanceNo) {
 
     // Add a random salt to increase uniqueness
-    String salt = randomDicomUidSalt(person);
+    String salt = randomDicomUidSalt(random);
 
     String now = String.valueOf(time);
     String uid = "1.2.840.99999999";  // 99999999 is an arbitrary organizational identifier
@@ -352,13 +352,14 @@ public class Utilities {
 
   /**
    * Generates a random string of 8 numbers to use as a salt for DICOM UIDs.
+   * @param random the source of randomness
    * @return The 8-digit numeric salt, as a String
    */
-  private static String randomDicomUidSalt(Person person) {
+  private static String randomDicomUidSalt(RandomNumberGenerator random) {
     final int MIN = 10000000;
     final int MAX = 99999999;
 
-    int saltInt = person.randInt(MAX - MIN + 1) + MIN;
+    int saltInt = random.randInt(MAX - MIN + 1) + MIN;
     return String.valueOf(saltInt);
   }
   

--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -28,6 +28,10 @@ public final class CardiovascularDiseaseModule extends Module {
     this.name = "Cardiovascular Disease";
   }
 
+  public Module clone() {
+    return this;
+  }
+
   @Override
   public boolean process(Person person, long time) {
     if (!person.alive(time)) {

--- a/src/main/java/org/mitre/synthea/modules/EncounterModule.java
+++ b/src/main/java/org/mitre/synthea/modules/EncounterModule.java
@@ -49,6 +49,10 @@ public final class EncounterModule extends Module {
     this.name = "Encounter";
   }
 
+  public Module clone() {
+    return this;
+  }
+
   @Override
   public boolean process(Person person, long time) {
     if (!person.alive(time)) {
@@ -144,7 +148,7 @@ public final class EncounterModule extends Module {
     prov.incrementEncounters(type, year);
     encounter.provider = prov;
     // assign a clinician
-    encounter.clinician = prov.chooseClinicianList(specialty, person.random);
+    encounter.clinician = prov.chooseClinicianList(specialty, person);
     return encounter;
   }
 

--- a/src/main/java/org/mitre/synthea/modules/HealthInsuranceModule.java
+++ b/src/main/java/org/mitre/synthea/modules/HealthInsuranceModule.java
@@ -33,6 +33,10 @@ public class HealthInsuranceModule extends Module {
    */
   public HealthInsuranceModule() {}
 
+  public Module clone() {
+    return this;
+  }
+
   /**
    * Process this HealthInsuranceModule with the given Person at the specified
    * time within the simulation.

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -95,6 +94,10 @@ public final class LifecycleModule extends Module {
     return soDistribution;
   }
 
+  public Module clone() {
+    return this;
+  }
+
   @Override
   public boolean process(Person person, long time) {
     if (!person.alive(time)) {
@@ -133,8 +136,8 @@ public final class LifecycleModule extends Module {
     attributes.put(Person.BIRTHDATE, time);
     String gender = (String) attributes.get(Person.GENDER);
     String language = (String) attributes.get(Person.FIRST_LANGUAGE);
-    String firstName = fakeFirstName(gender, language, person.random);
-    String lastName = fakeLastName(language, person.random);
+    String firstName = fakeFirstName(gender, language, person);
+    String lastName = fakeLastName(language, person);
     if (appendNumbersToNames) {
       firstName = addHash(firstName);
       lastName = addHash(lastName);
@@ -143,15 +146,15 @@ public final class LifecycleModule extends Module {
     attributes.put(Person.LAST_NAME, lastName);
     attributes.put(Person.NAME, firstName + " " + lastName);
 
-    String motherFirstName = fakeFirstName("F", language, person.random);
-    String motherLastName = fakeLastName(language, person.random);
+    String motherFirstName = fakeFirstName("F", language, person);
+    String motherLastName = fakeLastName(language, person);
     if (appendNumbersToNames) {
       motherFirstName = addHash(motherFirstName);
       motherLastName = addHash(motherLastName);
     }
     attributes.put(Person.NAME_MOTHER, motherFirstName + " " + motherLastName);
     
-    String fatherFirstName = fakeFirstName("M", language, person.random);
+    String fatherFirstName = fakeFirstName("M", language, person);
     if (appendNumbersToNames) {
       fatherFirstName = addHash(fatherFirstName);
     }
@@ -180,10 +183,10 @@ public final class LifecycleModule extends Module {
       person.attributes.put(Person.ZIP, location.getZipCode(city, person));
       String[] birthPlace;
       if ("english".equalsIgnoreCase((String) attributes.get(Person.FIRST_LANGUAGE))) {
-        birthPlace = location.randomBirthPlace(person.random);
+        birthPlace = location.randomBirthPlace(person);
       } else {
         birthPlace = location.randomBirthplaceByLanguage(
-            person.random, (String) person.attributes.get(Person.FIRST_LANGUAGE));
+            person, (String) person.attributes.get(Person.FIRST_LANGUAGE));
       }
       attributes.put(Person.BIRTH_CITY, birthPlace[0]);
       attributes.put(Person.BIRTH_STATE, birthPlace[1]);
@@ -193,7 +196,7 @@ public final class LifecycleModule extends Module {
     }
     
     boolean hasStreetAddress2 = person.rand() < 0.5;
-    attributes.put(Person.ADDRESS, fakeAddress(hasStreetAddress2, person.random));
+    attributes.put(Person.ADDRESS, fakeAddress(hasStreetAddress2, person));
 
     attributes.put(Person.ACTIVE_WEIGHT_MANAGEMENT, false);
     // TODO: Why are the percentiles a vital sign? Sounds more like an attribute?
@@ -205,7 +208,7 @@ public final class LifecycleModule extends Module {
     person.attributes.put(Person.GROWTH_TRAJECTORY, pgt);
 
     // Temporarily generate a mother
-    Person mother = new Person(person.random.nextLong());
+    Person mother = new Person(person.randLong());
     mother.attributes.put(Person.GENDER, "F");
     mother.attributes.put("pregnant", true);
     mother.attributes.put(Person.RACE, person.attributes.get(Person.RACE));
@@ -232,7 +235,7 @@ public final class LifecycleModule extends Module {
     grow(person, time); // set initial height and weight from percentiles
     calculateVitalSigns(person, time);  // Set initial values for many vital signs.
 
-    String orientation = sexualOrientationData.next(person.random);
+    String orientation = sexualOrientationData.next(person);
     attributes.put(Person.SEXUAL_ORIENTATION, orientation);
 
     // Setup vital signs which follow the generator approach
@@ -263,11 +266,11 @@ public final class LifecycleModule extends Module {
    * Generate a first name appropriate for a given gender and language.
    * @param gender Gender of the name, "M" or "F"
    * @param language Origin language of the name, "english", "spanish"
-   * @param random Random number generator to use.
+   * @param person person to generate a name for.
    * @return First name.
    */
   @SuppressWarnings("unchecked")
-  public static String fakeFirstName(String gender, String language, Random random) {
+  public static String fakeFirstName(String gender, String language, Person person) {
     List<String> choices;
     if ("spanish".equalsIgnoreCase(language)) {
       choices = (List<String>) names.get("spanish." + gender);
@@ -275,17 +278,17 @@ public final class LifecycleModule extends Module {
       choices = (List<String>) names.get("english." + gender);
     }
     // pick a random item from the list
-    return choices.get(random.nextInt(choices.size()));
+    return choices.get(person.randInt(choices.size()));
   }
   
   /**
    * Generate a surname appropriate for a given language.
    * @param language Origin language of the name, "english", "spanish"
-   * @param random Random number generator to use.
+   * @param person person to generate a name for.
    * @return Surname or Family Name.
    */
   @SuppressWarnings("unchecked")
-  public static String fakeLastName(String language, Random random) {
+  public static String fakeLastName(String language, Person person) {
     List<String> choices;
     if ("spanish".equalsIgnoreCase(language)) {
       choices = (List<String>) names.get("spanish.family");
@@ -293,30 +296,30 @@ public final class LifecycleModule extends Module {
       choices = (List<String>) names.get("english.family");
     }
     // pick a random item from the list
-    return choices.get(random.nextInt(choices.size()));
+    return choices.get(person.randInt(choices.size()));
   }
 
   /**
    * Generate a Street Address.
    * @param includeLine2 Whether or not the address should have a second line,
    *     which can take the form of an apartment, unit, or suite number.
-   * @param random Random number generator to use.
+   * @param person person to generate an address for.
    * @return First name.
    */
   @SuppressWarnings("unchecked")
-  public static String fakeAddress(boolean includeLine2, Random random) {
-    int number = random.nextInt(1000) + 100;
+  public static String fakeAddress(boolean includeLine2, Person person) {
+    int number = person.randInt(1000) + 100;
     List<String> n = (List<String>)names.get("english.family");
     // for now just use family names as the street name. 
     // could expand with a few more but probably not worth it
-    String streetName = n.get(random.nextInt(n.size()));
+    String streetName = n.get(person.randInt(n.size()));
     List<String> a = (List<String>)names.get("street.type");
-    String streetType = a.get(random.nextInt(a.size()));
+    String streetType = a.get(person.randInt(a.size()));
     
     if (includeLine2) {
-      int addtlNum = random.nextInt(100);
+      int addtlNum = person.randInt(100);
       List<String> s = (List<String>)names.get("street.secondary");
-      String addtlType = s.get(random.nextInt(s.size()));
+      String addtlType = s.get(person.randInt(s.size()));
       return number + " " + streetName + " " + streetType + " " + addtlType + " " + addtlNum;
     } else {
       return number + " " + streetName + " " + streetType;
@@ -352,7 +355,6 @@ public final class LifecycleModule extends Module {
     int newAgeMos = person.ageInMonths(time);
     person.attributes.put(AGE, newAge);
     person.attributes.put(AGE_MONTHS, newAgeMos);
-
     switch (newAge) {
       case 16:
         // driver's license
@@ -404,7 +406,7 @@ public final class LifecycleModule extends Module {
               person.attributes.put(Person.MAIDEN_NAME, person.attributes.get(Person.LAST_NAME));
               String firstName = ((String) person.attributes.get(Person.FIRST_NAME));
               String language = (String) person.attributes.get(Person.FIRST_LANGUAGE);
-              String newLastName = fakeLastName(language, person.random);
+              String newLastName = fakeLastName(language, person);
               if (appendNumbersToNames) {
                 newLastName = addHash(newLastName);
               }
@@ -512,7 +514,7 @@ public final class LifecycleModule extends Module {
       weight = lookupGrowthChart("weight", gender, ageInMonths,
           person.getVitalSign(VitalSign.WEIGHT_PERCENTILE, time));
     } else if (age < 20) {
-      double currentBMI = pgt.currentBMI(person, time, person.random);
+      double currentBMI = pgt.currentBMI(person, time);
       double height = growthChart.get(GrowthChart.ChartType.HEIGHT).lookUp(ageInMonths,
           gender, heightPercentile);
       weight = BMI.weightForHeightAndBMI(height, currentBMI);

--- a/src/main/java/org/mitre/synthea/modules/QualityOfLifeModule.java
+++ b/src/main/java/org/mitre/synthea/modules/QualityOfLifeModule.java
@@ -36,6 +36,10 @@ public class QualityOfLifeModule extends Module {
     this.name = "Quality of Life";
   }
 
+  public Module clone() {
+    return this;
+  }
+
   @SuppressWarnings("unchecked")
   @Override
   public boolean process(Person person, long time) {

--- a/src/main/java/org/mitre/synthea/modules/WeightLossModule.java
+++ b/src/main/java/org/mitre/synthea/modules/WeightLossModule.java
@@ -57,6 +57,9 @@ public final class WeightLossModule extends Module {
   public static final double maxPedPercentileChange =
       (double) BiometricsConfig.get("max_ped_percentile_change", 0.1);
 
+  public Module clone() {
+    return this;
+  }
 
   @Override
   public boolean process(Person person, long time) {
@@ -238,7 +241,7 @@ public final class WeightLossModule extends Module {
     if (time + ONE_YEAR > pgt.tail().timeInSimulation) {
       GrowthChart bmiChart = growthChart.get(GrowthChart.ChartType.BMI);
       String gender = (String) person.attributes.get(Person.GENDER);
-      double bmiAtStart = pgt.currentBMI(person, start, person.random);
+      double bmiAtStart = pgt.currentBMI(person, start);
       double originalPercentile = bmiChart.percentileFor(startAgeInMonths, gender, bmiAtStart);
       double percentileChange = (double) person.attributes.get(WEIGHT_LOSS_BMI_PERCENTILE_CHANGE);
       int nextAgeInMonths = pgt.tail().ageInMonths + 12;
@@ -265,7 +268,7 @@ public final class WeightLossModule extends Module {
         (PediatricGrowthTrajectory) person.attributes.get(Person.GROWTH_TRAJECTORY);
     long start = (long) person.attributes.get(WEIGHT_MANAGEMENT_START);
     int startAgeInMonths = person.ageInMonths(start);
-    double bmiAtStart = pgt.currentBMI(person, start, person.random);
+    double bmiAtStart = pgt.currentBMI(person, start);
     String gender = (String) person.attributes.get(Person.GENDER);
     double originalPercentile = bmiChart.percentileFor(startAgeInMonths, gender, bmiAtStart);
     double bmiForPercentileAtTwenty = bmiChart.lookUp(240, gender, originalPercentile);
@@ -297,7 +300,7 @@ public final class WeightLossModule extends Module {
     PediatricGrowthTrajectory pgt =
         (PediatricGrowthTrajectory) person.attributes.get(Person.GROWTH_TRAJECTORY);
     double percentileChange = (double) person.attributes.get(WEIGHT_LOSS_BMI_PERCENTILE_CHANGE);
-    double bmiAtStart = pgt.currentBMI(person, start, person.random);
+    double bmiAtStart = pgt.currentBMI(person, start);
     double startPercentile = bmiChart.percentileFor(startAgeInMonths, gender, bmiAtStart);
     int currentTailAge = pgt.tail().ageInMonths;
     double currentTailBMI = pgt.tail().bmi;

--- a/src/main/java/org/mitre/synthea/world/agents/Clinician.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Clinician.java
@@ -117,10 +117,6 @@ public class Clinician implements Serializable, QuadTreeElement {
   public int getEncounterCount() {
     return encounters;
   }
-  
-  public int randInt() {
-    return random.nextInt();
-  }
 
   public int randInt(int bound) {
     return random.nextInt(bound);

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -13,10 +13,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.math3.random.JDKRandomGenerator;
 import org.mitre.synthea.engine.ExpressedConditionRecord;
 import org.mitre.synthea.engine.ExpressedSymptom;
 import org.mitre.synthea.engine.Module;
@@ -87,7 +87,7 @@ public class Person implements Serializable, QuadTreeElement {
   private static final String DEDUCTIBLE = "deductible";
   private static final String LAST_MONTH_PAID = "last_month_paid";
 
-  public final JDKRandomGenerator random;
+  private final Random random;
   public final long seed;
   public long populationSeed;
   /** 
@@ -139,13 +139,13 @@ public class Person implements Serializable, QuadTreeElement {
    * Person constructor.
    */
   public Person(long seed) {
-    this.seed = seed; // keep track of seed so it can be exported later
-    random = new JDKRandomGenerator((int) seed);
+    this.seed = seed;
+    random = new Random(seed);
     attributes = new ConcurrentHashMap<String, Object>();
     vitalSigns = new ConcurrentHashMap<VitalSign, ValueGenerator>();
-    symptoms = new ConcurrentHashMap<String, ExpressedSymptom>();   
+    symptoms = new ConcurrentHashMap<String, ExpressedSymptom>();
     /* initialized the onsetConditions field */
-    onsetConditionRecord = new ExpressedConditionRecord(this);    
+    onsetConditionRecord = new ExpressedConditionRecord(this);
     /* Chronic Medications which will be renewed at each Wellness Encounter */
     chronicMedications = new ConcurrentHashMap<String, HealthRecord.Medication>();
     hasMultipleRecords =
@@ -168,7 +168,7 @@ public class Person implements Serializable, QuadTreeElement {
   }
 
   /**
-   * Retuns a random double.
+   * Returns a random double.
    */
   public double rand() {
     return random.nextDouble();
@@ -178,7 +178,7 @@ public class Person implements Serializable, QuadTreeElement {
    * Returns a random double in the given range.
    */
   public double rand(double low, double high) {
-    return (low + ((high - low) * random.nextDouble()));
+    return (low + ((high - low) * rand()));
   }
 
   /**
@@ -221,7 +221,8 @@ public class Person implements Serializable, QuadTreeElement {
    * @return One of the options randomly selected.
    */
   public String rand(String[] choices) {
-    return choices[random.nextInt(choices.length)];
+    int value = random.nextInt(choices.length);
+    return choices[value];
   }
 
   /**
@@ -246,6 +247,13 @@ public class Person implements Serializable, QuadTreeElement {
   }
 
   /**
+   * Returns a random boolean.
+   */
+  public boolean randBoolean() {
+    return random.nextBoolean();
+  }
+
+  /**
    * Returns a random integer.
    */
   public int randInt() {
@@ -257,6 +265,20 @@ public class Person implements Serializable, QuadTreeElement {
    */
   public int randInt(int bound) {
     return random.nextInt(bound);
+  }
+
+  /**
+   * Returns a double from a normal distribution.
+   */
+  public double randGaussian() {
+    return random.nextGaussian();
+  }
+
+  /**
+   * Return a random long.
+   */
+  public long randLong() {
+    return random.nextLong();
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -8,7 +8,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.ZoneId;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -23,6 +22,7 @@ import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.engine.State;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.ConstantValueGenerator;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.helpers.ValueGenerator;
 import org.mitre.synthea.modules.QualityOfLifeModule;
@@ -33,7 +33,7 @@ import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
 import org.mitre.synthea.world.concepts.VitalSign;
 import org.mitre.synthea.world.geography.quadtree.QuadTreeElement;
 
-public class Person implements Serializable, QuadTreeElement {
+public class Person implements Serializable, RandomNumberGenerator, QuadTreeElement {
   private static final long serialVersionUID = 4322116644425686379L;
   private static final ZoneId timeZone = ZoneId.systemDefault();
 
@@ -172,78 +172,6 @@ public class Person implements Serializable, QuadTreeElement {
    */
   public double rand() {
     return random.nextDouble();
-  }
-
-  /**
-   * Returns a random double in the given range.
-   */
-  public double rand(double low, double high) {
-    return (low + ((high - low) * rand()));
-  }
-
-  /**
-   * Returns a random double in the given range with no more that the specified
-   * number of decimal places.
-   */
-  public double rand(double low, double high, Integer decimals) {
-    double value = rand(low, high);
-    if (decimals != null) {
-      value = BigDecimal.valueOf(value).setScale(decimals, RoundingMode.HALF_UP).doubleValue();
-    }
-    return value;
-  }
-
-  /**
-   * Helper function to get a random number based on an array of [min, max]. This
-   * should be used primarily when pulling ranges from YML.
-   * 
-   * @param range array [min, max]
-   * @return random double between min and max
-   */
-  public double rand(double[] range) {
-    if (range == null || range.length != 2) {
-      throw new IllegalArgumentException(
-          "input range must be of length 2 -- got " + Arrays.toString(range));
-    }
-
-    if (range[0] > range[1]) {
-      throw new IllegalArgumentException(
-          "range must be of the form {low, high} -- got " + Arrays.toString(range));
-    }
-
-    return rand(range[0], range[1]);
-  }
-
-  /**
-   * Return one of the options randomly with uniform distribution.
-   * 
-   * @param choices The options to be returned.
-   * @return One of the options randomly selected.
-   */
-  public String rand(String[] choices) {
-    int value = random.nextInt(choices.length);
-    return choices[value];
-  }
-
-  /**
-   * Helper function to get a random number based on an integer array of [min,
-   * max]. This should be used primarily when pulling ranges from YML.
-   * 
-   * @param range array [min, max]
-   * @return random double between min and max
-   */
-  public double rand(int[] range) {
-    if (range == null || range.length != 2) {
-      throw new IllegalArgumentException(
-          "input range must be of length 2 -- got " + Arrays.toString(range));
-    }
-
-    if (range[0] > range[1]) {
-      throw new IllegalArgumentException(
-          "range must be of the form {low, high} -- got " + Arrays.toString(range));
-    }
-
-    return rand(range[0], range[1]);
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.modules.LifecycleModule;
@@ -488,12 +489,12 @@ public class Provider implements QuadTreeElement, Serializable {
   /**
    * Randomly chooses a clinician out of a given clinician list.
    * @param specialty - the specialty to choose from.
-   * @param person - the patient.
+   * @param rand - random number generator.
    * @return A clinician with the required specialty.
    */
-  public Clinician chooseClinicianList(String specialty, Person person) {
+  public Clinician chooseClinicianList(String specialty, RandomNumberGenerator rand) {
     ArrayList<Clinician> clinicians = this.clinicianMap.get(specialty);
-    Clinician doc = clinicians.get(person.randInt(clinicians.size()));
+    Clinician doc = clinicians.get(rand.randInt(clinicians.size()));
     doc.incrementEncounters();
     return doc;
   }

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -439,7 +439,8 @@ public class Provider implements QuadTreeElement, Serializable {
       long clinicianIdentifier, Provider provider) {
     Clinician clinician = null;
     try {
-      Demographics city = location.randomCity(clinicianRand);
+      Person doc = new Person(clinicianIdentifier);
+      Demographics city = location.randomCity(doc);
       Map<String, Object> out = new HashMap<>();
 
       String race = city.pickRace(clinicianRand);
@@ -464,8 +465,8 @@ public class Provider implements QuadTreeElement, Serializable {
       clinician.attributes.put(Person.ZIP, provider.zip);
       clinician.attributes.put(Person.COORDINATE, provider.coordinates);
 
-      String firstName = LifecycleModule.fakeFirstName(gender, language, clinician.random);
-      String lastName = LifecycleModule.fakeLastName(language, clinician.random);
+      String firstName = LifecycleModule.fakeFirstName(gender, language, doc);
+      String lastName = LifecycleModule.fakeLastName(language, doc);
 
       if (LifecycleModule.appendNumbersToNames) {
         firstName = LifecycleModule.addHash(firstName);
@@ -486,13 +487,13 @@ public class Provider implements QuadTreeElement, Serializable {
 
   /**
    * Randomly chooses a clinician out of a given clinician list.
-   * @param specialty - the specialty to choose from
-   * @param random - random to help choose clinician
+   * @param specialty - the specialty to choose from.
+   * @param person - the patient.
    * @return A clinician with the required specialty.
    */
-  public Clinician chooseClinicianList(String specialty, Random random) {
+  public Clinician chooseClinicianList(String specialty, Person person) {
     ArrayList<Clinician> clinicians = this.clinicianMap.get(specialty);
-    Clinician doc = clinicians.get(random.nextInt(clinicians.size()));
+    Clinician doc = clinicians.get(person.randInt(clinicians.size()));
     doc.incrementEncounters();
     return doc;
   }

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/IPayerFinder.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/IPayerFinder.java
@@ -2,6 +2,7 @@ package org.mitre.synthea.world.agents.behaviors;
 
 import java.util.List;
 
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.modules.HealthInsuranceModule;
 import org.mitre.synthea.world.agents.Payer;
 import org.mitre.synthea.world.agents.Person;
@@ -51,14 +52,14 @@ public interface IPayerFinder {
    * @param options the list of acceptable payer options that the person can recieve.
    * @return a random payer from the given list of options.
    */
-  public default Payer chooseRandomlyFromList(List<Payer> options, Person person) {
+  public default Payer chooseRandomlyFromList(List<Payer> options, RandomNumberGenerator rand) {
     if (options.isEmpty()) {
       return Payer.noInsurance;
     } else if (options.size() == 1) {
       return options.get(0);
     } else {
       // There are a few equally good options, pick one randomly.
-      return options.get(person.randInt(options.size()));
+      return options.get(rand.randInt(options.size()));
     }
   }
 }

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/IPayerFinder.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/IPayerFinder.java
@@ -1,7 +1,6 @@
 package org.mitre.synthea.world.agents.behaviors;
 
 import java.util.List;
-import java.util.Random;
 
 import org.mitre.synthea.modules.HealthInsuranceModule;
 import org.mitre.synthea.world.agents.Payer;
@@ -52,15 +51,14 @@ public interface IPayerFinder {
    * @param options the list of acceptable payer options that the person can recieve.
    * @return a random payer from the given list of options.
    */
-  public default Payer chooseRandomlyFromList(List<Payer> options) {
+  public default Payer chooseRandomlyFromList(List<Payer> options, Person person) {
     if (options.isEmpty()) {
       return Payer.noInsurance;
     } else if (options.size() == 1) {
       return options.get(0);
     } else {
       // There are a few equally good options, pick one randomly.
-      Random r = new Random();
-      return options.get(r.nextInt(options.size()));
+      return options.get(person.randInt(options.size()));
     }
   }
 }

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/PayerFinderRandom.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/PayerFinderRandom.java
@@ -30,6 +30,6 @@ public class PayerFinderRandom implements IPayerFinder {
       }
     }
     // Choose a payer from the list of options.
-    return chooseRandomlyFromList(options);
+    return chooseRandomlyFromList(options, person);
   }
 }

--- a/src/main/java/org/mitre/synthea/world/concepts/BirthStatistics.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/BirthStatistics.java
@@ -104,7 +104,7 @@ public class BirthStatistics {
     if (mother.attributes.containsKey(BIRTH_SEX)) {
       babySex = (String) mother.attributes.get(BIRTH_SEX);
     } else {
-      if (mother.random.nextBoolean()) {
+      if (mother.randBoolean()) {
         babySex = "M";
       } else {
         babySex = "F";

--- a/src/main/java/org/mitre/synthea/world/concepts/Costs.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/Costs.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.SimpleCSV;
@@ -70,7 +69,7 @@ public class Costs {
     // Retrieve the base cost based on the code.
     double baseCost;
     if (costs != null && costs.containsKey(code)) {
-      baseCost = costs.get(code).chooseCost(person.random);
+      baseCost = costs.get(code).chooseCost(person);
     } else {
       baseCost = defaultCost;
     }
@@ -193,8 +192,8 @@ public class Costs {
      * @param random Source of randomness
      * @return Single cost within the range this set of cost data represents
      */
-    private double chooseCost(Random random) {
-      return triangularDistribution(min, max, mode, random.nextDouble());
+    private double chooseCost(Person person) {
+      return triangularDistribution(min, max, mode, person.rand());
     }
 
     /**

--- a/src/main/java/org/mitre/synthea/world/concepts/Costs.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/Costs.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
@@ -173,7 +174,7 @@ public class Costs {
    * Helper class to store a grouping of cost data for a single concept. Currently
    * cost data includes a minimum, maximum, and mode (most common value).
    * Selection of individual prices based on this cost data should be done using
-   * the chooseCost(Random) method.
+   * the chooseCost method.
    */
   private static class CostData {
     private double min;
@@ -189,11 +190,11 @@ public class Costs {
     /**
      * Select an individual cost based on this cost data. Uses a triangular
      * distribution to pick a randomized value.
-     * @param random Source of randomness
+     * @param rand Source of randomness
      * @return Single cost within the range this set of cost data represents
      */
-    private double chooseCost(Person person) {
-      return triangularDistribution(min, max, mode, person.rand());
+    private double chooseCost(RandomNumberGenerator rand) {
+      return triangularDistribution(min, max, mode, rand.rand());
     }
 
     /**

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Clinician;
 import org.mitre.synthea.world.agents.Person;
@@ -408,14 +409,14 @@ public class HealthRecord implements Serializable {
 
     /**
      * Set the human readable form of the UDI for this Person's device.
-     * @param person The person who owns or contains the device.
+     * @param random the random number generator
      */
-    public void generateUDI(Person person) {
-      deviceIdentifier = trimLong(person.randLong(), 14);
+    public void generateUDI(RandomNumberGenerator random) {
+      deviceIdentifier = trimLong(random.randLong(), 14);
       manufactureTime = start - Utilities.convertTime("weeks", 3);
       expirationTime = start + Utilities.convertTime("years", 25);
-      lotNumber = trimLong(person.randLong(), (int) person.rand(4, 20));
-      serialNumber = trimLong(person.randLong(), (int) person.rand(4, 20));
+      lotNumber = trimLong(random.randLong(), (int) random.rand(4, 20));
+      serialNumber = trimLong(random.randLong(), (int) random.rand(4, 20));
 
       udi = "(01)" + deviceIdentifier;
       udi += "(11)" + udiDate(manufactureTime);

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -317,9 +317,9 @@ public class HealthRecord implements Serializable {
     /**
      * Constructor for ImagingStudy HealthRecord Entry.
      */
-    public ImagingStudy(long time, String type) {
+    public ImagingStudy(Person person, long time, String type) {
       super(time, type);
-      this.dicomUid = Utilities.randomDicomUid(0, 0);
+      this.dicomUid = Utilities.randomDicomUid(person, time, 0, 0);
       this.series = new ArrayList<Series>();
     }
 
@@ -411,11 +411,11 @@ public class HealthRecord implements Serializable {
      * @param person The person who owns or contains the device.
      */
     public void generateUDI(Person person) {
-      deviceIdentifier = trimLong(person.random.nextLong(), 14);
+      deviceIdentifier = trimLong(person.randLong(), 14);
       manufactureTime = start - Utilities.convertTime("weeks", 3);
       expirationTime = start + Utilities.convertTime("years", 25);
-      lotNumber = trimLong(person.random.nextLong(), (int) person.rand(4, 20));
-      serialNumber = trimLong(person.random.nextLong(), (int) person.rand(4, 20));
+      lotNumber = trimLong(person.randLong(), (int) person.rand(4, 20));
+      serialNumber = trimLong(person.randLong(), (int) person.rand(4, 20));
 
       udi = "(01)" + deviceIdentifier;
       udi += "(11)" + udiDate(manufactureTime);
@@ -1175,10 +1175,11 @@ public class HealthRecord implements Serializable {
    * @param series the series associated with the study.
    * @return 
    */
-  public ImagingStudy imagingStudy(long time, String type, List<ImagingStudy.Series> series) {
-    ImagingStudy study = new ImagingStudy(time, type);
+  public ImagingStudy imagingStudy(long time, String type,
+      List<ImagingStudy.Series> series) {
+    ImagingStudy study = new ImagingStudy(this.person, time, type);
     study.series = series;
-    assignImagingStudyDicomUids(study);
+    assignImagingStudyDicomUids(time, study);
     currentEncounter(time).imagingStudies.add(study);
     return study;
   }
@@ -1186,18 +1187,18 @@ public class HealthRecord implements Serializable {
   /**
    * Assigns random DICOM UIDs to each Series and Instance in an imaging study
    * after creation.
-   *
+   * @param time the time of the study.
    * @param study the ImagingStudy to populate with DICOM UIDs.
    */
-  private void assignImagingStudyDicomUids(ImagingStudy study) {
+  private void assignImagingStudyDicomUids(long time, ImagingStudy study) {
 
     int seriesNo = 1;
     for (ImagingStudy.Series series : study.series) {
-      series.dicomUid = Utilities.randomDicomUid(seriesNo, 0);
+      series.dicomUid = Utilities.randomDicomUid(this.person, time, seriesNo, 0);
 
       int instanceNo = 1;
       for (ImagingStudy.Instance instance : series.instances) {
-        instance.dicomUid = Utilities.randomDicomUid(seriesNo, instanceNo);
+        instance.dicomUid = Utilities.randomDicomUid(this.person, time, seriesNo, instanceNo);
         instanceNo += 1;
       }
       seriesNo += 1;

--- a/src/main/java/org/mitre/synthea/world/concepts/NHANESSample.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/NHANESSample.java
@@ -39,6 +39,11 @@ public class NHANESSample implements Serializable {
   // Weighted probability that this sample should be selected relative to the other selected samples
   public double prob;
 
+  public String toString() {
+    return String.format("{%d %d %d %f %f %f %s %f %f}",
+        id, sex, agem, wt, ht, swt, racec, bmi, prob);
+  }
+
   /**
    * Load the NHANES samples from resources.
    * @return A list of samples.

--- a/src/main/java/org/mitre/synthea/world/concepts/PediatricGrowthTrajectory.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/PediatricGrowthTrajectory.java
@@ -11,7 +11,6 @@ import java.util.Map;
 
 import org.apache.commons.math3.distribution.EnumeratedDistribution;
 import org.apache.commons.math3.distribution.NormalDistribution;
-import org.apache.commons.math3.random.JDKRandomGenerator;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
 
@@ -68,7 +67,7 @@ public class PediatricGrowthTrajectory implements Serializable {
       GrowthChart.loadCharts();
 
   private static Map<String, YearInformation> yearCorrelations = loadCorrelations();
-  private static NormalDistribution normalDistribution = new NormalDistribution();
+  private static NormalDistribution normalDistribution = new NormalDistribution(null, 0, 1);
   private static EnumeratedDistribution<NHANESSample> nhanesSamples =
       NHANESSample.loadDistribution();
 
@@ -89,11 +88,15 @@ public class PediatricGrowthTrajectory implements Serializable {
     public int ageInMonths;
     public long timeInSimulation;
     public double bmi;
+
+    public String toString() {
+      return String.format("{Age: %d, Time: %d, BMI: %f}", ageInMonths, timeInSimulation, bmi);
+    }
   }
 
   private NHANESSample initialSample;
   private List<Point> trajectory;
-
+  private long seed;
 
   /**
    * Starts a new pediatric growth trajectory. Selects a start BMI between 2 and 3 years old by
@@ -104,14 +107,21 @@ public class PediatricGrowthTrajectory implements Serializable {
    */
   public PediatricGrowthTrajectory(long personSeed, long birthTime) {
     // TODO: Make the selection sex specific
-    nhanesSamples.reseedRandomGenerator(personSeed);
-    this.initialSample = nhanesSamples.sample();
+    this.seed = personSeed;
+    this.initialSample = getSample(personSeed);
     this.trajectory = new LinkedList<Point>();
     Point p = new Point();
     p.ageInMonths = this.initialSample.agem;
     p.bmi = this.initialSample.bmi;
     p.timeInSimulation = birthTime + Utilities.convertTime("months", this.initialSample.agem);
     this.trajectory.add(p);
+  }
+
+  private static NHANESSample getSample(long personSeed) {
+    synchronized (nhanesSamples) {
+      nhanesSamples.reseedRandomGenerator(personSeed);
+      return nhanesSamples.sample();
+    }
   }
 
   /**
@@ -135,10 +145,8 @@ public class PediatricGrowthTrajectory implements Serializable {
    * consideration people at or above the 95th percentile, as the growth charts start to break down.
    * @param person to generate the new BMI for
    * @param time current time
-   * @param randomGenerator Apache Commons Math random thingy needed to sample a value
    */
-  public void generateNextYearBMI(Person person, long time,
-                                    JDKRandomGenerator randomGenerator) {
+  public void generateNextYearBMI(Person person, long time) {
     double age = person.ageInDecimalYears(time);
     double nextAgeYear = age + 1;
     String sex = (String) person.attributes.get(Person.GENDER);
@@ -150,8 +158,7 @@ public class PediatricGrowthTrajectory implements Serializable {
     double ezscore = extendedZScore(currentBMI, lastPoint.ageInMonths, sex, sigma);
     double mean = yi.correlation * ezscore + yi.diff;
     double sd = Math.sqrt(1 - Math.pow(yi.correlation, 2));
-    NormalDistribution nextZDistro = new NormalDistribution(randomGenerator, mean, sd);
-    double nextYearZscore = nextZDistro.sample();
+    double nextYearZscore = (person.randGaussian() * sd) + mean;
     double nextYearPercentile = GrowthChart.zscoreToPercentile(nextYearZscore);
     double nextPointBMI = percentileToBMI(nextYearPercentile, lastPoint.ageInMonths + 12,
         sex, sigma(sex, nextAgeYear));
@@ -254,16 +261,15 @@ public class PediatricGrowthTrajectory implements Serializable {
    * will happen before the person is 20 years old.
    * @param person to get the BMI for
    * @param time the time at which you want the BMI
-   * @param randomGenerator Apache Commons Math random thingy needed to sample a value
    * @return a BMI value
    */
-  public double currentBMI(Person person, long time, JDKRandomGenerator randomGenerator) {
+  public double currentBMI(Person person, long time) {
     Point lastPoint = tail();
     if (lastPoint.timeInSimulation <= time) {
       if (lastPoint.ageInMonths > NINETEEN_YEARS_IN_MONTHS) {
         return lastPoint.bmi;
       }
-      generateNextYearBMI(person, time, randomGenerator);
+      generateNextYearBMI(person, time);
     }
     Point previous = justBefore(time);
     Point next = justAfter(time);
@@ -272,6 +278,18 @@ public class PediatricGrowthTrajectory implements Serializable {
     double bmiDifference = next.bmi - previous.bmi;
 
     return previous.bmi + (bmiDifference * percentOfTimeBetweenPointsElapsed);
+  }
+
+  private static double cumulativeProbability(double value) {
+    synchronized (normalDistribution) {
+      return normalDistribution.cumulativeProbability(value);
+    }
+  }
+
+  private static double inverseCumulativeProbability(double value) {
+    synchronized (normalDistribution) {
+      return normalDistribution.inverseCumulativeProbability(value);
+    }
   }
 
   /**
@@ -292,7 +310,7 @@ public class PediatricGrowthTrajectory implements Serializable {
       double ninetyFifth = growthChart.get(GrowthChart.ChartType.BMI)
           .lookUp(ageInMonths, sex, 0.95);
       return ninetyFifth
-          + normalDistribution.inverseCumulativeProbability((percentile - 0.9) * 10) * sigma;
+          + inverseCumulativeProbability((percentile - 0.9) * 10) * sigma;
     }
   }
 
@@ -314,8 +332,8 @@ public class PediatricGrowthTrajectory implements Serializable {
       double ninetyFifth = growthChart.get(GrowthChart.ChartType.BMI)
           .lookUp(ageInMonths, sex, 0.95);
       double ebmiPercentile = 90 + 10
-          * normalDistribution.cumulativeProbability((bmi - ninetyFifth) / sigma);
-      return normalDistribution.inverseCumulativeProbability(ebmiPercentile / 100);
+          * cumulativeProbability((bmi - ninetyFifth) / sigma);
+      return inverseCumulativeProbability(ebmiPercentile / 100);
     }
   }
 

--- a/src/test/java/org/mitre/synthea/editors/GrowthDataErrorsEditorTest.java
+++ b/src/test/java/org/mitre/synthea/editors/GrowthDataErrorsEditorTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-import java.util.Random;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -47,7 +46,7 @@ public class GrowthDataErrorsEditorTest {
   @Test
   public void process() {
     GrowthDataErrorsEditor m = new GrowthDataErrorsEditor();
-    m.process(new Person(1), record.encounters, 100000, new Random());
+    m.process(new Person(1), record.encounters, 100000);
   }
 
 
@@ -106,7 +105,8 @@ public class GrowthDataErrorsEditorTest {
 
   @Test
   public void introduceHeightAbsoluteError() {
-    GrowthDataErrorsEditor.introduceHeightAbsoluteError(first, new Random());
+    Person person = new Person(0L);
+    GrowthDataErrorsEditor.introduceHeightAbsoluteError(first, person);
     assertTrue((Double) first.findObservation(
             GrowthDataErrorsEditor.HEIGHT_LOINC_CODE).value <= 147d);
     assertTrue((Double) first.findObservation(
@@ -115,7 +115,8 @@ public class GrowthDataErrorsEditorTest {
 
   @Test
   public void introduceWeightDuplicateError() {
-    GrowthDataErrorsEditor.introduceWeightDuplicateError(first, new Random());
+    Person person = new Person(0L);
+    GrowthDataErrorsEditor.introduceWeightDuplicateError(first, person);
     long obsCount = first.observations.stream()
         .filter(o -> o.type.equals(GrowthDataErrorsEditor.WEIGHT_LOINC_CODE))
         .count();
@@ -124,7 +125,8 @@ public class GrowthDataErrorsEditorTest {
 
   @Test
   public void introduceHeightDuplicateError() {
-    GrowthDataErrorsEditor.introduceHeightDuplicateError(first, new Random());
+    Person person = new Person(0L);
+    GrowthDataErrorsEditor.introduceHeightDuplicateError(first, person);
     long obsCount = first.observations.stream()
         .filter(o -> o.type.equals(GrowthDataErrorsEditor.HEIGHT_LOINC_CODE))
         .count();

--- a/src/test/java/org/mitre/synthea/engine/HealthRecordEditorsTest.java
+++ b/src/test/java/org/mitre/synthea/engine/HealthRecordEditorsTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.util.List;
-import java.util.Random;
 
 import org.junit.Test;
 import org.mitre.synthea.world.agents.Person;
@@ -20,8 +19,7 @@ public class HealthRecordEditorsTest {
     }
 
     @Override
-    public void process(Person person, List<HealthRecord.Encounter> encounters, long time, 
-            Random random) {
+    public void process(Person person, List<HealthRecord.Encounter> encounters, long time) {
       person.attributes.put(Person.ZIP, "01730");
     }
   }
@@ -36,9 +34,9 @@ public class HealthRecordEditorsTest {
     HealthRecordEditors hrm = HealthRecordEditors.getInstance();
     hrm.registerEditor(new Dummy());
     Person p = new Person(1);
-    hrm.executeAll(p, new HealthRecord(p), 1, 1, new Random());
+    hrm.executeAll(p, new HealthRecord(p), 1, 1);
     assertNull(p.attributes.get(Person.ZIP));
-    hrm.executeAll(p, new HealthRecord(p), 1100, 1, new Random());
+    hrm.executeAll(p, new HealthRecord(p), 1100, 1);
     assertEquals("01730", p.attributes.get(Person.ZIP));
     hrm.resetEditors();
   }

--- a/src/test/java/org/mitre/synthea/engine/ModuleTest.java
+++ b/src/test/java/org/mitre/synthea/engine/ModuleTest.java
@@ -16,9 +16,15 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
@@ -33,14 +39,123 @@ public class ModuleTest {
     List<Module> allModules = Module.getModules();
     List<Module> someModules = Module.getModules(path -> path.contains("ti"));
     
-    assertTrue(allModules.containsAll(someModules));
-    assertFalse(someModules.containsAll(allModules));
+    assertTrue(contains(allModules, someModules));
+    assertFalse(contains(someModules, allModules));
     assertTrue(allModules.size() > someModules.size());
     assertTrue(someModules.size() > 0);
 
     assertTrue(allModules.stream().anyMatch(filterOnModuleName("COPD")));
     assertTrue(someModules.stream().anyMatch(filterOnModuleName("Dermatitis")));
     assertFalse(someModules.stream().anyMatch(filterOnModuleName("COPD")));
+  }
+
+  /** Manually compare lists since the Modules are clones and not originals. */
+  private boolean contains(List<Module> superset, List<Module> subset) {
+    for (Module subsetModule : subset) {
+      boolean found = false;
+      for (Module supersetModule : superset) {
+        if (supersetModule.name.equals(subsetModule.name)
+            && supersetModule.submodule == subsetModule.submodule
+            && ((supersetModule.remarks == null && subsetModule.remarks == null)
+                || supersetModule.remarks.equals(subsetModule.remarks))) {
+          found = true;
+        }
+      }
+      if (!found) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Test
+  public void getModulesInPredictableOrder() {
+    List<Module> modulesA = Module.getModules();
+    List<Module> modulesB = Module.getModules();
+    
+    // verify with list
+    assertEquals(modulesA.size(), modulesB.size());
+    for (int i = 0; i < modulesA.size(); i++) {
+      assertEquals(modulesA.get(i).name, modulesB.get(i).name);
+      assertEquals(modulesA.get(i).submodule, modulesB.get(i).submodule);
+      assertEquals(modulesA.get(i).getStateNames(), modulesB.get(i).getStateNames());
+    }
+
+    // verify with iterator
+    Iterator<Module> iterA = modulesA.iterator();
+    Iterator<Module> iterB = modulesB.iterator();
+    while (iterA.hasNext()) {
+      Module modA = iterA.next();
+      Module modB = iterB.next();
+      assertEquals(modA.name, modB.name);
+      assertEquals(modA.submodule, modB.submodule);
+      assertEquals(modA.getStateNames(), modB.getStateNames());
+    }
+  }
+
+  @Test
+  public void getModulesInPredictableOrderThreadPool() {
+    ExecutorService threadPool = Executors.newFixedThreadPool(8);
+
+    List<Module> modules = Module.getModules();
+
+    for (int i = 0; i < 1000; i++) {
+      threadPool.submit(() -> {
+        List<Module> localModules = Module.getModules();
+        assertEquals(modules.size(), localModules.size());
+        for (int j = 0; j < modules.size(); j++) {
+          assertEquals(modules.get(j), localModules.get(j));
+        }
+      });
+    }
+
+    try {
+      threadPool.shutdown();
+      while (!threadPool.awaitTermination(30, TimeUnit.SECONDS)) {
+        System.out.println("Waiting for threads to finish... " + threadPool);
+      }
+    } catch (InterruptedException e) {
+      System.out.println("Test interrupted. Attempting to shut down associated thread pool.");
+      threadPool.shutdownNow();
+    }
+  }
+
+  @Test
+  public void getModulesInPredictableOrderWithRemoval() {
+    List<String> resultsA = new ArrayList<String>();
+    List<String> resultsB = new ArrayList<String>();
+
+    Random randA = new Random(9L);
+    Random randB = new Random(9L);
+
+    List<Module> modulesA = Module.getModules();
+    while (!modulesA.isEmpty()) {
+      Iterator<Module> iter = modulesA.iterator();
+      while (iter.hasNext()) {
+        Module mod = iter.next();
+        resultsA.add(mod.name);
+        if (randA.nextDouble() < 0.1) {
+          iter.remove();
+        }
+      }
+    }
+    
+    List<Module> modulesB = Module.getModules();
+    while (!modulesB.isEmpty()) {
+      Iterator<Module> iter = modulesB.iterator();
+      while (iter.hasNext()) {
+        Module mod = iter.next();
+        resultsB.add(mod.name);
+        if (randB.nextDouble() < 0.1) {
+          iter.remove();
+        }
+      }
+    }
+
+    assertEquals(resultsA.size(), resultsB.size());
+    for (int i = 0; i < resultsA.size(); i++) {
+      assertEquals(resultsA.get(i), resultsB.get(i));
+    }
   }
 
   @Test

--- a/src/test/java/org/mitre/synthea/export/CodeResolveAndExportTest.java
+++ b/src/test/java/org/mitre/synthea/export/CodeResolveAndExportTest.java
@@ -123,7 +123,7 @@ public class CodeResolveAndExportTest {
     TestHelper.loadTestProperties();
     Generator.DEFAULT_STATE = Config.get("test_state.default", "Massachusetts");
     Location location = new Location(Generator.DEFAULT_STATE, null);
-    location.assignPoint(person, location.randomCityName(person.random));
+    location.assignPoint(person, location.randomCityName(person));
     Provider.loadProviders(location, 1L);
 
     Payer.clear();

--- a/src/test/java/org/mitre/synthea/export/ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/ExporterTest.java
@@ -46,7 +46,7 @@ public class ExporterTest {
     TestHelper.loadTestProperties();
     Generator.DEFAULT_STATE = Config.get("test_state.default", "Massachusetts");
     Location location = new Location(Generator.DEFAULT_STATE, null);
-    location.assignPoint(patient, location.randomCityName(patient.random));
+    location.assignPoint(patient, location.randomCityName(patient));
     Provider.loadProviders(location, 1L);
     record = patient.record;
     // Ensure Person's Payer is not null.

--- a/src/test/java/org/mitre/synthea/export/FHIRDSTU2ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRDSTU2ExporterTest.java
@@ -116,7 +116,7 @@ public class FHIRDSTU2ExporterTest {
       TestHelper.exportOff();
       Person person = generator.generatePerson(i);
       Config.set("exporter.fhir_dstu2.export", "true");
-      FhirDstu2.TRANSACTION_BUNDLE = person.random.nextBoolean();
+      FhirDstu2.TRANSACTION_BUNDLE = person.randBoolean();
       String fhirJson = FhirDstu2.convertToFHIRJson(person, System.currentTimeMillis());
       // Check that the fhirJSON doesn't contain unresolved SNOMED-CT strings
       // (these should have been converted into URIs)

--- a/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
@@ -111,8 +111,8 @@ public class FHIRR4ExporterTest {
       int x = validationErrors.size();
       TestHelper.exportOff();
       Person person = generator.generatePerson(i);
-      FhirR4.TRANSACTION_BUNDLE = person.random.nextBoolean();
-      FhirR4.USE_US_CORE_IG = person.random.nextBoolean();
+      FhirR4.TRANSACTION_BUNDLE = person.randBoolean();
+      FhirR4.USE_US_CORE_IG = person.randBoolean();
       FhirR4.USE_SHR_EXTENSIONS = false;
       String fhirJson = FhirR4.convertToFHIRJson(person, System.currentTimeMillis());
       // Check that the fhirJSON doesn't contain unresolved SNOMED-CT strings

--- a/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
@@ -120,7 +120,7 @@ public class FHIRSTU3ExporterTest {
       Person person = generator.generatePerson(i);
       Config.set("exporter.fhir_stu3.export", "true");
       Config.set("exporter.fhir.use_shr_extensions", "true");
-      FhirStu3.TRANSACTION_BUNDLE = person.random.nextBoolean();
+      FhirStu3.TRANSACTION_BUNDLE = person.randBoolean();
       String fhirJson = FhirStu3.convertToFHIRJson(person, System.currentTimeMillis());
       // Check that the fhirJSON doesn't contain unresolved SNOMED-CT strings
       // (these should have been converted into URIs)

--- a/src/test/java/org/mitre/synthea/export/ValueSetCodeResolverTest.java
+++ b/src/test/java/org/mitre/synthea/export/ValueSetCodeResolverTest.java
@@ -68,7 +68,7 @@ public class ValueSetCodeResolverTest {
     TestHelper.loadTestProperties();
     Generator.DEFAULT_STATE = Config.get("test_state.default", "Massachusetts");
     Location location = new Location(Generator.DEFAULT_STATE, null);
-    location.assignPoint(person, location.randomCityName(person.random));
+    location.assignPoint(person, location.randomCityName(person));
     Provider.loadProviders(location, 1L);
 
     Payer.clear();

--- a/src/test/java/org/mitre/synthea/modules/EncounterModuleTest.java
+++ b/src/test/java/org/mitre/synthea/modules/EncounterModuleTest.java
@@ -33,7 +33,7 @@ public class EncounterModuleTest {
     TestHelper.loadTestProperties();
     String testState = Config.get("test_state.default", "Massachusetts");
     location = new Location(testState, null);
-    location.assignPoint(person, location.randomCityName(person.random));
+    location.assignPoint(person, location.randomCityName(person));
     Provider.loadProviders(location, 1L);
     module = new EncounterModule();
     // Ensure Person's Payer is not null.

--- a/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
@@ -92,7 +92,7 @@ public class ProviderTest {
   public void testNearestInpatientInState() {
     Provider.loadProviders(location, 1L);
     Person person = new Person(0L);
-    location.assignPoint(person, location.randomCityName(person.random));
+    location.assignPoint(person, location.randomCityName(person));
     Provider provider = Provider.findService(person, EncounterType.INPATIENT, 0);
     Assert.assertNotNull(provider);
   }
@@ -101,7 +101,7 @@ public class ProviderTest {
   public void testNearestAmbulatoryInState() {
     Provider.loadProviders(location, 1L);
     Person person = new Person(0L);
-    location.assignPoint(person, location.randomCityName(person.random));
+    location.assignPoint(person, location.randomCityName(person));
     Provider provider = Provider.findService(person, EncounterType.AMBULATORY, 0);
     Assert.assertNotNull(provider);
   }
@@ -110,7 +110,7 @@ public class ProviderTest {
   public void testNearestWellnessInState() {
     Provider.loadProviders(location, 1L);
     Person person = new Person(0L);
-    location.assignPoint(person, location.randomCityName(person.random));
+    location.assignPoint(person, location.randomCityName(person));
     Provider provider = Provider.findService(person, EncounterType.WELLNESS, 0);
     Assert.assertNotNull(provider);
   }
@@ -119,7 +119,7 @@ public class ProviderTest {
   public void testNearestEmergencyInState() {
     Provider.loadProviders(location, 1L);
     Person person = new Person(0L);
-    location.assignPoint(person, location.randomCityName(person.random));
+    location.assignPoint(person, location.randomCityName(person));
     Provider provider = Provider.findService(person, EncounterType.EMERGENCY, 0);
     Assert.assertNotNull(provider);
   }
@@ -133,7 +133,7 @@ public class ProviderTest {
     Location capital = new Location("District of Columbia", null);
     Provider.loadProviders(capital, 1L);
     Person person = new Person(0L);
-    capital.assignPoint(person, capital.randomCityName(person.random));
+    capital.assignPoint(person, capital.randomCityName(person));
     Provider provider = Provider.findService(person, EncounterType.EMERGENCY, 0);
     Assert.assertNotNull(provider);
   }
@@ -142,7 +142,7 @@ public class ProviderTest {
   public void testNearestUrgentCareInState() {
     Provider.loadProviders(location, 1L);
     Person person = new Person(0L);
-    location.assignPoint(person, location.randomCityName(person.random));
+    location.assignPoint(person, location.randomCityName(person));
     Provider provider = Provider.findService(person, EncounterType.URGENTCARE, 0);
     Assert.assertNotNull(provider); 
   }
@@ -151,7 +151,7 @@ public class ProviderTest {
   public void testNearestInpatientInCity() {
     Provider.loadProviders(city, 1L);
     Person person = new Person(0L);
-    city.assignPoint(person, city.randomCityName(person.random));
+    city.assignPoint(person, city.randomCityName(person));
     Provider provider = Provider.findService(person, EncounterType.INPATIENT, 0);
     Assert.assertNotNull(provider);
   }
@@ -160,7 +160,7 @@ public class ProviderTest {
   public void testNearestAmbulatoryInCity() {
     Provider.loadProviders(city, 1L);
     Person person = new Person(0L);
-    city.assignPoint(person, city.randomCityName(person.random));
+    city.assignPoint(person, city.randomCityName(person));
     Provider provider = Provider.findService(person, EncounterType.AMBULATORY, 0);
     Assert.assertNotNull(provider);
   }
@@ -169,7 +169,7 @@ public class ProviderTest {
   public void testNearestWellnessInCity() {
     Provider.loadProviders(city, 1L);
     Person person = new Person(0L);
-    city.assignPoint(person, city.randomCityName(person.random));
+    city.assignPoint(person, city.randomCityName(person));
     Provider provider = Provider.findService(person, EncounterType.WELLNESS, 0);
     Assert.assertNotNull(provider);
   }
@@ -178,7 +178,7 @@ public class ProviderTest {
   public void testNearestEmergencyInCity() {
     Provider.loadProviders(city, 1L);
     Person person = new Person(0L);
-    city.assignPoint(person, city.randomCityName(person.random));
+    city.assignPoint(person, city.randomCityName(person));
     Provider provider = Provider.findService(person, EncounterType.EMERGENCY, 0);
     Assert.assertNotNull(provider);
   }
@@ -187,7 +187,7 @@ public class ProviderTest {
   public void testNearestUrgentCareInCity() {
     Provider.loadProviders(city, 1L);
     Person person = new Person(0L);
-    city.assignPoint(person, city.randomCityName(person.random));
+    city.assignPoint(person, city.randomCityName(person));
     Provider provider = Provider.findService(person, EncounterType.URGENTCARE, 0);
     Assert.assertNotNull(provider);
   }

--- a/src/test/java/org/mitre/synthea/world/concepts/NHANESSampleTest.java
+++ b/src/test/java/org/mitre/synthea/world/concepts/NHANESSampleTest.java
@@ -2,7 +2,13 @@ package org.mitre.synthea.world.concepts;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.math3.distribution.EnumeratedDistribution;
 import org.junit.Test;
 
 public class NHANESSampleTest {
@@ -12,5 +18,62 @@ public class NHANESSampleTest {
     List<NHANESSample> list = NHANESSample.loadSamples();
     NHANESSample first = list.get(0);
     assertEquals(11.9, first.wt, 0.001);
+  }
+
+  @Test
+  public void predictableSamplesSingleThread() {
+    EnumeratedDistribution<NHANESSample> nhanesSamples = NHANESSample.loadDistribution();
+
+    List<NHANESSample> foo = new ArrayList<NHANESSample>();
+    List<NHANESSample> bar = new ArrayList<NHANESSample>();
+
+    for (int i = 0; i < 10; i++) {
+      nhanesSamples.reseedRandomGenerator(0L);
+      foo.add(nhanesSamples.sample());
+
+      nhanesSamples.reseedRandomGenerator(9L);
+      bar.add(nhanesSamples.sample());
+    }
+
+    for (int j = 1; j < foo.size(); j++) {
+      assertEquals(foo.get(j - 1).toString(), foo.get(j).toString());
+      assertEquals(bar.get(j - 1).toString(), bar.get(j).toString());
+    }
+  }
+
+  @Test
+  public void predictableSamplesMultiThread() throws InterruptedException {
+    EnumeratedDistribution<NHANESSample> nhanesSamples = NHANESSample.loadDistribution();
+    ExecutorService threadPool = Executors.newFixedThreadPool(8);
+    List<List<NHANESSample>> results = new ArrayList<List<NHANESSample>>();
+
+    for (int i = 0; i < 10; i++) {
+      results.add(new ArrayList<NHANESSample>());
+    }
+
+    for (int i = 0; i < 10; i++) {
+      final int k = i;
+      threadPool.submit(() -> {
+        for (int j = 0; j < 1000; j++) {
+          results.get(k).add(threadSample(nhanesSamples, j));
+        }
+      });
+    }
+
+    threadPool.shutdown();
+    while (!threadPool.awaitTermination(30, TimeUnit.SECONDS)) { /* wait */ }
+
+    for (int i = 1; i < results.size(); i++) {
+      for (int j = 0; j < results.get(i).size(); j++) {
+        assertEquals(results.get(i - 1).get(j).toString(), results.get(i).get(j).toString());
+      }
+    }
+  }
+
+  private NHANESSample threadSample(EnumeratedDistribution<NHANESSample> nhanesSamples, long seed) {
+    synchronized (nhanesSamples) {
+      nhanesSamples.reseedRandomGenerator(seed);
+      return nhanesSamples.sample();
+    }
   }
 }

--- a/src/test/java/org/mitre/synthea/world/concepts/PediatricGrowthTrajectoryTest.java
+++ b/src/test/java/org/mitre/synthea/world/concepts/PediatricGrowthTrajectoryTest.java
@@ -3,7 +3,6 @@ package org.mitre.synthea.world.concepts;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
-import org.apache.commons.math3.random.JDKRandomGenerator;
 import org.junit.Test;
 import org.mitre.synthea.TestHelper;
 import org.mitre.synthea.helpers.Utilities;
@@ -17,14 +16,13 @@ public class PediatricGrowthTrajectoryTest {
     Person person = new Person(0L);
     person.attributes.put(Person.BIRTHDATE, birthDay);
     person.attributes.put(Person.GENDER, "M");
-    JDKRandomGenerator random = new JDKRandomGenerator(6454);
     PediatricGrowthTrajectory pgt = new PediatricGrowthTrajectory(0L, birthDay);
     // This will be the initial NHANES Sample
     long sampleSimulationTime = pgt.tail().timeInSimulation;
     double initialBMI = pgt.tail().bmi;
     long sixMonthsAfterInitial = sampleSimulationTime + Utilities.convertTime("months", 6);
     // Will cause generateNextYearBMI to be run
-    double sixMonthLaterBMI = pgt.currentBMI(person, sixMonthsAfterInitial, random);
+    double sixMonthLaterBMI = pgt.currentBMI(person, sixMonthsAfterInitial);
     double oneYearLaterBMI = pgt.tail().bmi;
     double bmiDiff = oneYearLaterBMI - initialBMI;
     assertEquals(initialBMI + (0.5 * bmiDiff), sixMonthLaterBMI, 0.01);

--- a/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
+++ b/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
@@ -8,7 +8,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 
 import org.junit.Assert;
@@ -146,8 +145,8 @@ public class LocationTest {
 
   @Test
   public void testGetForeignPlaceOfBirth_HappyPath() {
-    Random random = new Random(4L);
-    String[] placeOfBirth = location.randomBirthplaceByLanguage(random, "german");
+    Person person = new Person(4L);
+    String[] placeOfBirth = location.randomBirthplaceByLanguage(person, "german");
     for (String part : placeOfBirth) {
       Assert.assertNotNull(part);
       Assert.assertTrue(placeOfBirth[placeOfBirth.length - 1].contains(part));
@@ -156,8 +155,8 @@ public class LocationTest {
 
   @Test
   public void testGetForeignPlaceOfBirth_ValidStringInvalidFormat_1() {
-    Random random = new Random(0L);
-    String[] placeOfBirth = location.randomBirthplaceByLanguage(random, "too_many_elements");
+    Person person = new Person(0L);
+    String[] placeOfBirth = location.randomBirthplaceByLanguage(person, "too_many_elements");
     for (String part : placeOfBirth) {
       Assert.assertNotNull(part);
       Assert.assertTrue(placeOfBirth[placeOfBirth.length - 1].contains(part));
@@ -166,8 +165,8 @@ public class LocationTest {
 
   @Test
   public void testGetForeignPlaceOfBirth_ValidStringInvalidFormat_2() {
-    Random random = new Random(0L);
-    String[] placeOfBirth = location.randomBirthplaceByLanguage(random, "not_enough_elements");
+    Person person = new Person(0L);
+    String[] placeOfBirth = location.randomBirthplaceByLanguage(person, "not_enough_elements");
     for (String part : placeOfBirth) {
       Assert.assertNotNull(part);
       Assert.assertTrue(placeOfBirth[placeOfBirth.length - 1].contains(part));
@@ -176,8 +175,8 @@ public class LocationTest {
 
   @Test
   public void testGetForeignPlaceOfBirth_MissingValue() {
-    Random random = new Random(0L);
-    String[] placeOfBirth = location.randomBirthplaceByLanguage(random, "unknown_ethnicity");
+    Person person = new Person(0L);
+    String[] placeOfBirth = location.randomBirthplaceByLanguage(person, "unknown_ethnicity");
     for (String part : placeOfBirth) {
       Assert.assertNotNull(part);
       Assert.assertTrue(placeOfBirth[placeOfBirth.length - 1].contains(part));
@@ -186,8 +185,8 @@ public class LocationTest {
 
   @Test
   public void testGetForeignPlaceOfBirth_EmptyValue() {
-    Random random = new Random(0L);
-    String[] placeOfBirth = location.randomBirthplaceByLanguage(random, "empty_ethnicity");
+    Person person = new Person(0L);
+    String[] placeOfBirth = location.randomBirthplaceByLanguage(person, "empty_ethnicity");
     for (String part : placeOfBirth) {
       Assert.assertNotNull(part);
       Assert.assertTrue(placeOfBirth[placeOfBirth.length - 1].contains(part));


### PR DESCRIPTION
This pull request attempts to address #752.

Recreation of data requires the use of a random seed (`-s`), a clinician seed (`-cs`), and a reference date (`-r`).

Things that will not be identical:

- UUIDs: these will change across runs. Sorry.
- Export History: if you run the same parameters next year, and only keep the default 10 years of history, then the data in the record will be filtered differently (i.e. the oldest one year from the first run will not be exported)..

## Summary of Changes

- Randomness
  - I made the `Random` inside `Person` to be `private` and made a few new accessor methods (e.g. `randBoolean()`).
  - Except for a few places (e.g. `Generator.java`), that means `Random` objects are no longer passed around as method arguments, and there should be no use of `Random` in the code.
  - All random number access goes through the `Person#rand*` methods.
  - There should also be no `System.currentTimeInMillis()` calls except for a few spots (e.g. `Generator.java` and sometimes export paths when folder per run settings are used).
- Reference Dates
  - I added an optional `-r` switch for `referenceDate` which can be used to specify when Synthea bases all the birth dates from. In my testing I used `20200320` (or March 20th, 2020) but you can use any date. This defaults to now (`System.currentTimeinMillis()`) if no value is supplied.
- Modules and States
  - All modules and states are completely cloned across the patients now. The modules used to be passed directly, and only the states were cloned. Now the modules are cloned as well. This was done to remove any possibility of multi-thread race conditions on accessing modules. Possibly unnecessary.
- Wiki
  - I added this https://github.com/synthetichealth/synthea/wiki/Contributing#new-sources-of-randomness to the wiki.