### PR TITLE
Reproducible IDs for FHIR resources and CCDA elements.

### DIFF
--- a/src/main/java/org/mitre/synthea/datastore/DataStore.java
+++ b/src/main/java/org/mitre/synthea/datastore/DataStore.java
@@ -9,7 +9,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mitre.synthea.helpers.Utilities;
@@ -283,7 +282,7 @@ public class DataStore {
       stmt.executeBatch();
 
       for (Encounter encounter : p.record.encounters) {
-        String encounterID = UUID.randomUUID().toString();
+        String encounterID = p.randUUID().toString();
 
         String providerID = null;
 
@@ -343,7 +342,7 @@ public class DataStore {
         }
 
         for (Report report : encounter.reports) {
-          String reportID = UUID.randomUUID().toString();
+          String reportID = p.randUUID().toString();
 
           // CREATE TABLE IF NOT EXISTS REPORT (id varchar, person_id varchar, encounter_id varchar,
           // name varchar, type varchar, start bigint, code varchar, display varchar, system
@@ -475,7 +474,7 @@ public class DataStore {
               "INSERT INTO MEDICATION "
               + "(id, person_id, provider_id, name, type, start, stop, code, display, system) "
               + "VALUES (?,?,?,?,?,?,?,?,?,?);");
-          String medicationID = UUID.randomUUID().toString();
+          String medicationID = p.randUUID().toString();
           stmt.setString(1, medicationID);
           stmt.setString(2, personID);
           stmt.setString(3, providerID);
@@ -501,7 +500,7 @@ public class DataStore {
               "INSERT INTO CLAIM "
               + "(id, person_id, encounter_id, medication_id, time, cost) "
               + "VALUES (?,?,?,?,?,?)");
-          stmt.setString(1, UUID.randomUUID().toString());
+          stmt.setString(1, p.randUUID().toString());
           stmt.setString(2, personID);
           stmt.setString(3, encounterID);
           stmt.setString(4, medicationID);
@@ -544,7 +543,7 @@ public class DataStore {
               "INSERT INTO careplan "
               + "(id, person_id, provider_id, name, type, start, stop, code, display, system) "
               + "VALUES (?,?,?,?,?,?,?,?,?,?);");
-          stmt.setString(1, UUID.randomUUID().toString());
+          stmt.setString(1, p.randUUID().toString());
           stmt.setString(2, personID);
           if (encounter.provider == null) {
             stmt.setString(3, null);
@@ -580,7 +579,7 @@ public class DataStore {
               + "(id, uid, person_id, encounter_id, start, modality_code, modality_display, "
               + "modality_system, bodysite_code, bodysite_display, bodysite_system, sop_class) "
               + "VALUES (?,?,?,?,?,?,?,?,?,?,?,?);");
-          stmt.setString(1, UUID.randomUUID().toString());
+          stmt.setString(1, p.randUUID().toString());
           stmt.setString(2, imagingStudy.dicomUid);
           stmt.setString(3, personID);
           stmt.setString(4, encounterID);
@@ -608,7 +607,7 @@ public class DataStore {
             "INSERT INTO CLAIM "
             + "(id, person_id, encounter_id, medication_id, time, cost) "
             + "VALUES (?,?,?,?,?,?)");
-        stmt.setString(1, UUID.randomUUID().toString());
+        stmt.setString(1, p.randUUID().toString());
         stmt.setString(2, personID);
         stmt.setString(3, encounterID);
         stmt.setString(4, null);

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -28,6 +28,7 @@ import org.mitre.synthea.editors.GrowthDataErrorsEditor;
 import org.mitre.synthea.export.CDWExporter;
 import org.mitre.synthea.export.Exporter;
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.TransitionMetrics;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.modules.DeathModule;
@@ -45,7 +46,7 @@ import org.mitre.synthea.world.geography.Location;
 /**
  * Generator creates a population by running the generic modules each timestep per Person.
  */
-public class Generator {
+public class Generator implements RandomNumberGenerator {
 
   public DataStore database;
   public GeneratorOptions options;
@@ -360,6 +361,7 @@ public class Generator {
    * simulation. This means that if in the course of the simulation the person dies, a new person
    * will be started to replace them. 
    * The seed used to generate the person is randomized as well.
+   * Note that this method is only used by unit tests.
    * 
    * @param index Target index in the whole set of people to generate
    * @return generated Person
@@ -667,4 +669,54 @@ public class Generator {
         IOCase.INSENSITIVE);
     return path -> filenameFilter.accept(null, path);
   }
+
+  /**
+   * Returns a random double.
+   */
+  public double rand() {
+    return random.nextDouble();
+  }
+
+  /**
+   * Returns a random boolean.
+   */
+  public boolean randBoolean() {
+    return random.nextBoolean();
+  }
+
+  /**
+   * Returns a random integer.
+   */
+  public int randInt() {
+    return random.nextInt();
+  }
+
+  /**
+   * Returns a random integer in the given bound.
+   */
+  public int randInt(int bound) {
+    return random.nextInt(bound);
+  }
+
+  /**
+   * Returns a double from a normal distribution.
+   */
+  public double randGaussian() {
+    return random.nextGaussian();
+  }
+
+  /**
+   * Return a random long.
+   */
+  public long randLong() {
+    return random.nextLong();
+  }
+  
+  /**
+   * Return a random UUID.
+   */
+  public UUID randUUID() {
+    return new UUID(randLong(), randLong());
+  }
+  
 }

--- a/src/main/java/org/mitre/synthea/export/CCDAExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CCDAExporter.java
@@ -6,7 +6,7 @@ import freemarker.template.TemplateException;
 
 import java.io.Serializable;
 import java.io.StringWriter;
-import java.util.UUID;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
@@ -20,18 +20,21 @@ public class CCDAExporter {
   private static final Configuration TEMPLATES = templateConfiguration();
   
   /**
-   * This is a dummy class and object for FreeMarker, because the library cannot access static
-   * class methods such as UUID.randomUUID()
+   * This is a dummy class and object for FreeMarker templates that create IDs.
    */
   private static class UUIDGenerator implements Serializable {
+    private RandomNumberGenerator rand;
+    
+    public UUIDGenerator(RandomNumberGenerator rand) {
+      this.rand = rand;
+    }
+    
     @Override
     public String toString() {
-      return UUID.randomUUID().toString();
+      return rand.randUUID().toString();
     }
   }
   
-  private static final Object UUID_GEN = new UUIDGenerator();
-
   private static Configuration templateConfiguration() {
     Configuration configuration = new Configuration(Configuration.VERSION_2_3_26);
     configuration.setDefaultEncoding("UTF-8");
@@ -82,7 +85,7 @@ public class CCDAExporter {
 
     // The export templates fill in the record by accessing the attributes
     // of the Person, so we add a few attributes just for the purposes of export.
-    person.attributes.put("UUID", UUID_GEN);
+    person.attributes.put("UUID", new UUIDGenerator(person));
     person.attributes.put("ehr_encounters", person.record.encounters);
     person.attributes.put("ehr_observations", superEncounter.observations);
     person.attributes.put("ehr_reports", superEncounter.reports);

--- a/src/main/java/org/mitre/synthea/export/CPCDSExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CPCDSExporter.java
@@ -18,6 +18,7 @@ import java.util.Random;
 import java.util.UUID;
 
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.HealthRecord.CarePlan;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
@@ -232,8 +233,8 @@ public class CPCDSExporter {
     long end = 0;
 
     for (Encounter encounter : person.record.encounters) {
-      String encounterID = UUID.randomUUID().toString();
-      UUID medRecordNumber = UUID.randomUUID();
+      String encounterID = person.randUUID().toString();
+      UUID medRecordNumber = person.randUUID();
       CPCDSAttributes encounterAttributes = new CPCDSAttributes(encounter);
 
 
@@ -256,9 +257,9 @@ public class CPCDSExporter {
       if (start == 999999999999999999L) {
         start = end;
       }
-      String coverageID = coverage(personID, start, end, payerId, type, groupId, groupName,
+      String coverageID = coverage(person, personID, start, end, payerId, type, groupId, groupName,
               planName, planId);
-      claim(encounter, personID, encounterID, medRecordNumber, encounterAttributes, payerId,
+      claim(person, encounter, personID, encounterID, medRecordNumber, encounterAttributes, payerId,
               coverageID);
       hospital(encounter, encounterAttributes, payerName);
     }
@@ -326,16 +327,18 @@ public class CPCDSExporter {
   /**
    * Write a single Coverage CPCDS file.
    *
+   * @param rand        Source of randomness to use when generating ids etc
    * @param personID    ID of the person prescribed the careplan.
    * @param encounterID ID of the encounter where the careplan was prescribed
    * @param careplan    The careplan itself
    * @throws IOException if any IO error occurs
    */
-  private String coverage(String personID, long start, long stop, String payerId, String type,
-          UUID groupId, String groupName, String name, String planId) throws IOException {
+  private String coverage(RandomNumberGenerator rand, String personID, long start, long stop,
+          String payerId, String type, UUID groupId, String groupName, String name, 
+          String planId) throws IOException {
 
     StringBuilder s = new StringBuilder();
-    String coverageID = UUID.randomUUID().toString();
+    String coverageID = rand.randUUID().toString();
     s.append(coverageID).append(',');
     s.append(personID).append(',');
     s.append(personID).append(',');
@@ -370,6 +373,7 @@ public class CPCDSExporter {
    * Method to write a single Claims file. Take an encounter in the parameters and
    * processes Diagnoses, Procedures, and Pharmacy claims for each one, in order.
    * 
+   * @param rand            Source of randomness to use when generating ids etc
    * @param encounter       The encounter object itself
    * @param personID        The Id of the involved patient
    * @param encounterID     The Id of the encounter
@@ -378,8 +382,9 @@ public class CPCDSExporter {
    * @param payerId         The Id of the payer
    * @throws IOException Throws this exception
    */
-  private void claim(Encounter encounter, String personID, String encounterID, UUID medRecordNumber,
-      CPCDSAttributes attributes, String payerId, String coverageID) throws IOException {
+  private void claim(RandomNumberGenerator rand, Encounter encounter, String personID, 
+          String encounterID, UUID medRecordNumber, CPCDSAttributes attributes, String payerId,
+          String coverageID) throws IOException {
 
     StringBuilder s = new StringBuilder();
 
@@ -742,7 +747,7 @@ public class CPCDSExporter {
                   * dayMultiplier.get(duration.get("unit").getAsString());
         }
 
-        UUID rxRef = UUID.randomUUID();
+        UUID rxRef = rand.randUUID();
 
         String[] serviceTypeList = { "01", "04", "06" };
         String serviceType = serviceTypeList[(int) randomLongWithBounds(0, 2)];

--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -19,10 +19,10 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.modules.QualityOfLifeModule;
 import org.mitre.synthea.world.agents.Clinician;
@@ -379,7 +379,7 @@ public class CSVExporter {
 
     for (Encounter encounter : person.record.encounters) {
 
-      String encounterID = encounter(personID, encounter);
+      String encounterID = encounter(person, personID, encounter);
       String payerID = encounter.claim.payer.uuid;
 
       for (HealthRecord.Entry condition : encounter.conditions) {
@@ -407,11 +407,11 @@ public class CSVExporter {
       }
 
       for (CarePlan careplan : encounter.careplans) {
-        careplan(personID, encounterID, careplan);
+        careplan(person, personID, encounterID, careplan);
       }
 
       for (ImagingStudy imagingStudy : encounter.imagingStudies) {
-        imagingStudy(personID, encounterID, imagingStudy);
+        imagingStudy(person, personID, encounterID, imagingStudy);
       }
       
       for (Device device : encounter.devices) {
@@ -544,17 +544,19 @@ public class CSVExporter {
   /**
    * Write a single Encounter line to encounters.csv.
    *
+   * @param rand      Source of randomness to use when generating ids etc
    * @param personID  The ID of the person that had this encounter
    * @param encounter The encounter itself
    * @return The encounter ID, to be referenced as a "foreign key" if necessary
    * @throws IOException if any IO error occurs
    */
-  private String encounter(String personID, Encounter encounter) throws IOException {
+  private String encounter(RandomNumberGenerator rand, String personID, 
+          Encounter encounter) throws IOException {
     // Id,START,STOP,PATIENT,ORGANIZATION,PROVIDER,PAYER,ENCOUNTERCLASS,CODE,DESCRIPTION,
     // BASE_ENCOUNTER_COST,TOTAL_CLAIM_COST,PAYER_COVERAGE,REASONCODE,REASONDESCRIPTION
     StringBuilder s = new StringBuilder();
 
-    String encounterID = UUID.randomUUID().toString();
+    String encounterID = rand.randUUID().toString();
     // ID
     s.append(encounterID).append(',');
     // START
@@ -873,17 +875,18 @@ public class CSVExporter {
   /**
    * Write a single CarePlan to careplans.csv.
    *
+   * @param rand        Source of randomness to use when generating ids etc
    * @param personID    ID of the person prescribed the careplan.
    * @param encounterID ID of the encounter where the careplan was prescribed
    * @param careplan    The careplan itself
    * @throws IOException if any IO error occurs
    */
-  private String careplan(String personID, String encounterID,
+  private String careplan(RandomNumberGenerator rand, String personID, String encounterID,
       CarePlan careplan) throws IOException {
     // Id,START,STOP,PATIENT,ENCOUNTER,CODE,DESCRIPTION,REASONCODE,REASONDESCRIPTION
     StringBuilder s = new StringBuilder();
 
-    String careplanID = UUID.randomUUID().toString();
+    String careplanID = rand.randUUID().toString();
     s.append(careplanID).append(',');
     s.append(dateFromTimestamp(careplan.start)).append(',');
     if (careplan.stop != 0L) {
@@ -915,18 +918,19 @@ public class CSVExporter {
   /**
    * Write a single ImagingStudy to imaging_studies.csv.
    *
+   * @param rand         Source of randomness to use when generating ids etc
    * @param personID     ID of the person the ImagingStudy was taken of.
    * @param encounterID  ID of the encounter where the ImagingStudy was performed
    * @param imagingStudy The ImagingStudy itself
    * @throws IOException if any IO error occurs
    */
-  private String imagingStudy(String personID, String encounterID,
+  private String imagingStudy(RandomNumberGenerator rand, String personID, String encounterID,
       ImagingStudy imagingStudy) throws IOException {
     // Id,DATE,PATIENT,ENCOUNTER,BODYSITE_CODE,BODYSITE_DESCRIPTION,
     // MODALITY_CODE,MODALITY_DESCRIPTION,SOP_CODE,SOP_DESCRIPTION
     StringBuilder s = new StringBuilder();
 
-    String studyID = UUID.randomUUID().toString();
+    String studyID = rand.randUUID().toString();
     s.append(studyID).append(',');
     s.append(iso8601Timestamp(imagingStudy.start)).append(',');
     s.append(personID).append(',');

--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -147,7 +147,7 @@ public abstract class Exporter {
    * @param person   Patient to export
    * @param stopTime Time at which the simulation stopped
    */
-  protected static void export(Person person, long stopTime) {
+  public static void export(Person person, long stopTime) {
     export(person, stopTime, new ExporterRuntimeOptions());
   }
 
@@ -366,20 +366,20 @@ public abstract class Exporter {
 
     // Before we force bulk data to be off...
     try {
-      FhirGroupExporterR4.exportAndSave(generator.stop);
+      FhirGroupExporterR4.exportAndSave(generator, generator.stop);
     } catch (Exception e) {
       e.printStackTrace();
     }
 
     Config.set("exporter.fhir.bulk_data", "false");
     try {
-      HospitalExporterR4.export(generator.stop);
+      HospitalExporterR4.export(generator, generator.stop);
     } catch (Exception e) {
       e.printStackTrace();
     }
 
     try {
-      FhirPractitionerExporterR4.export(generator.stop);
+      FhirPractitionerExporterR4.export(generator, generator.stop);
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/src/main/java/org/mitre/synthea/export/FhirGroupExporterR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirGroupExporterR4.java
@@ -12,12 +12,12 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 import org.hl7.fhir.r4.model.Group;
 import org.hl7.fhir.r4.model.Group.GroupType;
 import org.hl7.fhir.r4.model.Reference;
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 
 public abstract class FhirGroupExporterR4 {
 
@@ -44,8 +44,8 @@ public abstract class FhirGroupExporterR4 {
    * @param stop The stop time.
    * @return FHIR Group resource.
    */
-  public static Group export(long stop) {
-    String uuid = UUID.randomUUID().toString();
+  public static Group export(RandomNumberGenerator rand, long stop) {
+    String uuid = rand.randUUID().toString();
 
     Group group = new Group();
     group.setId(uuid);
@@ -65,10 +65,11 @@ public abstract class FhirGroupExporterR4 {
 
   /**
    * Export the current patient list as a FHIR Group resource and save it as a JSON file.
+   * @param stop The stop time.
    */
-  public static void exportAndSave(long stop) {
+  public static void exportAndSave(RandomNumberGenerator rand, long stop) {
     if (Boolean.parseBoolean(Config.get("exporter.groups.fhir.export"))) {
-      Group group = export(stop);
+      Group group = export(rand, stop);
 
       // get output folder
       List<String> folders = new ArrayList<>();

--- a/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterR4.java
@@ -21,6 +21,7 @@ import org.hl7.fhir.r4.model.Bundle.BundleType;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.world.agents.Clinician;
 import org.mitre.synthea.world.agents.Provider;
 
@@ -34,7 +35,7 @@ public abstract class FhirPractitionerExporterR4 {
   /**
    * Export the practitioner in FHIR R4 format.
    */
-  public static void export(long stop) {
+  public static void export(RandomNumberGenerator rand, long stop) {
     if (Boolean.parseBoolean(Config.get("exporter.practitioner.fhir.export"))) {
 
       Bundle bundle = new Bundle();
@@ -55,7 +56,7 @@ public abstract class FhirPractitionerExporterR4 {
             ArrayList<Clinician> docs = clinicians.get(specialty);
             for (Clinician doc : docs) {
               if (doc.getEncounterCount() > 0) {
-                BundleEntryComponent entry = FhirR4.practitioner(bundle, doc);
+                BundleEntryComponent entry = FhirR4.practitioner(rand, bundle, doc);
                 Practitioner practitioner = (Practitioner) entry.getResource();
                 practitioner.addExtension()
                   .setUrl(EXTENSION_URI)

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.hl7.fhir.r4.model.Address;
@@ -129,6 +128,7 @@ import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 import org.mitre.synthea.engine.Components;
 import org.mitre.synthea.engine.Components.Attachment;
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Clinician;
@@ -257,33 +257,33 @@ public class FhirR4 {
       BundleEntryComponent encounterEntry = encounter(person, personEntry, bundle, encounter);
 
       for (HealthRecord.Entry condition : encounter.conditions) {
-        condition(personEntry, bundle, encounterEntry, condition);
+        condition(person, personEntry, bundle, encounterEntry, condition);
       }
 
       for (HealthRecord.Entry allergy : encounter.allergies) {
-        allergy(personEntry, bundle, encounterEntry, allergy);
+        allergy(person, personEntry, bundle, encounterEntry, allergy);
       }
 
       for (Observation observation : encounter.observations) {
         // If the Observation contains an attachment, use a Media resource, since
         // Observation resources in v4 don't support Attachments
         if (observation.value instanceof Attachment) {
-          media(personEntry, bundle, encounterEntry, observation);
+          media(person, personEntry, bundle, encounterEntry, observation);
         } else {
-          observation(personEntry, bundle, encounterEntry, observation);
+          observation(person, personEntry, bundle, encounterEntry, observation);
         }
       }
 
       for (Procedure procedure : encounter.procedures) {
-        procedure(personEntry, bundle, encounterEntry, procedure);
+        procedure(person, personEntry, bundle, encounterEntry, procedure);
       }
 
       for (HealthRecord.Device device : encounter.devices) {
-        device(personEntry, bundle, device);
+        device(person, personEntry, bundle, device);
       }
       
       for (HealthRecord.Supply supply : encounter.supplies) {
-        supplyDelivery(personEntry, bundle, supply, encounter);
+        supplyDelivery(person, personEntry, bundle, supply, encounter);
       }
 
       for (Medication medication : encounter.medications) {
@@ -291,28 +291,29 @@ public class FhirR4 {
       }
 
       for (HealthRecord.Entry immunization : encounter.immunizations) {
-        immunization(personEntry, bundle, encounterEntry, immunization);
+        immunization(person, personEntry, bundle, encounterEntry, immunization);
       }
 
       for (Report report : encounter.reports) {
-        report(personEntry, bundle, encounterEntry, report);
+        report(person, personEntry, bundle, encounterEntry, report);
       }
 
       for (CarePlan careplan : encounter.careplans) {
-        BundleEntryComponent careTeamEntry =
-            careTeam(personEntry, bundle, encounterEntry, careplan);
-        carePlan(personEntry, bundle, encounterEntry, encounter.provider, careTeamEntry, careplan);
+        BundleEntryComponent careTeamEntry = 
+                careTeam(person, personEntry, bundle, encounterEntry, careplan);
+        carePlan(person, personEntry, bundle, encounterEntry, encounter.provider, careTeamEntry,
+                careplan);
       }
 
       for (ImagingStudy imagingStudy : encounter.imagingStudies) {
-        imagingStudy(personEntry, bundle, encounterEntry, imagingStudy);
+        imagingStudy(person, personEntry, bundle, encounterEntry, imagingStudy);
       }
       
       if (USE_US_CORE_IG) {
         String clinicalNoteText = ClinicalNoteExporter.export(person, encounter);
         boolean lastNote =
             (encounter == person.record.encounters.get(person.record.encounters.size() - 1));
-        clinicalNote(personEntry, bundle, encounterEntry, clinicalNoteText, lastNote);
+        clinicalNote(person, personEntry, bundle, encounterEntry, clinicalNoteText, lastNote);
       }
 
       // one claim per encounter
@@ -703,7 +704,7 @@ public class FhirR4 {
       if (providerFullUrl != null) {
         encounterResource.setServiceProvider(new Reference(providerFullUrl));
       } else {
-        BundleEntryComponent providerOrganization = provider(bundle, encounter.provider);
+        BundleEntryComponent providerOrganization = provider(person, bundle, encounter.provider);
         encounterResource.setServiceProvider(new Reference(providerOrganization.getFullUrl()));
       }
       encounterResource.getServiceProvider().setDisplay(encounter.provider.name);
@@ -719,7 +720,7 @@ public class FhirR4 {
       if (providerFullUrl != null) {
         encounterResource.setServiceProvider(new Reference(providerFullUrl));
       } else {
-        BundleEntryComponent providerOrganization = provider(bundle, provider);
+        BundleEntryComponent providerOrganization = provider(person, bundle, provider);
         encounterResource.setServiceProvider(new Reference(providerOrganization.getFullUrl()));
       }
       encounterResource.getServiceProvider().setDisplay(provider.name);
@@ -736,7 +737,7 @@ public class FhirR4 {
       if (practitionerFullUrl != null) {
         encounterResource.addParticipant().setIndividual(new Reference(practitionerFullUrl));
       } else {
-        BundleEntryComponent practitioner = practitioner(bundle, encounter.clinician);
+        BundleEntryComponent practitioner = practitioner(person, bundle, encounter.clinician);
         encounterResource.addParticipant().setIndividual(new Reference(practitioner.getFullUrl()));
       }
       encounterResource.getParticipantFirstRep().getIndividual()
@@ -756,7 +757,7 @@ public class FhirR4 {
       encounterResource.setHospitalization(hospitalization);
     }
 
-    BundleEntryComponent entry = newEntry(bundle, encounterResource);
+    BundleEntryComponent entry = newEntry(person, bundle, encounterResource);
     if (USE_US_CORE_IG) {
       // US Core Encounters should have an identifier to support the required
       // Encounter.identifier search parameter
@@ -892,7 +893,7 @@ public class FhirR4 {
     moneyResource.setCurrency("USD");
     claimResource.setTotal(moneyResource);
 
-    return newEntry(bundle, claimResource);
+    return newEntry(person, bundle, claimResource);
   }
 
   /**
@@ -1017,7 +1018,7 @@ public class FhirR4 {
     moneyResource.setValue(claim.getTotalClaimCost());
     claimResource.setTotal(moneyResource);
 
-    return newEntry(bundle, claimResource);
+    return newEntry(person, bundle, claimResource);
   }
 
   /**
@@ -1333,20 +1334,22 @@ public class FhirR4 {
     eob.setPayment(new ExplanationOfBenefit.PaymentComponent()
         .setAmount(payment));
 
-    return newEntry(bundle,eob);
+    return newEntry(person, bundle,eob);
   }
 
   /**
    * Map the Condition into a FHIR Condition resource, and add it to the given Bundle.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         The Bundle to add to
    * @param encounterEntry The current Encounter entry
    * @param condition      The Condition
    * @return The added Entry
    */
-  private static BundleEntryComponent condition(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, HealthRecord.Entry condition) {
+  private static BundleEntryComponent condition(RandomNumberGenerator rand, 
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          HealthRecord.Entry condition) {
     Condition conditionResource = new Condition();
 
     if (USE_US_CORE_IG) {
@@ -1390,7 +1393,7 @@ public class FhirR4 {
       status.getCodingFirstRep().setCode("resolved");
     }
 
-    BundleEntryComponent conditionEntry = newEntry(bundle, conditionResource);
+    BundleEntryComponent conditionEntry = newEntry(rand, bundle, conditionResource);
 
     condition.fullUrl = conditionEntry.getFullUrl();
 
@@ -1400,14 +1403,16 @@ public class FhirR4 {
   /**
    * Map the Condition into a FHIR AllergyIntolerance resource, and add it to the given Bundle.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         The Bundle to add to
    * @param encounterEntry The current Encounter entry
    * @param allergy        The Allergy Entry
    * @return The added Entry
    */
-  private static BundleEntryComponent allergy(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, HealthRecord.Entry allergy) {
+  private static BundleEntryComponent allergy(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          HealthRecord.Entry allergy) {
 
     AllergyIntolerance allergyResource = new AllergyIntolerance();
     allergyResource.setRecordedDate(new Date(allergy.start));
@@ -1444,7 +1449,7 @@ public class FhirR4 {
           "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance");
       allergyResource.setMeta(meta);
     }
-    BundleEntryComponent allergyEntry = newEntry(bundle, allergyResource);
+    BundleEntryComponent allergyEntry = newEntry(rand, bundle, allergyResource);
     allergy.fullUrl = allergyEntry.getFullUrl();
     return allergyEntry;
   }
@@ -1453,14 +1458,16 @@ public class FhirR4 {
   /**
    * Map the given Observation into a FHIR Observation resource, and add it to the given Bundle.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Person Entry
    * @param bundle         The Bundle to add to
    * @param encounterEntry The current Encounter entry
    * @param observation    The Observation
    * @return The added Entry
    */
-  private static BundleEntryComponent observation(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, Observation observation) {
+  private static BundleEntryComponent observation(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          Observation observation) {
     org.hl7.fhir.r4.model.Observation observationResource =
         new org.hl7.fhir.r4.model.Observation();
 
@@ -1533,7 +1540,7 @@ public class FhirR4 {
       observationResource.setMeta(meta);
     }
 
-    BundleEntryComponent entry = newEntry(bundle, observationResource);
+    BundleEntryComponent entry = newEntry(rand, bundle, observationResource);
     observation.fullUrl = entry.getFullUrl();
     return entry;
   }
@@ -1603,14 +1610,16 @@ public class FhirR4 {
   /**
    * Map the given Procedure into a FHIR Procedure resource, and add it to the given Bundle.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Person entry
    * @param bundle         Bundle to add to
    * @param encounterEntry The current Encounter entry
    * @param procedure      The Procedure
    * @return The added Entry
    */
-  private static BundleEntryComponent procedure(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, Procedure procedure) {
+  private static BundleEntryComponent procedure(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          Procedure procedure) {
     org.hl7.fhir.r4.model.Procedure procedureResource = new org.hl7.fhir.r4.model.Procedure();
     if (USE_US_CORE_IG) {
       Meta meta = new Meta();
@@ -1668,7 +1677,7 @@ public class FhirR4 {
       procedureResource.addExtension(performedContext);
     }
 
-    BundleEntryComponent procedureEntry = newEntry(bundle, procedureResource);
+    BundleEntryComponent procedureEntry = newEntry(rand, bundle, procedureResource);
     procedure.fullUrl = procedureEntry.getFullUrl();
 
     return procedureEntry;
@@ -1677,13 +1686,14 @@ public class FhirR4 {
   /**
    * Map the HealthRecord.Device into a FHIR Device and add it to the Bundle.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Person entry.
    * @param bundle         Bundle to add to.
    * @param device         The device to add.
    * @return The added Entry.
    */
-  private static BundleEntryComponent device(BundleEntryComponent personEntry, Bundle bundle,
-      HealthRecord.Device device) {
+  private static BundleEntryComponent device(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, HealthRecord.Device device) {
     Device deviceResource = new Device();
     if (USE_US_CORE_IG) {
       Meta meta = new Meta();
@@ -1710,20 +1720,22 @@ public class FhirR4 {
         .setType(DeviceNameType.USERFRIENDLYNAME);
     deviceResource.setType(mapCodeToCodeableConcept(device.codes.get(0), SNOMED_URI));
     deviceResource.setPatient(new Reference(personEntry.getFullUrl()));
-    return newEntry(bundle, deviceResource);
+    return newEntry(rand, bundle, deviceResource);
   }
   
   /**
    * Map the JsonObject for a Supply into a FHIR SupplyDelivery and add it to the Bundle.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Person entry.
    * @param bundle         Bundle to add to.
    * @param supply         The supplied object to add.
    * @param encounter      The encounter during which the supplies were delivered
    * @return The added Entry.
    */
-  private static BundleEntryComponent supplyDelivery(BundleEntryComponent personEntry,
-          Bundle bundle, HealthRecord.Supply supply, Encounter encounter) {
+  private static BundleEntryComponent supplyDelivery(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, HealthRecord.Supply supply,
+          Encounter encounter) {
    
     SupplyDelivery supplyResource = new SupplyDelivery();
     supplyResource.setStatus(SupplyDeliveryStatus.COMPLETED);
@@ -1744,7 +1756,7 @@ public class FhirR4 {
     
     supplyResource.setOccurrence(convertFhirDateTime(supply.start, true));
     
-    return newEntry(bundle, supplyResource);
+    return newEntry(rand, bundle, supplyResource);
   }
 
   /**
@@ -1810,11 +1822,12 @@ public class FhirR4 {
     agent.setOnBehalfOf(new Reference()
         .setReference(organizationFullUrl)
         .setDisplay(providerOrganization.name));
-    return newEntry(bundle, provenance);
+    return newEntry(person, bundle, provenance);
   }
 
-  private static BundleEntryComponent immunization(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, HealthRecord.Entry immunization) {
+  private static BundleEntryComponent immunization(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          HealthRecord.Entry immunization) {
     Immunization immResource = new Immunization();
     if (USE_US_CORE_IG) {
       Meta meta = new Meta();
@@ -1842,7 +1855,7 @@ public class FhirR4 {
       immResource.setLocation(encounterResource.getLocationFirstRep().getLocation());
     }
 
-    BundleEntryComponent immunizationEntry = newEntry(bundle, immResource);
+    BundleEntryComponent immunizationEntry = newEntry(rand, bundle, immResource);
     immunization.fullUrl = immunizationEntry.getFullUrl();
 
     return immunizationEntry;
@@ -1907,7 +1920,7 @@ public class FhirR4 {
       drugResource.setMeta(meta);
       drugResource.setCode(mapCodeToCodeableConcept(code, system));
       drugResource.setStatus(MedicationStatus.ACTIVE);
-      BundleEntryComponent drugEntry = newEntry(bundle, drugResource);
+      BundleEntryComponent drugEntry = newEntry(person, bundle, drugResource);
       medicationResource.setMedication(new Reference(drugEntry.getFullUrl()));
     }
 
@@ -1998,14 +2011,15 @@ public class FhirR4 {
 
     }
 
-    BundleEntryComponent medicationEntry = newEntry(bundle, medicationResource);
+    BundleEntryComponent medicationEntry = newEntry(person, bundle, medicationResource);
     // create new claim for medication
     medicationClaim(person, personEntry, bundle, encounterEntry,
         medication.claim, medicationEntry);
 
     // Create new administration for medication, if needed
     if (medication.administration) {
-      medicationAdministration(personEntry, bundle, encounterEntry, medication, medicationResource);
+      medicationAdministration(person, personEntry, bundle, encounterEntry, medication,
+              medicationResource);
     }
 
     return medicationEntry;
@@ -2014,6 +2028,7 @@ public class FhirR4 {
   /**
    * Add a MedicationAdministration if needed for the given medication.
    * 
+   * @param rand              Source of randomness to use when generating ids etc
    * @param personEntry       The Entry for the Person
    * @param bundle            Bundle to add the MedicationAdministration to
    * @param encounterEntry    Current Encounter entry
@@ -2022,8 +2037,9 @@ public class FhirR4 {
    * @return The added Entry
    */
   private static BundleEntryComponent medicationAdministration(
-      BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
-      Medication medication, MedicationRequest medicationRequest) {
+      RandomNumberGenerator rand, BundleEntryComponent personEntry, Bundle bundle,
+          BundleEntryComponent encounterEntry, Medication medication,
+          MedicationRequest medicationRequest) {
 
     MedicationAdministration medicationResource = new MedicationAdministration();
 
@@ -2080,7 +2096,7 @@ public class FhirR4 {
       }
     }
 
-    BundleEntryComponent medicationAdminEntry = newEntry(bundle, medicationResource);
+    BundleEntryComponent medicationAdminEntry = newEntry(rand, bundle, medicationResource);
     return medicationAdminEntry;
   }
 
@@ -2092,14 +2108,16 @@ public class FhirR4 {
   /**
    * Map the given Report to a FHIR DiagnosticReport resource, and add it to the given Bundle.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the Report to
    * @param encounterEntry Current Encounter entry
    * @param report         The Report
    * @return The added Entry
    */
-  private static BundleEntryComponent report(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, Report report) {
+  private static BundleEntryComponent report(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          Report report) {
     DiagnosticReport reportResource = new DiagnosticReport();
     if (USE_US_CORE_IG) {
       Meta meta = new Meta();
@@ -2124,13 +2142,14 @@ public class FhirR4 {
       reportResource.addResult(reference);
     }
 
-    return newEntry(bundle, reportResource);
+    return newEntry(rand, bundle, reportResource);
   }
 
   /**
    * Add a clinical note to the Bundle, which adds both a DocumentReference and a
    * DiagnosticReport.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the Report to
    * @param encounterEntry Current Encounter entry
@@ -2138,8 +2157,9 @@ public class FhirR4 {
    * @param currentNote If this is the most current note.
    * @return The entry for the DocumentReference.
    */
-  private static BundleEntryComponent clinicalNote(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, String clinicalNoteText, boolean currentNote) {
+  private static BundleEntryComponent clinicalNote(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          String clinicalNoteText, boolean currentNote) {
     // We'll need the encounter...
     org.hl7.fhir.r4.model.Encounter encounter =
         (org.hl7.fhir.r4.model.Encounter) encounterEntry.getResource();
@@ -2170,7 +2190,7 @@ public class FhirR4 {
     reportResource.addPresentedForm()
         .setContentType("text/plain")
         .setData(clinicalNoteText.getBytes());
-    newEntry(bundle, reportResource);
+    newEntry(rand, bundle, reportResource);
 
     // Add a DocumentReference
     DocumentReference documentReference = new DocumentReference();
@@ -2205,12 +2225,13 @@ public class FhirR4 {
         .addEncounter(reportResource.getEncounter())
         .setPeriod(encounter.getPeriod()));
 
-    return newEntry(bundle, documentReference);
+    return newEntry(rand, bundle, documentReference);
   }
 
   /**
    * Map the given CarePlan to a FHIR CarePlan resource, and add it to the given Bundle.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the CarePlan to
    * @param encounterEntry Current Encounter entry
@@ -2218,9 +2239,9 @@ public class FhirR4 {
    * @param carePlan       The CarePlan to map to FHIR and add to the bundle
    * @return The added Entry
    */
-  private static BundleEntryComponent carePlan(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, Provider provider,
-      BundleEntryComponent careTeamEntry, CarePlan carePlan) {
+  private static BundleEntryComponent carePlan(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          Provider provider, BundleEntryComponent careTeamEntry, CarePlan carePlan) {
     org.hl7.fhir.r4.model.CarePlan careplanResource = new org.hl7.fhir.r4.model.CarePlan();
 
     if (USE_US_CORE_IG) {
@@ -2302,28 +2323,29 @@ public class FhirR4 {
 
     for (JsonObject goal : carePlan.goals) {
       BundleEntryComponent goalEntry =
-          careGoal(bundle, personEntry, carePlan.start, goalStatus, goal);
+          careGoal(rand, bundle, personEntry, carePlan.start, goalStatus, goal);
       careplanResource.addGoal().setReference(goalEntry.getFullUrl());
     }
 
     careplanResource.setText(new Narrative().setStatus(NarrativeStatus.GENERATED)
         .setDiv(new XhtmlNode(NodeType.Element).setValue(narrative)));
 
-    return newEntry(bundle, careplanResource);
+    return newEntry(rand, bundle, careplanResource);
   }
 
   /**
    * Map the JsonObject into a FHIR Goal resource, and add it to the given Bundle.
+   * @param rand Source of randomness to use when generating ids etc
    * @param bundle The Bundle to add to
    * @param goalStatus The GoalStatus
    * @param goal The JsonObject
    * @return The added Entry
    */
   private static BundleEntryComponent careGoal(
-      Bundle bundle,
+      RandomNumberGenerator rand, Bundle bundle,
       BundleEntryComponent personEntry, long carePlanStart,
       CodeableConcept goalStatus, JsonObject goal) {
-    String resourceID = UUID.randomUUID().toString();
+    String resourceID = rand.randUUID().toString();
 
     Goal goalResource = new Goal();
     if (USE_US_CORE_IG) {
@@ -2400,20 +2422,22 @@ public class FhirR4 {
       }
     }
 
-    return newEntry(bundle, goalResource);
+    return newEntry(rand, bundle, goalResource);
   }
 
   /**
    * Map the given CarePlan to a FHIR CareTeam resource, and add it to the given Bundle.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the CarePlan to
    * @param encounterEntry Current Encounter entry
    * @param carePlan       The CarePlan to map to FHIR and add to the bundle
    * @return The added Entry
    */
-  private static BundleEntryComponent careTeam(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, CarePlan carePlan) {
+  private static BundleEntryComponent careTeam(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          CarePlan carePlan) {
 
     CareTeam careTeam = new CareTeam();
 
@@ -2479,7 +2503,7 @@ public class FhirR4 {
     participant.setMember(encounter.getServiceProvider());
     careTeam.addManagingOrganization(encounter.getServiceProvider());
 
-    return newEntry(bundle, careTeam);
+    return newEntry(rand, bundle, careTeam);
   }
 
   private static Identifier generateIdentifier(String uid) {
@@ -2493,14 +2517,16 @@ public class FhirR4 {
   /**
    * Map the given ImagingStudy to a FHIR ImagingStudy resource, and add it to the given Bundle.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the ImagingStudy to
    * @param encounterEntry Current Encounter entry
    * @param imagingStudy   The ImagingStudy to map to FHIR and add to the bundle
    * @return The added Entry
    */
-  private static BundleEntryComponent imagingStudy(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, ImagingStudy imagingStudy) {
+  private static BundleEntryComponent imagingStudy(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          ImagingStudy imagingStudy) {
     org.hl7.fhir.r4.model.ImagingStudy imagingStudyResource =
         new org.hl7.fhir.r4.model.ImagingStudy();
 
@@ -2571,21 +2597,23 @@ public class FhirR4 {
 
     imagingStudyResource.setSeries(seriesResourceList);
     imagingStudyResource.setNumberOfInstances(totalNumberOfInstances);
-    return newEntry(bundle, imagingStudyResource);
+    return newEntry(rand, bundle, imagingStudyResource);
   }
   
   /**
    * Map the given Observation with attachment element to a FHIR Media resource, and add it to the
    * given Bundle.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the Media to
    * @param encounterEntry Current Encounter entry
    * @param obs   The Observation to map to FHIR and add to the bundle
    * @return The added Entry
    */
-  private static BundleEntryComponent media(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, Observation obs) {
+  private static BundleEntryComponent media(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          Observation obs) {
     org.hl7.fhir.r4.model.Media mediaResource =
         new org.hl7.fhir.r4.model.Media();
 
@@ -2622,17 +2650,19 @@ public class FhirR4 {
 
     mediaResource.setContent(contentResource);
 
-    return newEntry(bundle, mediaResource);
+    return newEntry(rand, bundle, mediaResource);
   }
 
   /**
    * Map the Provider into a FHIR Organization resource, and add it to the given Bundle.
    *
+   * @param rand     Source of randomness to use when generating ids etc
    * @param bundle   The Bundle to add to
    * @param provider The Provider
    * @return The added Entry
    */
-  protected static BundleEntryComponent provider(Bundle bundle, Provider provider) {
+  protected static BundleEntryComponent provider(RandomNumberGenerator rand, Bundle bundle,
+          Provider provider) {
     Organization organizationResource = new Organization();
     if (USE_US_CORE_IG) {
       Meta meta = new Meta();
@@ -2686,7 +2716,7 @@ public class FhirR4 {
     }
 
     if (USE_US_CORE_IG) {
-      providerLocation(bundle, provider);
+      providerLocation(rand, bundle, provider);
     }
 
     return newEntry(bundle, organizationResource, provider.getResourceID());
@@ -2695,11 +2725,13 @@ public class FhirR4 {
   /**
    * Map the Provider into a FHIR Location resource, and add it to the given Bundle.
    *
+   * @param rand     Source of randomness to use when generating ids etc
    * @param bundle   The Bundle to add to
    * @param provider The Provider
    * @return The added Entry
    */
-  protected static BundleEntryComponent providerLocation(Bundle bundle, Provider provider) {
+  protected static BundleEntryComponent providerLocation(RandomNumberGenerator rand, Bundle bundle,
+          Provider provider) {
     org.hl7.fhir.r4.model.Location location = new org.hl7.fhir.r4.model.Location();
     if (USE_US_CORE_IG) {
       Meta meta = new Meta();
@@ -2738,16 +2770,18 @@ public class FhirR4 {
     location.setManagingOrganization(new Reference()
         .setReference(getUrlPrefix("Organization") + provider.getResourceID())
         .setDisplay(provider.name));
-    return newEntry(bundle, location);
+    return newEntry(rand, bundle, location);
   }
 
   /**
    * Map the clinician into a FHIR Practitioner resource, and add it to the given Bundle.
+   * @param rand   Source of randomness to use when generating ids etc
    * @param bundle The Bundle to add to
    * @param clinician The clinician
    * @return The added Entry
    */
-  protected static BundleEntryComponent practitioner(Bundle bundle, Clinician clinician) {
+  protected static BundleEntryComponent practitioner(RandomNumberGenerator rand, Bundle bundle,
+          Clinician clinician) {
     Practitioner practitionerResource = new Practitioner();
     if (USE_US_CORE_IG) {
       Meta meta = new Meta();
@@ -2825,7 +2859,7 @@ public class FhirR4 {
       }
       practitionerRole.addTelecom(practitionerResource.getTelecomFirstRep());
 
-      newEntry(bundle, practitionerRole);
+      newEntry(rand, bundle, practitionerRole);
     }
 
     return practitionerEntry;
@@ -2912,12 +2946,14 @@ public class FhirR4 {
    * resourceID to a random UUID, sets the entry's fullURL to that resourceID, and adds the entry to
    * the bundle.
    *
+   * @param rand     Source of randomness to use when generating ids etc
    * @param bundle   The Bundle to add the Entry to
    * @param resource Resource the new Entry should contain
    * @return the created Entry
    */
-  private static BundleEntryComponent newEntry(Bundle bundle, Resource resource) {
-    String resourceID = UUID.randomUUID().toString();
+  private static BundleEntryComponent newEntry(RandomNumberGenerator rand, Bundle bundle,
+          Resource resource) {
+    String resourceID = rand.randUUID().toString();
     return newEntry(bundle, resource, resourceID);
   }
 

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.hl7.fhir.dstu3.model.Address;
@@ -114,6 +113,7 @@ import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 import org.mitre.synthea.engine.Components;
 import org.mitre.synthea.engine.Components.Attachment;
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Clinician;
@@ -239,57 +239,57 @@ public class FhirStu3 {
       BundleEntryComponent encounterEntry = encounter(person, personEntry, bundle, encounter);
 
       for (HealthRecord.Entry condition : encounter.conditions) {
-        condition(personEntry, bundle, encounterEntry, condition);
+        condition(person, personEntry, bundle, encounterEntry, condition);
       }
 
       for (HealthRecord.Entry allergy : encounter.allergies) {
-        allergy(personEntry, bundle, encounterEntry, allergy);
+        allergy(person, personEntry, bundle, encounterEntry, allergy);
       }
 
       for (Observation observation : encounter.observations) {
         // If the Observation contains an attachment, use a Media resource, since
         // Observation resources in stu3 don't support Attachments
         if (observation.value instanceof Attachment) {
-          media(personEntry, bundle, encounterEntry, observation);
+          media(person, personEntry, bundle, encounterEntry, observation);
         } else {
-          observation(personEntry, bundle, encounterEntry, observation);
+          observation(person, personEntry, bundle, encounterEntry, observation);
         }
       }
 
       for (Procedure procedure : encounter.procedures) {
-        procedure(personEntry, bundle, encounterEntry, procedure);
+        procedure(person, personEntry, bundle, encounterEntry, procedure);
       }
 
       for (Medication medication : encounter.medications) {
-        medication(personEntry, bundle, encounterEntry, medication);
+        medication(person, personEntry, bundle, encounterEntry, medication);
       }
 
       for (HealthRecord.Entry immunization : encounter.immunizations) {
-        immunization(personEntry, bundle, encounterEntry, immunization);
+        immunization(person, personEntry, bundle, encounterEntry, immunization);
       }
 
       for (Report report : encounter.reports) {
-        report(personEntry, bundle, encounterEntry, report);
+        report(person, personEntry, bundle, encounterEntry, report);
       }
 
       for (CarePlan careplan : encounter.careplans) {
-        careplan(personEntry, bundle, encounterEntry, careplan);
+        careplan(person, personEntry, bundle, encounterEntry, careplan);
       }
 
       for (ImagingStudy imagingStudy : encounter.imagingStudies) {
-        imagingStudy(personEntry, bundle, encounterEntry, imagingStudy);
+        imagingStudy(person, personEntry, bundle, encounterEntry, imagingStudy);
       }
 
       for (HealthRecord.Device device : encounter.devices) {
-        device(personEntry, bundle, device);
+        device(person, personEntry, bundle, device);
       }
       
       for (HealthRecord.Supply supply : encounter.supplies) {
-        supplyDelivery(personEntry, bundle, supply, encounter);
+        supplyDelivery(person, personEntry, bundle, supply, encounter);
       }
       
       // one claim per encounter
-      BundleEntryComponent encounterClaim = encounterClaim(personEntry, bundle,
+      BundleEntryComponent encounterClaim = encounterClaim(person, personEntry, bundle,
           encounterEntry, encounter.claim);
 
       explanationOfBenefit(personEntry,bundle,encounterEntry,person,
@@ -589,7 +589,7 @@ public class FhirStu3 {
       personMeta.addProfile(SHR_EXT + "shr-entity-Person");
       personResource.setMeta(personMeta);
 
-      BundleEntryComponent personEntry = newEntry(bundle, personResource);
+      BundleEntryComponent personEntry = newEntry(person, bundle, personResource);
       patientResource.addExtension()
           .setUrl(SHR_EXT + "shr-entity-Person-extension")
           .setValue(new Reference(personEntry.getFullUrl()));
@@ -708,7 +708,7 @@ public class FhirStu3 {
       encounterResource.addExtension(performedContext);
     }
 
-    return newEntry(bundle, encounterResource);
+    return newEntry(person, bundle, encounterResource);
   }
 
   /**
@@ -751,6 +751,7 @@ public class FhirStu3 {
   /**
    * Create an entry for the given Claim, which references a Medication.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry Entry for the person
    * @param bundle The Bundle to add to
    * @param encounterEntry The current Encounter
@@ -758,9 +759,9 @@ public class FhirStu3 {
    * @param medicationEntry The Entry for the Medication object, previously created
    * @return the added Entry
    */
-  private static BundleEntryComponent medicationClaim(BundleEntryComponent personEntry,
-      Bundle bundle, BundleEntryComponent encounterEntry, Claim claim,
-      BundleEntryComponent medicationEntry) {
+  private static BundleEntryComponent medicationClaim(RandomNumberGenerator rand, 
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          Claim claim, BundleEntryComponent medicationEntry) {
     org.hl7.fhir.dstu3.model.Claim claimResource = new org.hl7.fhir.dstu3.model.Claim();
     org.hl7.fhir.dstu3.model.Encounter encounterResource =
         (org.hl7.fhir.dstu3.model.Encounter) encounterEntry.getResource();
@@ -787,20 +788,22 @@ public class FhirStu3 {
     moneyResource.setSystem("urn:iso:std:iso:4217");
     claimResource.setTotal(moneyResource);
 
-    return newEntry(bundle, claimResource);
+    return newEntry(rand, bundle, claimResource);
   }
 
   /**
    * Create an entry for the given Claim, associated to an Encounter.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry Entry for the person
    * @param bundle The Bundle to add to
    * @param encounterEntry The current Encounter
    * @param claim the Claim object
    * @return the added Entry
    */
-  private static BundleEntryComponent encounterClaim(BundleEntryComponent personEntry,
-      Bundle bundle, BundleEntryComponent encounterEntry, Claim claim) {
+  private static BundleEntryComponent encounterClaim(RandomNumberGenerator rand, 
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          Claim claim) {
     org.hl7.fhir.dstu3.model.Claim claimResource = new org.hl7.fhir.dstu3.model.Claim();
     org.hl7.fhir.dstu3.model.Encounter encounterResource =
         (org.hl7.fhir.dstu3.model.Encounter) encounterEntry.getResource();
@@ -891,7 +894,7 @@ public class FhirStu3 {
     moneyResource.setValue(claim.getTotalClaimCost());
     claimResource.setTotal(moneyResource);
 
-    return newEntry(bundle, claimResource);
+    return newEntry(rand, bundle, claimResource);
   }
 
   /**
@@ -1505,20 +1508,22 @@ public class FhirStu3 {
             .setDisplay("Part B physician/supplier claim record (processed by local "
                       + "carriers; can include DMEPOS services)")));
 
-    return newEntry(bundle,eob);
+    return newEntry(person, bundle,eob);
   }
 
   /**
    * Map the Condition into a FHIR Condition resource, and add it to the given Bundle.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry The Entry for the Person
    * @param bundle The Bundle to add to
    * @param encounterEntry The current Encounter entry
    * @param condition The Condition
    * @return The added Entry
    */
-  private static BundleEntryComponent condition(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, HealthRecord.Entry condition) {
+  private static BundleEntryComponent condition(RandomNumberGenerator rand, 
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          HealthRecord.Entry condition) {
     Condition conditionResource = new Condition();
 
     conditionResource.setSubject(new Reference(personEntry.getFullUrl()));
@@ -1550,7 +1555,7 @@ public class FhirStu3 {
       // required fields for this profile are clinicalStatus, assertedDate, category
     }
 
-    BundleEntryComponent conditionEntry = newEntry(bundle, conditionResource);
+    BundleEntryComponent conditionEntry = newEntry(rand, bundle, conditionResource);
 
     condition.fullUrl = conditionEntry.getFullUrl();
 
@@ -1560,14 +1565,16 @@ public class FhirStu3 {
   /**
    * Map the Condition into a FHIR AllergyIntolerance resource, and add it to the given Bundle.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry The Entry for the Person
    * @param bundle The Bundle to add to
    * @param encounterEntry The current Encounter entry
    * @param allergy The Allergy Entry
    * @return The added Entry
    */
-  private static BundleEntryComponent allergy(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, HealthRecord.Entry allergy) {
+  private static BundleEntryComponent allergy(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          HealthRecord.Entry allergy) {
 
     AllergyIntolerance allergyResource = new AllergyIntolerance();
 
@@ -1595,7 +1602,7 @@ public class FhirStu3 {
       // verificationStatus, code, patient, assertedDate
       allergyResource.setMeta(meta);
     }
-    BundleEntryComponent allergyEntry = newEntry(bundle, allergyResource);
+    BundleEntryComponent allergyEntry = newEntry(rand, bundle, allergyResource);
     allergy.fullUrl = allergyEntry.getFullUrl();
     return allergyEntry;
   }
@@ -1604,14 +1611,16 @@ public class FhirStu3 {
   /**
    * Map the given Observation into a FHIR Observation resource, and add it to the given Bundle.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry The Person Entry
    * @param bundle The Bundle to add to
    * @param encounterEntry The current Encounter entry
    * @param observation The Observation
    * @return The added Entry
    */
-  private static BundleEntryComponent observation(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, Observation observation) {
+  private static BundleEntryComponent observation(RandomNumberGenerator rand, 
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          Observation observation) {
     org.hl7.fhir.dstu3.model.Observation observationResource =
         new org.hl7.fhir.dstu3.model.Observation();
 
@@ -1657,7 +1666,7 @@ public class FhirStu3 {
       observationResource.setMeta(meta);
     }
 
-    BundleEntryComponent entry = newEntry(bundle, observationResource);
+    BundleEntryComponent entry = newEntry(rand, bundle, observationResource);
     observation.fullUrl = entry.getFullUrl();
     return entry;
   }
@@ -1735,14 +1744,16 @@ public class FhirStu3 {
   /**
    * Map the given Procedure into a FHIR Procedure resource, and add it to the given Bundle.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry The Person entry
    * @param bundle Bundle to add to
    * @param encounterEntry The current Encounter entry
    * @param procedure  The Procedure
    * @return The added Entry
    */
-  private static BundleEntryComponent procedure(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, Procedure procedure) {
+  private static BundleEntryComponent procedure(RandomNumberGenerator rand, 
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          Procedure procedure) {
     org.hl7.fhir.dstu3.model.Procedure procedureResource = new org.hl7.fhir.dstu3.model.Procedure();
 
     procedureResource.setStatus(ProcedureStatus.COMPLETED);
@@ -1790,14 +1801,15 @@ public class FhirStu3 {
       procedureResource.addExtension(performedContext);
     }
 
-    BundleEntryComponent procedureEntry = newEntry(bundle, procedureResource);
+    BundleEntryComponent procedureEntry = newEntry(rand, bundle, procedureResource);
     procedure.fullUrl = procedureEntry.getFullUrl();
 
     return procedureEntry;
   }
 
-  private static BundleEntryComponent immunization(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, HealthRecord.Entry immunization) {
+  private static BundleEntryComponent immunization(RandomNumberGenerator rand, 
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          HealthRecord.Entry immunization) {
     Immunization immResource = new Immunization();
     immResource.setStatus(ImmunizationStatus.COMPLETED);
     immResource.setDate(new Date(immunization.start));
@@ -1821,7 +1833,7 @@ public class FhirStu3 {
       immResource.addExtension(performedContext);
     }
 
-    BundleEntryComponent immunizationEntry = newEntry(bundle, immResource);
+    BundleEntryComponent immunizationEntry = newEntry(rand, bundle, immResource);
     immunization.fullUrl = immunizationEntry.getFullUrl();
 
     return immunizationEntry;
@@ -1830,14 +1842,16 @@ public class FhirStu3 {
   /**
    * Map the given Medication to a FHIR MedicationRequest resource, and add it to the given Bundle.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry The Entry for the Person
    * @param bundle Bundle to add the Medication to
    * @param encounterEntry Current Encounter entry
    * @param medication The Medication
    * @return The added Entry
    */
-  private static BundleEntryComponent medication(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, Medication medication) {
+  private static BundleEntryComponent medication(RandomNumberGenerator rand, 
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          Medication medication) {
     MedicationRequest medicationResource = new MedicationRequest();
 
     medicationResource.setSubject(new Reference(personEntry.getFullUrl()));
@@ -1947,13 +1961,14 @@ public class FhirStu3 {
       medicationResource.addExtension(requestedContext);
     }
 
-    BundleEntryComponent medicationEntry = newEntry(bundle, medicationResource);
+    BundleEntryComponent medicationEntry = newEntry(rand, bundle, medicationResource);
     // create new claim for medication
-    medicationClaim(personEntry, bundle, encounterEntry, medication.claim, medicationEntry);
+    medicationClaim(rand, personEntry, bundle, encounterEntry, medication.claim, medicationEntry);
 
     // Create new administration for medication, if needed
     if (medication.administration) {
-      medicationAdministration(personEntry, bundle, encounterEntry, medication, medicationResource);
+      medicationAdministration(rand, personEntry, bundle, encounterEntry, medication,
+              medicationResource);
     }
 
     return medicationEntry;
@@ -1962,6 +1977,7 @@ public class FhirStu3 {
   /**
    * Add a MedicationAdministration if needed for the given medication.
    * 
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry       The Entry for the Person
    * @param bundle            Bundle to add the MedicationAdministration to
    * @param encounterEntry    Current Encounter entry
@@ -1970,8 +1986,9 @@ public class FhirStu3 {
    * @return The added Entry
    */
   private static BundleEntryComponent medicationAdministration(
-      BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
-      Medication medication, MedicationRequest medicationRequest) {
+          RandomNumberGenerator rand, BundleEntryComponent personEntry, Bundle bundle,
+          BundleEntryComponent encounterEntry, Medication medication,
+          MedicationRequest medicationRequest) {
 
     MedicationAdministration medicationResource = new MedicationAdministration();
 
@@ -2023,7 +2040,7 @@ public class FhirStu3 {
       }
     }
 
-    BundleEntryComponent medicationAdminEntry = newEntry(bundle, medicationResource);
+    BundleEntryComponent medicationAdminEntry = newEntry(rand, bundle, medicationResource);
     return medicationAdminEntry;
   }
 
@@ -2036,14 +2053,16 @@ public class FhirStu3 {
   /**
    * Map the given Report to a FHIR DiagnosticReport resource, and add it to the given Bundle.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry The Entry for the Person
    * @param bundle Bundle to add the Report to
    * @param encounterEntry Current Encounter entry
    * @param report The Report
    * @return The added Entry
    */
-  private static BundleEntryComponent report(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, Report report) {
+  private static BundleEntryComponent report(RandomNumberGenerator rand, 
+          BundleEntryComponent personEntry, Bundle bundle,
+          BundleEntryComponent encounterEntry, Report report) {
     DiagnosticReport reportResource = new DiagnosticReport();
     reportResource.setStatus(DiagnosticReportStatus.FINAL);
     reportResource.setCode(mapCodeToCodeableConcept(report.codes.get(0), LOINC_URI));
@@ -2059,20 +2078,22 @@ public class FhirStu3 {
 
     // no SHR profile for DiagnosticReport
 
-    return newEntry(bundle, reportResource);
+    return newEntry(rand, bundle, reportResource);
   }
 
   /**
    * Map the given CarePlan to a FHIR CarePlan resource, and add it to the given Bundle.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry The Entry for the Person
    * @param bundle Bundle to add the CarePlan to
    * @param encounterEntry Current Encounter entry
    * @param carePlan The CarePlan to map to FHIR and add to the bundle
    * @return The added Entry
    */
-  private static BundleEntryComponent careplan(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, CarePlan carePlan) {
+  private static BundleEntryComponent careplan(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          CarePlan carePlan) {
     org.hl7.fhir.dstu3.model.CarePlan careplanResource = new org.hl7.fhir.dstu3.model.CarePlan();
     careplanResource.setIntent(CarePlanIntent.ORDER);
     careplanResource.setSubject(new Reference(personEntry.getFullUrl()));
@@ -2128,24 +2149,26 @@ public class FhirStu3 {
     }
 
     for (JsonObject goal : carePlan.goals) {
-      BundleEntryComponent goalEntry = caregoal(bundle, goalStatus, goal);
+      BundleEntryComponent goalEntry = caregoal(rand, bundle, goalStatus, goal);
       careplanResource.addGoal().setReference(goalEntry.getFullUrl());
     }
 
-    return newEntry(bundle, careplanResource);
+    return newEntry(rand, bundle, careplanResource);
   }
 
   /**
    * Map the given ImagingStudy to a FHIR ImagingStudy resource, and add it to the given Bundle.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry The Entry for the Person
    * @param bundle Bundle to add the ImagingStudy to
    * @param encounterEntry Current Encounter entry
    * @param imagingStudy The ImagingStudy to map to FHIR and add to the bundle
    * @return The added Entry
    */
-  private static BundleEntryComponent imagingStudy(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, ImagingStudy imagingStudy) {
+  private static BundleEntryComponent imagingStudy(RandomNumberGenerator rand, 
+          BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
+          ImagingStudy imagingStudy) {
     org.hl7.fhir.dstu3.model.ImagingStudy imagingStudyResource =
         new org.hl7.fhir.dstu3.model.ImagingStudy();
 
@@ -2208,20 +2231,22 @@ public class FhirStu3 {
 
     imagingStudyResource.setSeries(seriesResourceList);
     imagingStudyResource.setNumberOfInstances(totalNumberOfInstances);
-    return newEntry(bundle, imagingStudyResource);
+    return newEntry(rand, bundle, imagingStudyResource);
   }
   
   /**
    * Map the given Media element to a FHIR Media resource, and add it to the given Bundle.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the Media to
    * @param encounterEntry Current Encounter entry
    * @param obs   The Observation to map to FHIR and add to the bundle
    * @return The added Entry
    */
-  private static BundleEntryComponent media(BundleEntryComponent personEntry, Bundle bundle,
-      BundleEntryComponent encounterEntry, Observation obs) {
+  private static BundleEntryComponent media(RandomNumberGenerator rand, 
+          BundleEntryComponent personEntry, Bundle bundle,
+          BundleEntryComponent encounterEntry, Observation obs) {
     org.hl7.fhir.dstu3.model.Media mediaResource =
         new org.hl7.fhir.dstu3.model.Media();
 
@@ -2255,19 +2280,20 @@ public class FhirStu3 {
     
     mediaResource.setContent(contentResource);
 
-    return newEntry(bundle, mediaResource);
+    return newEntry(rand, bundle, mediaResource);
   }
 
   /**
    * Map the HealthRecord.Device into a FHIR Device and add it to the Bundle.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param personEntry    The Person entry.
    * @param bundle         Bundle to add to.
    * @param device         The device to add.
    * @return The added Entry.
    */
-  private static BundleEntryComponent device(BundleEntryComponent personEntry, Bundle bundle,
-      HealthRecord.Device device) {
+  private static BundleEntryComponent device(RandomNumberGenerator rand, 
+          BundleEntryComponent personEntry, Bundle bundle, HealthRecord.Device device) {
     Device deviceResource = new Device();
     Device.DeviceUdiComponent udi = new Device.DeviceUdiComponent()
         .setDeviceIdentifier(device.deviceIdentifier)
@@ -2285,20 +2311,22 @@ public class FhirStu3 {
     deviceResource.setLotNumber(device.lotNumber);
     deviceResource.setType(mapCodeToCodeableConcept(device.codes.get(0), SNOMED_URI));
     deviceResource.setPatient(new Reference(personEntry.getFullUrl()));
-    return newEntry(bundle, deviceResource);
+    return newEntry(rand, bundle, deviceResource);
   }
   
   /**
    * Map the JsonObject for a Supply into a FHIR SupplyDelivery and add it to the Bundle.
    *
+   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Person entry.
    * @param bundle         Bundle to add to.
    * @param supply         The supplied object to add.
    * @param encounter      The encounter during which the supplies were delivered
    * @return The added Entry.
    */
-  private static BundleEntryComponent supplyDelivery(BundleEntryComponent personEntry, 
-          Bundle bundle, HealthRecord.Supply supply, Encounter encounter) {
+  private static BundleEntryComponent supplyDelivery(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry, Bundle bundle, HealthRecord.Supply supply,
+          Encounter encounter) {
    
     SupplyDelivery supplyResource = new SupplyDelivery();
     supplyResource.setStatus(SupplyDeliveryStatus.COMPLETED);
@@ -2322,7 +2350,7 @@ public class FhirStu3 {
     
     supplyResource.setOccurrence(convertFhirDateTime(supply.start, true));
     
-    return newEntry(bundle, supplyResource);
+    return newEntry(rand, bundle, supplyResource);
   }
   
   /**
@@ -2427,14 +2455,15 @@ public class FhirStu3 {
 
   /**
    * Map the JsonObject into a FHIR Goal resource, and add it to the given Bundle.
+   * @param rand Source of randomness to use when generating ids etc
    * @param bundle The Bundle to add to
    * @param goalStatus The GoalStatus
    * @param goal The JsonObject
    * @return The added Entry
    */
   private static BundleEntryComponent caregoal(
-      Bundle bundle, GoalStatus goalStatus, JsonObject goal) {
-    String resourceID = UUID.randomUUID().toString();
+      RandomNumberGenerator rand, Bundle bundle, GoalStatus goalStatus, JsonObject goal) {
+    String resourceID = rand.randUUID().toString();
 
     org.hl7.fhir.dstu3.model.Goal goalResource =
         new org.hl7.fhir.dstu3.model.Goal();
@@ -2502,7 +2531,7 @@ public class FhirStu3 {
       }
     }
 
-    return newEntry(bundle, goalResource);
+    return newEntry(rand, bundle, goalResource);
   }
 
   /**
@@ -2586,12 +2615,14 @@ public class FhirStu3 {
    * resourceID to a random UUID, sets the entry's fullURL to that resourceID, and adds the entry to
    * the bundle.
    *
+   * @param rand Source of randomness to use when generating ids etc
    * @param bundle The Bundle to add the Entry to
    * @param resource Resource the new Entry should contain
    * @return the created Entry
    */
-  private static BundleEntryComponent newEntry(Bundle bundle, Resource resource) {
-    String resourceID = UUID.randomUUID().toString();
+  private static BundleEntryComponent newEntry(RandomNumberGenerator rand, Bundle bundle, 
+          Resource resource) {
+    String resourceID = rand.randUUID().toString();
     return newEntry(bundle, resource, resourceID);
   }
 

--- a/src/main/java/org/mitre/synthea/export/HospitalExporterR4.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporterR4.java
@@ -22,6 +22,7 @@ import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Organization;
 
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.world.agents.Provider;
 
 public abstract class HospitalExporterR4 {
@@ -33,7 +34,7 @@ public abstract class HospitalExporterR4 {
   /**
    * Export the hospital in FHIR R4 format.
    */
-  public static void export(long stop) {
+  public static void export(RandomNumberGenerator rand, long stop) {
     if (Boolean.parseBoolean(Config.get("exporter.hospital.fhir.export"))) {
 
       Bundle bundle = new Bundle();
@@ -48,7 +49,7 @@ public abstract class HospitalExporterR4 {
         int totalEncounters = utilization.column(Provider.ENCOUNTERS).values().stream()
             .mapToInt(ai -> ai.get()).sum();
         if (totalEncounters > 0) {
-          BundleEntryComponent entry = FhirR4.provider(bundle, h);
+          BundleEntryComponent entry = FhirR4.provider(rand, bundle, h);
           addHospitalExtensions(h, (Organization) entry.getResource());
         }
       }

--- a/src/main/java/org/mitre/synthea/helpers/RandomNumberGenerator.java
+++ b/src/main/java/org/mitre/synthea/helpers/RandomNumberGenerator.java
@@ -3,6 +3,7 @@ package org.mitre.synthea.helpers;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Arrays;
+import java.util.UUID;
 
 public interface RandomNumberGenerator {
   /** Returns a double between 0-1 from a uniform distribution. */
@@ -97,4 +98,7 @@ public interface RandomNumberGenerator {
 
   /** Return a random long. */
   public long randLong();
+  
+  /** Return a random UUID. */
+  public UUID randUUID();
 }

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -132,7 +132,7 @@ public final class LifecycleModule extends Module {
   public static void birth(Person person, long time) {
     Map<String, Object> attributes = person.attributes;
 
-    attributes.put(Person.ID, UUID.randomUUID().toString());
+    attributes.put(Person.ID, person.randUUID().toString());
     attributes.put(Person.BIRTHDATE, time);
     String gender = (String) attributes.get(Person.GENDER);
     String language = (String) attributes.get(Person.FIRST_LANGUAGE);

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.mitre.synthea.engine.ExpressedConditionRecord;
@@ -208,7 +209,14 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
   public long randLong() {
     return random.nextLong();
   }
-
+  
+  /**
+   * Return a random UUID.
+   */
+  public UUID randUUID() {
+    return new UUID(randLong(), randLong());
+  }
+  
   /**
    * Returns a person's age in Period form.
    */
@@ -509,7 +517,7 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
 
     HealthRecord returnValue = this.defaultRecord;
     if (hasMultipleRecords) {
-      String key = provider.uuid;
+      String key = provider.getResourceID();
       if (!records.containsKey(key)) {
         HealthRecord record = null;
         if (this.record != null && this.record.provider == null) {

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -62,7 +62,7 @@ public class Provider implements QuadTreeElement, Serializable {
   private static IProviderFinder providerFinder = buildProviderFinder();
 
   public Map<String, Object> attributes;
-  public String uuid;
+  private String uuid;
   public String id;
   public String name;
   private Location location;
@@ -118,6 +118,7 @@ public class Provider implements QuadTreeElement, Serializable {
    * Create a new Provider with no information.
    */
   public Provider() {
+    // the uuid field is reinitialized by csvLineToProvider
     uuid = UUID.randomUUID().toString();
     attributes = new LinkedTreeMap<>();
     revenue = 0.0;

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -188,7 +188,7 @@ public class Location implements Serializable {
   }
 
   /**
-   * Pick the name of a random city from the current "world"?
+   * Pick the name of a random city from the current "world".
    * @param random The source of randomness.
    * @return Demographics of a random city.
    */

--- a/src/test/java/org/mitre/synthea/engine/LogicTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LogicTest.java
@@ -51,13 +51,13 @@ public class LogicTest {
     // Give person an income to prevent null pointer.
     person.attributes.put(Person.INCOME, 10000000);
     Provider mock = Mockito.mock(Provider.class);
-    mock.uuid = "Mock-Provider";
+    Mockito.when(mock.getResourceID()).thenReturn("Mock-Provider");
     for (EncounterType type : EncounterType.values()) {
       person.setProvider(type, mock);
     }
 
     mock = Mockito.mock(Provider.class);
-    mock.uuid = "Mock-Emergency";
+    Mockito.when(mock.getResourceID()).thenReturn("Mock-Emergency");
     person.setProvider(EncounterType.EMERGENCY, mock);
     person.attributes.put(Person.BIRTHDATE, 0L);
     time = System.currentTimeMillis();

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -74,7 +74,7 @@ public class StateTest {
 
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class, withSettings().serializable());
-    mock.uuid = "Mock-UUID";
+    Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
     person.setProvider(EncounterType.AMBULATORY, mock);
     person.setProvider(EncounterType.WELLNESS, mock);
     person.setProvider(EncounterType.EMERGENCY, mock);

--- a/src/test/java/org/mitre/synthea/export/FHIRDSTU2ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRDSTU2ExporterTest.java
@@ -173,7 +173,7 @@ public class FHIRDSTU2ExporterTest {
 
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
-    mock.uuid = "Mock-UUID";
+    Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
     person.setProvider(EncounterType.AMBULATORY, mock);
     person.setProvider(EncounterType.WELLNESS, mock);
     person.setProvider(EncounterType.EMERGENCY, mock);
@@ -235,7 +235,7 @@ public class FHIRDSTU2ExporterTest {
 
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
-    mock.uuid = "Mock-UUID";
+    Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
     person.setProvider(EncounterType.AMBULATORY, mock);
     person.setProvider(EncounterType.WELLNESS, mock);
     person.setProvider(EncounterType.EMERGENCY, mock);

--- a/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
@@ -199,7 +199,7 @@ public class FHIRR4ExporterTest {
 
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
-    mock.uuid = "Mock-UUID";
+    Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
     person.setProvider(EncounterType.AMBULATORY, mock);
     person.setProvider(EncounterType.WELLNESS, mock);
     person.setProvider(EncounterType.EMERGENCY, mock);
@@ -261,7 +261,7 @@ public class FHIRR4ExporterTest {
 
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
-    mock.uuid = "Mock-UUID";
+    Mockito.when(mock.getResourceID()).thenReturn("Mock-Provider");
     person.setProvider(EncounterType.AMBULATORY, mock);
     person.setProvider(EncounterType.WELLNESS, mock);
     person.setProvider(EncounterType.EMERGENCY, mock);

--- a/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
@@ -250,7 +250,7 @@ public class FHIRSTU3ExporterTest {
 
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
-    mock.uuid = "Mock-UUID";
+    Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
     person.setProvider(EncounterType.AMBULATORY, mock);
     person.setProvider(EncounterType.WELLNESS, mock);
     person.setProvider(EncounterType.EMERGENCY, mock);
@@ -312,7 +312,7 @@ public class FHIRSTU3ExporterTest {
 
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
-    mock.uuid = "Mock-UUID";
+    Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
     person.setProvider(EncounterType.AMBULATORY, mock);
     person.setProvider(EncounterType.WELLNESS, mock);
     person.setProvider(EncounterType.EMERGENCY, mock);

--- a/src/test/java/org/mitre/synthea/export/HospitalExporterTestR4.java
+++ b/src/test/java/org/mitre/synthea/export/HospitalExporterTestR4.java
@@ -49,7 +49,7 @@ public class HospitalExporterTestR4 {
     assertFalse(Provider.getProviderList().isEmpty());
 
     Provider.getProviderList().get(0).incrementEncounters(EncounterType.WELLNESS, 0);
-    HospitalExporterR4.export(0L);
+    HospitalExporterR4.export(new Generator(), 0L);
 
     File expectedExportFolder = tempOutputFolder.toPath().resolve("fhir").toFile();
     assertTrue(expectedExportFolder.exists() && expectedExportFolder.isDirectory());

--- a/src/test/java/org/mitre/synthea/modules/DeathModuleTest.java
+++ b/src/test/java/org/mitre/synthea/modules/DeathModuleTest.java
@@ -36,7 +36,7 @@ public class DeathModuleTest {
 
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
-    mock.uuid = "Mock-UUID";
+    Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
     person.setProvider(EncounterType.AMBULATORY, mock);
     person.setProvider(EncounterType.WELLNESS, mock);
     person.setProvider(EncounterType.EMERGENCY, mock);


### PR DESCRIPTION
This pull request builds on recent work to improve the reproducibility of generated records when using the same patient seed, provider seed and reference date. This pull request introduces reproducible resource and element ids so diffing two sets of generated patients will not yield differences resulting from random ids.

To test:

```
./run_synthea -p 10 -s 5 -cs 10 -r 20200701
mv output/fhir output/fhir2
./run_synthea -p 10 -s 5 -cs 10 -r 20200701
```

Diff the corresponding files in `output/fhir` and `output/fhir2`.