### PR TITLE
Make max heap size of application process configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,6 +235,10 @@ run {
   if (project.hasProperty("arams")) {
     args Eval.me(arams)
   }
+  def maxHeapSizeVar = System.getenv("MAX_HEAP_SIZE")
+  if (maxHeapSizeVar != null) {
+    maxHeapSize = maxHeapSizeVar
+  }
 }
 
 task sourceJar(type: Jar) {


### PR DESCRIPTION
When generating large sets of data, I noticed that the generation was gradually slowing down time went on. I figured this was due to memory starvation.

I couldn't figure out a way to set the Xmx of the application process through the command line without changing the build.gradle file. So I added in a way to specify it using an environment variable.

Let me know if there is a better way of doing this!