### PR TITLE
Allow for Gaussian distributions of random delay/procedure times

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/DurationProvider.java
+++ b/src/main/java/org/mitre/synthea/engine/DurationProvider.java
@@ -3,10 +3,43 @@ package org.mitre.synthea.engine;
 import com.google.gson.JsonObject;
 import org.mitre.synthea.world.agents.Person;
 
+/**
+ * DurationProvider is an interface that should be implemented to provide durations for Delay and
+ * Procedure states. It is assumed that implementations will provide different ways of determining
+ * a duration for a given situation.
+ */
 public interface DurationProvider {
+  /**
+   * Set the unit of the duration: hour, day, year, etc.
+   * @param unit hour, day, year, etc
+   */
   void setUnit(String unit);
+
+  /**
+   * Get the unit of the duration.
+   * @return the unit
+   */
   String getUnit();
+
+  /**
+   * Provides the implementation with the JSON it should look through to grab whatever it needs to
+   * fully populate an instance of itself.
+   * @param definition The range property for Delay states or
+   *                   duration property for Procedure states
+   */
   void load(JsonObject definition);
+
+  /**
+   * Called to obtain the duration for the state.
+   * @param person The person to use to obtain randomness, if needed
+   * @return How long the thing should be
+   */
   long generate(Person person);
+
+  /**
+   * Given some JSON, does it look like it has the correct properties for the implementation.
+   * @param definition The JSON to look through
+   * @return true if this the JSON has the correct properties for a distribution
+   */
   boolean detect(JsonObject definition);
 }

--- a/src/main/java/org/mitre/synthea/engine/DurationProvider.java
+++ b/src/main/java/org/mitre/synthea/engine/DurationProvider.java
@@ -1,0 +1,12 @@
+package org.mitre.synthea.engine;
+
+import com.google.gson.JsonObject;
+import org.mitre.synthea.world.agents.Person;
+
+public interface DurationProvider {
+  void setUnit(String unit);
+  String getUnit();
+  void load(JsonObject definition);
+  long generate(Person person);
+  boolean detect(JsonObject definition);
+}

--- a/src/main/java/org/mitre/synthea/engine/RandomDurations.java
+++ b/src/main/java/org/mitre/synthea/engine/RandomDurations.java
@@ -1,0 +1,103 @@
+package org.mitre.synthea.engine;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import org.mitre.synthea.world.agents.Person;
+
+import java.io.Serializable;
+import java.lang.reflect.Type;
+
+public abstract class RandomDurations {
+  public static DurationProvider detectDurationType(JsonObject definition) {
+    Uniform u = new Uniform();
+    if (u.detect(definition)) {
+      return u;
+    }
+    Gaussian g = new Gaussian();
+    if (g.detect(definition)) {
+      return g;
+    }
+    return null;
+  }
+
+  public static class DurationDeserializer implements JsonDeserializer<DurationProvider> {
+
+    @Override
+    public DurationProvider deserialize(JsonElement json, Type typeOfT,
+                                        JsonDeserializationContext context)
+        throws JsonParseException {
+      JsonObject definition = json.getAsJsonObject();
+      DurationProvider dp = detectDurationType(definition);
+      if (dp != null) {
+        dp.load(definition);
+      }
+      return dp;
+    }
+  }
+
+  public abstract static class AbstractDurationProvider implements DurationProvider, Serializable {
+    protected String unit;
+
+    @Override
+    public void setUnit(String unit) {
+      this.unit = unit;
+    }
+
+    @Override
+    public String getUnit() {
+      return this.unit;
+    }
+
+    @Override
+    public void load(JsonObject definition) {
+      this.unit = definition.get("unit").getAsString();
+    }
+  }
+
+  public static class Uniform extends AbstractDurationProvider implements Serializable {
+    private double low;
+    private double high;
+
+    @Override
+    public void load(JsonObject definition) {
+      super.load(definition);
+      this.low = definition.get("low").getAsDouble();
+      this.high = definition.get("high").getAsDouble();
+    }
+
+    @Override
+    public long generate(Person person) {
+      return (long) person.rand(this.low, this.high);
+    }
+
+    @Override
+    public boolean detect(JsonObject definition) {
+      return definition.has("low") && definition.has("high");
+    }
+  }
+
+  public static class Gaussian extends AbstractDurationProvider implements Serializable {
+    private double mean;
+    private double standardDeviation;
+
+    @Override
+    public void load(JsonObject definition) {
+      super.load(definition);
+      this.mean = definition.get("mean").getAsDouble();
+      this.standardDeviation = definition.get("standardDeviation").getAsDouble();
+    }
+
+    @Override
+    public long generate(Person person) {
+      return (long) ((person.randGaussian() * this.standardDeviation) + this.mean);
+    }
+
+    @Override
+    public boolean detect(JsonObject definition) {
+      return definition.has("mean") && definition.has("standardDeviation");
+    }
+  }
+}

--- a/src/main/java/org/mitre/synthea/engine/RandomDurations.java
+++ b/src/main/java/org/mitre/synthea/engine/RandomDurations.java
@@ -5,12 +5,25 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import org.mitre.synthea.world.agents.Person;
 
 import java.io.Serializable;
 import java.lang.reflect.Type;
 
+import org.mitre.synthea.world.agents.Person;
+
+/**
+ * A place for all random duration types for Delay and Procedure states.
+ */
 public abstract class RandomDurations {
+
+  /**
+   * This is essentially a DurationProvider factory. Given JSON, it will provide the correct
+   * DurationProvider by using their detect methods.
+   * @param definition The JSON to look at
+   * @return The appropriate DurationProvider. null if there aren't any properties that will
+   *         satisfy any DurationProvider
+   *
+   */
   public static DurationProvider detectDurationType(JsonObject definition) {
     Uniform u = new Uniform();
     if (u.detect(definition)) {
@@ -23,6 +36,9 @@ public abstract class RandomDurations {
     return null;
   }
 
+  /**
+   * Class to work with Gson to properly parse DurationProviders.
+   */
   public static class DurationDeserializer implements JsonDeserializer<DurationProvider> {
 
     @Override
@@ -38,6 +54,9 @@ public abstract class RandomDurations {
     }
   }
 
+  /**
+   * Base class for building DurationProviders. Handles the duration unit.
+   */
   public abstract static class AbstractDurationProvider implements DurationProvider, Serializable {
     protected String unit;
 
@@ -57,6 +76,11 @@ public abstract class RandomDurations {
     }
   }
 
+  /**
+   * DurationProvider that supplies a random length of time based on a uniform distribution.
+   * Expected properties are "low" and "high" representing the minimum and maximum values
+   * for the duration.
+   */
   public static class Uniform extends AbstractDurationProvider implements Serializable {
     private double low;
     private double high;
@@ -79,6 +103,11 @@ public abstract class RandomDurations {
     }
   }
 
+  /**
+   * DurationProvider that supplies a random length of time based on a Gaussian or normal
+   * distribution. Expected properties are "mean" and "standardDeviation" representing the mean and
+   * standard deviation for the distribution.
+   */
   public static class Gaussian extends AbstractDurationProvider implements Serializable {
     private double mean;
     private double standardDeviation;

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -464,7 +464,7 @@ public abstract class State implements Cloneable, Serializable {
    * step) time.
    */
   public static class Delay extends Delayable {
-    private RangeWithUnit<Long> range;
+    private DurationProvider range;
     private ExactWithUnit<Long> exact;
 
     @Override
@@ -482,7 +482,7 @@ public abstract class State implements Cloneable, Serializable {
         return time + Utilities.convertTime(exact.unit, exact.quantity);
       } else if (range != null) {
         // use a range
-        return time + Utilities.convertTime(range.unit, (long) person.rand(range.low, range.high));
+        return time + Utilities.convertTime(range.getUnit(), range.generate(person));
       } else {
         throw new RuntimeException("Delay state has no exact or range: " + this);
       }
@@ -1342,7 +1342,7 @@ public abstract class State implements Cloneable, Serializable {
   public static class Procedure extends Delayable {
     private List<Code> codes;
     private String reason;
-    private RangeWithUnit<Long> duration;
+    private DurationProvider duration;
     private String assignToAttribute;
     private Long stop;
 
@@ -1389,8 +1389,8 @@ public abstract class State implements Cloneable, Serializable {
         }
       }
       if (duration != null && this.stop == null) {
-        double durationVal = person.rand(duration.low, duration.high);
-        this.stop = procedure.start + Utilities.convertTime(duration.unit, (long) durationVal);
+        double durationVal = duration.generate(person);
+        this.stop = procedure.start + Utilities.convertTime(duration.getUnit(), (long) durationVal);
         procedure.stop = this.stop;
       }
       // increment number of procedures by respective hospital

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -18,7 +18,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import org.mitre.synthea.engine.DurationProvider;
 import org.mitre.synthea.engine.Logic;
+import org.mitre.synthea.engine.RandomDurations;
 import org.mitre.synthea.engine.State;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 
@@ -320,6 +322,7 @@ public class Utilities {
       .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
       .registerTypeAdapterFactory(InnerClassTypeAdapterFactory.of(Logic.class,"condition_type"))
       .registerTypeAdapterFactory(InnerClassTypeAdapterFactory.of(State.class, "type"))
+      .registerTypeAdapter(DurationProvider.class, new RandomDurations.DurationDeserializer())
       .create();
   }
 

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -389,6 +389,14 @@ public class StateTest {
     assertFalse(delay.process(person, time + 1L * 1000 * 60 * 60 * 24 * 365));
     assertFalse(delay.process(person, time + 2L * 1000 * 60 * 60 * 24 * 365));
     assertTrue(delay.process(person, time + 10L * 1000 * 60 * 60 * 24 * 365));
+
+    // Years
+    delay = module.getState("5_Year_Mean_Gaussian_Delay");
+    delay.entered = time;
+    assertFalse(delay.process(person, time));
+    assertFalse(delay.process(person, time + 1L * 1000 * 60 * 60 * 24 * 365));
+    assertFalse(delay.process(person, time + 2L * 1000 * 60 * 60 * 24 * 365));
+    assertTrue(delay.process(person, time + 10L * 1000 * 60 * 60 * 24 * 365));
   }
 
   @Test

--- a/src/test/resources/generic/delay.json
+++ b/src/test/resources/generic/delay.json
@@ -122,6 +122,15 @@
                 "high": 10,
                 "unit": "years"
             },
+            "direct_transition": "5_Year_Mean_Gaussian_Delay"
+        },
+        "5_Year_Mean_Gaussian_Delay": {
+            "type": "Delay",
+            "range": {
+                "mean": 5,
+                "standardDeviation": 2,
+                "unit": "years"
+            },
             "direct_transition": "Terminal"
         },
         "Terminal": {


### PR DESCRIPTION
Current durations for Delay and Procedure states can be random within a range. However, Synthea only allows a uniform distribution between the low and high end of a range. This PR adds in the ability to have duration times that follow a Gaussian / normal distribution by specifying a mean and standard deviation. It also provides a framework for introducing other types of distributions and loading their parameters for GMF JSON.