### PR TITLE
Fix procedures with delays to ensure the record entry is only added once

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -438,9 +438,24 @@ public abstract class State implements Cloneable, Serializable {
 
     public abstract long endOfDelay(long time, Person person);
 
+    /**
+     * Process any aspect of this state which should only happen once.
+     * Because of the nature of Delay states, this state may get called
+     * multiple times: once per timestep while delaying. To ensure
+     * any actions which are supposed to happen only happen once,
+     * this function should be overriden in subclasses.
+     *
+     * @param person the person being simulated
+     * @param time the date within the simulated world
+     */
+    public void processOnce(Person person, long time) {
+      // do nothing. allow subclasses to override
+    }
+
     @Override
     public boolean process(Person person, long time) {
       if (this.next == null) {
+        this.processOnce(person, time);
         this.next = this.endOfDelay(time, person);
       }
 
@@ -1366,7 +1381,7 @@ public abstract class State implements Cloneable, Serializable {
     }
 
     @Override
-    public boolean process(Person person, long time) {
+    public void processOnce(Person person, long time) {
       String primaryCode = codes.get(0).code;
       HealthRecord.Procedure procedure = person.record.procedure(time, primaryCode);
       entry = procedure;
@@ -1406,8 +1421,6 @@ public abstract class State implements Cloneable, Serializable {
       if (assignToAttribute != null) {
         person.attributes.put(assignToAttribute, procedure);
       }
-
-      return super.process(person, time);
     }
   }
 

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -617,7 +617,10 @@ public class StateTest {
     long nextStep = time + Utilities.convertTime("days", 7);
     assertTrue(appendectomy.process(person, nextStep));
 
-    HealthRecord.Procedure proc = person.record.encounters.get(0).procedures.get(0);
+    List<HealthRecord.Procedure> procedures = person.record.encounters.get(0).procedures;
+    assertEquals(1, procedures.size());
+    
+    HealthRecord.Procedure proc = procedures.get(0);
     Code code = proc.codes.get(0);
 
     assertEquals("6025007", code.code);


### PR DESCRIPTION
This PR tweaks the `Delayable` interface that `Procedure` and `Delay` states and adds a new `processOnce` method, which should only be executed a single time, regardless of how many times the `process` method gets called. The `Procedure` state now overrides this "hook" method instead of having a `process` method which calls back to `super.process`.
(I can envision in the future we might want a "processEveryTimestep" hook method as well, but since we don't need one today and it's trivial to add later, I didn't add it now)

This addresses a bug where Procedures were being added to the record twice because the corresponding state was processing twice. 