### PR TITLE
Use “Non Hispanic or Latino” instead of “Not Hispanic or Latino”

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -455,7 +455,7 @@ public class FhirR4 {
         ethnicityDisplay = "Hispanic or Latino";
       } else {
         ethnicity = "nonhispanic";
-        ethnicityDisplay = "Not Hispanic or Latino";
+        ethnicityDisplay = "Non Hispanic or Latino";
       }
 
       String ethnicityNum = (String) raceEthnicityCodes.get(ethnicity);

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -415,7 +415,7 @@ public class FhirStu3 {
       ethnicityDisplay = "Hispanic or Latino";
     } else {
       ethnicity = "nonhispanic";
-      ethnicityDisplay = "Not Hispanic or Latino";
+      ethnicityDisplay = "Non Hispanic or Latino";
     }
 
     String ethnicityNum = (String) raceEthnicityCodes.get(ethnicity);


### PR DESCRIPTION
Fixes #783 