### PR TITLE
Ignore test generated output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bin/**
 /bin/
 
 /output/
+/out/
 
 # don't commit the autobuilt version file
 src/main/resources/version.txt


### PR DESCRIPTION
One line added to gitignore file to ignore generated files in project's `out/` directory. The directory is populated when tests are run.