### PR TITLE
Support different distribution types for random variables in a new GMF format

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Distribution.java
+++ b/src/main/java/org/mitre/synthea/engine/Distribution.java
@@ -42,6 +42,9 @@ public class Distribution implements Serializable {
    * @return True if it is valid, false otherwise
    */
   public boolean validate() {
+    if (parameters == null) {
+      return false;
+    }
     switch (this.kind) {
       case EXACT:
         return this.parameters.containsKey("value");

--- a/src/main/java/org/mitre/synthea/engine/Distribution.java
+++ b/src/main/java/org/mitre/synthea/engine/Distribution.java
@@ -1,10 +1,14 @@
 package org.mitre.synthea.engine;
 
-import org.mitre.synthea.world.agents.Person;
-
 import java.io.Serializable;
 import java.util.HashMap;
 
+import org.mitre.synthea.world.agents.Person;
+
+/**
+ * Representation of different types of distributions that can be used to represent
+ * random variables used in Synthea States.
+ */
 public class Distribution implements Serializable {
   public enum Kind {
     EXACT, GAUSSIAN, UNIFORM
@@ -13,6 +17,11 @@ public class Distribution implements Serializable {
   public Kind kind;
   public HashMap<String, Double> parameters;
 
+  /**
+   * Generate a sample from the random variable.
+   * @param person The place to obtain a repeatable source of randomness
+   * @return The value
+   */
   public double generate(Person person) {
     switch (this.kind) {
       case EXACT:
@@ -27,6 +36,11 @@ public class Distribution implements Serializable {
     }
   }
 
+  /**
+   * Determine whether the Distribution has all of the information it needs to generate a sample
+   * value.
+   * @return True if it is valid, false otherwise
+   */
   public boolean validate() {
     switch (this.kind) {
       case EXACT:

--- a/src/main/java/org/mitre/synthea/engine/Distribution.java
+++ b/src/main/java/org/mitre/synthea/engine/Distribution.java
@@ -1,0 +1,43 @@
+package org.mitre.synthea.engine;
+
+import org.mitre.synthea.world.agents.Person;
+
+import java.io.Serializable;
+import java.util.HashMap;
+
+public class Distribution implements Serializable {
+  public enum Kind {
+    EXACT, GAUSSIAN, UNIFORM
+  }
+
+  public Kind kind;
+  public HashMap<String, Double> parameters;
+
+  public double generate(Person person) {
+    switch (this.kind) {
+      case EXACT:
+        return this.parameters.get("value");
+      case UNIFORM:
+        return person.rand(this.parameters.get("low"), this.parameters.get("high"));
+      case GAUSSIAN:
+        return (this.parameters.get("standardDeviation") * person.randGaussian())
+            + this.parameters.get("mean");
+      default:
+        return -1;
+    }
+  }
+
+  public boolean validate() {
+    switch (this.kind) {
+      case EXACT:
+        return this.parameters.containsKey("value");
+      case UNIFORM:
+        return this.parameters.containsKey("low") && this.parameters.containsKey("high");
+      case GAUSSIAN:
+        return this.parameters.containsKey("mean")
+            && this.parameters.containsKey("standardDeviation");
+      default:
+        return false;
+    }
+  }
+}

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -54,7 +54,7 @@ import org.mitre.synthea.world.agents.Person;
  */
 public class Module implements Cloneable, Serializable {
 
-  public static final Double GMF_VERSION = 1.0;
+  public static final Double GMF_VERSION = 2.0;
 
   private static final Configuration JSON_PATH_CONFIG = Configuration.builder()
       .jsonProvider(new GsonJsonProvider())

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1408,12 +1408,15 @@ public abstract class State implements Cloneable, Serializable {
       }
       if ((duration != null || distribution != null) && this.stop == null) {
         double durationVal;
+        String procedureDurationUnit;
         if (duration != null) {
           durationVal = person.rand(duration.low, duration.high);
+          procedureDurationUnit = duration.unit;
         } else {
           durationVal = distribution.generate(person);
+          procedureDurationUnit = this.unit;
         }
-        this.stop = procedure.start + Utilities.convertTime(duration.unit, durationVal);
+        this.stop = procedure.start + Utilities.convertTime(procedureDurationUnit, durationVal);
         procedure.stop = this.stop;
       }
       // increment number of procedures by respective hospital

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1398,12 +1398,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public Procedure clone() {
       Procedure clone = (Procedure) super.clone();
-      clone.codes = codes;
-      clone.reason = reason;
-      clone.duration = duration;
-      clone.assignToAttribute = assignToAttribute;
-      clone.distribution = distribution;
-      clone.unit = unit;
       return clone;
     }
 
@@ -1888,11 +1882,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public Symptom clone() {
       Symptom clone = (Symptom) super.clone();
-      clone.symptom = symptom;
-      clone.cause = cause;
-      clone.probability = probability;
-      clone.addressed = addressed;
-      clone.distribution = distribution;
       return clone;
     }
 

--- a/src/main/java/org/mitre/synthea/helpers/RandomValueGenerator.java
+++ b/src/main/java/org/mitre/synthea/helpers/RandomValueGenerator.java
@@ -1,9 +1,9 @@
 package org.mitre.synthea.helpers;
 
+import java.util.HashMap;
+
 import org.mitre.synthea.engine.Distribution;
 import org.mitre.synthea.world.agents.Person;
-
-import java.util.HashMap;
 
 /**
  * Generate random values within a defined range.

--- a/src/main/java/org/mitre/synthea/helpers/RandomValueGenerator.java
+++ b/src/main/java/org/mitre/synthea/helpers/RandomValueGenerator.java
@@ -1,13 +1,15 @@
 package org.mitre.synthea.helpers;
 
+import org.mitre.synthea.engine.Distribution;
 import org.mitre.synthea.world.agents.Person;
+
+import java.util.HashMap;
 
 /**
  * Generate random values within a defined range.
  */
 public class RandomValueGenerator extends ValueGenerator {
-  private double low;
-  private double high;
+  private Distribution distribution;
 
   /**
    * Create a new RandomValueGenerator.
@@ -17,12 +19,21 @@ public class RandomValueGenerator extends ValueGenerator {
    */
   public RandomValueGenerator(Person person, double low, double high) {
     super(person);
-    this.low = low;
-    this.high = high;
+    this.distribution = new Distribution();
+    distribution.kind = Distribution.Kind.UNIFORM;
+    HashMap<String, Double> parameters = new HashMap();
+    parameters.put("low", low);
+    parameters.put("high", high);
+    distribution.parameters = parameters;
+  }
+
+  public RandomValueGenerator(Person person, Distribution distribution) {
+    super(person);
+    this.distribution = distribution;
   }
 
   @Override
   public double getValue(long time) {
-    return person.rand(low, high);
+    return distribution.generate(this.person);
   }
 }

--- a/src/test/java/org/mitre/synthea/engine/DistributionTest.java
+++ b/src/test/java/org/mitre/synthea/engine/DistributionTest.java
@@ -1,0 +1,4 @@
+import static org.junit.Assert.*;
+public class DistributionTest {
+  
+}

--- a/src/test/java/org/mitre/synthea/engine/DistributionTest.java
+++ b/src/test/java/org/mitre/synthea/engine/DistributionTest.java
@@ -1,4 +1,22 @@
+package org.mitre.synthea.engine;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
 import static org.junit.Assert.*;
+
 public class DistributionTest {
-  
+  @Test
+  public void testValidate() {
+    Distribution d = new Distribution();
+    d.kind = Distribution.Kind.UNIFORM;
+    assertFalse(d.validate());
+    HashMap<String, Double> parameters = new HashMap();
+    parameters.put("low", 1d);
+    parameters.put("high", 10d);
+    d.parameters = parameters;
+    assertTrue(d.validate());
+  }
+
 }

--- a/src/test/java/org/mitre/synthea/engine/ModuleTest.java
+++ b/src/test/java/org/mitre/synthea/engine/ModuleTest.java
@@ -205,6 +205,23 @@ public class ModuleTest {
   }
 
   @Test
+  public void rejectModulesWithBadDistributions() throws Exception {
+    try {
+      String jsonString = Files.readAllLines(Paths.get("src", "test",
+          "resources", "busted_distribution", "module_with_bad_distribution.json"))
+          .stream()
+          .collect(Collectors.joining("\n"));
+      JsonParser parser = new JsonParser();
+      JsonObject object = parser.parse(jsonString).getAsJsonObject();
+      new Module(object, false);
+      // Should never get here
+      fail("Didn't throw exception when loading module with version from the future");
+    } catch (IllegalStateException ise) {
+      assertTrue(ise.getMessage().startsWith("State 2_Second_Delay contains an invalid distribution"));
+    }
+  }
+
+  @Test
   public void getModuleByPath_missingModule() {
     Module module = Module.getModuleByPath("missing_module");
     assertNull(module);

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -508,6 +508,16 @@ public class StateTest {
   }
 
   @Test
+  public void gmfTwoSymptom() throws Exception {
+    Module module = TestHelper.getFixture("gmf_two_point_oh.json");
+
+    State symptom1 = module.getState("SymptomOnset");
+    assertTrue(symptom1.process(person, time));
+    int symptomValue = person.getSymptom("Chest Pain");
+    assertTrue(1 <= symptomValue && symptomValue <= 10);
+  }
+
+  @Test
   public void symptoms() throws Exception {
     Module module = TestHelper.getFixture("symptom.json");
 
@@ -538,6 +548,17 @@ public class StateTest {
     assertTrue(set1.process(person, time));
 
     assertEquals("Vicodin", person.attributes.get("Current Opioid Prescription"));
+  }
+
+  @Test
+  public void gmfTwoSetAttributeWithValue() throws Exception {
+    Module module = TestHelper.getFixture("gmf_two_point_oh.json");
+
+    person.attributes.remove("Favorite Number");
+    State set1 = module.getState("Set_Attribute_1");
+    assertTrue(set1.process(person, time));
+
+    assertEquals(2.0, person.attributes.get("Favorite Number"));
   }
 
   @Test
@@ -609,6 +630,25 @@ public class StateTest {
   }
 
   @Test
+  public void gmfTwoProcedure() throws Exception {
+    person.attributes.remove("Most Recent Surgery");
+    Module module = TestHelper.getFixture("gmf_two_point_oh.json");
+
+    State appendectomy = module.getState("Appendectomy");
+    appendectomy.process(person, time);
+
+    HealthRecord.Procedure procedure = (HealthRecord.Procedure) person.attributes
+        .get("Most Recent Surgery");
+
+    assertEquals(time, procedure.start);
+
+    Code code = procedure.codes.get(0);
+
+    assertEquals("6025007", code.code);
+    assertEquals("Laparoscopic appendectomy", code.display);
+  }
+
+  @Test
   public void procedure_assigns_entity_attribute() throws Exception {
     person.attributes.remove("Most Recent Surgery");
     Module module = TestHelper.getFixture("procedure.json");
@@ -661,6 +701,19 @@ public class StateTest {
   }
 
   @Test
+  public void gmfTwoObservation() throws Exception {
+    Module module = TestHelper.getFixture("gmf_two_point_oh.json");
+    State os = module.getState("Observation");
+    assertTrue(os.process(person, time));
+
+    HealthRecord.Observation observation = person.record.encounters.get(0).observations.get(0);
+    assertEquals("mg/dL", observation.unit);
+    double obsValue = (double) observation.value;
+    assertTrue(obsValue > 0);
+    assertTrue(obsValue < 400);
+  }
+
+    @Test
   public void observation() throws Exception {
     Module module = TestHelper.getFixture("observation.json");
 

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -268,6 +268,19 @@ public class StateTest {
   }
 
   @Test
+  public void gmfTwoDelayExactTime() throws Exception {
+    Module module = TestHelper.getFixture("gmf_two_point_oh.json");
+
+    // Seconds
+    State delay = module.getState("2_Second_Delay");
+    delay.entered = time;
+    assertFalse(delay.process(person, time));
+    assertFalse(delay.process(person, time + 1L * 1000));
+    assertTrue(delay.process(person, time + 2L * 1000));
+    assertTrue(delay.process(person, time + 3L * 1000));
+  }
+
+  @Test
   public void delay_passes_after_exact_time() throws Exception {
     Module module = TestHelper.getFixture("delay.json");
 
@@ -448,6 +461,24 @@ public class StateTest {
     long encounterStop = person.record.encounters.get(0).stop;
     assertTrue(deathDate >= encounterStop);
   }
+
+  @Test
+  public void gmfTwoVitalSign() throws Exception {
+    // Setup a mock to track calls to the patient record
+    // In this case, the record shouldn't be called at all
+    person.record = Mockito.mock(HealthRecord.class);
+
+    Module module = TestHelper.getFixture("gmf_two_point_oh.json");
+
+    State vitalSign = module.getState("VitalSign").clone();
+    assertTrue(vitalSign.process(person, time));
+
+    assertTrue(person.getVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, time) >= 110);
+    assertTrue(person.getVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, time) <= 130);
+
+    verifyZeroInteractions(person.record);
+  }
+
 
   @Test
   public void vitalsign() throws Exception {

--- a/src/test/resources/busted_distribution/module_with_bad_distribution.json
+++ b/src/test/resources/busted_distribution/module_with_bad_distribution.json
@@ -1,0 +1,24 @@
+{
+  "name": "GMF 2.0",
+  "gmf_version": 2.0,
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "2_Second_Delay"
+    },
+    "2_Second_Delay": {
+      "type": "Delay",
+      "unit": "seconds",
+      "distribution": {
+        "kind": "EXACT",
+        "parameters": {
+          "ToTaLlyWrOnG": 2
+        }
+      },
+      "direct_transition": "Terminal"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/src/test/resources/generic/gmf_two_point_oh.json
+++ b/src/test/resources/generic/gmf_two_point_oh.json
@@ -1,0 +1,37 @@
+{
+  "name": "GMF 2.0",
+  "gmf_version": 2.0,
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "2_Second_Delay"
+    },
+    "2_Second_Delay": {
+      "type": "Delay",
+      "unit": "seconds",
+      "distribution": {
+        "kind": "EXACT",
+        "parameters": {
+          "value": 2
+        }
+      },
+      "direct_transition": "VitalSign"
+    },
+    "VitalSign" : {
+      "type" : "VitalSign",
+      "vital_sign" : "Systolic Blood Pressure",
+      "distribution" : {
+        "kind" : "UNIFORM",
+        "parameters": {
+          "low": 110,
+          "high": 130
+        }
+      },
+      "unit" : "mm[Hg]",
+      "direct_transition" : "Terminal"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    }
+  }
+}

--- a/src/test/resources/generic/gmf_two_point_oh.json
+++ b/src/test/resources/generic/gmf_two_point_oh.json
@@ -28,7 +28,69 @@
         }
       },
       "unit" : "mm[Hg]",
-      "direct_transition" : "Terminal"
+      "direct_transition" : "Observation"
+    },
+    "Observation" : {
+      "type" : "Observation",
+      "category" : "procedure",
+      "codes" : [
+        {
+          "system" : "LOINC",
+          "code" : "2089-1",
+          "display" : "Cholesterol in LDL"
+        }
+      ],
+      "distribution": {
+        "kind": "GAUSSIAN",
+        "parameters": {
+          "mean": 140,
+          "standardDeviation": 15
+        }
+      },
+      "unit": "mg/dL",
+      "direct_transition" : "Set_Attribute_1"
+    },
+    "Set_Attribute_1": {
+      "type": "SetAttribute",
+      "attribute" : "Favorite Number",
+      "distribution": {
+        "kind": "EXACT",
+        "parameters": {
+          "value": 2
+        }
+      },
+      "direct_transition": "Appendectomy"
+    },
+    "Appendectomy": {
+      "type": "Procedure",
+      "target_encounter": "Inpatient_Encounter",
+      "codes": [{
+        "system": "SNOMED-CT",
+        "code": "6025007",
+        "display": "Laparoscopic appendectomy"
+      }],
+      "unit": "minutes",
+      "distribution" : {
+        "kind": "UNIFORM",
+        "parameters": {
+          "low": 45,
+          "high" : 60
+        }
+      },
+      "assign_to_attribute" : "Most Recent Surgery",
+      "direct_transition": "SymptomOnset"
+    },
+    "SymptomOnset" : {
+      "type" : "Symptom",
+      "symptom" : "Chest Pain",
+      "distribution" : {
+        "kind": "UNIFORM",
+        "parameters": {
+          "low" : 1,
+          "high" : 10
+        }
+      },
+      "direct_transition": "Terminal"
     },
     "Terminal": {
       "type": "Terminal"


### PR DESCRIPTION
This change supports a new `distribution` property in `Delay`, `Observation`, `Procedure`, `SetAttribute`, `Symptom` and `VitalSign` states. 

For example, an `Observation` of LDL Cholesterol with a Gaussian distribution of results would be:

```json
    "Observation" : {
      "type" : "Observation",
      "category" : "procedure",
      "codes" : [
        {
          "system" : "LOINC",
          "code" : "2089-1",
          "display" : "Cholesterol in LDL"
        }
      ],
      "distribution": {
        "kind": "GAUSSIAN",
        "parameters": {
          "mean": 140,
          "standardDeviation": 15
        }
      },
      "unit": "mg/dL",
    }
```

All states still support the "legacy" format for defining ranges or whatever they call themselves. Current distribution types in this PR are:
* Exact
* Uniform
* Gaussian

The Distribution class should make it easy to add any other distribution types desired.