### PR TITLE
Fix FHIR identifiers that require prefix.

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -2207,7 +2207,7 @@ public class FhirR4 {
     }
     documentReference.addIdentifier()
       .setSystem("urn:ietf:rfc:3986")
-      .setValue(reportResource.getId());
+      .setValue("urn:uuid:" + reportResource.getId());
     documentReference.setType(reportResource.getCategoryFirstRep());
     documentReference.addCategory(new CodeableConcept(
         new Coding("http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
@@ -2673,7 +2673,7 @@ public class FhirR4 {
       organizationResource.setMeta(new Meta().addProfile(SHR_EXT + "shr-entity-Organization"));
       organizationResource.addIdentifier()
           .setSystem("urn:ietf:rfc:3986")
-          .setValue(provider.getResourceID());
+          .setValue("urn:uuid" + provider.getResourceID());
       organizationResource.addContact().setName(new HumanName().setText("Synthetic Provider"));
     }
     List<CodeableConcept> organizationType = new ArrayList<CodeableConcept>();

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -2410,7 +2410,7 @@ public class FhirStu3 {
 
       organizationResource.addIdentifier()
           .setSystem("urn:ietf:rfc:3986")
-          .setValue(provider.getResourceID());
+          .setValue("urn:uuid:" + provider.getResourceID());
       organizationResource.addContact().setName(new HumanName().setText("Synthetic Provider"));
     }
 


### PR DESCRIPTION
Fixes FHIR Identifiers with a system of `urn:ietf:rfc:3986` which require a value that is a URI with a proper prefix (e.g. `urn:uuid:`).

See http://hl7.org/fhir/R4/datatypes.html#Identifier and https://github.com/onc-healthit/inferno-program/issues/179
