### PR TITLE
Apply resource deduplification fix from FHIR R4 exporter to DSTU2 and STU3 exporters

### DIFF
--- a/src/main/java/org/mitre/synthea/export/ExportHelper.java
+++ b/src/main/java/org/mitre/synthea/export/ExportHelper.java
@@ -2,7 +2,9 @@ package org.mitre.synthea.export;
 
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -10,6 +12,7 @@ import org.hl7.fhir.dstu3.model.Condition;
 import org.mitre.synthea.engine.Components.Attachment;
 import org.mitre.synthea.engine.Components.SampledData;
 import org.mitre.synthea.helpers.TimeSeriesData;
+import org.mitre.synthea.world.agents.Clinician;
 import org.mitre.synthea.world.concepts.HealthRecord;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 import org.mitre.synthea.world.concepts.HealthRecord.Observation;
@@ -214,4 +217,38 @@ public abstract class ExportHelper {
     }
     return system;
   }
+  
+  /**
+   * Build a FHIR search url for the specified type of resource and identifier. This method
+   * hard codes the identifier type to "https://github.com/synthetichealth/synthea".
+   * @param resourceType type of FHIR resource
+   * @param identifier the identifier value
+   * @return FHIR search URL
+   */
+  public static String buildFhirSearchUrl(String resourceType, String identifier) {
+    return String.format("%s?identifier=%s|%s", resourceType, 
+            "https://github.com/synthetichealth/synthea", identifier);
+  }
+  
+  /**
+   * Build a FHIR search URL for a clinician using the clinician's NPI identifier.
+   * @param clinician the Synthea clinician instance
+   * @return FHIR search URL or null if clinician is null
+   */
+  public static String buildFhirNpiSearchUrl(Clinician clinician) {
+    if (clinician == null) {
+      return null;
+    } else {
+      return String.format("%s?identifier=%s|%s", "Practitioner", 
+              "http://hl7.org/fhir/sid/us-npi",
+              Long.toString(9_999_999_999L - clinician.identifier));
+    }
+  }
+  
+  /**
+   * FHIR resources that should include an ifNoneExist precondition when outputting transaction
+   * bundles.
+   */
+  public static final List<String> UNDUPLICATED_FHIR_RESOURCES = Arrays.asList(
+          "Location", "Organization", "Practitioner");
 }

--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -8,6 +8,7 @@ import ca.uhn.fhir.model.dstu2.composite.CodeableConceptDt;
 import ca.uhn.fhir.model.dstu2.composite.CodingDt;
 import ca.uhn.fhir.model.dstu2.composite.ContactPointDt;
 import ca.uhn.fhir.model.dstu2.composite.HumanNameDt;
+import ca.uhn.fhir.model.dstu2.composite.IdentifierDt;
 import ca.uhn.fhir.model.dstu2.composite.MoneyDt;
 import ca.uhn.fhir.model.dstu2.composite.NarrativeDt;
 import ca.uhn.fhir.model.dstu2.composite.PeriodDt;
@@ -541,40 +542,43 @@ public class FhirDstu2 {
           .setDisplay(encounter.reason.display).setSystem(SNOMED_URI);
     }
 
-    if (encounter.provider != null) {
-      String providerFullUrl = findProviderUrl(encounter.provider, bundle);
-
-      if (providerFullUrl != null) {
-        encounterResource.setServiceProvider(new ResourceReferenceDt(providerFullUrl));
-      } else {
-        Entry providerOrganization = provider(bundle, encounter.provider);
-        encounterResource
-            .setServiceProvider(new ResourceReferenceDt(providerOrganization.getFullUrl()));
-      }
-    } else { // no associated provider, patient goes to wellness provider
-      Provider provider = person.getProvider(EncounterType.WELLNESS, encounter.start);
+    Provider provider = encounter.provider;
+    if (provider == null) {
+      // no associated provider, patient goes to wellness provider
+      provider = person.getProvider(EncounterType.WELLNESS, encounter.start);
+    }
+    if (TRANSACTION_BUNDLE) {
+      encounterResource.setServiceProvider(new ResourceReferenceDt(
+              ExportHelper.buildFhirSearchUrl("Organization", provider.getResourceID())));
+    } else {
       String providerFullUrl = findProviderUrl(provider, bundle);
-
       if (providerFullUrl != null) {
         encounterResource.setServiceProvider(new ResourceReferenceDt(providerFullUrl));
       } else {
         Entry providerOrganization = provider(bundle, provider);
-        encounterResource
-            .setServiceProvider(new ResourceReferenceDt(providerOrganization.getFullUrl()));
+        encounterResource.setServiceProvider(new ResourceReferenceDt(
+                providerOrganization.getFullUrl()));
       }
     }
-
+    encounterResource.getServiceProvider().setDisplay(provider.name);
+    
     if (encounter.clinician != null) {
-      String practitionerFullUrl = findPractitioner(encounter.clinician, bundle);
-
-      if (practitionerFullUrl != null) {
-        encounterResource.addParticipant().setIndividual(
-            new ResourceReferenceDt(practitionerFullUrl));
+      if (TRANSACTION_BUNDLE) {
+        encounterResource.addParticipant().setIndividual(new ResourceReferenceDt(
+                ExportHelper.buildFhirNpiSearchUrl(encounter.clinician)));
       } else {
-        Entry practitioner = practitioner(bundle, encounter.clinician);
-        encounterResource.addParticipant().setIndividual(
-            new ResourceReferenceDt(practitioner.getFullUrl()));
+        String practitionerFullUrl = findPractitioner(encounter.clinician, bundle);
+        if (practitionerFullUrl != null) {
+          encounterResource.addParticipant().setIndividual(
+              new ResourceReferenceDt(practitionerFullUrl));
+        } else {
+          Entry practitioner = practitioner(bundle, encounter.clinician);
+          encounterResource.addParticipant().setIndividual(
+              new ResourceReferenceDt(practitioner.getFullUrl()));
+        }
       }
+      encounterResource.getParticipantFirstRep().getIndividual()
+              .setDisplay(encounter.clinician.getFullname());
     }
 
     if (encounter.discharge != null) {
@@ -1624,8 +1628,9 @@ public class FhirDstu2 {
   protected static Entry practitioner(Bundle bundle, Clinician clinician) {
     Practitioner practitionerResource = new Practitioner();
 
-    practitionerResource.addIdentifier().setSystem("http://hl7.org/fhir/sid/us-npi")
-    .setValue("" + clinician.identifier);
+    practitionerResource.addIdentifier()
+            .setSystem("http://hl7.org/fhir/sid/us-npi")
+            .setValue("" + (9_999_999_999L - clinician.identifier));
     practitionerResource.setActive(true);
     practitionerResource.getName().addFamily(
         (String) clinician.attributes.get(Clinician.LAST_NAME))
@@ -1829,7 +1834,27 @@ public class FhirDstu2 {
     if (TRANSACTION_BUNDLE) {
       EntryRequest request = entry.getRequest();
       request.setMethod(HTTPVerbEnum.POST);
-      request.setUrl(resource.getResourceName());
+      String resourceType = resource.getResourceName();
+      request.setUrl(resourceType);
+      if (ExportHelper.UNDUPLICATED_FHIR_RESOURCES.contains(resourceType)) {
+        IdentifierDt identifier = null;
+        switch (resourceType) {
+          case "Practitioner":
+            Practitioner practitioner = (Practitioner)resource;
+            identifier = practitioner.getIdentifierFirstRep();
+            break;
+          case "Organization":
+            Organization organization = (Organization)resource;
+            identifier = organization.getIdentifierFirstRep();
+            break;
+          default:
+            break;
+        }
+        if (identifier != null) {
+          request.setIfNoneExist(
+              "identifier=" + identifier.getSystem() + "|" + identifier.getValue());
+        }
+      }
       entry.setRequest(request);
     }
 

--- a/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterDstu2.java
@@ -41,7 +41,7 @@ public abstract class FhirPractitionerExporterDstu2 {
 
       Bundle bundle = new Bundle();
       if (Config.getAsBoolean("exporter.fhir.transaction_bundle")) {
-        bundle.setType(BundleTypeEnum.TRANSACTION);
+        bundle.setType(BundleTypeEnum.BATCH);
       } else {
         bundle.setType(BundleTypeEnum.COLLECTION);
       }

--- a/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterStu3.java
@@ -39,7 +39,7 @@ public abstract class FhirPractitionerExporterStu3 {
 
       Bundle bundle = new Bundle();
       if (Config.getAsBoolean("exporter.fhir.transaction_bundle")) {
-        bundle.setType(BundleType.TRANSACTION);
+        bundle.setType(BundleType.BATCH);
       } else {
         bundle.setType(BundleType.COLLECTION);
       }

--- a/src/main/java/org/mitre/synthea/export/HospitalExporterDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporterDstu2.java
@@ -38,7 +38,7 @@ public abstract class HospitalExporterDstu2 {
       
       Bundle bundle = new Bundle();
       if (Config.getAsBoolean("exporter.fhir.transaction_bundle")) {
-        bundle.setType(BundleTypeEnum.TRANSACTION);
+        bundle.setType(BundleTypeEnum.BATCH);
       } else {
         bundle.setType(BundleTypeEnum.COLLECTION);
       }

--- a/src/main/java/org/mitre/synthea/export/HospitalExporterStu3.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporterStu3.java
@@ -37,7 +37,7 @@ public abstract class HospitalExporterStu3 {
 
       Bundle bundle = new Bundle();
       if (Config.getAsBoolean("exporter.fhir.transaction_bundle")) {
-        bundle.setType(BundleType.TRANSACTION);
+        bundle.setType(BundleType.BATCH);
       } else {
         bundle.setType(BundleType.COLLECTION);
       }


### PR DESCRIPTION
Also:

- Adds display text to practitioner references in encounter resources.
- Makes practitioner IDs consistent across R4, DSTU2 and STU3.