### PR TITLE
WIP: Improving/expanding Cardiovascular Disease modules

### DIFF
--- a/src/main/java/org/mitre/synthea/helpers/Attributes.java
+++ b/src/main/java/org/mitre/synthea/helpers/Attributes.java
@@ -40,6 +40,8 @@ import org.mitre.synthea.modules.HealthInsuranceModule;
 import org.mitre.synthea.modules.Immunizations;
 import org.mitre.synthea.modules.LifecycleModule;
 import org.mitre.synthea.modules.QualityOfLifeModule;
+import org.mitre.synthea.modules.risk_calculators.ASCVD;
+import org.mitre.synthea.modules.risk_calculators.Framingham;
 import org.mitre.synthea.world.agents.Person;
 
 /**
@@ -143,6 +145,8 @@ public class Attributes {
     });
 
     CardiovascularDiseaseModule.inventoryAttributes(attributes);
+    Framingham.inventoryAttributes(attributes);
+    ASCVD.inventoryAttributes(attributes);
     DeathModule.inventoryAttributes(attributes);
     EncounterModule.inventoryAttributes(attributes);
     HealthInsuranceModule.inventoryAttributes(attributes);

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -109,7 +109,14 @@ public class Utilities {
   public static double convertRiskToTimestep(double risk, double originalPeriodInMS) {
     double currTimeStepInMS = Double.parseDouble(Config.get("generate.timestep"));
 
-    return 1 - Math.pow(1 - risk, currTimeStepInMS / originalPeriodInMS);
+    return convertRiskToTimestep(risk, originalPeriodInMS, currTimeStepInMS);
+  }
+  
+  /**
+   * Calculates 1 - (1-risk)^(newTimeStepInMS/originalPeriodInMS).
+   */
+  public static double convertRiskToTimestep(double risk, double originalPeriodInMS, double newTimeStepInMS) {
+    return 1 - Math.pow(1 - risk, newTimeStepInMS / originalPeriodInMS);
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -42,6 +42,7 @@ public final class CardiovascularDiseaseModule extends Module {
     // since this is intended to only be temporary
     // until we can convert this module to GMF
 
+    // TODO: make this a config parameter for which risk system we want to use
     boolean useFramingham = false;
     if (useFramingham) {
         calculateCardioRisk(person, time);
@@ -388,83 +389,100 @@ public final class CardiovascularDiseaseModule extends Module {
   
   
   /**
-   * Computes the ASCVD Risk Estimate for an individual over the next 10 years.
-   * @param patientInfo - patientInfo object from ASCVDRisk data model
-   * @returns {*} Returns the risk score or 0 if not in the appropriate age range
+   * Equation Parameters of the Pooled Cohort Equations for Estimation of 10-Year Risk of Hard ASCVD
+   * See Appendix 7, Table A  https://doi.org/10.1161/01.cir.0000437741.48606.98
+   * "N/A" becomes 0
    */
-	private static void calculateAscvdRisk(Person person, long time) {
-		int age = person.ageInYears(time);
-		String gender = (String) person.attributes.get(Person.GENDER);
-		String race = (String) person.attributes.get(Person.RACE);
-		Double sysBP = person.getVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, time);
-		Double diaBP = person.getVitalSign(VitalSign.DIASTOLIC_BLOOD_PRESSURE, time);
-		Double totalChol = person.getVitalSign(VitalSign.TOTAL_CHOLESTEROL, time);
-		Double hdl = person.getVitalSign(VitalSign.HDL, time);
+	private static final double[][] ASCVD_COEFFICIENTS = {
+                          // sex:  ------women-----   ----men----
+                          // race: ---w---  --aa--  ---w--  --aa--
+/* Ln Age (y) */                 { -29.799, 17.114,  12.344, 2.469 },
+/* (Ln Age)^2 */                 { 4.884,   0,       0,      0 },
+/* Ln Total Chol */              { 13.540,  0.940,   11.853, 0.302 },
+/* Ln Age × Ln Total Chol */     { -3.114,  0,       -2.664, 0 },
+/* Ln HDL-C */                   { -13.578, -18.920, -7.990, -0.307 },
+/* Ln Age × Ln HDL-C */          { 3.149,   4.475,   1.769,  0 },
+/* Ln Treated SysBP */           { 2.019,   29.291,  1.797,  1.916 },
+/* Ln Age × Ln Treated SysBP */  { 0,       -6.432,  0,      0 },
+/* Ln Untreated SysBP */         { 1.957,   27.820,  1.764,  1.809 },
+/* Ln Age × Ln Untreat SysBP */  { 0,       -6.087,  0,      0 },
+/* Current Smoker (1=Y, 0=N) */  { 7.574,   0.691,   7.837,  0.549 },
+/* Ln Age × Current Smoker */    { -1.665,  0,       -1.795, 0 },
+/* Diabetes (1=Y, 0=N) */        { 0.661,   0.874,   0.658,  0.645 },
 
-		boolean smoker = (Boolean) person.attributes.getOrDefault(Person.SMOKER, false);
-		boolean diabetic = (Boolean) person.attributes.getOrDefault("diabetes", false);
-		boolean hypertensive = (Boolean) person.attributes.getOrDefault("hypertension", false);
-		if (sysBP == null || diaBP == null || totalChol == null) {
-			return;
-		}
-		if (age < 40 || age > 79) {
-			return;
-		}
-		double lnAge = Math.log(age);
-		double lnTotalChol = Math.log(totalChol);
-		double lnHdl = Math.log(hdl);
-		double trlnsbp = hypertensive ? Math.log(sysBP) : 0;
-		double ntlnsbp = hypertensive ? 0 : Math.log(diaBP);
-		double ageTotalChol = lnAge * lnTotalChol;
-		double ageHdl = lnAge * lnHdl;
-		double agetSbp = lnAge * trlnsbp;
-		double agentSbp = lnAge * ntlnsbp;
-		double ageSmoke = smoker ? lnAge : 0;
+/* Mean (Coefficient × Value) */ { -29.18,  86.61,   61.18,  19.54 },
+/* Baseline Survival */          { 0.9665,  0.9533,  0.9144, 0.8954 }
+	};
 
-		boolean isAA = race.equals("black");
-		boolean isMale = gender.equals("M");
-		double s010Ret = 0;
-		double mnxbRet = 0;
-		double predictRet = 0;
 
-		int smokerInt = smoker ? 1 : 0;
-		int diabeticInt = diabetic ? 1 : 0;
+  /**
+   * Calculates the 10-year ASCVD Risk Estimates.
+   */
+  private static void calculateAscvdRisk(Person person, long time) {
+	int age = person.ageInYears(time);
+	String gender = (String) person.attributes.get(Person.GENDER);
+	String race = (String) person.attributes.get(Person.RACE);
+	Double sysBP = person.getVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, time);
+	Double diaBP = person.getVitalSign(VitalSign.DIASTOLIC_BLOOD_PRESSURE, time);
+	Double totalChol = person.getVitalSign(VitalSign.TOTAL_CHOLESTEROL, time);
+	Double hdl = person.getVitalSign(VitalSign.HDL, time);
 
-		if (isAA && !isMale) {
-			s010Ret = 0.95334;
-			mnxbRet = 86.6081;
-			predictRet = (17.1141 * lnAge) + (0.9396 * lnTotalChol) + (-18.9196 * lnHdl) + (4.4748 * ageHdl)
-					+ (29.2907 * trlnsbp) + (-6.4321 * agetSbp) + (27.8197 * ntlnsbp) + (-6.0873 * agentSbp)
-					+ (0.6908 * smokerInt) + (0.8738 * diabeticInt);
-		} else if (!isAA && !isMale) {
-			s010Ret = 0.96652;
-			mnxbRet = -29.1817;
-			predictRet = (-29.799 * lnAge) + (4.884 * (lnAge * lnAge)) + (13.54 * lnTotalChol) + (-3.114 * ageTotalChol)
-					+ (-13.578 * lnHdl) + (3.149 * ageHdl) + (2.019 * trlnsbp) + (1.957 * ntlnsbp) + (7.574 * smokerInt)
-					+ (-1.665 * ageSmoke) + (0.661 * diabeticInt);
-		} else if (isAA && isMale) {
-			s010Ret = 0.89536;
-			mnxbRet = 19.5425;
-			predictRet = (2.469 * lnAge) + (0.302 * lnTotalChol) + (-0.307 * lnHdl) + (1.916 * trlnsbp)
-					+ (1.809 * ntlnsbp) + (0.549 * smokerInt) + (0.645 * diabeticInt);
-		} else {
-			s010Ret = 0.91436;
-			mnxbRet = 61.1816;
-			predictRet = (12.344 * lnAge) + (11.853 * lnTotalChol) + (-2.664 * ageTotalChol) + (-7.99 * lnHdl)
-					+ (1.769 * ageHdl) + (1.797 * trlnsbp) + (1.764 * ntlnsbp) + (7.837 * smokerInt)
-					+ (-1.795 * ageSmoke) + (0.658 * diabeticInt);
-		}
-
-		double ascvdRisk = (1 - Math.pow(s010Ret, Math.exp(predictRet - mnxbRet)));
-		
-	    person.attributes.put("ascvd_risk", ascvdRisk);
-
-	    double timestepRisk = Utilities.convertRiskToTimestep(ascvdRisk, tenYearsInMS);
-	    person.attributes.put("cardio_risk", timestepRisk);
-	    
-	    double monthlyRisk = Utilities.convertRiskToTimestep(ascvdRisk, tenYearsInMS, oneMonthInMS);
-	    person.attributes.put("mi_risk", monthlyRisk);
+	boolean smoker = (Boolean) person.attributes.getOrDefault(Person.SMOKER, false);
+	boolean diabetic = (Boolean) person.attributes.getOrDefault("diabetes", false);
+	boolean hypertensive = (Boolean) person.attributes.getOrDefault("hypertension", false);
+	if (sysBP == null || diaBP == null || totalChol == null) {
+		return;
 	}
+	if (age < 40 || age > 79) {
+		return;
+	}
+	double lnAge = Math.log(age);
+	double lnTotalChol = Math.log(totalChol);
+	double lnHdl = Math.log(hdl);
+	double lnTreatedSBP = hypertensive ? Math.log(sysBP) : 0;    
+	double lnUntreatSBP = hypertensive ? 0 : Math.log(sysBP);
+    int smokerInt = smoker ? 1 : 0;
+    int diabeticInt = diabetic ? 1 : 0;
+
+    double[] values = {
+/* Ln Age (y) */                lnAge,
+/* (Ln Age)^2 */                (lnAge * lnAge),
+/* Ln Total Chol */             lnTotalChol,
+/* Ln Age × Ln Total Chol */    (lnAge * lnTotalChol),
+/* Ln HDL-C */                  lnHdl,
+/* Ln Age × Ln HDL-C */         (lnAge * lnHdl),
+/* Ln Treated SysBP */          lnTreatedSBP,
+/* Ln Age × Ln Treated SysBP */ (lnAge * lnTreatedSBP),
+/* Ln Untreated SysBP */        lnUntreatSBP,
+/* Ln Age × Ln Untreat SysBP */ (lnAge * lnUntreatSBP),
+/* Current Smoker (1=Y, 0=N) */ smokerInt,
+/* Ln Age × Current Smoker */   (lnAge * smokerInt),
+/* Diabetes (1=Y, 0=N) */       diabeticInt
+    };
+
+    int raceSexIndex = 0; // index in ASCVD_COEFFICIENTS above
+    if (gender.equals("M")) raceSexIndex += 2;
+    if (race.equals("black")) raceSexIndex += 1;
+
+
+	double raceSexMean = ASCVD_COEFFICIENTS[13][raceSexIndex];
+    double baselineSurvival = ASCVD_COEFFICIENTS[14][raceSexIndex];
+	double individualSum = 0;
+
+    for (int i = 0 ; i < 13 ; i++) {
+      individualSum += ASCVD_COEFFICIENTS[i][raceSexIndex] * values[i];
+    }
+
+	double ascvdRisk = (1 - Math.pow(baselineSurvival, Math.exp(individualSum - raceSexMean)));
+	
+    person.attributes.put("ascvd_risk", ascvdRisk);
+
+    double timestepRisk = Utilities.convertRiskToTimestep(ascvdRisk, tenYearsInMS);
+    person.attributes.put("cardio_risk", timestepRisk);
+    
+    double monthlyRisk = Utilities.convertRiskToTimestep(ascvdRisk, tenYearsInMS, oneMonthInMS);
+    person.attributes.put("mi_risk", monthlyRisk);
+  }
 
 
   /**

--- a/src/main/java/org/mitre/synthea/modules/risk_calculators/ASCVD.java
+++ b/src/main/java/org/mitre/synthea/modules/risk_calculators/ASCVD.java
@@ -1,0 +1,125 @@
+package org.mitre.synthea.modules.risk_calculators;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.mitre.synthea.helpers.Utilities;
+import org.mitre.synthea.helpers.Attributes.Inventory;
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.concepts.VitalSign;
+
+public class ASCVD {
+  
+  public static final long TEN_YEARS_IN_MS = TimeUnit.DAYS.toMillis(3650);
+
+  /**
+   * Equation Parameters of the Pooled Cohort Equations for Estimation of 10-Year Risk of Hard ASCVD
+   * See Appendix 7, Table A  https://doi.org/10.1161/01.cir.0000437741.48606.98
+   * "N/A" becomes 0
+   */
+  private static final double[][] ASCVD_COEFFICIENTS = {
+                          // sex:  ------women-----   ----men----
+                          // race: ---w---  --aa--  ---w--  --aa--
+/* Ln Age (y) */                 { -29.799, 17.114,  12.344, 2.469 },
+/* (Ln Age)^2 */                 { 4.884,   0,       0,      0 },
+/* Ln Total Chol */              { 13.540,  0.940,   11.853, 0.302 },
+/* Ln Age x Ln Total Chol */     { -3.114,  0,       -2.664, 0 },
+/* Ln HDL-C */                   { -13.578, -18.920, -7.990, -0.307 },
+/* Ln Age x Ln HDL-C */          { 3.149,   4.475,   1.769,  0 },
+/* Ln Treated SysBP */           { 2.019,   29.291,  1.797,  1.916 },
+/* Ln Age x Ln Treated SysBP */  { 0,       -6.432,  0,      0 },
+/* Ln Untreated SysBP */         { 1.957,   27.820,  1.764,  1.809 },
+/* Ln Age x Ln Untreat SysBP */  { 0,       -6.087,  0,      0 },
+/* Current Smoker (1=Y, 0=N) */  { 7.574,   0.691,   7.837,  0.549 },
+/* Ln Age x Current Smoker */    { -1.665,  0,       -1.795, 0 },
+/* Diabetes (1=Y, 0=N) */        { 0.661,   0.874,   0.658,  0.645 },
+
+/* Mean (Coefficient x Value) */ { -29.18,  86.61,   61.18,  19.54 },
+/* Baseline Survival */          { 0.9665,  0.9533,  0.9144, 0.8954 }
+  };
+
+
+  /**
+   * Calculates the 10-year ASCVD Risk Estimates, based on the
+   * Pooled Cohort Equations for Estimation of 10-Year Risk of Hard ASCVD.
+   * https://doi.org/10.1161/01.cir.0000437741.48606.98
+   * @param person The patient.
+   * @param time Time to calculate risk as of
+   * @param perTimestep Whether to return the risk per timestep (default 7 days) or per 10 years
+   * @return the patient's ASCVD risk score
+   */
+  public static double ascvd10Year(Person person, long time, boolean perTimestep) {
+    int age = person.ageInYears(time);
+    String gender = (String) person.attributes.get(Person.GENDER);
+    String race = (String) person.attributes.get(Person.RACE);
+    Double sysBP = person.getVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, time);
+    Double diaBP = person.getVitalSign(VitalSign.DIASTOLIC_BLOOD_PRESSURE, time);
+    Double totalChol = person.getVitalSign(VitalSign.TOTAL_CHOLESTEROL, time);
+    Double hdl = person.getVitalSign(VitalSign.HDL, time);
+
+    boolean smoker = (Boolean) person.attributes.getOrDefault(Person.SMOKER, false);
+    boolean diabetic = (Boolean) person.attributes.getOrDefault("diabetes", false);
+    boolean hypertensive = (Boolean) person.attributes.getOrDefault("hypertension", false);
+    if (sysBP == null || diaBP == null || totalChol == null) {
+      return -1;
+    }
+    if (age < 40 || age > 79) {
+      return -1;
+    }
+    double lnAge = Math.log(age);
+    double lnTotalChol = Math.log(totalChol);
+    double lnHdl = Math.log(hdl);
+    double lnTreatedSBP = hypertensive ? Math.log(sysBP) : 0;
+    double lnUntreatSBP = hypertensive ? 0 : Math.log(sysBP);
+    int smokerInt = smoker ? 1 : 0;
+    int diabeticInt = diabetic ? 1 : 0;
+
+    double[] values = {
+/* Ln Age (y) */                lnAge,
+/* (Ln Age)^2 */                (lnAge * lnAge),
+/* Ln Total Chol */             lnTotalChol,
+/* Ln Age x Ln Total Chol */    (lnAge * lnTotalChol),
+/* Ln HDL-C */                  lnHdl,
+/* Ln Age x Ln HDL-C */         (lnAge * lnHdl),
+/* Ln Treated SysBP */          lnTreatedSBP,
+/* Ln Age x Ln Treated SysBP */ (lnAge * lnTreatedSBP),
+/* Ln Untreated SysBP */        lnUntreatSBP,
+/* Ln Age x Ln Untreat SysBP */ (lnAge * lnUntreatSBP),
+/* Current Smoker (1=Y, 0=N) */ smokerInt,
+/* Ln Age x Current Smoker */   (lnAge * smokerInt),
+/* Diabetes (1=Y, 0=N) */       diabeticInt
+    };
+
+    int raceSexIndex = 0; // index in ASCVD_COEFFICIENTS above
+    if (gender.equals("M"))
+      raceSexIndex += 2;
+    if (race.equals("black"))
+      raceSexIndex += 1;
+
+    double raceSexMean = ASCVD_COEFFICIENTS[13][raceSexIndex];
+    double baselineSurvival = ASCVD_COEFFICIENTS[14][raceSexIndex];
+    double individualSum = 0;
+
+    for (int i = 0; i < 13; i++) {
+      individualSum += ASCVD_COEFFICIENTS[i][raceSexIndex] * values[i];
+    }
+
+    double ascvdRisk = (1 - Math.pow(baselineSurvival, Math.exp(individualSum - raceSexMean)));
+
+    if (perTimestep) {
+      ascvdRisk = Utilities.convertRiskToTimestep(ascvdRisk, TEN_YEARS_IN_MS);
+    }
+    
+    return ascvdRisk;
+  }
+  
+  /**
+   * Populate the given attribute map with the list of attributes that this
+   * module reads/writes with example values when appropriate.
+   *
+   * @param attributes Attribute map to populate.
+   */
+  public static void inventoryAttributes(Map<String,Inventory> attributes) {
+    
+  }
+}

--- a/src/main/java/org/mitre/synthea/modules/risk_calculators/Framingham.java
+++ b/src/main/java/org/mitre/synthea/modules/risk_calculators/Framingham.java
@@ -1,0 +1,554 @@
+package org.mitre.synthea.modules.risk_calculators;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.mitre.synthea.helpers.Utilities;
+import org.mitre.synthea.helpers.Attributes.Inventory;
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.concepts.VitalSign;
+
+public class Framingham {
+
+  public static final long TEN_YEARS_IN_MS = TimeUnit.DAYS.toMillis(3650);
+
+  private static int bound(int value, int min, int max) {
+    return Math.min(Math.max(value, min), max);
+  }
+  
+  // estimate cardiovascular risk of developing coronary heart disease (CHD)
+  // http://www.nhlbi.nih.gov/health-pro/guidelines/current/cholesterol-guidelines/quick-desk-reference-html/10-year-risk-framingham-table
+
+  // Indices in the array correspond to these age ranges: 20-24, 25-29, 30-34 35-39, 40-44, 45-49,
+  // 50-54, 55-59, 60-64, 65-69, 70-74, 75-79
+  private static final int[] age_chd_m = { -9, -9, -9, -4, 0, 3, 6, 8, 10, 11, 12, 13 };
+  private static final int[] age_chd_f = { -7, -7, -7, -3, 0, 3, 6, 8, 10, 12, 14, 16 };
+
+  private static final int[][] age_chol_chd_m = {
+      // <160, 160-199, 200-239, 240-279, >280
+      { 0, 4, 7, 9, 11 }, // 20-29 years
+      { 0, 4, 7, 9, 11 }, // 30-39 years
+      { 0, 3, 5, 6, 8 }, // 40-49 years
+      { 0, 2, 3, 4, 5 }, // 50-59 years
+      { 0, 1, 1, 2, 3 }, // 60-69 years
+      { 0, 0, 0, 1, 1 } // 70-79 years
+  };
+
+  private static final int[][] age_chol_chd_f = {
+      // <160, 160-199, 200-239, 240-279, >280
+      { 0, 4, 8, 11, 13 }, // 20-29 years
+      { 0, 4, 8, 11, 13 }, // 30-39 years
+      { 0, 3, 6, 8, 10 }, // 40-49 years
+      { 0, 2, 4, 5, 7 }, // 50-59 years
+      { 0, 1, 2, 3, 4 }, // 60-69 years
+      { 0, 1, 1, 2, 2 } // 70-79 years
+  };
+
+  // 20-29, 30-39, 40-49, 50-59, 60-69, 70-79 age ranges
+  private static final int[] age_smoke_chd_m = { 8, 8, 5, 3, 1, 1 };
+  private static final int[] age_smoke_chd_f = { 9, 9, 7, 4, 2, 1 };
+
+  // true/false refers to whether or not blood pressure is treated
+  private static final int[][] sys_bp_chd_m = {
+      // true, false
+      { 0, 0 }, // <120
+      { 1, 0 }, // 120-129
+      { 2, 1 }, // 130-139
+      { 2, 1 }, // 140-149
+      { 2, 1 }, // 150-159
+      { 3, 2 } // >=160
+  };
+  private static final int[][] sys_bp_chd_f = {
+      // true, false
+      { 0, 0 }, // <120
+      { 3, 1 }, // 120-129
+      { 4, 2 }, // 130-139
+      { 5, 3 }, // 140-149
+      { 5, 3 }, // 150-159
+      { 6, 4 } // >=160
+  };
+
+  private static final int[] hdl_lookup_chd = { 2, 1, 0, -1 }; // <40, 40-49, 50-59, >60
+
+  private static final Map<Integer, Double> risk_chd_m;
+  private static final Map<Integer, Double> risk_chd_f;
+  
+  
+  
+  // 10 year risk of CVD, based on 2008 Framingham update
+  // https://www.ahajournals.org/doi/10.1161/CIRCULATIONAHA.107.699579
+  // male = 0, female = 1
+  
+  // Indices in the array correspond to these age ranges: 
+  // 30-34, 35-39, 40-44, 45-49, 50-54, 55-59, 60-64, 65-69, 70-74, 75+
+  private static final int[][] age_cvd_points = { 
+      { 0, 2, 5, 6, 8, 10, 11, 12, 14, 15 }, 
+      { 0, 2, 4, 5, 7,  8,  9, 10, 11, 12 }
+  };
+  
+  // indices correspond to these ranges:
+  // <35, 35-39, 40-44, 45-49, 50-54, 55-59, 60+
+  // note that 2 of the entries in the source table are a range of 10
+  private static int[] hdl_cvd_points = { 2, 1, 1, 0, -1, -1, -2 };
+  
+  // indices correspond to these cholesterol ranges:
+  // <160, 160-199, 200-239, 240-279, 280+
+  private static int[][] totalChol_cvd_points = {
+      { 0, 1, 2, 3, 4 },
+      { 0, 1, 3, 4, 5 }
+  };
+  
+  // indices in the array correspond to these SBP ranges:
+  // <120, 120-130, 130-140, 140-150, 150-160, 160+
+  private static final int[][][] sbp_cvd_points = {
+      { // male (note the source table shows 140-159 as one entry)
+        { -2, 0, 1, 2, 2, 3 }, // not treated
+        {  0, 2, 3, 4, 4, 5 } // treated
+      },
+      { // female
+        { -3, 0, 1, 2, 4, 5 }, // not treated
+        { -1, 2, 3, 5, 6, 7 } // treated
+      }
+  };
+  
+  private static final int[] cvd_smoker_points = { 4, 3 };
+  private static final int[] cvd_diabetes_points = { 3, 4 };
+  
+  private static final Map<Integer, Double> risk_cvd_m;
+  private static final Map<Integer, Double> risk_cvd_f;
+  
+  static {
+    // framingham point scores gives a 10-year risk
+    risk_chd_m = new HashMap<>();
+    risk_chd_m.put(-1, 0.005); // '-1' represents all scores <0
+    risk_chd_m.put(0, 0.01);
+    risk_chd_m.put(1, 0.01);
+    risk_chd_m.put(2, 0.01);
+    risk_chd_m.put(3, 0.01);
+    risk_chd_m.put(4, 0.01);
+    risk_chd_m.put(5, 0.02);
+    risk_chd_m.put(6, 0.02);
+    risk_chd_m.put(7, 0.03);
+    risk_chd_m.put(8, 0.04);
+    risk_chd_m.put(9, 0.05);
+    risk_chd_m.put(10, 0.06);
+    risk_chd_m.put(11, 0.08);
+    risk_chd_m.put(12, 0.1);
+    risk_chd_m.put(13, 0.12);
+    risk_chd_m.put(14, 0.16);
+    risk_chd_m.put(15, 0.20);
+    risk_chd_m.put(16, 0.25);
+    risk_chd_m.put(17, 0.3); // '17' represents all scores >16
+
+    risk_chd_f = new HashMap<>();
+    risk_chd_f.put(8, 0.005); // '8' represents all scores <9
+    risk_chd_f.put(9, 0.01);
+    risk_chd_f.put(10, 0.01);
+    risk_chd_f.put(11, 0.01);
+    risk_chd_f.put(12, 0.01);
+    risk_chd_f.put(13, 0.02);
+    risk_chd_f.put(14, 0.02);
+    risk_chd_f.put(15, 0.03);
+    risk_chd_f.put(16, 0.04);
+    risk_chd_f.put(17, 0.05);
+    risk_chd_f.put(18, 0.06);
+    risk_chd_f.put(19, 0.08);
+    risk_chd_f.put(20, 0.11);
+    risk_chd_f.put(21, 0.14);
+    risk_chd_f.put(22, 0.17);
+    risk_chd_f.put(23, 0.22);
+    risk_chd_f.put(24, 0.27);
+    risk_chd_f.put(25, 0.3); // '25' represents all scores >24
+    
+    // -------
+    
+    // see Table 8 in https://www.ahajournals.org/doi/10.1161/CIRCULATIONAHA.107.699579
+    risk_cvd_m = new HashMap<>();
+    risk_cvd_m.put(-3, 0.01); // '-3' represents all scores <-2
+    risk_cvd_m.put(-2, 0.011);
+    risk_cvd_m.put(-1, 0.014);
+    risk_cvd_m.put(0, 0.016);
+    risk_cvd_m.put(1, 0.019);
+    risk_cvd_m.put(2, 0.023);
+    risk_cvd_m.put(3, 0.028);
+    risk_cvd_m.put(4, 0.033);
+    risk_cvd_m.put(5, 0.039);
+    risk_cvd_m.put(6, 0.047);
+    risk_cvd_m.put(7, 0.056);
+    risk_cvd_m.put(8, 0.067);
+    risk_cvd_m.put(9, 0.079);
+    risk_cvd_m.put(10, 0.094);
+    risk_cvd_m.put(11, 0.112);
+    risk_cvd_m.put(12, 0.132);
+    risk_cvd_m.put(13, 0.156);
+    risk_cvd_m.put(14, 0.184);
+    risk_cvd_m.put(15, 0.216);
+    risk_cvd_m.put(16, 0.253);
+    risk_cvd_m.put(17, 0.294);
+    risk_cvd_m.put(18, 0.3); // '18' represents all scores >17
+
+    // see Table 6 in https://www.ahajournals.org/doi/10.1161/CIRCULATIONAHA.107.699579
+    risk_cvd_f = new HashMap<>();
+    risk_cvd_f.put(-2, 0.005); // '-2' represents all scores <-1
+    risk_cvd_f.put(-1, 0.01);
+    risk_cvd_f.put(0, 0.012);
+    risk_cvd_f.put(1, 0.015);
+    risk_cvd_f.put(2, 0.017);
+    risk_cvd_f.put(3, 0.02);
+    risk_cvd_f.put(4, 0.024);
+    risk_cvd_f.put(5, 0.028);
+    risk_cvd_f.put(6, 0.033);
+    risk_cvd_f.put(7, 0.039);
+    risk_cvd_f.put(8, 0.045);
+    risk_cvd_f.put(9, 0.053);
+    risk_cvd_f.put(10, 0.063);
+    risk_cvd_f.put(11, 0.073);
+    risk_cvd_f.put(12, 0.086);
+    risk_cvd_f.put(13, 0.10);
+    risk_cvd_f.put(14, 0.117);
+    risk_cvd_f.put(15, 0.137);
+    risk_cvd_f.put(16, 0.159);
+    risk_cvd_f.put(17, 0.185);
+    risk_cvd_f.put(18, 0.215);
+    risk_cvd_f.put(19, 0.248);
+    risk_cvd_f.put(20, 0.285);
+    risk_cvd_f.put(21, 0.30); // '21' represents all scores >20
+    
+  }
+  
+
+  /**
+   * Calculates a patient's risk of coronary heart disease, based on the 1998 Framingham study group.
+   * This includes events such as Angina Pectoris, Unstable Angina, MI, and CHD Death.
+   * @param person The patient
+   * @param time Time to calculate risk as of
+   * @param perTimestep Whether to return the risk per timestep (default 7 days) or per 10 years
+   * @return The patient's risk of CHD
+   */
+  public static double chd10Year(Person person, long time, boolean perTimestep) {
+    int age = person.ageInYears(time);
+    String gender = (String) person.attributes.get(Person.GENDER);
+    Double sysBP = person.getVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, time);
+    Double diaBP = person.getVitalSign(VitalSign.DIASTOLIC_BLOOD_PRESSURE, time);
+    Double chol = person.getVitalSign(VitalSign.TOTAL_CHOLESTEROL, time);
+    if (sysBP == null || diaBP == null || chol == null) {
+      return -1;
+    }
+
+    Boolean bpTreated = (Boolean)
+        person.attributes.getOrDefault("blood_pressure_controlled", false);
+
+    Double hdl = person.getVitalSign(VitalSign.HDL, time);
+
+    // calculate which index in a lookup array a number corresponds to based on ranges in scoring
+    int shortAgeRange = bound((age - 20) / 5, 0, 11);
+    int longAgeRange = bound((age - 20) / 10, 0, 5);
+
+    // 0: <160, 1: 160-199, 2: 200-239, 3: 240-279, 4: >280
+    int cholRange = bound((chol.intValue() - 160) / 40 + 1, 0, 4);
+
+    // 0: <120, 1: 120-129, 2: 130-139, 3: 140-149, 4: 150-159, 5: >=160
+    int bpRange = bound((sysBP.intValue() - 120) / 10 + 1, 0, 5);
+    int framinghamPoints = 0;
+
+    int[] ageChd;
+    int[][] ageCholChd;
+    int[] ageSmokeChd;
+    int[][] sysBpChd;
+
+    if (gender.equals("M")) {
+      ageChd = age_chd_m;
+      ageCholChd = age_chol_chd_m;
+      ageSmokeChd = age_smoke_chd_m;
+      sysBpChd = sys_bp_chd_m;
+    } else {
+      ageChd = age_chd_f;
+      ageCholChd = age_chol_chd_f;
+      ageSmokeChd = age_smoke_chd_f;
+      sysBpChd = sys_bp_chd_f;
+    }
+
+    framinghamPoints += ageChd[shortAgeRange];
+    framinghamPoints += ageCholChd[longAgeRange][cholRange];
+
+    if ((Boolean) person.attributes.getOrDefault(Person.SMOKER, false)) {
+      framinghamPoints += ageSmokeChd[longAgeRange];
+    }
+
+    // 0: <40, 1: 40-49, 2: 50-59, 3: >60
+    int hdlRange = bound((hdl.intValue() - 40) / 10 + 1, 0, 3);
+    framinghamPoints += hdl_lookup_chd[hdlRange];
+
+    int treated = bpTreated ? 0 : 1;
+    framinghamPoints += sysBpChd[bpRange][treated];
+    double framinghamRisk;
+    // restrict lower and upper bound of framingham score
+    if (gender.equals("M")) {
+      framinghamPoints = bound(framinghamPoints, 0, 17);
+      framinghamRisk = risk_chd_m.get(framinghamPoints);
+    } else {
+      framinghamPoints = bound(framinghamPoints, 8, 25);
+      framinghamRisk = risk_chd_f.get(framinghamPoints);
+    }
+    
+    if (perTimestep) {
+      framinghamRisk = Utilities.convertRiskToTimestep(framinghamRisk, TEN_YEARS_IN_MS);
+    }
+    
+    return framinghamRisk;
+  }
+  
+  
+  /**
+   * Calculates a patient's risk of cardiovascular disease, based on the 2008 Framingham study group.
+   * This includes "Hard ASCVD" events: MI, CHD Death, Stroke, and Stroke Death.
+   * @param person The patient
+   * @param time Time to calculate risk as of
+   * @param perTimestep Whether to return the risk per timestep (default 7 days) or per 10 years
+   * @return The patient's risk of CVD
+   */
+  public static double cvd10Year(Person person, long time, boolean perTimestep) {
+    int age = person.ageInYears(time);
+    
+    if (age < 30) {
+      return -1;
+    }
+    
+    String gender = (String) person.attributes.get(Person.GENDER);
+    Double sysBP = person.getVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, time);
+    Double chol = person.getVitalSign(VitalSign.TOTAL_CHOLESTEROL, time);
+    if (sysBP == null || chol == null) {
+      return -1;
+    }
+
+    boolean bpTreated = (boolean)
+        person.attributes.getOrDefault("blood_pressure_controlled", false);
+    
+    Double hdl = person.getVitalSign(VitalSign.HDL, time);
+    
+    int genderIndex = (person.attributes.get(Person.GENDER).equals("M")) ? 0 : 1;
+    
+    int framinghamPoints = 0;
+    
+    // age
+    int ageIndex = bound((age - 30) / 5, 0, 9);
+    framinghamPoints += age_cvd_points[genderIndex][ageIndex];
+    
+    // hdl
+    int hdlIndex = bound((hdl.intValue() - 35) / 5 + 1, 0, 6);
+    framinghamPoints += hdl_cvd_points[hdlIndex];
+    
+    // total cholesterol
+    int cholIndex = bound(((chol.intValue() - 160) / 40) + 1, 0, 4);
+    framinghamPoints += totalChol_cvd_points[genderIndex][cholIndex];
+    
+    // sbp
+    int bpTreatedIndex = bpTreated ? 1 : 0; // true = 1, false = 0
+    int bpIndex = bound(((sysBP.intValue() - 120) / 10) + 1, 0, 5);
+    framinghamPoints += sbp_cvd_points[genderIndex][bpTreatedIndex][bpIndex];
+    
+    
+    if ((boolean) person.attributes.getOrDefault(Person.SMOKER, false)) {
+      framinghamPoints += cvd_smoker_points[genderIndex];
+    }
+    
+    if ((boolean) person.attributes.getOrDefault("diabetes", false)) {
+      framinghamPoints += cvd_diabetes_points[genderIndex];
+    }
+    
+    double framinghamRisk;
+    // restrict lower and upper bound of framingham score
+    if (gender.equals("M")) {
+      framinghamPoints = bound(framinghamPoints, -3, 18);
+      framinghamRisk = risk_cvd_m.get(framinghamPoints);
+    } else {
+      framinghamPoints = bound(framinghamPoints, -2, 21);
+      framinghamRisk = risk_cvd_f.get(framinghamPoints);
+    }
+    
+    if (perTimestep) {
+      framinghamRisk = Utilities.convertRiskToTimestep(framinghamRisk, TEN_YEARS_IN_MS);
+    }
+    
+    return framinghamRisk;
+    
+  }
+  
+  // Framingham score system for calculating atrial fibrillation (significant factor for stroke
+  // risk)
+  private static final int[][] age_af = {
+      // age ranges: 45-49, 50-54, 55-59, 60-64, 65-69, 70-74, 75-79, 80-84, >84
+      { 1, 2, 3, 4, 5, 6, 7, 7, 8 }, // male
+      { -3, -2, 0, 1, 3, 4, 6, 7, 8 } // female
+  };
+
+  // only covers points 1-9. <=0 and >= 10 are in if statement
+  private static final double[] risk_af_table = { 0.01, // 0 or less
+      0.02, 0.02, 0.03, 0.04, 0.06, 0.08, 0.12, 0.16, 0.22, 0.3 // 10 or greater
+  };
+  
+  public static double atrialFibrillation10Year(Person person, long time, boolean perTimestep) {
+    int age = person.ageInYears(time);
+    if (age < 45 || person.attributes.containsKey("atrial_fibrillation")
+        || person.getVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, time) == null
+        || person.getVitalSign(VitalSign.BMI, time) == null) {
+      return -1;
+    }
+
+    int afScore = 0;
+    int ageRange = Math.min((age - 45) / 5, 8);
+    int genderIndex = (person.attributes.get(Person.GENDER).equals("M")) ? 0 : 1;
+    afScore += age_af[genderIndex][ageRange];
+    if (person.getVitalSign(VitalSign.BMI, time) >= 30) {
+      afScore += 1;
+    }
+
+    if (person.getVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, time) >= 160) {
+      afScore += 1;
+    }
+
+    if ((Boolean) person.attributes.getOrDefault("blood_pressure_controlled", false)) {
+      afScore += 1;
+    }
+
+    afScore = bound(afScore, 0, 10);
+
+    double afRisk = risk_af_table[afScore]; // 10-yr risk
+    
+    if (perTimestep) {
+      afRisk = Utilities.convertRiskToTimestep(afRisk, TEN_YEARS_IN_MS);
+    }
+    
+    return afRisk;
+  }
+  
+  // https://www.heart.org/idc/groups/heart-public/@wcm/@sop/@smd/documents/downloadable/ucm_449858.pdf
+  // Prevalence of stroke by age and sex (Male, Female)
+  private static final double[] stroke_rate_20_39 = { 0.002, 0.007 };
+  private static final double[] stroke_rate_40_59 = { 0.019, 0.022 };
+
+  private static final double[][] ten_year_stroke_risk = {
+      { 0, 0.03, 0.03, 0.04, 0.04, 0.05, 0.05, 0.06, 0.07, 0.08, 0.1, // male section
+          0.11, 0.13, 0.15, 0.17, 0.2, 0.22, 0.26, 0.29, 0.33, 0.37, 0.42, 0.47, 0.52, 0.57, 0.63,
+          0.68, 0.74, 0.79, 0.84, 0.88 },
+      { 0, 0.01, 0.01, 0.02, 0.02, 0.02, 0.03, 0.04, 0.04, 0.05, 0.06, // female
+          0.08, 0.09, 0.11, 0.13, 0.16, 0.19, 0.23, 0.27, 0.32, 0.37, 0.43, 0.5, 0.57, 0.64, 0.71,
+          0.78, 0.84 } };
+
+  // the index for each range corresponds to the number of points
+  private static final int[][] age_stroke = { 
+      { 54, 57, 60, 63, 66, 69, 73, 76, 79, 82, 85 }, // male
+      { 54, 57, 60, 63, 65, 68, 71, 74, 77, 79, 82 } // female
+  };
+
+  private static final int[][] untreated_sys_bp_stroke = {
+      { 0, 106, 116, 126, 136, 146, 156, 166, 176, 185, 196 }, // male
+      { 0, 95, 107, 119, 131, 144, 156, 168, 181, 193, 205 } // female
+  };
+
+  private static final int[][] treated_sys_bp_stroke = {
+      { 0, 106, 113, 118, 124, 130, 136, 143, 151, 162, 177 }, // male
+      { 0, 95, 107, 114, 120, 126, 132, 140, 149, 161, 205 } // female
+  };
+
+  private static final int getIndexForValueInRangelist(int value, int[] data) {
+    for (int i = 0; i < data.length - 1; i++) {
+      if (data[i] <= value && value <= data[i + 1]) {
+        return i;
+      }
+    }
+    // the last segment is open-ended
+    if (value >= data[data.length - 1]) {
+      return data.length - 1;
+    }
+
+    // shouldn't be possible to get here if we do everything right
+    throw new RuntimeException("unexpected value " + value + " for data " + Arrays.toString(data));
+  }
+
+  private static final double[] diabetes_stroke = { 2, 3 };
+  private static final double[] chd_stroke_points = { 4, 2 };
+  private static final double[] atrial_fibrillation_stroke_points = { 4, 6 };
+
+  
+  public static double stroke10Year(Person person, long time, boolean perTimestep) {
+    Double bloodPressure = person.getVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, time);
+    if (bloodPressure == null) {
+      return -1;
+    }
+
+    // https://www.heart.org/idc/groups/heart-public/@wcm/@sop/@smd/documents/downloadable/ucm_449858.pdf
+    // calculate stroke risk based off of prevalence of stroke in age group for people younger than
+    // 54. Framingham score system does not cover these.
+
+    int genderIndex = ((String) person.attributes.get(Person.GENDER)).equals("M") ? 0 : 1;
+
+    int age = person.ageInYears(time);
+    double strokeRisk;
+    
+    if (age < 20) {
+      // no risk set
+      return -1;
+    } else if (age < 40) {
+      strokeRisk = stroke_rate_20_39[genderIndex];
+    } else if (age < 55) {
+      strokeRisk = stroke_rate_40_59[genderIndex];
+    } else {
+      int strokePoints = 0;
+      if ((Boolean) person.attributes.getOrDefault(Person.SMOKER, false)) {
+        strokePoints += 3;
+      }
+      if ((Boolean) person.attributes.getOrDefault("left_ventricular_hypertrophy", false)) {
+        strokePoints += 5;
+      }
+
+      strokePoints += getIndexForValueInRangelist(age, age_stroke[genderIndex]);
+
+      int bp = bloodPressure.intValue();
+      
+      if ((Boolean) person.attributes.getOrDefault("blood_pressure_controlled", false)) {
+        strokePoints += getIndexForValueInRangelist(bp, treated_sys_bp_stroke[genderIndex]);
+      } else {
+        strokePoints += getIndexForValueInRangelist(bp, untreated_sys_bp_stroke[genderIndex]);
+      }
+
+      if ((Boolean) person.attributes.getOrDefault("diabetes", false)) {
+        strokePoints += diabetes_stroke[genderIndex];
+      }
+
+      if ((Boolean) person.attributes.getOrDefault("coronary_heart_disease", false)) {
+        strokePoints += chd_stroke_points[genderIndex];
+      }
+
+      if ((Boolean) person.attributes.getOrDefault("atrial_fibrillation", false)) {
+        strokePoints += atrial_fibrillation_stroke_points[genderIndex];
+      }
+
+      if (strokePoints >= ten_year_stroke_risk[genderIndex].length) {
+        // off the charts
+        int worstCase = ten_year_stroke_risk[genderIndex].length - 1;
+        strokeRisk = ten_year_stroke_risk[genderIndex][worstCase];
+      } else {
+        strokeRisk = ten_year_stroke_risk[genderIndex][strokePoints];
+      }
+    }
+
+    if (perTimestep) {
+      strokeRisk = Utilities.convertRiskToTimestep(strokeRisk, TEN_YEARS_IN_MS);
+    }
+   
+    return strokeRisk;
+  }
+  
+  /**
+   * Populate the given attribute map with the list of attributes that this
+   * module reads/writes with example values when appropriate.
+   *
+   * @param attributes Attribute map to populate.
+   */
+  public static void inventoryAttributes(Map<String,Inventory> attributes) {
+    
+  }
+}

--- a/src/main/resources/modules/atrial_fibrillation.json
+++ b/src/main/resources/modules/atrial_fibrillation.json
@@ -1,0 +1,39 @@
+{
+  "name": "Atrial Fibrillation",
+  "remarks": [
+    "A blank module"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Chance_of_AFib"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Chance_of_AFib": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 1,
+        "unit": "months"
+      },
+      "distributed_transition": [
+        {
+          "transition": "Diagnosis",
+          "distribution": {
+            "attribute": "atrial_fibrillation_risk",
+            "default": 0
+          }
+        },
+        {
+          "transition": "Chance_of_AFib",
+          "distribution": 1
+        }
+      ]
+    },
+    "Diagnosis": {
+      "type": "Simple",
+      "direct_transition": "Terminal"
+    }
+  }
+}

--- a/src/main/resources/modules/heart/nsteacs_pathway.json
+++ b/src/main/resources/modules/heart/nsteacs_pathway.json
@@ -1,0 +1,254 @@
+{
+  "name": "NSTEACS Pathway",
+  "remarks": [
+    "A blank module"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "ECG"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "ECG": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "1234",
+          "display": "SNOMED Code"
+        }
+      ],
+      "duration": {
+        "low": 30,
+        "high": 30,
+        "unit": "minutes"
+      },
+      "direct_transition": "Check_Troponin_I",
+      "remarks": [
+        "Repeat ECG x2 q 30 mins"
+      ]
+    },
+    "Check_Troponin_I": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "transition": "NSTEMI",
+          "condition": {
+            "condition_type": "Observation",
+            "codes": [
+              {
+                "system": "LOINC",
+                "code": "89579-7",
+                "display": "Troponin I.cardiac [Mass/volume] in Serum or Plasma by High sensitivity method"
+              }
+            ],
+            "operator": ">",
+            "value": 0.04
+          }
+        },
+        {
+          "transition": "Unstable_Angina"
+        }
+      ]
+    },
+    "NSTEMI": {
+      "type": "ConditionOnset",
+      "assign_to_attribute": "acs_variant",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 401314000,
+          "display": "Acute non-ST segment elevation myocardial infarction (disorder)"
+        }
+      ],
+      "direct_transition": "Risk_Assessment"
+    },
+    "Unstable_Angina": {
+      "type": "ConditionOnset",
+      "assign_to_attribute": "acs_variant",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 4557003,
+          "display": "Preinfarction syndrome (disorder)"
+        }
+      ],
+      "direct_transition": "Risk_Assessment"
+    },
+    "Risk_Assessment": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 225338004,
+          "display": "Risk assessment (procedure)"
+        }
+      ],
+      "duration": {
+        "low": 30,
+        "high": 30,
+        "unit": "minutes"
+      },
+      "direct_transition": "Hospital_Admission",
+      "reason": "acs_variant"
+    },
+    "Ischemia-Guided": {
+      "type": "Simple",
+      "direct_transition": "Enoxaparin"
+    },
+    "Invasive Care": {
+      "type": "Simple",
+      "direct_transition": "Heparin"
+    },
+    "Enoxaparin": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 854255,
+          "display": "enoxaparin sodium 100 MG/ML Injectable Solution"
+        }
+      ],
+      "direct_transition": "Ticagrelor",
+      "reason": "acs_variant"
+    },
+    "Ticagrelor": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 1116635,
+          "display": "ticagrelor 90 MG Oral Tablet"
+        }
+      ],
+      "direct_transition": "Stress_Testing",
+      "reason": "acs_variant"
+    },
+    "Stress_Testing": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 76746007,
+          "display": "Cardiovascular stress testing (procedure)"
+        }
+      ],
+      "duration": {
+        "low": 30,
+        "high": 45,
+        "unit": "minutes"
+      },
+      "distributed_transition": [
+        {
+          "transition": "Referral",
+          "distribution": 0.3
+        },
+        {
+          "transition": "Terminal",
+          "distribution": 0.7
+        }
+      ],
+      "reason": "acs_variant"
+    },
+    "Referral": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "PCI",
+          "distribution": 0.9
+        },
+        {
+          "transition": "Terminal",
+          "distribution": 0.1
+        }
+      ]
+    },
+    "PCI": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 415070008,
+          "display": "Percutaneous coronary intervention (procedure)"
+        }
+      ],
+      "duration": {
+        "low": 45,
+        "high": 90,
+        "unit": "minutes"
+      },
+      "direct_transition": "Terminal",
+      "reason": "acs_variant"
+    },
+    "Hospital_Admission": {
+      "type": "Encounter",
+      "encounter_class": "inpatient",
+      "reason": "acs_variant",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 32485007,
+          "display": "Hospital admission (procedure)"
+        }
+      ],
+      "complex_transition": [
+        {
+          "condition": {
+            "condition_type": "Age",
+            "operator": ">",
+            "quantity": 0,
+            "unit": "years"
+          },
+          "distributions": [
+            {
+              "transition": "Ischemia-Guided",
+              "distribution": 0.8
+            },
+            {
+              "transition": "Invasive Care",
+              "distribution": 0.2
+            }
+          ]
+        }
+      ]
+    },
+    "Heparin": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1234",
+          "display": "RxNorm Code"
+        }
+      ],
+      "direct_transition": "CABG_Referral"
+    },
+    "CABG_Referral": {
+      "type": "Simple",
+      "direct_transition": "Ticagrelor2"
+    },
+    "Ticagrelor2": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 1116635,
+          "display": "ticagrelor 90 MG Oral Tablet"
+        }
+      ],
+      "distributed_transition": [
+        {
+          "transition": "PCI",
+          "distribution": 0.9
+        },
+        {
+          "transition": "Terminal",
+          "distribution": 0.1
+        }
+      ],
+      "reason": "acs_variant"
+    }
+  }
+}

--- a/src/main/resources/modules/heart/nsteacs_pathway.json
+++ b/src/main/resources/modules/heart/nsteacs_pathway.json
@@ -16,8 +16,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "1234",
-          "display": "SNOMED Code"
+          "code": 29303009,
+          "display": "Electrocardiographic procedure (procedure)"
         }
       ],
       "duration": {
@@ -219,11 +219,14 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "1234",
-          "display": "RxNorm Code"
+          "code": 1361048,
+          "display": "heparin sodium, porcine 100 UNT/ML Injectable Solution"
         }
       ],
-      "direct_transition": "CABG_Referral"
+      "direct_transition": "CABG_Referral",
+      "remarks": [
+        "TODO: fix this code! almost certainly the wrong code"
+      ]
     },
     "CABG_Referral": {
       "type": "Simple",

--- a/src/main/resources/modules/heart/stemi_pathway.json
+++ b/src/main/resources/modules/heart/stemi_pathway.json
@@ -1,0 +1,192 @@
+{
+  "name": "STEMI Pathway",
+  "remarks": [
+    "A blank module"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "STEMI"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Admission_to_Hospital": {
+      "type": "Encounter",
+      "encounter_class": "inpatient",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 32485007,
+          "display": "Hospital admission (procedure)"
+        }
+      ],
+      "direct_transition": "CABG_Referral1",
+      "reason": "STEMI"
+    },
+    "CABG_Referral1": {
+      "type": "Simple",
+      "direct_transition": "Ticagrelor"
+    },
+    "Ticagrelor": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 1116635,
+          "display": "ticagrelor 90 MG Oral Tablet"
+        }
+      ],
+      "direct_transition": "Bivalirudin",
+      "reason": "STEMI"
+    },
+    "Bivalirudin": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 1997015,
+          "display": "50 ML bivalirudin 5 MG/ML Injection"
+        }
+      ],
+      "direct_transition": "Pick_a_better_name_for_this",
+      "reason": "STEMI"
+    },
+    "Referral_to_Cardiac_Surgery": {
+      "type": "Simple",
+      "direct_transition": "Terminal"
+    },
+    "Pick_a_better_name_for_this": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "PCI",
+          "distribution": 0.96
+        },
+        {
+          "transition": "Terminal",
+          "distribution": 0.04
+        }
+      ]
+    },
+    "Tenecteplase": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 313212,
+          "display": "tenecteplase 50 MG Injection"
+        }
+      ],
+      "direct_transition": "Clopidogrel_Once",
+      "reason": "STEMI"
+    },
+    "Enoxaparin": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 854255,
+          "display": "enoxaparin sodium 100 MG/ML Injectable Solution"
+        }
+      ],
+      "direct_transition": "Hospital_Transfer",
+      "reason": "STEMI",
+      "administration": true
+    },
+    "Hospital_Admission": {
+      "type": "Encounter",
+      "encounter_class": "inpatient",
+      "reason": "STEMI",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 32485007,
+          "display": "Hospital admission (procedure)"
+        }
+      ],
+      "direct_transition": "CABG_Referral2"
+    },
+    "Hospital_Transfer": {
+      "type": "Simple",
+      "direct_transition": "Hospital_Admission"
+    },
+    "CABG_Referral2": {
+      "type": "Simple",
+      "direct_transition": "Pick_a_better_name_for_this"
+    },
+    "PCI": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 415070008,
+          "display": "Percutaneous coronary intervention (procedure)"
+        }
+      ],
+      "duration": {
+        "low": 45,
+        "high": 90,
+        "unit": "minutes"
+      },
+      "distributed_transition": [
+        {
+          "transition": "Referral_to_Cardiac_Surgery",
+          "distribution": 0.0104
+        },
+        {
+          "transition": "Terminal",
+          "distribution": 0.9896
+        }
+      ],
+      "reason": "STEMI"
+    },
+    "Clopidogrel_Once": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 309362,
+          "display": "clopidogrel 75 MG Oral Tablet"
+        }
+      ],
+      "direct_transition": "Clopidogrel_Daily",
+      "reason": "STEMI",
+      "administration": true
+    },
+    "Clopidogrel_Daily": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 309362,
+          "display": "clopidogrel 75 MG Oral Tablet"
+        }
+      ],
+      "direct_transition": "Enoxaparin",
+      "reason": "STEMI",
+      "chronic": true
+    },
+    "STEMI": {
+      "type": "ConditionOnset",
+      "assign_to_attribute": "acs_variant",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 401303003,
+          "display": "Acute ST segment elevation myocardial infarction (disorder)"
+        }
+      ],
+      "distributed_transition": [
+        {
+          "transition": "Admission_to_Hospital",
+          "distribution": 0.95
+        },
+        {
+          "transition": "Tenecteplase",
+          "distribution": 0.05
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/modules/myocardial_infarction.json
+++ b/src/main/resources/modules/myocardial_infarction.json
@@ -34,7 +34,7 @@
     },
     "STEMI": {
       "type": "CallSubmodule",
-      "submodule": "",
+      "submodule": "heart/stemi_pathway",
       "direct_transition": "TTE"
     },
     "End_Encounter": {
@@ -111,8 +111,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "1234",
-          "display": "RxNorm Code"
+          "code": 198039,
+          "display": "nitroglycerin 0.4 MG Sublingual Tablet"
         }
       ],
       "direct_transition": "Lab test"
@@ -225,8 +225,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "1234",
-          "display": "SNOMED Code"
+          "code": 736372004,
+          "display": "Discharge care plan (record artifact)"
         }
       ],
       "direct_transition": "History of MI"
@@ -246,7 +246,7 @@
     },
     "NSTEACS": {
       "type": "CallSubmodule",
-      "submodule": "",
+      "submodule": "heart/nsteacs_pathway",
       "direct_transition": "TTE"
     },
     "Aspirin_Once": {

--- a/src/main/resources/modules/myocardial_infarction.json
+++ b/src/main/resources/modules/myocardial_infarction.json
@@ -11,77 +11,9 @@
     "Terminal": {
       "type": "Terminal"
     },
-    "Nitroglycerin": {
-      "type": "MedicationOrder",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": 705129,
-          "display": "Nitroglycerin 0.4 MG/ACTUAT Mucosal Spray"
-        }
-      ],
-      "direct_transition": "Atorvastatin"
-    },
-    "Atorvastatin": {
-      "type": "MedicationOrder",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": 259255,
-          "display": "Atorvastatin 80 MG Oral Tablet"
-        }
-      ],
-      "direct_transition": "Captopril"
-    },
-    "Captopril": {
-      "type": "MedicationOrder",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": 833036,
-          "display": "aptopril 25 MG Oral Tablet"
-        }
-      ],
-      "direct_transition": "Clopidogrel"
-    },
-    "Clopidogrel": {
-      "type": "MedicationOrder",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": 309362,
-          "display": "Clopidogrel 75 MG Oral Tablet"
-        }
-      ],
-      "direct_transition": "Echocardiogram"
-    },
-    "Echocardiogram": {
-      "type": "Procedure",
-      "codes": [
-        {
-          "system": "SNOMED-CT",
-          "code": 40701008,
-          "display": "Echocardiography (procedure)"
-        }
-      ],
-      "duration": {
-        "low": 30,
-        "high": 30,
-        "unit": "minutes"
-      },
-      "direct_transition": "CABG"
-    },
-    "CABG": {
-      "type": "Simple",
-      "direct_transition": "History of MI",
-      "remarks": [
-        "TODO: replace this with a CallSubmodule"
-      ]
-    },
     "History of MI": {
       "type": "ConditionOnset",
       "assign_to_attribute": "",
-      "target_encounter": "",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -100,31 +32,279 @@
         }
       ]
     },
-    "NSTEMI": {
-      "type": "ConditionOnset",
-      "assign_to_attribute": "myocardial_infarction",
-      "target_encounter": "Emergency_Encounter",
-      "codes": [
+    "STEMI": {
+      "type": "CallSubmodule",
+      "submodule": "",
+      "direct_transition": "TTE"
+    },
+    "End_Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Chance_of_Recurrent_MI"
+    },
+    "Death": {
+      "type": "Death",
+      "direct_transition": "Terminal",
+      "referenced_by_attribute": "acs_variant"
+    },
+    "Chance_of_MI": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 1,
+        "unit": "months"
+      },
+      "distributed_transition": [
         {
-          "system": "SNOMED-CT",
-          "code": 401314000,
-          "display": "Acute non-ST segment elevation myocardial infarction (disorder)"
+          "transition": "Symptoms",
+          "distribution": {
+            "attribute": "mi_risk",
+            "default": 0
+          }
+        },
+        {
+          "transition": "Chance_of_MI",
+          "distribution": 1
         }
-      ],
+      ]
+    },
+    "Symptoms": {
+      "type": "Simple",
       "direct_transition": "Emergency_Encounter"
     },
-    "STEMI": {
-      "type": "ConditionOnset",
-      "assign_to_attribute": "myocardial_infarction",
-      "target_encounter": "Emergency_Encounter",
+    "Cardiac_Assessment": {
+      "type": "Procedure",
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": 401303003,
-          "display": "Acute ST segment elevation myocardial infarction (disorder)"
+          "code": 710839006,
+          "display": "Assessment of cardiac status using monitoring device (procedure)"
         }
       ],
-      "direct_transition": "Emergency_Encounter"
+      "duration": {
+        "low": 8,
+        "high": 12,
+        "unit": "minutes"
+      },
+      "direct_transition": "Oxygen"
+    },
+    "Oxygen": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 371908008,
+          "display": "Oxygen administration by mask (procedure)"
+        }
+      ],
+      "distributed_transition": [
+        {
+          "transition": "Aspirin_Once",
+          "distribution": 0.98
+        },
+        {
+          "transition": "Nitroglycerin",
+          "distribution": 0.02
+        }
+      ]
+    },
+    "Nitroglycerin": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1234",
+          "display": "RxNorm Code"
+        }
+      ],
+      "direct_transition": "Lab test"
+    },
+    "Lab test": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 15220000,
+          "display": "Laboratory test (procedure)"
+        }
+      ],
+      "duration": {
+        "low": 30,
+        "high": 30,
+        "unit": "minutes"
+      },
+      "direct_transition": "CBC"
+    },
+    "Morphine": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 1728805,
+          "display": "2 ML morphine sulfate 1 MG/ML Injection"
+        }
+      ],
+      "direct_transition": "Atorvastatin_2",
+      "administration": true
+    },
+    "Atorvastatin_2": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 259255,
+          "display": "Atorvastatin 80 MG Oral Tablet"
+        }
+      ],
+      "direct_transition": "Metoprolol Succinate"
+    },
+    "Metoprolol Succinate": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 1999035,
+          "display": "24 HR metoprolol succinate 25 MG Extended Release Oral Capsule"
+        }
+      ],
+      "direct_transition": "ECG"
+    },
+    "ECG": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 29303009,
+          "display": "Electrocardiographic procedure (procedure)"
+        }
+      ],
+      "duration": {
+        "low": 30,
+        "high": 30,
+        "unit": "minutes"
+      },
+      "distributed_transition": [
+        {
+          "transition": "NSTEACS",
+          "distribution": 0.6
+        },
+        {
+          "transition": "STEMI",
+          "distribution": 0.4
+        }
+      ]
+    },
+    "TTE": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 433236007,
+          "display": "Transthoracic echocardiography (procedure)"
+        }
+      ],
+      "duration": {
+        "low": 30,
+        "high": 30,
+        "unit": "minutes"
+      },
+      "direct_transition": "Lisinopril"
+    },
+    "Lisinopril": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 314076,
+          "display": "lisinopril 10 MG Oral Tablet"
+        }
+      ],
+      "direct_transition": "Discharge_Care_Plan",
+      "chronic": true
+    },
+    "Discharge_Care_Plan": {
+      "type": "CarePlanStart",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "1234",
+          "display": "SNOMED Code"
+        }
+      ],
+      "direct_transition": "History of MI"
+    },
+    "Chance_of_Recurrent_MI": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Terminal",
+          "distribution": 1
+        },
+        {
+          "transition": "Symptoms",
+          "distribution": 1
+        }
+      ]
+    },
+    "NSTEACS": {
+      "type": "CallSubmodule",
+      "submodule": "",
+      "direct_transition": "TTE"
+    },
+    "Aspirin_Once": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 243670,
+          "display": "aspirin 81 MG Oral Tablet"
+        }
+      ],
+      "direct_transition": "Aspirin_Daily",
+      "administration": true,
+      "prescription": {
+        "dosage": {
+          "amount": 4,
+          "frequency": 1,
+          "period": 1,
+          "unit": "hours"
+        },
+        "duration": {
+          "quantity": 1,
+          "unit": "days"
+        }
+      }
+    },
+    "Aspirin_Daily": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 243670,
+          "display": "aspirin 81 MG Oral Tablet"
+        }
+      ],
+      "direct_transition": "Nitroglycerin",
+      "chronic": true
+    },
+    "Chest_XRay": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 399208008,
+          "display": "Plain chest X-ray (procedure)"
+        }
+      ],
+      "duration": {
+        "low": 10,
+        "high": 10,
+        "unit": "minutes"
+      },
+      "distributed_transition": [
+        {
+          "transition": "Morphine",
+          "distribution": 1
+        }
+      ]
     },
     "Emergency_Encounter": {
       "type": "Encounter",
@@ -137,49 +317,581 @@
           "display": "Emergency room admission (procedure)"
         }
       ],
-      "direct_transition": "Nitroglycerin"
+      "direct_transition": "Cardiac_Assessment"
     },
-    "End_Encounter": {
-      "type": "EncounterEnd",
-      "direct_transition": "Terminal"
-    },
-    "Death": {
-      "type": "Death",
-      "direct_transition": "Terminal",
-      "referenced_by_attribute": "myocardial_infarction"
-    },
-    "Chance_of_MI": {
-      "type": "Delay",
-      "exact": {
-        "quantity": 1,
-        "unit": "months"
-      },
-      "distributed_transition": [
+    "CBC": {
+      "type": "DiagnosticReport",
+      "codes": [
         {
-          "transition": "MI_Variants",
-          "distribution": {
-            "attribute": "mi_risk",
-            "default": 0
+          "system": "LOINC",
+          "code": "58410-2",
+          "display": "Complete blood count (hemogram) panel - Blood by Automated count"
+        }
+      ],
+      "observations": [
+        {
+          "category": "laboratory",
+          "unit": "10*3/uL",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "6690-2",
+              "display": "Leukocytes [#/volume] in Blood by Automated count"
+            }
+          ],
+          "range": {
+            "low": 3,
+            "high": 4
           }
         },
         {
-          "transition": "Chance_of_MI",
-          "distribution": 1
-        }
-      ]
-    },
-    "MI_Variants": {
-      "type": "Simple",
-      "distributed_transition": [
-        {
-          "transition": "NSTEMI",
-          "distribution": 0.6
+          "category": "laboratory",
+          "unit": "10*6/uL",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "789-8",
+              "display": "Erythrocytes [#/volume] in Blood by Automated count"
+            }
+          ],
+          "range": {
+            "low": 3.77,
+            "high": 5.8
+          }
         },
         {
-          "transition": "STEMI",
-          "distribution": 0.4
+          "category": "laboratory",
+          "unit": "g/dL",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "718-7",
+              "display": "Hemoglobin [Mass/volume] in Blood"
+            }
+          ],
+          "range": {
+            "low": 11.1,
+            "high": 14.1
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "%",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "4544-3",
+              "display": "Hematocrit [Volume Fraction] of Blood by Automated count"
+            }
+          ],
+          "range": {
+            "low": 37.5,
+            "high": 46.6
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "fL",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "787-2",
+              "display": "MCV [Entitic volume] by Automated count"
+            }
+          ],
+          "range": {
+            "low": 79,
+            "high": 97
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "pg",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "785-6",
+              "display": "MCH [Entitic mass] by Automated count"
+            }
+          ],
+          "range": {
+            "low": 26.6,
+            "high": 33
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "g/dL",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "786-4",
+              "display": "MCHC [Mass/volume] by Automated count"
+            }
+          ],
+          "range": {
+            "low": 31.5,
+            "high": 35.7
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "%",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "788-0",
+              "display": "Erythrocyte distribution width [Ratio] by Automated count"
+            }
+          ],
+          "range": {
+            "low": 12.3,
+            "high": 15.4
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "10*3/uL",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "777-3",
+              "display": "Platelets [#/volume] in Blood by Automated count"
+            }
+          ],
+          "range": {
+            "low": 99,
+            "high": 150
+          }
         }
+      ],
+      "remarks": [
+        "In the most severe patients, white-cell counts should be less than 4000 per mm3",
+        "In the most severe patients, platelet counts should also trend towards being less than 150K per mm3",
+        "In the most severe patients, median hemoglobin should be around 12.8 g/dL"
+      ],
+      "direct_transition": "Record_CMP"
+    },
+    "Magnesium": {
+      "type": "Observation",
+      "category": "laboratory",
+      "unit": "mg/dL",
+      "codes": [
+        {
+          "system": "LOINC",
+          "code": "21377-7",
+          "display": "Magnesium [Mass/volume] in Blood"
+        }
+      ],
+      "direct_transition": "Lipids",
+      "range": {
+        "low": 1.7,
+        "high": 2.2
+      },
+      "remarks": [
+        "normal range reference: https://medlineplus.gov/ency/article/003487.htm",
+        "",
+        "should we have a different range here?"
       ]
+    },
+    "Lipids": {
+      "type": "DiagnosticReport",
+      "codes": [
+        {
+          "system": "LOINC",
+          "code": "57698-3",
+          "display": "Lipid Panel"
+        }
+      ],
+      "observations": [
+        {
+          "category": "laboratory",
+          "vital_sign": "Total Cholesterol",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "2093-3",
+              "display": "Total Cholesterol"
+            }
+          ],
+          "unit": "mg/dL",
+          "range": {
+            "low": 205,
+            "high": 305
+          }
+        },
+        {
+          "category": "laboratory",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "2571-8",
+              "display": "Triglycerides"
+            }
+          ],
+          "unit": "mg/dL",
+          "range": {
+            "low": 100,
+            "high": 400
+          }
+        },
+        {
+          "category": "laboratory",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "18262-6",
+              "display": "Low Density Lipoprotein Cholesterol"
+            }
+          ],
+          "unit": "mg/dL",
+          "range": {
+            "low": 101,
+            "high": 200
+          }
+        },
+        {
+          "category": "laboratory",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "2085-9",
+              "display": "High Density Lipoprotein Cholesterol"
+            }
+          ],
+          "unit": "mg/dL",
+          "range": {
+            "low": 20,
+            "high": 65
+          }
+        }
+      ],
+      "direct_transition": "HbA1c",
+      "remarks": [
+        "copied from Veteran hyperlipidemia module, need to review values"
+      ]
+    },
+    "HbA1c": {
+      "type": "Observation",
+      "category": "laboratory",
+      "unit": "%",
+      "codes": [
+        {
+          "system": "LOINC",
+          "code": "4548-4",
+          "display": "Hemoglobin A1c/Hemoglobin.total in Blood"
+        }
+      ],
+      "direct_transition": "PT/INR",
+      "vital_sign": "Blood Glucose"
+    },
+    "PT/INR": {
+      "type": "Observation",
+      "category": "vital-signs",
+      "unit": "",
+      "codes": [
+        {
+          "system": "LOINC",
+          "code": "1234",
+          "display": "LOINC Code"
+        }
+      ],
+      "exact": {
+        "quantity": 1
+      },
+      "direct_transition": "PTT"
+    },
+    "PTT": {
+      "type": "Observation",
+      "category": "vital-signs",
+      "unit": "",
+      "codes": [
+        {
+          "system": "LOINC",
+          "code": "1234",
+          "display": "LOINC Code"
+        }
+      ],
+      "exact": {
+        "quantity": 1
+      },
+      "direct_transition": "Troponin-I"
+    },
+    "Troponin-I": {
+      "type": "Observation",
+      "category": "laboratory",
+      "unit": "ng/mL",
+      "codes": [
+        {
+          "system": "LOINC",
+          "code": "89579-7",
+          "display": "Troponin I.cardiac [Mass/volume] in Serum or Plasma by High sensitivity method"
+        }
+      ],
+      "direct_transition": "NT-proBNP",
+      "range": {
+        "low": 1,
+        "high": 2
+      }
+    },
+    "NT-proBNP": {
+      "type": "Observation",
+      "category": "vital-signs",
+      "unit": "pg/mL",
+      "codes": [
+        {
+          "system": "LOINC",
+          "code": "71425-3",
+          "display": "Natriuretic peptide.B prohormone N-Terminal [Mass/volume] in Blood by Immunoassay"
+        }
+      ],
+      "direct_transition": "Chest_XRay",
+      "range": {
+        "low": 1,
+        "high": 2
+      },
+      "remarks": [
+        "A normal level of NT-proBNP, based on Cleveland Clinic’s Reference Range is:",
+        "",
+        "Less than 125 pg/mL for patients aged 0-74 years",
+        "Less than 450 pg/mL for patients aged 75-99 years",
+        "If you have heart failure, the following NT-proBNP levels could mean your heart function is unstable:",
+        "",
+        "Higher than 450 pg/mL for patients under age 50",
+        "Higher than 900 pg/mL for patients age 50 and older"
+      ]
+    },
+    "Record_CMP": {
+      "type": "DiagnosticReport",
+      "codes": [
+        {
+          "system": "LOINC",
+          "code": "24323-8",
+          "display": "Comprehensive metabolic 2000 panel - Serum or Plasma"
+        }
+      ],
+      "observations": [
+        {
+          "category": "laboratory",
+          "vital_sign": "Glucose",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "2339-0",
+              "display": "Glucose"
+            }
+          ],
+          "unit": "mg/dL"
+        },
+        {
+          "category": "laboratory",
+          "vital_sign": "Urea Nitrogen",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "6299-2",
+              "display": "Urea Nitrogen"
+            }
+          ],
+          "unit": "mg/dL"
+        },
+        {
+          "category": "laboratory",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "38483-4",
+              "display": "Creatinine"
+            }
+          ],
+          "unit": "mg/dL",
+          "range": {
+            "low": 2.5,
+            "high": 3.5
+          }
+        },
+        {
+          "category": "laboratory",
+          "vital_sign": "Calcium",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "49765-1",
+              "display": "Calcium"
+            }
+          ],
+          "unit": "mg/dL"
+        },
+        {
+          "category": "laboratory",
+          "vital_sign": "Sodium",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "2947-0",
+              "display": "Sodium"
+            }
+          ],
+          "unit": "mmol/L"
+        },
+        {
+          "category": "laboratory",
+          "vital_sign": "Potassium",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "6298-4",
+              "display": "Potassium"
+            }
+          ],
+          "unit": "mmol/L"
+        },
+        {
+          "category": "laboratory",
+          "vital_sign": "Chloride",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "2069-3",
+              "display": "Chloride"
+            }
+          ],
+          "unit": "mmol/L"
+        },
+        {
+          "category": "laboratory",
+          "vital_sign": "Carbon Dioxide",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "20565-8",
+              "display": "Carbon Dioxide"
+            }
+          ],
+          "unit": "mmol/L"
+        },
+        {
+          "category": "laboratory",
+          "unit": "mL/min",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "33914-3",
+              "display": "Glomerular filtration rate/1.73 sq M.predicted"
+            }
+          ],
+          "range": {
+            "low": 65,
+            "high": 90
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "g/dL",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "2885-2",
+              "display": "Protein [Mass/volume] in Serum or Plasma"
+            }
+          ],
+          "range": {
+            "low": 60,
+            "high": 80
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "g/dL",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "1751-7",
+              "display": "Albumin [Mass/volume] in Serum or Plasma"
+            }
+          ],
+          "range": {
+            "low": 3.5,
+            "high": 5.5
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "g/L",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "10834-0",
+              "display": "Globulin [Mass/volume] in Serum by calculation"
+            }
+          ],
+          "range": {
+            "low": 2,
+            "high": 3.5
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "mg/dL",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "1975-2",
+              "display": "Bilirubin.total [Mass/volume] in Serum or Plasma"
+            }
+          ],
+          "range": {
+            "low": 0.1,
+            "high": 1.2
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "U/L",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "6768-6",
+              "display": "Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma"
+            }
+          ],
+          "range": {
+            "low": 20,
+            "high": 140
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "U/L",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "1742-6",
+              "display": "Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma"
+            }
+          ],
+          "range": {
+            "low": 20,
+            "high": 60
+          }
+        },
+        {
+          "category": "laboratory",
+          "unit": "U/L",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "1920-8",
+              "display": "Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma"
+            }
+          ],
+          "range": {
+            "low": 6,
+            "high": 40
+          }
+        }
+      ],
+      "direct_transition": "Magnesium"
     }
   }
 }

--- a/src/main/resources/modules/myocardial_infarction.json
+++ b/src/main/resources/modules/myocardial_infarction.json
@@ -1,0 +1,185 @@
+{
+  "name": "Myocardial Infarction",
+  "remarks": [
+    "A blank module"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Chance_of_MI"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Nitroglycerin": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 705129,
+          "display": "Nitroglycerin 0.4 MG/ACTUAT Mucosal Spray"
+        }
+      ],
+      "direct_transition": "Atorvastatin"
+    },
+    "Atorvastatin": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 259255,
+          "display": "Atorvastatin 80 MG Oral Tablet"
+        }
+      ],
+      "direct_transition": "Captopril"
+    },
+    "Captopril": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 833036,
+          "display": "aptopril 25 MG Oral Tablet"
+        }
+      ],
+      "direct_transition": "Clopidogrel"
+    },
+    "Clopidogrel": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 309362,
+          "display": "Clopidogrel 75 MG Oral Tablet"
+        }
+      ],
+      "direct_transition": "Echocardiogram"
+    },
+    "Echocardiogram": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 40701008,
+          "display": "Echocardiography (procedure)"
+        }
+      ],
+      "duration": {
+        "low": 30,
+        "high": 30,
+        "unit": "minutes"
+      },
+      "direct_transition": "CABG"
+    },
+    "CABG": {
+      "type": "Simple",
+      "direct_transition": "History of MI",
+      "remarks": [
+        "TODO: replace this with a CallSubmodule"
+      ]
+    },
+    "History of MI": {
+      "type": "ConditionOnset",
+      "assign_to_attribute": "",
+      "target_encounter": "",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 399211009,
+          "display": "History of myocardial infarction (situation)"
+        }
+      ],
+      "distributed_transition": [
+        {
+          "transition": "End_Encounter",
+          "distribution": 0.5
+        },
+        {
+          "transition": "Death",
+          "distribution": 0.5
+        }
+      ]
+    },
+    "NSTEMI": {
+      "type": "ConditionOnset",
+      "assign_to_attribute": "myocardial_infarction",
+      "target_encounter": "Emergency_Encounter",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 401314000,
+          "display": "Acute non-ST segment elevation myocardial infarction (disorder)"
+        }
+      ],
+      "direct_transition": "Emergency_Encounter"
+    },
+    "STEMI": {
+      "type": "ConditionOnset",
+      "assign_to_attribute": "myocardial_infarction",
+      "target_encounter": "Emergency_Encounter",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 401303003,
+          "display": "Acute ST segment elevation myocardial infarction (disorder)"
+        }
+      ],
+      "direct_transition": "Emergency_Encounter"
+    },
+    "Emergency_Encounter": {
+      "type": "Encounter",
+      "encounter_class": "emergency",
+      "reason": "",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 50849002,
+          "display": "Emergency room admission (procedure)"
+        }
+      ],
+      "direct_transition": "Nitroglycerin"
+    },
+    "End_Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
+    },
+    "Death": {
+      "type": "Death",
+      "direct_transition": "Terminal",
+      "referenced_by_attribute": "myocardial_infarction"
+    },
+    "Chance_of_MI": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 1,
+        "unit": "months"
+      },
+      "distributed_transition": [
+        {
+          "transition": "MI_Variants",
+          "distribution": {
+            "attribute": "mi_risk",
+            "default": 0
+          }
+        },
+        {
+          "transition": "Chance_of_MI",
+          "distribution": 1
+        }
+      ]
+    },
+    "MI_Variants": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "NSTEMI",
+          "distribution": 0.6
+        },
+        {
+          "transition": "STEMI",
+          "distribution": 0.4
+        }
+      ]
+    }
+  }
+}

--- a/src/main/resources/modules/stable_ischemic_heart_disease.json
+++ b/src/main/resources/modules/stable_ischemic_heart_disease.json
@@ -174,8 +174,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "1234",
-          "display": "RxNorm Code"
+          "code": 309362,
+          "display": "Clopidogrel 75 MG Oral Tablet"
         }
       ],
       "direct_transition": "Start_Simvastatin"
@@ -185,8 +185,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "1234",
-          "display": "RxNorm Code"
+          "code": 312961,
+          "display": "Simvastatin 20 MG Oral Tablet"
         }
       ],
       "direct_transition": "Start_Amlodipine"
@@ -196,8 +196,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "1234",
-          "display": "RxNorm Code"
+          "code": 197361,
+          "display": "Amlodipine 5 MG Oral Tablet"
         }
       ],
       "direct_transition": "Start_Nitroglycerin"
@@ -207,8 +207,8 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": "1234",
-          "display": "RxNorm Code"
+          "code": 705129,
+          "display": "Nitroglycerin 0.4 MG/ACTUAT Mucosal Spray"
         }
       ],
       "distributed_transition": [

--- a/src/main/resources/modules/stable_ischemic_heart_disease.json
+++ b/src/main/resources/modules/stable_ischemic_heart_disease.json
@@ -1,0 +1,236 @@
+{
+  "name": "Stable Ischemic Heart Disease",
+  "remarks": [
+    "A blank module"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Chance_of_IHD"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Chance_of_IHD": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 1,
+        "unit": "months"
+      },
+      "distributed_transition": [
+        {
+          "transition": "IHD_Start",
+          "distribution": {
+            "attribute": "ihd_risk",
+            "default": 0
+          }
+        },
+        {
+          "transition": "Chance_of_IHD",
+          "distribution": 1
+        }
+      ]
+    },
+    "IHD_Start": {
+      "type": "ConditionOnset",
+      "assign_to_attribute": "",
+      "target_encounter": "Diagnosis_Encounter",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 414545008,
+          "display": "Ischemic heart disease (disorder)"
+        }
+      ],
+      "direct_transition": "Delay_Until_Symptoms"
+    },
+    "Delay_Until_Symptoms": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 1,
+        "unit": "months"
+      },
+      "distributed_transition": [
+        {
+          "transition": "Symptoms_Start",
+          "distribution": 1
+        },
+        {
+          "transition": "Cardiac_Arrest",
+          "distribution": 1
+        },
+        {
+          "transition": "Delay_Until_Symptoms",
+          "distribution": 1
+        }
+      ]
+    },
+    "Symptoms_Start": {
+      "type": "Symptom",
+      "symptom": "Chest Pain",
+      "cause": "",
+      "probability": 1,
+      "exact": {
+        "quantity": 1
+      },
+      "direct_transition": "New_State"
+    },
+    "Cardiac_Arrest": {
+      "type": "Death",
+      "direct_transition": "Terminal",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 410429000,
+          "display": "Cardiac arrest (disorder)"
+        }
+      ]
+    },
+    "ECG / Labs": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Stress Test",
+          "distribution": 1
+        },
+        {
+          "transition": "CABG",
+          "distribution": 1
+        }
+      ]
+    },
+    "Stress Test": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Medical_Therapy",
+          "distribution": 1
+        },
+        {
+          "transition": "CABG",
+          "distribution": 1
+        }
+      ]
+    },
+    "Medical_Therapy": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 1,
+        "unit": "weeks"
+      },
+      "direct_transition": "Prescribe_CHD_Meds"
+    },
+    "Symptoms_Continue": {
+      "type": "Simple",
+      "direct_transition": "CABG"
+    },
+    "CABG": {
+      "type": "Simple",
+      "direct_transition": "Terminal"
+    },
+    "Diagnosis_Encounter": {
+      "type": "Encounter",
+      "reason": "",
+      "direct_transition": "ECG / Labs",
+      "wellness": true
+    },
+    "Prescribe_CHD_Meds": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "transition": "Start_Clopidogrel",
+          "condition": {
+            "condition_type": "Date",
+            "operator": ">=",
+            "year": 1997,
+            "value": 0
+          }
+        },
+        {
+          "transition": "Start_Amlodipine",
+          "condition": {
+            "condition_type": "Date",
+            "operator": ">=",
+            "year": 1994,
+            "value": 0
+          }
+        },
+        {
+          "transition": "Start_Simvastatin",
+          "condition": {
+            "condition_type": "Date",
+            "operator": ">=",
+            "year": 1991,
+            "value": 0
+          }
+        },
+        {
+          "transition": "Start_Nitroglycerin"
+        }
+      ]
+    },
+    "Start_Clopidogrel": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1234",
+          "display": "RxNorm Code"
+        }
+      ],
+      "direct_transition": "Start_Simvastatin"
+    },
+    "Start_Simvastatin": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1234",
+          "display": "RxNorm Code"
+        }
+      ],
+      "direct_transition": "Start_Amlodipine"
+    },
+    "Start_Amlodipine": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1234",
+          "display": "RxNorm Code"
+        }
+      ],
+      "direct_transition": "Start_Nitroglycerin"
+    },
+    "Start_Nitroglycerin": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1234",
+          "display": "RxNorm Code"
+        }
+      ],
+      "distributed_transition": [
+        {
+          "transition": "Symptoms_Continue",
+          "distribution": 1
+        },
+        {
+          "transition": "Medical_Therapy",
+          "distribution": 1
+        }
+      ]
+    },
+    "New_State": {
+      "type": "Symptom",
+      "symptom": "Dyspnea on exertion",
+      "cause": "",
+      "probability": 1,
+      "exact": {
+        "quantity": 1
+      },
+      "direct_transition": "Diagnosis_Encounter"
+    }
+  }
+}

--- a/src/main/resources/modules/stroke.json
+++ b/src/main/resources/modules/stroke.json
@@ -1,0 +1,139 @@
+{
+  "name": "Stroke",
+  "remarks": [
+    "A blank module"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Chance_of_Stroke"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Mechanical Thrombectomy": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 433112001,
+          "display": "Percutaneous mechanical thrombectomy of portal vein using fluoroscopic guidance"
+        }
+      ],
+      "duration": {
+        "low": 30,
+        "high": 30,
+        "unit": "minutes"
+      },
+      "direct_transition": "End_Encounter"
+    },
+    "Stroke": {
+      "type": "ConditionOnset",
+      "assign_to_attribute": "",
+      "target_encounter": "Emergency_Encounter",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 230690007,
+          "display": "Stroke"
+        }
+      ],
+      "direct_transition": "Emergency_Encounter"
+    },
+    "Emergency_Encounter": {
+      "type": "Encounter",
+      "encounter_class": "emergency",
+      "reason": "",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 50849002,
+          "display": "Emergency room admission (procedure)"
+        }
+      ],
+      "conditional_transition": [
+        {
+          "transition": "Clopidogrel",
+          "condition": {
+            "condition_type": "Date",
+            "operator": ">",
+            "year": 1997
+          }
+        },
+        {
+          "transition": "Alteplase",
+          "condition": {
+            "condition_type": "Date",
+            "operator": ">",
+            "year": 1987
+          }
+        },
+        {
+          "transition": "Echocardiogram"
+        }
+      ]
+    },
+    "End_Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
+    },
+    "Chance_of_Stroke": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 1,
+        "unit": "months"
+      },
+      "distributed_transition": [
+        {
+          "transition": "Stroke",
+          "distribution": {
+            "attribute": "stroke_risk",
+            "default": 0
+          }
+        },
+        {
+          "transition": "Chance_of_Stroke",
+          "distribution": 1
+        }
+      ]
+    },
+    "Clopidogrel": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 309362,
+          "display": "Clopidogrel 75 MG Oral Tablet"
+        }
+      ],
+      "direct_transition": "Alteplase"
+    },
+    "Alteplase": {
+      "type": "MedicationOrder",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": 1804799,
+          "display": "Alteplase 100 MG Injection"
+        }
+      ],
+      "direct_transition": "Echocardiogram"
+    },
+    "Echocardiogram": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 40701008,
+          "display": "Echocardiography (procedure)"
+        }
+      ],
+      "duration": {
+        "low": 30,
+        "high": 30,
+        "unit": "minutes"
+      },
+      "direct_transition": "Mechanical Thrombectomy"
+    }
+  }
+}

--- a/src/test/java/org/mitre/synthea/modules/risk_calculators/FraminghamTest.java
+++ b/src/test/java/org/mitre/synthea/modules/risk_calculators/FraminghamTest.java
@@ -1,0 +1,85 @@
+package org.mitre.synthea.modules.risk_calculators;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.mitre.synthea.helpers.Utilities;
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.concepts.VitalSign;
+
+public class FraminghamTest {
+
+  @Test
+  public void testCvdModelPatient1() {
+    // https://www.ahajournals.org/doi/10.1161/CIRCULATIONAHA.107.699579
+    // see table 11. case 1
+    
+    /*
+    Risk Factor       Value   Points
+    Age                61       9
+    Total cholesterol 180       1
+    HDL                47       0
+    Nontreated SBP    124       0
+    Treated SBP       N/A       0
+    Smoker            Yes       3
+    Diabetes           No       0
+    -----------------------------
+    Point total                13
+    Estimate of risk, %      10.0
+    Heart age/vascular age, y  73
+    */
+   
+    long now = System.currentTimeMillis();
+    long dob = now - Utilities.convertTime("years", 61);
+    
+    Person p = new Person(1L);
+    p.attributes.put(Person.GENDER, "F");
+    p.attributes.put(Person.BIRTHDATE, dob);
+    p.setVitalSign(VitalSign.TOTAL_CHOLESTEROL, 180);
+    p.setVitalSign(VitalSign.HDL, 47);
+    p.setVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, 124);
+    p.attributes.put("blood_pressure_controlled", false);
+    p.attributes.put(Person.SMOKER, true);
+    p.attributes.put("diabetes", false);
+    
+    double risk = Framingham.cvd10Year(p, now, false);
+    assertEquals(0.1, risk, 0.001);
+  }
+  
+  @Test
+  public void testCvdModelPatient2() {
+    // https://www.ahajournals.org/doi/10.1161/CIRCULATIONAHA.107.699579
+    // see table 12. case 2 
+    
+    /*
+    Risk Factor       Value   Points
+    Age                53       8
+    Total cholesterol 161       1
+    HDL                55      −1
+    Nontreated SBP    N/A       0
+    Treated SBP       125       2
+    Smoker             No       0
+    Diabetes          Yes       3
+    -----------------------------
+    Point total                13
+    Estimate of risk, %      15.6
+    Heart age/vascular age, y  64
+    */
+    
+    long now = System.currentTimeMillis();
+    long dob = now - Utilities.convertTime("years", 53);
+    
+    Person p = new Person(2L);
+    p.attributes.put(Person.GENDER, "M");
+    p.attributes.put(Person.BIRTHDATE, dob);
+    p.setVitalSign(VitalSign.TOTAL_CHOLESTEROL, 161);
+    p.setVitalSign(VitalSign.HDL, 55);
+    p.setVitalSign(VitalSign.SYSTOLIC_BLOOD_PRESSURE, 125);
+    p.attributes.put("blood_pressure_controlled", true);
+    p.attributes.put(Person.SMOKER, false);
+    p.attributes.put("diabetes", true);
+    
+    double risk = Framingham.cvd10Year(p, now, false);
+    assertEquals(0.156, risk, 0.001);
+  }
+}


### PR DESCRIPTION
Work in progress to break out the currently Java-based CardiovascularDiseaseModule into a number of GMF modules for specific conditions/cardiac events.

The basic idea is to create a centralized "cardiovascular risk" module, which will calculate various risk scores, and then a set of modules that will use those risk scores to drive when events like MI, stroke, etc, occur. Step 1 of this will keep the risk score calculation in a Java module, and potentially we can try to convert that to GMF as well later. This also introduces the ACC pooled cohort equation for cardiovascular risk as a supplement to the Framingham risk scores. We're likely to support multiple risk score systems/frameworks to allow for different use cases and comparisons between them.

See https://github.com/synthetichealth/synthea/projects/2 for the full list of what we're aiming to do