### PR TITLE
Adding procedure codes to Imaging Studies

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1735,8 +1735,11 @@ public abstract class State implements Cloneable, Serializable {
       String primaryModality = series.get(0).modality.code;
       entry = person.record.imagingStudy(time, primaryModality, series);
 
-      // Also add the Procedure equivalent of this ImagingStudy to the patient's record
+      // Add the procedure code to the ImagingStudy
       String primaryProcedureCode = procedureCode.code;
+      entry.codes.add(procedureCode);
+
+      // Also add the Procedure equivalent of this ImagingStudy to the patient's record
       HealthRecord.Procedure procedure = person.record.procedure(time, primaryProcedureCode);
       procedure.name = this.name;
       procedure.codes.add(procedureCode);

--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -246,7 +246,7 @@ public class CSVExporter {
         + "BASE_ENCOUNTER_COST,TOTAL_CLAIM_COST,PAYER_COVERAGE,REASONCODE,REASONDESCRIPTION");
     encounters.write(NEWLINE);
     imagingStudies.write("Id,DATE,PATIENT,ENCOUNTER,BODYSITE_CODE,BODYSITE_DESCRIPTION,"
-        + "MODALITY_CODE,MODALITY_DESCRIPTION,SOP_CODE,SOP_DESCRIPTION");
+        + "MODALITY_CODE,MODALITY_DESCRIPTION,SOP_CODE,SOP_DESCRIPTION,PROCEDURE_CODE");
     imagingStudies.write(NEWLINE);
     devices.write("START,STOP,PATIENT,ENCOUNTER,CODE,DESCRIPTION,UDI");
     devices.write(NEWLINE);
@@ -939,7 +939,7 @@ public class CSVExporter {
   private String imagingStudy(RandomNumberGenerator rand, String personID, String encounterID,
       ImagingStudy imagingStudy) throws IOException {
     // Id,DATE,PATIENT,ENCOUNTER,BODYSITE_CODE,BODYSITE_DESCRIPTION,
-    // MODALITY_CODE,MODALITY_DESCRIPTION,SOP_CODE,SOP_DESCRIPTION
+    // MODALITY_CODE,MODALITY_DESCRIPTION,SOP_CODE,SOP_DESCRIPTION,PROCEDURE_CODE
     StringBuilder s = new StringBuilder();
 
     String studyID = rand.randUUID().toString();
@@ -962,7 +962,8 @@ public class CSVExporter {
     s.append(modality.display).append(',');
 
     s.append(sopClass.code).append(',');
-    s.append(sopClass.display);
+    s.append(sopClass.display).append(',');
+    s.append(imagingStudy.codes.get(0).code);
 
     s.append(NEWLINE);
 

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -2575,6 +2575,10 @@ public class FhirR4 {
       imagingStudyResource.setLocation(encounterResource.getLocationFirstRep().getLocation());
     }
 
+    if (! imagingStudy.codes.isEmpty()) {
+      imagingStudyResource.addProcedureCode(mapCodeToCodeableConcept(imagingStudy.codes.get(0), SNOMED_URI));
+    }
+
     Date startDate = new Date(imagingStudy.start);
     imagingStudyResource.setStarted(startDate);
 

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -2194,6 +2194,10 @@ public class FhirStu3 {
     imagingStudyResource.setPatient(new Reference(personEntry.getFullUrl()));
     imagingStudyResource.setContext(new Reference(encounterEntry.getFullUrl()));
 
+    if (! imagingStudy.codes.isEmpty()) {
+      imagingStudyResource.addProcedureCode(mapCodeToCodeableConcept(imagingStudy.codes.get(0), SNOMED_URI));
+    }
+
     Date startDate = new Date(imagingStudy.start);
     imagingStudyResource.setStarted(startDate);
 


### PR DESCRIPTION
Synthea ImagingStudy states can have procedure codes, but nothing really
happens with them in the simulation or export.

This takes the procedure code and adds it to the entry for ImagingStudy
in the HealthRecord. It then updates the export for FHIR STU3, R4 and
CSV so that the procedure code is exported. FHIR DSTU2 doesn't appear to
have a place in the ImagingStudy resource for procedure code.