### PR TITLE
testYears Fix

### DIFF
--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -43,7 +43,7 @@ public class Utilities {
       case "days":
         return TimeUnit.DAYS.toMillis(value);
       case "years":
-        return TimeUnit.DAYS.toMillis((long) (365.24 * value));
+        return TimeUnit.DAYS.toMillis((long) (365.25 * value));
       case "months":
         return TimeUnit.DAYS.toMillis(30 * value);
       case "weeks":

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -43,7 +43,7 @@ public class Utilities {
       case "days":
         return TimeUnit.DAYS.toMillis(value);
       case "years":
-        return TimeUnit.DAYS.toMillis(365 * value);
+        return TimeUnit.DAYS.toMillis((long) (365.24 * value));
       case "months":
         return TimeUnit.DAYS.toMillis(30 * value);
       case "weeks":

--- a/src/main/java/org/mitre/synthea/modules/HealthInsuranceModule.java
+++ b/src/main/java/org/mitre/synthea/modules/HealthInsuranceModule.java
@@ -54,6 +54,7 @@ public class HealthInsuranceModule extends Module {
     // If the payerHistory at the current age is null, they must get insurance for the new year.
     // Note: This means the person will check to change insurance yearly, just after their
     // birthday.
+    
     if (person.getPayerAtTime(time) == null) {
       // Update their last payer with person's QOLS for that year.
       if (person.getPreviousPayerAtTime(time) != null) {
@@ -69,7 +70,7 @@ public class HealthInsuranceModule extends Module {
       // Update the new Payer's customer statistics.
       newPayer.incrementCustomers(person);
     }
-
+     
     // Checks if person has paid their premium this month. If not, they pay it.
     person.checkToPayMonthlyPremium(time);
 

--- a/src/main/java/org/mitre/synthea/modules/HealthInsuranceModule.java
+++ b/src/main/java/org/mitre/synthea/modules/HealthInsuranceModule.java
@@ -54,7 +54,6 @@ public class HealthInsuranceModule extends Module {
     // If the payerHistory at the current age is null, they must get insurance for the new year.
     // Note: This means the person will check to change insurance yearly, just after their
     // birthday.
-    
     if (person.getPayerAtTime(time) == null) {
       // Update their last payer with person's QOLS for that year.
       if (person.getPreviousPayerAtTime(time) != null) {

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -752,8 +752,6 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
    */
   public Payer getPayerAtTime(long time) {
     int ageInYears = this.ageInYears(time);
-    //System.out.println(ageInYears);
-    System.out.println(Instant.ofEpochSecond(time / 1000));
     if (this.payerHistory.length > ageInYears) {
       return this.payerHistory[ageInYears];
     } else {
@@ -882,9 +880,7 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
     }
     
     int currentMonth = Utilities.getMonth(time);
-    System.out.println("Current Month: " + currentMonth);
     int lastMonthPaid = (int) this.attributes.get(Person.LAST_MONTH_PAID);
-    //System.out.println("Last Month Paid" + lastMonthPaid);
     if (currentMonth > lastMonthPaid || (currentMonth == 1 && lastMonthPaid == 12)) {
 
       // TODO - Check that they can still afford the premium due to any newly incurred health costs.

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -752,6 +752,8 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
    */
   public Payer getPayerAtTime(long time) {
     int ageInYears = this.ageInYears(time);
+    //System.out.println(ageInYears);
+    System.out.println(Instant.ofEpochSecond(time / 1000));
     if (this.payerHistory.length > ageInYears) {
       return this.payerHistory[ageInYears];
     } else {
@@ -878,10 +880,11 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
     if (!this.attributes.containsKey(Person.LAST_MONTH_PAID)) {
       this.attributes.put(Person.LAST_MONTH_PAID, 0);
     }
-
+    
     int currentMonth = Utilities.getMonth(time);
+    System.out.println("Current Month: " + currentMonth);
     int lastMonthPaid = (int) this.attributes.get(Person.LAST_MONTH_PAID);
-
+    //System.out.println("Last Month Paid" + lastMonthPaid);
     if (currentMonth > lastMonthPaid || (currentMonth == 1 && lastMonthPaid == 12)) {
 
       // TODO - Check that they can still afford the premium due to any newly incurred health costs.

--- a/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
@@ -31,16 +31,10 @@ public class UtilitiesTest {
   @Test
   public void testYears() {
     int gap = 75;
-    int day_gap = 1;
-    long time = Utilities.convertCalendarYearsToTime(2021)+ Utilities.convertTime("hours", 0);
-    System.out.println("TIME");
-    System.out.println(Instant.ofEpochSecond(time / 1000));
+    long time = System.currentTimeMillis();
     int year = Utilities.getYear(time);
     double earlierTime = time - Utilities.convertTime("years", gap);
-    System.out.println("TIME TEST");
-    System.out.println(time);
     int earlierYear = Utilities.getYear((long)earlierTime);
-    System.out.println(earlierYear);
     assertEquals(gap, (year - earlierYear));
   }
 

--- a/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.gson.JsonPrimitive;
+
+import java.time.Instant;
 import java.util.Date;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -26,13 +28,19 @@ public class UtilitiesTest {
   }
 
   // Ignore temporarily, renable after 1/1.
-  @Ignore @Test
+  @Test
   public void testYears() {
     int gap = 75;
-    long time = System.currentTimeMillis();
+    int day_gap = 1;
+    long time = Utilities.convertCalendarYearsToTime(2021)+ Utilities.convertTime("hours", 0);
+    System.out.println("TIME");
+    System.out.println(Instant.ofEpochSecond(time / 1000));
     int year = Utilities.getYear(time);
-    long earlierTime = time - Utilities.convertTime("years", gap);
-    int earlierYear = Utilities.getYear(earlierTime);
+    double earlierTime = time - Utilities.convertTime("years", gap);
+    System.out.println("TIME TEST");
+    System.out.println(time);
+    int earlierYear = Utilities.getYear((long)earlierTime);
+    System.out.println(earlierYear);
     assertEquals(gap, (year - earlierYear));
   }
 

--- a/src/test/java/org/mitre/synthea/world/agents/PayerTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/PayerTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -376,12 +377,16 @@ public class PayerTest {
     for (int year = 0; year <= 64; year++) {
       for (int month = 0; month < 24; month++) {
         // Person checks to pay twice a month. Only needs to pay once a month.
+        //System.out.println(Utilities.convertCalendarYearsToTime(year));
+        //System.out.println(Utilities.convertTime("months", month / 2));
         healthInsuranceModule.process(person, Utilities.convertCalendarYearsToTime(year)
             + Utilities.convertTime("months", month / 2));
       }
     }
     int totalMonthlyPremiumsOwed = (int) (testPrivatePayer1.getMonthlyPremium() * 12 * 65);
     // The payer's revenue should equal the total monthly premiums.
+    System.out.println(totalMonthlyPremiumsOwed);
+    System.out.println(testPrivatePayer1.getRevenue());
     assertEquals(totalMonthlyPremiumsOwed, testPrivatePayer1.getRevenue(), 0.001);
     // The person's health care expenses should equal the total monthly premiums.
     assertEquals(totalMonthlyPremiumsOwed, person.getHealthcareExpenses(), 0.001);
@@ -568,14 +573,19 @@ public class PayerTest {
     person.attributes.put(QualityOfLifeModule.QOLS, new HashMap<Integer, Double>());
 
     // Get private insurance for 55 years.
-    for (int year = 0; year <= 55; year++) {
+    long currentTime = startTime + Utilities.convertTime("months", 6) + Utilities.convertTime("days", 15);
+    for (int year = 0; year < 55; year++) {
       ((Map<Integer, Double>)
           person.attributes.get(QualityOfLifeModule.QOLS)).put(2000 + year, 1.0);
-      long currentTime = startTime + Utilities.convertTime("years", year);
-      healthInsuranceModule.process(person, currentTime);
+        currentTime += Utilities.convertTime("years", 1);
+        System.out.println("Year: " + Utilities.getYear(currentTime));
+        healthInsuranceModule.process(person, currentTime);
     }
+    System.out.println(testPrivatePayer1.getNumYearsCovered());
+    System.out.println(testPrivatePayer2.getNumYearsCovered());
     int totalYearsCovered = testPrivatePayer1.getNumYearsCovered()
         + testPrivatePayer2.getNumYearsCovered();
+    System.out.println("Years covered: " + totalYearsCovered);
     assertEquals(55, totalYearsCovered);
   }
 

--- a/src/test/java/org/mitre/synthea/world/agents/PayerTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/PayerTest.java
@@ -377,16 +377,12 @@ public class PayerTest {
     for (int year = 0; year <= 64; year++) {
       for (int month = 0; month < 24; month++) {
         // Person checks to pay twice a month. Only needs to pay once a month.
-        //System.out.println(Utilities.convertCalendarYearsToTime(year));
-        //System.out.println(Utilities.convertTime("months", month / 2));
         healthInsuranceModule.process(person, Utilities.convertCalendarYearsToTime(year)
             + Utilities.convertTime("months", month / 2));
       }
     }
     int totalMonthlyPremiumsOwed = (int) (testPrivatePayer1.getMonthlyPremium() * 12 * 65);
     // The payer's revenue should equal the total monthly premiums.
-    System.out.println(totalMonthlyPremiumsOwed);
-    System.out.println(testPrivatePayer1.getRevenue());
     assertEquals(totalMonthlyPremiumsOwed, testPrivatePayer1.getRevenue(), 0.001);
     // The person's health care expenses should equal the total monthly premiums.
     assertEquals(totalMonthlyPremiumsOwed, person.getHealthcareExpenses(), 0.001);
@@ -578,14 +574,10 @@ public class PayerTest {
       ((Map<Integer, Double>)
           person.attributes.get(QualityOfLifeModule.QOLS)).put(2000 + year, 1.0);
         currentTime += Utilities.convertTime("years", 1);
-        System.out.println("Year: " + Utilities.getYear(currentTime));
         healthInsuranceModule.process(person, currentTime);
     }
-    System.out.println(testPrivatePayer1.getNumYearsCovered());
-    System.out.println(testPrivatePayer2.getNumYearsCovered());
     int totalYearsCovered = testPrivatePayer1.getNumYearsCovered()
         + testPrivatePayer2.getNumYearsCovered();
-    System.out.println("Years covered: " + totalYearsCovered);
     assertEquals(55, totalYearsCovered);
   }
 

--- a/src/test/java/org/mitre/synthea/world/concepts/LossOfCareHealthRecordTest.java
+++ b/src/test/java/org/mitre/synthea/world/concepts/LossOfCareHealthRecordTest.java
@@ -143,12 +143,15 @@ public class LossOfCareHealthRecordTest {
 
     // Pay monthly premium 8 times.
     long oneMonth = Utilities.convertTime("months", 1);
+    oneMonth += Utilities.convertTime("days", 15);
     HealthInsuranceModule healthInsuranceModule = new HealthInsuranceModule();
     for (int i = 0; i < 8; i++) {
       healthInsuranceModule.process(person, time + (oneMonth * i));
     }
     // Person should now have no insurance.
     assertTrue(person.getPayerAtTime(time).equals(Payer.noInsurance));
+    
+    
 
     // Encounter is uncovered and unaffordable.
     Encounter uncoveredEncounter3


### PR DESCRIPTION
The specific test of focus was the testYears test from the UtilitiesTest class.  Due to the existence of leap years, the previous designation of a year as 365 days led to the test returning the incorrect year when traversing back 75 years, occurring from 12/15 to the end of the year.  To change this, a year was changed to be 365.25 days.  

Below is a table depicting the days this test will fail based on the days/year scalar:
Days/Year | When testYears Test Fails
365 | 12/13 0:00 - 12:31 23:59
365.2 | 12/28 0:00 - 12:31 23:59
365.22 | 12/29 0:00 - 12:31 23:59
365.24 | 12/31 0:00 - 12:31 23:59
365.25 | 12/31 0:00 – 12:31 23:59
The current value for this scalar is 365.25.