### PR TITLE
Include/Exclude for CSV exporter files

### DIFF
--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -30,6 +30,15 @@ exporter.csv.export = false
 exporter.csv.append_mode = false
 # if exporter.csv.folder_per_run = true, then each run will have CSVs placed into a unique subfolder. if false, each run will only use the top-level csv folder
 exporter.csv.folder_per_run = false
+# included_files and excluded_files list out the files to include/exclude in the csv exporter
+# only one of these may be set at a time, if both are set then both will be ignored
+# if neither is set, then all files will be included
+# see list of files at: https://github.com/synthetichealth/synthea/wiki/CSV-File-Data-Dictionary
+# include filenames separated with a comma, ex: patients.csv,procedures.csv,medications.csv
+# NOTE: the csv exporter does not actively delete files, so if Run 1 you included a file, then Run 2 you exclude that file, the version from Run 1 will still be present
+exporter.csv.included_files = 
+exporter.csv.excluded_files = 
+
 exporter.cpcds.export = false
 exporter.cpcds.append_mode = false
 exporter.cpcds.folder_per_run = false

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -5,7 +5,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
-import org.junit.BeforeClass;
+
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -32,19 +33,24 @@ public class CSVExporterTest {
    * Global setup for export tests.
    * @throws Exception if something goes wrong
    */
-  @BeforeClass
-  public static void setUpExportDir() throws Exception {
+  @Before
+  public void setUpExportDir() throws Exception {
     TestHelper.exportOff();
     TestHelper.loadTestProperties();
     Generator.DEFAULT_STATE = Config.get("test_state.default", "Massachusetts");
     Config.set("exporter.csv.export", "true");
     Config.set("exporter.csv.folder_per_run", "false");
+
     exportDir = tempFolder.newFolder();
-    Config.set("exporter.baseDirectory", exportDir.toString());    
+    Config.set("exporter.baseDirectory", exportDir.toString());
   }
   
   @Test
   public void testDeferredCSVExport() throws Exception {
+    Config.set("exporter.csv.included_files", "");
+    Config.set("exporter.csv.excluded_files", "");
+    CSVExporter.getInstance().init();
+    
     Payer.clear();
     Config.set("generate.payers.insurance_companies.default_file",
         "generic/payers/test_payers.csv");
@@ -85,6 +91,156 @@ public class CSVExporterTest {
       count++;
     }
 
-    assertEquals("Expected 16 CSV files in the output directory, found " + count, 16, count);
+    assertEquals("Expected " + CSVExporter.NUMBER_OF_FILES
+        + " CSV files in the output directory, found " + count, CSVExporter.NUMBER_OF_FILES, count);
   }
+  
+  @Test
+  public void testCSVExportIncludes() throws Exception {
+    Config.set("exporter.csv.included_files", "patients.csv,medications.csv,procedures.csv");
+    Config.set("exporter.csv.excluded_files", "");
+    CSVExporter.getInstance().init();
+
+    Payer.clear();
+    Config.set("generate.payers.insurance_companies.default_file",
+        "generic/payers/test_payers.csv");
+    Payer.loadPayers(new Location(Generator.DEFAULT_STATE, null));
+
+    int numberOfPeople = 10;
+    ExporterRuntimeOptions exportOpts = new ExporterRuntimeOptions();
+    exportOpts.deferExports = true;
+    GeneratorOptions generatorOpts = new GeneratorOptions();
+    generatorOpts.population = numberOfPeople;
+    Generator generator = new Generator(generatorOpts, exportOpts);
+    generator.options.overflow = false;
+    for (int i = 0; i < numberOfPeople; i++) {
+      generator.generatePerson(i);
+    }
+    // Adding post completion exports to generate organizations and providers CSV files
+    Exporter.runPostCompletionExports(generator, exportOpts);
+
+    // if we get here we at least had no exceptions
+
+    File expectedExportFolder = exportDir.toPath().resolve("csv").toFile();
+
+    assertTrue(expectedExportFolder.exists() && expectedExportFolder.isDirectory());
+
+    boolean foundPatients = false;
+    boolean foundMedications = false;
+    boolean foundProcedures = false;
+    
+    int count = 0;
+    for (File csvFile : expectedExportFolder.listFiles()) {
+      if (!csvFile.getName().endsWith(".csv")) {
+        continue;
+      }
+
+      switch (csvFile.getName()) {
+        case "patients.csv":
+          foundPatients = true;
+          break;
+        case "medications.csv":
+          foundMedications = true;
+          break;
+        case "procedures.csv":
+          foundProcedures = true;
+          break;
+        default:
+          // do nothing
+      }
+      
+      String csvData = new String(Files.readAllBytes(csvFile.toPath()));
+
+      // the CSV exporter doesn't use the SimpleCSV class to write the data,
+      // so we can use it here for a level of validation
+      SimpleCSV.parse(csvData);
+      assertTrue(SimpleCSV.isValid(csvData));
+
+      count++;
+    }
+
+    assertEquals("Expected 3 CSV files in the output directory, found " + count, 3, count);
+    assertTrue("patients.csv file missing but should have been included", foundPatients);
+    assertTrue("medications.csv file missing but should have been included", foundMedications);
+    assertTrue("procedures.csv file missing but should have been included", foundProcedures);
+  }
+  
+  @Test
+  public void testCSVExportExcludes() throws Exception {  
+    Config.set("exporter.csv.included_files", "");
+    Config.set("exporter.csv.excluded_files", "patients.csv, medications, payers, providers");
+    CSVExporter.getInstance().init();
+
+    Payer.clear();
+    Config.set("generate.payers.insurance_companies.default_file",
+        "generic/payers/test_payers.csv");
+    Payer.loadPayers(new Location(Generator.DEFAULT_STATE, null));
+
+    int numberOfPeople = 10;
+    ExporterRuntimeOptions exportOpts = new ExporterRuntimeOptions();
+    exportOpts.deferExports = true;
+    GeneratorOptions generatorOpts = new GeneratorOptions();
+    generatorOpts.population = numberOfPeople;
+    Generator generator = new Generator(generatorOpts, exportOpts);
+    generator.options.overflow = false;
+    for (int i = 0; i < numberOfPeople; i++) {
+      generator.generatePerson(i);
+    }
+    // Adding post completion exports to generate organizations and providers CSV files
+    Exporter.runPostCompletionExports(generator, exportOpts);
+
+    // if we get here we at least had no exceptions
+
+    File expectedExportFolder = exportDir.toPath().resolve("csv").toFile();
+
+    assertTrue(expectedExportFolder.exists() && expectedExportFolder.isDirectory());
+
+    boolean foundPatients = false;
+    boolean foundMedications = false;
+    boolean foundPayers = false;
+    boolean foundProviders = false;
+    
+    int count = 0;
+    for (File csvFile : expectedExportFolder.listFiles()) {
+      if (!csvFile.getName().endsWith(".csv")) {
+        continue;
+      }
+
+      switch (csvFile.getName()) {
+        case "patients.csv":
+          foundPatients = true;
+          break;
+        case "medications.csv":
+          foundMedications = true;
+          break;
+        case "payers.csv":
+          foundPayers = true;
+          break;
+        case "providers.csv":
+          foundProviders = true;
+          break;
+        default:
+          // do nothing
+      }
+      
+      String csvData = new String(Files.readAllBytes(csvFile.toPath()));
+
+      // the CSV exporter doesn't use the SimpleCSV class to write the data,
+      // so we can use it here for a level of validation
+      SimpleCSV.parse(csvData);
+      assertTrue(SimpleCSV.isValid(csvData));
+
+      count++;
+    }
+
+    int expected = CSVExporter.NUMBER_OF_FILES - 4;
+    assertEquals("Expected " + expected + " CSV files in the output directory, found " + count,
+        expected, count);
+    assertTrue("patients.csv is present but should have been excluded", !foundPatients);
+    assertTrue("medications.csv is present but should have been excluded", !foundMedications);
+    assertTrue("payers.csv is present but should have been excluded", !foundPayers);
+    assertTrue("providers.csv is present but should have been excluded", !foundProviders);
+  }
+  
+  
 }

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -29,6 +29,8 @@ public class CSVExporterTest {
   
   private static File exportDir;
 
+  private static final int NUMBER_OF_FILES = 16;
+
   /**
    * Global setup for export tests.
    * @throws Exception if something goes wrong
@@ -91,8 +93,8 @@ public class CSVExporterTest {
       count++;
     }
 
-    assertEquals("Expected " + CSVExporter.NUMBER_OF_FILES
-        + " CSV files in the output directory, found " + count, CSVExporter.NUMBER_OF_FILES, count);
+    assertEquals("Expected " + NUMBER_OF_FILES
+        + " CSV files in the output directory, found " + count, NUMBER_OF_FILES, count);
   }
   
   @Test
@@ -233,7 +235,7 @@ public class CSVExporterTest {
       count++;
     }
 
-    int expected = CSVExporter.NUMBER_OF_FILES - 4;
+    int expected = NUMBER_OF_FILES - 4;
     assertEquals("Expected " + expected + " CSV files in the output directory, found " + count,
         expected, count);
     assertTrue("patients.csv is present but should have been excluded", !foundPatients);


### PR DESCRIPTION
Adds configuration options for included and excluded files in the CSV exporter. Since many use cases don't require every single CSV file, we can save some space and computing time by not exporting them in the first place. (I'm looking at you, observations.csv...)

If you specify a list of files in `exporter.csv.included_files`, then only those files will be exported. (and if you don't include `patients.csv` in the list, it will yell at you but still process as expected)
If you specify a list of files in `exporter.csv.included_files`, then all other files will be exported and the named files will not be.
If you specify both config options, it will ignore both and do the default, export every file.

The basic approach here is to use a "no-op" implementation of an OutputStream, so that we only have to change the initialization of the file writers, not how they are called. This does mean though that the string content of the CSV is still created, but then thrown away. Since these work one line at a time it shouldn't mean a whole lot in terms of memory usage, but I can revisit if people think it's an issue.

Another minor change here is to move the actual initialization of the CSVExporter to an `init()` method so that it can be re-initialized if needed, for example in unit tests with different config settings