### PR TITLE
Even more assorted bugfixes

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1559,9 +1559,9 @@ public abstract class State implements Cloneable, Serializable {
       // we need to ensure we deep clone the list
       // (otherwise as this gets passed around, the same objects are used for different patients
       // which causes weird and unexpected results)
-      List<Observation> cloneObs = new ArrayList<>(observations);
-      for (int i = 0; i < cloneObs.size(); i++) {
-        cloneObs.set(i, cloneObs.get(i).clone());
+      List<Observation> cloneObs = new ArrayList<>(observations.size());
+      for (Observation o : observations) {
+        cloneObs.add(o.clone());
       }
       clone.observations = cloneObs;
       

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1554,7 +1554,6 @@ public abstract class State implements Cloneable, Serializable {
 
     public ObservationGroup clone() {
       ObservationGroup clone = (ObservationGroup) super.clone();
-      clone.codes = codes;
       
       // IMPORTANT: because each observation gets process()ed when the state gets processed,
       // we need to ensure we deep clone the list

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -121,14 +121,17 @@ public abstract class State implements Cloneable, Serializable {
    * clone() should copy all the necessary variables of this State so that it can be correctly
    * executed and modified without altering the original copy. So for example, 'entered' and
    * 'exited' times should not be copied so the clone can be cleanly executed.
+   * Implementation note: the base Object.clone() copies over all fields automatically
+   * (as a shallow copy), so we don't need to do that ourselves. Instead, we should 
+   * 1. explicitly null out any fields that should not be copied, such as entered/exited
+   * 2. deep copy mutable reference types, if necessary.
    */
   public State clone() {
     try {
       State clone = (State) super.clone();
-      clone.module = this.module;
-      clone.name = this.name;
-      clone.transition = this.transition;
-      clone.remarks = this.remarks;
+      clone.entered = null;
+      clone.exited = null;
+      clone.entry = null;
       return clone;
     } catch (CloneNotSupportedException e) {
       // should not happen, and not something we can handle
@@ -232,7 +235,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public CallSubmodule clone() {
       CallSubmodule clone = (CallSubmodule) super.clone();
-      clone.submodule = submodule;
       return clone;
     }
 
@@ -337,15 +339,7 @@ public abstract class State implements Cloneable, Serializable {
 
     @Override
     public Physiology clone() {
-      Physiology clone = (Physiology) super.clone();
-      clone.model = model;
-      clone.solver = solver;
-      clone.stepSize = stepSize;
-      clone.simDuration = simDuration;
-      clone.leadTime = leadTime;
-      clone.altDirectTransition = altDirectTransition;
-      clone.altTransition = altTransition;
-      
+      Physiology clone = (Physiology) super.clone();     
       List<IoMapper> inputList = new ArrayList<IoMapper>(inputs.size());
       for (IoMapper mapper : inputs) {
         inputList.add(new IoMapper(mapper));
@@ -433,9 +427,16 @@ public abstract class State implements Cloneable, Serializable {
   public abstract static class Delayable extends State {
     // next is "transient" in the sense that it represents object state
     // as opposed to the other fields which represent object definition
-    // hence it is not set in clone()
+    // hence it is unset in clone()
     public Long next;
 
+    @Override
+    public Delayable clone() {
+      Delayable clone = (Delayable) super.clone();
+      clone.next = null;
+      return clone;
+    }
+    
     public abstract long endOfDelay(long time, Person person);
 
     /**
@@ -485,8 +486,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public Delay clone() {
       Delay clone = (Delay) super.clone();
-      clone.exact = exact;
-      clone.range = range;
       return clone;
     }
 
@@ -524,7 +523,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public Guard clone() {
       Guard clone = (Guard) super.clone();
-      clone.allow = allow;
       return clone;
     }
 
@@ -590,14 +588,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public SetAttribute clone() {
       SetAttribute clone = (SetAttribute) super.clone();
-      clone.attribute = attribute;
-      clone.value = value;
-      clone.range = range;
-      clone.expression = expression;
-      // We shouldn't clone thread local objects since the application is multi-threaded.
-      // clone.threadExpProcessor = threadExpProcessor;
-      clone.seriesData = seriesData;
-      clone.period = period;
       return clone;
     }
 
@@ -660,9 +650,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public Counter clone() {
       Counter clone = (Counter) super.clone();
-      clone.attribute = attribute;
-      clone.increment = increment;
-      clone.amount = amount;
       return clone;
     }
 
@@ -724,10 +711,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public Encounter clone() {
       Encounter clone = (Encounter) super.clone();
-      clone.wellness = wellness;
-      clone.encounterClass = encounterClass;
-      clone.reason = reason;
-      clone.codes = codes;
       return clone;
     }
 
@@ -880,7 +863,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public EncounterEnd clone() {
       EncounterEnd clone = (EncounterEnd) super.clone();
-      clone.dischargeDisposition = dischargeDisposition;
       return clone;
     }
 
@@ -916,9 +898,6 @@ public abstract class State implements Cloneable, Serializable {
 
     public OnsetState clone() {
       OnsetState clone = (OnsetState) super.clone();
-      clone.codes = codes;
-      clone.assignToAttribute = assignToAttribute;
-      clone.targetEncounter = targetEncounter;
       return clone;
     }
 
@@ -999,9 +978,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public ConditionEnd clone() {
       ConditionEnd clone = (ConditionEnd) super.clone();
-      clone.codes = codes;
-      clone.conditionOnset = conditionOnset;
-      clone.referencedByAttribute = referencedByAttribute;
       return clone;
     }
 
@@ -1074,9 +1050,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public AllergyEnd clone() {
       AllergyEnd clone = (AllergyEnd) super.clone();
-      clone.codes = codes;
-      clone.allergyOnset = allergyOnset;
-      clone.referencedByAttribute = referencedByAttribute;
       return clone;
     }
 
@@ -1151,12 +1124,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public MedicationOrder clone() {
       MedicationOrder clone = (MedicationOrder) super.clone();
-      clone.codes = codes;
-      clone.reason = reason;
-      clone.prescription = prescription;
-      clone.assignToAttribute = assignToAttribute;
-      clone.administration = administration;
-      clone.chronic = chronic;
       return clone;
     }
 
@@ -1226,9 +1193,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public MedicationEnd clone() {
       MedicationEnd clone = (MedicationEnd) super.clone();
-      clone.codes = codes;
-      clone.medicationOrder = medicationOrder;
-      clone.referencedByAttribute = referencedByAttribute;
       return clone;
     }
 
@@ -1264,11 +1228,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public CarePlanStart clone() {
       CarePlanStart clone = (CarePlanStart) super.clone();
-      clone.codes = codes;
-      clone.activities = activities;
-      clone.goals = goals;
-      clone.reason = reason;
-      clone.assignToAttribute = assignToAttribute;
       return clone;
     }
 
@@ -1326,9 +1285,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public CarePlanEnd clone() {
       CarePlanEnd clone = (CarePlanEnd) super.clone();
-      clone.codes = codes;
-      clone.careplan = careplan;
-      clone.referencedByAttribute = referencedByAttribute;
       return clone;
     }
 
@@ -1364,10 +1320,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public Procedure clone() {
       Procedure clone = (Procedure) super.clone();
-      clone.codes = codes;
-      clone.reason = reason;
-      clone.duration = duration;
-      clone.assignToAttribute = assignToAttribute;
       return clone;
     }
 
@@ -1462,13 +1414,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public VitalSign clone() {
       VitalSign clone = (VitalSign) super.clone();
-      clone.range = range;
-      clone.exact = exact;
-      clone.vitalSign = vitalSign;
-      clone.unit = unit;
-      clone.expression = expression;
-      // We shouldn't clone thread local objects since the application is multi-threaded.
-      // clone.threadExpProcessor = threadExpProcessor;
       return clone;
     }
 
@@ -1558,19 +1503,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public Observation clone() {
       Observation clone = (Observation) super.clone();
-      clone.codes = codes;
-      clone.range = range;
-      clone.exact = exact;
-      clone.valueCode = valueCode;
-      clone.attribute = attribute;
-      clone.vitalSign = vitalSign;
-      clone.sampledData = sampledData;
-      clone.category = category;
-      clone.unit = unit;
-      clone.expression = expression;
-      // We shouldn't clone thread local objects since the application is multi-threaded.
-      // clone.threadExpProcessor = threadExpProcessor;
-      clone.attachment = attachment;
       return clone;
     }
 
@@ -1623,7 +1555,17 @@ public abstract class State implements Cloneable, Serializable {
     public ObservationGroup clone() {
       ObservationGroup clone = (ObservationGroup) super.clone();
       clone.codes = codes;
-      clone.observations = observations;
+      
+      // IMPORTANT: because each observation gets process()ed when the state gets processed,
+      // we need to ensure we deep clone the list
+      // (otherwise as this gets passed around, the same objects are used for different patients
+      // which causes weird and unexpected results)
+      List<Observation> cloneObs = new ArrayList<>(observations);
+      for (int i = 0; i < cloneObs.size(); i++) {
+        cloneObs.set(i, cloneObs.get(i).clone());
+      }
+      clone.observations = cloneObs;
+      
       return clone;
     }
   }
@@ -1642,7 +1584,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public MultiObservation clone() {
       MultiObservation clone = (MultiObservation) super.clone();
-      clone.category = category;
       return clone;
     }
 
@@ -1717,10 +1658,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public ImagingStudy clone() {
       ImagingStudy clone = (ImagingStudy) super.clone();
-      clone.procedureCode = procedureCode;
-      clone.series = series;
-      clone.minNumberSeries = minNumberSeries;
-      clone.maxNumberSeries = maxNumberSeries;
       return clone;
     }
 
@@ -1825,12 +1762,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public Symptom clone() {
       Symptom clone = (Symptom) super.clone();
-      clone.symptom = symptom;
-      clone.cause = cause;
-      clone.probability = probability;
-      clone.range = range;
-      clone.exact = exact;
-      clone.addressed = addressed;
       return clone;
     }
 
@@ -1869,10 +1800,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public Device clone() {
       Device clone = (Device) super.clone();
-      clone.code = code;
-      clone.manufacturer = manufacturer;
-      clone.model = model;
-      clone.assignToAttribute = assignToAttribute;
       return clone;
     }
 
@@ -1908,9 +1835,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public DeviceEnd clone() {
       DeviceEnd clone = (DeviceEnd) super.clone();
-      clone.codes = codes;
-      clone.device = device;
-      clone.referencedByAttribute = referencedByAttribute;
       return clone;
     }
 
@@ -1943,7 +1867,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public SupplyList clone() {
       SupplyList clone = (SupplyList) super.clone();
-      clone.supplies = supplies;
       return clone;
     }
 
@@ -1991,11 +1914,6 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public Death clone() {
       Death clone = (Death) super.clone();
-      clone.codes = codes;
-      clone.conditionOnset = conditionOnset;
-      clone.referencedByAttribute = referencedByAttribute;
-      clone.range = range;
-      clone.exact = exact;
       return clone;
     }
 

--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -372,6 +372,7 @@ public abstract class Exporter {
       for (Pair<Person, Long> entry: deferredExports) {
         export(entry.getLeft(), entry.getRight(), nonDeferredOptions);
       }
+      deferredExports.clear();
     }
     
     String bulk = Config.get("exporter.fhir.bulk_data");

--- a/src/test/java/org/mitre/synthea/engine/FixedRecordTest.java
+++ b/src/test/java/org/mitre/synthea/engine/FixedRecordTest.java
@@ -7,7 +7,7 @@ import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.mitre.synthea.engine.Generator.GeneratorOptions;
 import org.mitre.synthea.helpers.Config;
@@ -20,14 +20,14 @@ import org.mitre.synthea.world.agents.Provider;
 public class FixedRecordTest {
 
   // The generator.
-  private static Generator generator;
+  private Generator generator;
 
   /**
    * Configure settings across these tests.
    * @throws Exception on test configuration loading errors.
    */
-  @BeforeClass
-  public static void setup() {
+  @Before
+  public void setup() {
     Generator.DEFAULT_STATE = Config.get("test_state.default", "Massachusetts");
     Config.set("generate.only_dead_patients", "false"); 
     Config.set("exporter.split_records", "true");

--- a/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
@@ -16,7 +16,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.codec.binary.Base64;
-import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Media;
@@ -122,71 +121,72 @@ public class FHIRR4ExporterTest {
         validationErrors.add(
             "JSON contains unconverted references to 'SNOMED-CT' (should be URIs)");
       }
-      // Now validate the resource...
-      IBaseResource resource = ctx.newJsonParser().parseResource(fhirJson);
-      ValidationResult result = validator.validateR4(resource);
-      if (!result.isSuccessful()) {
-        // If the validation failed, let's crack open the Bundle and validate
-        // each individual entry.resource to get context-sensitive error
-        // messages...
-        Bundle bundle = parser.parseResource(Bundle.class, fhirJson);
-        for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
-          ValidationResult eresult = validator.validateR4(entry.getResource());
-          if (!eresult.isSuccessful()) {
-            for (SingleValidationMessage emessage : eresult.getMessages()) {
-              boolean valid = false;
-              if (emessage.getSeverity() == ResultSeverityEnum.INFORMATION
-                      || emessage.getSeverity() == ResultSeverityEnum.WARNING) {
-                /*
-                 * Ignore warnings.
-                 */
-                valid = true;
-              } else if (emessage.getMessage().contains("us-core-documentreference-type")) {
-                /*
-                 * The instance validator does not expand intentional value sets like this one.
-                 */
-                valid = true;
-              } else if (emessage.getMessage().contains("@ AllergyIntolerance ait-2")) {
-                /*
-                 * The ait-2 invariant:
-                 * Description:
-                 * AllergyIntolerance.clinicalStatus SHALL NOT be present
-                 * if verification Status is entered-in-error
-                 * Expression:
-                 * verificationStatus!='entered-in-error' or clinicalStatus.empty()
-                 */
-                valid = true;
-              } else if (emessage.getMessage().contains("@ ExplanationOfBenefit dom-3")) {
-                /*
-                 * For some reason, it doesn't like the contained ServiceRequest and contained
-                 * Coverage resources in the ExplanationOfBenefit, both of which are
-                 * properly referenced. Running $validate on test servers finds this valid...
-                 */
-                valid = true;
-              } else if (emessage.getMessage().contains(
-                  "per-1: If present, start SHALL have a lower value than end")) {
-                /*
-                 * The per-1 invariant does not account for daylight savings time... so, if the
-                 * daylight savings switch happens between the start and end, the validation
-                 * fails, even if it is valid.
-                 */
-                valid = true; // ignore this error
-              } else if (
-                  emessage.getMessage().contains("Unknown extension http://hl7.org/fhir/us/core")
-                  || emessage.getMessage().contains("Unknown extension http://synthetichealth")
-                  || emessage.getMessage().contains("not be resolved, so has not been checked")) {
-                /*
-                 * Despite setting instanceValidator.setAnyExtensionsAllowed(true) and
-                 * instanceValidator.setErrorForUnknownProfiles(false), the FHIR validator still
-                 * reports these as errors
-                 */
-                valid = true; // ignore this error
-              }
-              if (!valid) {
-                System.out.println(parser.encodeResourceToString(entry.getResource()));
-                System.out.println("ERROR: " + emessage.getMessage());
-                validationErrors.add(emessage.getMessage());
-              }
+
+      // Let's crack open the Bundle and validate
+      // each individual entry.resource to get context-sensitive error
+      // messages...
+      // IMPORTANT: this approach significantly reduces memory usage when compared to
+      // validating the entire bundle at a time, but means that validating references
+      // is impossible.
+      // As of 2021-01-05, validating the bundle didn't validate references anyway,
+      // but at some point we may want to do that.
+      Bundle bundle = parser.parseResource(Bundle.class, fhirJson);
+      for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
+        ValidationResult eresult = validator.validateR4(entry.getResource());
+        if (!eresult.isSuccessful()) {
+          for (SingleValidationMessage emessage : eresult.getMessages()) {
+            boolean valid = false;
+            if (emessage.getSeverity() == ResultSeverityEnum.INFORMATION
+                    || emessage.getSeverity() == ResultSeverityEnum.WARNING) {
+              /*
+               * Ignore warnings.
+               */
+              valid = true;
+            } else if (emessage.getMessage().contains("us-core-documentreference-type")) {
+              /*
+               * The instance validator does not expand intentional value sets like this one.
+               */
+              valid = true;
+            } else if (emessage.getMessage().contains("@ AllergyIntolerance ait-2")) {
+              /*
+               * The ait-2 invariant:
+               * Description:
+               * AllergyIntolerance.clinicalStatus SHALL NOT be present
+               * if verification Status is entered-in-error
+               * Expression:
+               * verificationStatus!='entered-in-error' or clinicalStatus.empty()
+               */
+              valid = true;
+            } else if (emessage.getMessage().contains("@ ExplanationOfBenefit dom-3")) {
+              /*
+               * For some reason, it doesn't like the contained ServiceRequest and contained
+               * Coverage resources in the ExplanationOfBenefit, both of which are
+               * properly referenced. Running $validate on test servers finds this valid...
+               */
+              valid = true;
+            } else if (emessage.getMessage().contains(
+                "per-1: If present, start SHALL have a lower value than end")) {
+              /*
+               * The per-1 invariant does not account for daylight savings time... so, if the
+               * daylight savings switch happens between the start and end, the validation
+               * fails, even if it is valid.
+               */
+              valid = true; // ignore this error
+            } else if (
+                emessage.getMessage().contains("Unknown extension http://hl7.org/fhir/us/core")
+                || emessage.getMessage().contains("Unknown extension http://synthetichealth")
+                || emessage.getMessage().contains("not be resolved, so has not been checked")) {
+              /*
+               * Despite setting instanceValidator.setAnyExtensionsAllowed(true) and
+               * instanceValidator.setErrorForUnknownProfiles(false), the FHIR validator still
+               * reports these as errors
+               */
+              valid = true; // ignore this error
+            }
+            if (!valid) {
+              System.out.println(parser.encodeResourceToString(entry.getResource()));
+              System.out.println("ERROR: " + emessage.getMessage());
+              validationErrors.add(emessage.getMessage());
             }
           }
         }

--- a/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
@@ -23,7 +23,6 @@ import org.hl7.fhir.dstu3.model.Media;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Quantity;
 import org.hl7.fhir.dstu3.model.SampledData;
-import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -128,84 +127,80 @@ public class FHIRSTU3ExporterTest {
         validationErrors.add(
             "JSON contains unconverted references to 'SNOMED-CT' (should be URIs)");
       }
-      // Now validate the resource...
-      IBaseResource resource = ctx.newJsonParser().parseResource(fhirJson);
-      ValidationResult result = validator.validateWithResult(resource);
-      if (!result.isSuccessful()) {
-        // If the validation failed, let's crack open the Bundle and validate
-        // each individual entry.resource to get context-sensitive error
-        // messages...
-        Bundle bundle = parser.parseResource(Bundle.class, fhirJson);
-        for (BundleEntryComponent entry : bundle.getEntry()) {
-          ValidationResult eresult = validator.validateWithResult(entry.getResource());
-          if (!eresult.isSuccessful()) {
-            for (SingleValidationMessage emessage : eresult.getMessages()) {
-              boolean valid = false;
-              if (emessage.getMessage().contains("@ Observation obs-7")) {
-                /*
-                 * The obs-7 invariant basically says that Observations should have values, unless
-                 * they are made of components. This test replaces an invalid XPath expression
-                 * that was causing correct instances to fail validation.
-                 */
-                valid = validateObs7((Observation) entry.getResource());
-              } else if (emessage.getMessage().contains("@ Condition con-4")) {
-                /*
-                 * The con-4 invariant says "If condition is abated, then clinicalStatus must be
-                 * either inactive, resolved, or remission" which is very clear and sensical.
-                 * However, the XPath expression does not evaluate correctly for valid instances,
-                 * so we must manually validate.
-                 */
-                valid = validateCon4((Condition) entry.getResource());
-              } else if (emessage.getMessage().contains("@ MedicationRequest mps-1")) {
-                /*
-                 * The mps-1 invariant says MedicationRequest.requester.onBehalfOf can only be
-                 * specified if MedicationRequest.requester.agent is practitioner or device.
-                 * But the invariant is poorly written and does not correctly handle references
-                 * starting with "urn:uuid"
-                 */
-                valid = true; // ignore this error
-              } else if (emessage.getMessage().contains(
-                  "per-1: If present, start SHALL have a lower value than end")) {
-                /*
-                 * The per-1 invariant does not account for daylight savings time... so, if the
-                 * daylight savings switch happens between the start and end, the validation
-                 * fails, even if it is valid.
-                 */
-                valid = true; // ignore this error
-              }
+      // let's crack open the Bundle and validate
+      // each individual entry.resource to get context-sensitive error
+      // messages...
+      Bundle bundle = parser.parseResource(Bundle.class, fhirJson);
+      for (BundleEntryComponent entry : bundle.getEntry()) {
+        ValidationResult eresult = validator.validateWithResult(entry.getResource());
+        if (!eresult.isSuccessful()) {
+          for (SingleValidationMessage emessage : eresult.getMessages()) {
+            boolean valid = false;
+            if (emessage.getMessage().contains("@ Observation obs-7")) {
+              /*
+               * The obs-7 invariant basically says that Observations should have values, unless
+               * they are made of components. This test replaces an invalid XPath expression
+               * that was causing correct instances to fail validation.
+               */
+              valid = validateObs7((Observation) entry.getResource());
+            } else if (emessage.getMessage().contains("@ Condition con-4")) {
+              /*
+               * The con-4 invariant says "If condition is abated, then clinicalStatus must be
+               * either inactive, resolved, or remission" which is very clear and sensical.
+               * However, the XPath expression does not evaluate correctly for valid instances,
+               * so we must manually validate.
+               */
+              valid = validateCon4((Condition) entry.getResource());
+            } else if (emessage.getMessage().contains("@ MedicationRequest mps-1")) {
+              /*
+               * The mps-1 invariant says MedicationRequest.requester.onBehalfOf can only be
+               * specified if MedicationRequest.requester.agent is practitioner or device.
+               * But the invariant is poorly written and does not correctly handle references
+               * starting with "urn:uuid"
+               */
+              valid = true; // ignore this error
+            } else if (emessage.getMessage().contains(
+                "per-1: If present, start SHALL have a lower value than end")) {
+              /*
+               * The per-1 invariant does not account for daylight savings time... so, if the
+               * daylight savings switch happens between the start and end, the validation
+               * fails, even if it is valid.
+               */
+              valid = true; // ignore this error
+            }
 
-              if (!valid) {
-                System.out.println(parser.encodeResourceToString(entry.getResource()));
-                System.out.println("ERROR: " + emessage.getMessage());
-                validationErrors.add(emessage.getMessage());
-              }
+            if (!valid) {
+              System.out.println(parser.encodeResourceToString(entry.getResource()));
+              System.out.println("ERROR: " + emessage.getMessage());
+              validationErrors.add(emessage.getMessage());
             }
           }
-          // Check ExplanationOfBenefit Resources against BlueButton
-          if (entry.getResource().fhirType().equals("ExplanationOfBenefit")) {
-            ValidationResult bbResult = validationResources.validateSTU3(entry.getResource());
+        }
+        // Check ExplanationOfBenefit Resources against BlueButton
+        if (entry.getResource().fhirType().equals("ExplanationOfBenefit")) {
+          ValidationResult bbResult = validationResources.validateSTU3(entry.getResource());
 
-            for (SingleValidationMessage message : bbResult.getMessages()) {
-              if (message.getMessage().contains("extension https://bluebutton.cms.gov/assets")) {
-                /*
-                 * The instance validator complains about the BlueButton extensions, ignore
-                 */
-                continue;
-              } else if (message.getSeverity() == ResultSeverityEnum.ERROR) {
-                if (!(message.getMessage().contains(
-                    "Element 'ExplanationOfBenefit.id': minimum required = 1, but only found 0")
-                    || message.getMessage().contains("Could not verify slice for profile"))) {
-                  // For some reason the validator is not detecting the IDs on the resources,
-                  // even though they appear to be present while debugging and during normal
-                  // operations.
-                  System.out.println(message.getSeverity() + ": " + message.getMessage());
-                  Assert.fail(message.getSeverity() + ": " + message.getMessage());
-                }
+          for (SingleValidationMessage message : bbResult.getMessages()) {
+            if (message.getMessage().contains("extension https://bluebutton.cms.gov/assets")) {
+              /*
+               * The instance validator complains about the BlueButton extensions, ignore
+               */
+              continue;
+            } else if (message.getSeverity() == ResultSeverityEnum.ERROR) {
+              if (!(message.getMessage().contains(
+                  "Element 'ExplanationOfBenefit.id': minimum required = 1, but only found 0")
+                  || message.getMessage().contains("Could not verify slice for profile"))) {
+                // For some reason the validator is not detecting the IDs on the resources,
+                // even though they appear to be present while debugging and during normal
+                // operations.
+                System.out.println(message.getSeverity() + ": " + message.getMessage());
+                Assert.fail(message.getSeverity() + ": " + message.getMessage());
               }
             }
           }
         }
       }
+
       int y = validationErrors.size();
       if (x != y) {
         Exporter.export(person, System.currentTimeMillis());


### PR DESCRIPTION
This PR intends to fix a few issues, mostly in unit tests, relating to memory usage and weird exceptions. This gets pretty involved so please don't hesitate to ask if the fixes aren't clear.

Note: when looking at the diff I highly recommend using "ignore whitespace changes" as the 3 FHIR exporter test diffs are mostly indentation changes

1. Occasionally I've seen `NotSerializableException`s in `GeneratorTest.testUpdateAfterCreationAndSerialization` because of FixedRecordGroup not being Serializable. At a glance this doesn't make sense because this test doesn't use fixed records. But deeper analysis revealed that our approach with `clone()` methods left some dangling references. 
   - First issue is that we aren't even using the `clone()` method correctly. The top-level `Object.clone()` already does a shallow copy of all fields on the object (see https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#clone-- ), so it's totally unnecessary to do it manually afterward. Instead we should make sure any object references or true "state" like when the State was entered/exited are explicitly nulled out. For the most part, there's nothing wrong with manually shallow copying fields to the clone, but I changed every State subclass to remove them anyway so we don't continue to use the unnecessary practice.  (Many say `clone()` is a bad practice by itself, but I'm not as worried about that for now)
   - So with that in mind, the one place where the shallow copy is a problem is on `ObservationGroup.observations`.  When the ObservationGroup (for example a DiagnosticReport state) gets processed, it calls `process` on each sub-observation, and that sets true state on the sub-observation, specifically the `entry` field. So what wound up happening is every instance of DiagnosticReport states shared the same instances of the subobservations, and things were stomping over each other all the time. I suspect there are a lot of ways this caused weirdness, but it was only really exposed in that unit test - the FixedRecordGroupTest ran and created a patient that had a FixedRecordGroup in their attributes, then later this test created a patient, and through a long chain of object references they linked back to that old patient. 
     - An actual example of a sequence of fields that got serialized:
person -> attributes -> list of one module's history -> state object -> module object -> list of all states in that module -> a diagnostic report state -> list of observations -> one observation -> healthrecord entry -> healthrecord -> encounters list -> one encounter -> claim -> person (not the same person we started with!) -> ...
---
2. `OutOfMemoryError`s tend to happen on the FHIRR4ExporterTest, and this is also one of the longest-running tests we have. The basic approach the 3 FHIR exporter tests take is:
   - for 1..10, generate a new patient
   - export the patient as FHIR JSON
   - parse the JSON back into a Resource
   - validate the Resource
   - if the Resource isn't valid (has errors), re-parse it as a Bundle, then validate each Resource in the Bundle individually, to check for known issues

It turns out that the way the FHIR validator works is to convert a Resource into a (XML) string, then parse that into an object tree of Elements. That parsing and the subsequent size of the tree is where OutOfMemoryErrors happen. (And when it's not an OOM, it often takes a long time because of memory pressure)
So my suggestion is to skip the validation of the Bundle as a whole, and just validate the individual Resources. For any patients where the bundle doesn't pass initial validation, this is definitely faster because it's just removing that first pass. For patients where the initial pass does succeed, I think this will probably be roughly the same amount of time, because the full bundle validation has to iterate over every resource anyway.  The main downside of this approach would be that it doesn't validate references within the Bundle, but actually I don't think the validator checks that as it is today. 

---
3. Some memory usage minutiae: 
   - Cleared out the static list Exporter.deferredExports once the records are actually exported, so they can be GC'ed
   - Changed FixedRecordTest.generator to be an instance variable instead of a static, again so it can be GC'ed