### PR TITLE
Fix test that fails towards end of calendar year

### DIFF
--- a/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.gson.JsonPrimitive;
+
+import java.util.Calendar;
 import java.util.Date;
 import org.junit.Test;
 import org.mitre.synthea.world.agents.Person;
@@ -27,7 +29,9 @@ public class UtilitiesTest {
   @Test
   public void testYears() {
     int gap = 75;
-    long time = System.currentTimeMillis();
+    Calendar calendar = Calendar.getInstance();
+    calendar.set(2020, Calendar.FEBRUARY, 1);
+    long time = calendar.getTimeInMillis();
     int year = Utilities.getYear(time);
     long earlierTime = time - Utilities.convertTime("years", gap);
     int earlierYear = Utilities.getYear(earlierTime);


### PR DESCRIPTION
testYears fails towards the end of the calendar year. This is due to the
fact that the convertTime method does not account for leap years.
Unfortunately, code in other parts of Synthea depends on this behavior.
This fixes the test from failing by using a fixed date for the test as
opposed to the current time, ensuring that the code doesn't encounter
a problematic date.

This PR eliminates the need for #842. 