### PR TITLE
Remove deprecated code

### DIFF
--- a/src/main/java/Graphviz.java
+++ b/src/main/java/Graphviz.java
@@ -83,7 +83,7 @@ public class Graphviz {
     System.out.format("Loading %s\n", path.toString());
     FileReader fileReader = new FileReader(path.toString());
     JsonReader reader = new JsonReader(fileReader);
-    JsonObject object = new JsonParser().parse(reader).getAsJsonObject();
+    JsonObject object = JsonParser.parseReader(reader).getAsJsonObject();
     fileReader.close();
     reader.close();
     return object;

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -189,8 +189,7 @@ public class Module implements Cloneable, Serializable {
     if (overrides != null) {
       jsonString = applyOverrides(jsonString, overrides, path.getFileName().toString());
     }
-    JsonParser parser = new JsonParser();
-    JsonObject object = parser.parse(jsonString).getAsJsonObject();
+    JsonObject object = JsonParser.parseString(jsonString).getAsJsonObject();
     return new Module(object, submodule);
   }
 

--- a/src/main/java/org/mitre/synthea/helpers/Attributes.java
+++ b/src/main/java/org/mitre/synthea/helpers/Attributes.java
@@ -135,7 +135,7 @@ public class Attributes {
 
     Utilities.walkAllModules((basePath, modulePath) -> {
       try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
-        JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
+        JsonObject module = JsonParser.parseReader(reader).getAsJsonObject();
         inventoryModule(attributes, module);
       } catch (IOException e) {
         throw new RuntimeException("Unable to read modules", e);

--- a/src/main/java/org/mitre/synthea/helpers/Concepts.java
+++ b/src/main/java/org/mitre/synthea/helpers/Concepts.java
@@ -72,7 +72,7 @@ public class Concepts {
 
     Utilities.walkAllModules((modulesPath, modulePath) -> {
       try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
-        JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
+        JsonObject module = JsonParser.parseReader(reader).getAsJsonObject();
         inventoryModule(concepts, module);
       } catch (IOException e) {
         throw new RuntimeException("Unable to read modules", e);

--- a/src/main/java/org/mitre/synthea/helpers/ModuleOverrides.java
+++ b/src/main/java/org/mitre/synthea/helpers/ModuleOverrides.java
@@ -148,7 +148,7 @@ public class ModuleOverrides {
     }
 
     try (JsonReader reader = new JsonReader(new FileReader(modulePath.toString()))) {
-      JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
+      JsonObject module = JsonParser.parseReader(reader).getAsJsonObject();
 
       String lineStart = moduleFilename + "\\:\\:$";
       lines.addAll(handleElement(lineStart, "$", module));

--- a/src/test/java/org/mitre/synthea/engine/LogicTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LogicTest.java
@@ -69,7 +69,7 @@ public class LogicTest {
     Path modulesFolder = Paths.get("src/test/resources/generic");
     Path logicFile = modulesFolder.resolve("logic.json");
     JsonReader reader = new JsonReader(new FileReader(logicFile.toString()));
-    tests = new JsonParser().parse(reader).getAsJsonObject();
+    tests = JsonParser.parseReader(reader).getAsJsonObject();
     reader.close();
   }
 

--- a/src/test/java/org/mitre/synthea/engine/ModuleTest.java
+++ b/src/test/java/org/mitre/synthea/engine/ModuleTest.java
@@ -194,8 +194,7 @@ public class ModuleTest {
           "resources", "future_module", "module_from_the_future.json"))
           .stream()
           .collect(Collectors.joining("\n"));
-      JsonParser parser = new JsonParser();
-      JsonObject object = parser.parse(jsonString).getAsJsonObject();
+      JsonObject object = JsonParser.parseString(jsonString).getAsJsonObject();
       new Module(object, false);
       // Should never get here
       fail("Didn't throw exception when loading module with version from the future");
@@ -270,8 +269,7 @@ public class ModuleTest {
       try {
         FileReader fileReader = new FileReader(t.toString());
         JsonReader reader = new JsonReader(fileReader);
-        JsonParser parser = new JsonParser();
-        JsonObject object = parser.parse(reader).getAsJsonObject();
+        JsonObject object = JsonParser.parseReader(reader).getAsJsonObject();
         JsonObject states = object.getAsJsonObject("states");
         for (String stateName : states.keySet()) {
           JsonObject state = states.getAsJsonObject(stateName);

--- a/src/test/java/org/mitre/synthea/helpers/ConceptsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/ConceptsTest.java
@@ -56,7 +56,7 @@ public class ConceptsTest {
     Path modulePath = modulesFolder.resolve("example_module.json");
     
     JsonReader reader = new JsonReader(new FileReader(modulePath.toString()));
-    JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
+    JsonObject module = JsonParser.parseReader(reader).getAsJsonObject();
     
     // example_module has 4 codes:
     List<Code> codes = new ArrayList<Code>();
@@ -79,7 +79,7 @@ public class ConceptsTest {
     Path modulePath = modulesFolder.resolve("condition_onset.json");
     
     JsonReader reader = new JsonReader(new FileReader(modulePath.toString()));
-    JsonObject module = new JsonParser().parse(reader).getAsJsonObject();
+    JsonObject module = JsonParser.parseReader(reader).getAsJsonObject();
     JsonObject state = module.getAsJsonObject("states").getAsJsonObject("Appendicitis");
     
     Concepts.inventoryState(concepts, state, module.get("name").getAsString());


### PR DESCRIPTION
Cleans up use of deprecated methods in both the main source code and test suite. This eliminates warnings for deprecation when the project builds.