### PR TITLE
Change procedures.csv DATE column to START and STOP

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -277,7 +277,7 @@ public class CSVExporter {
     careplans.write(NEWLINE);
     observations.write("DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,VALUE,UNITS,TYPE");
     observations.write(NEWLINE);
-    procedures.write("DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,BASE_COST,"
+    procedures.write("START,STOP,PATIENT,ENCOUNTER,CODE,DESCRIPTION,BASE_COST,"
         + "REASONCODE,REASONDESCRIPTION");
     procedures.write(NEWLINE);
     immunizations.write("DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,BASE_COST");
@@ -787,10 +787,14 @@ public class CSVExporter {
    */
   private void procedure(String personID, String encounterID,
       Procedure procedure) throws IOException {
-    // DATE,PATIENT,ENCOUNTER,CODE,DESCRIPTION,COST,REASONCODE,REASONDESCRIPTION
+    // START,STOP,PATIENT,ENCOUNTER,CODE,DESCRIPTION,COST,REASONCODE,REASONDESCRIPTION
     StringBuilder s = new StringBuilder();
 
     s.append(iso8601Timestamp(procedure.start)).append(',');
+    if (procedure.stop != 0L) {
+      s.append(iso8601Timestamp(procedure.stop));
+    }
+    s.append(',');
     s.append(personID).append(',');
     s.append(encounterID).append(',');
     // CODE


### PR DESCRIPTION
Updates the procedures.csv exporter to export the procedure end time, so we can track procedure duration. This was already in the HealthRecord data model, we just weren't exporting it in CSV. For consistency with other tables, I renamed the DATE column to START, so we now have START and STOP.

I think this might be the first time we are renaming a CSV column, and since we can't regenerate every old dataset that someone may have, I suggest we mention this in the wiki:

# Procedures
| | Column Name | Data Type | Required? | Description |
|-|-------------|-----------|-----------|-------------|
| | Start <br/> ("Date", prior to v3.0.0 ) | iso8601 UTC Date (`yyyy-MM-dd'T'HH:mm'Z'`) | `true` | The date and time the procedure was performed. |
| | Stop | iso8601 UTC Date (`yyyy-MM-dd'T'HH:mm'Z'`) | `false` | The date and time the procedure was completed, if applicable. 
| :old_key: | Patient | UUID | `true` | Foreign key to the Patient. |
| :old_key: | Encounter | UUID | `true` | Foreign key to the Encounter where the procedure was performed. 
| | Code | String | `true` | Procedure code from SNOMED-CT |
| | Description | String | `true` | Description of the procedure. |
| | Base_Cost | Numeric | `true` | The line item cost of the procedure. |
| | ReasonCode | String | `false` | Diagnosis code from SNOMED-CT specifying why this procedure was performed. |
| | ReasonDescription | String | `false` | Description of the reason code. |