### PR TITLE
Update run_synthea.bat to not evaluate args

### DIFF
--- a/run_synthea.bat
+++ b/run_synthea.bat
@@ -14,10 +14,12 @@ IF "%~1" == "" (
   @rem Running Synthea with arguments
   @rem For simplicity, do nothing and just pass the args to gradle
   SET syntheaArgs= 
-  for %%x in (%*) do (
-    SET syntheaArgs=!syntheaArgs!'%%~x',
-    @rem Trailing comma ok, don't need to remove it
-  ) 
-  
+
+  :loop
+  SET syntheaArgs=!syntheaArgs!'%1',
+  @rem Trailing comma ok, don't need to remove it
+  shift
+  if not "%~1"=="" goto loop
+
   gradlew.bat run -Params="[!syntheaArgs!]"
 )


### PR DESCRIPTION
The Windows batch script `run_synthea.bat` has a minor bug where as it copies arguments to pass into gradle, it also evaluates them. Most of the time this will have no impact, but if one of the command line args contains a wildcard (`*`) then this evaluates it again unexpectedly, and it essentially deletes that arg.
Note that I said "again" - the windows shell already does expansion once for anything that matches a wildcard, so for instance in the main synthea folder `g*` becomes `gradle gradlew gradlew.bat` but `go*` would stay `go*` since there are no maches. But in short I don't think there's any scenario where evaluating it a second time would be correct. This is tough to explain so some examples are below.

Really this only affects the `-m` flag, or possibly some config settings, but in case there are other uses in the future where we want wildcards I suggest we fix this.

Some commentary from stackoverflow:
 - The old version: https://stackoverflow.com/a/40974776
 - The new version: https://stackoverflow.com/a/39776524
 - In particular see the comments from "Arnaud"

For testing this I recommend adding a line to `main()` in `App.java`, to see what the app actually receives:
```java
System.out.println(Arrays.toString(args));
```


Examples:

`run_synthea Massachusetts`
Old: `[Massachusetts]`
New: `[Massachusetts]`

`run_synthea -m metabolic*`
Old: `[-m]`
New: `[-m, metabolic*]`


`run_synthea -m metabolic* Massachusetts`
Old: `[-m, Massachusetts]`
New: `[-m, metabolic*, Massachusetts]`


`run_synthea --dummy-setting g*`
Old: `[--dummy-setting, .gitignore, gradlew, gradlew.bat]`
New: `[--dummy-setting, gradle, gradlew, gradlew.bat]`
(I just noticed this one is different... huh? Needs another look but I have to run)

`run_synthea --dummy-setting go*`
Old: `[--dummy-setting]`
New: `[--dummy-setting, go*]`
