### PR TITLE
Odds and Ends

### DIFF
--- a/src/main/java/Graphviz.java
+++ b/src/main/java/Graphviz.java
@@ -655,7 +655,7 @@ public class Graphviz {
             + valueString + NEWLINE;
       case "Vital Sign":
         return "Vital Sign " + logic.get("vital_sign").getAsString() + " \\"
-            + logic.get("operator").getAsString() + " " + logic.get("value").getAsString() + "}"
+            + logic.get("operator").getAsString() + " " + logic.get("value").getAsString()
             + NEWLINE;
       case "Active Condition":
         String cond = findReferencedType(logic);

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -257,7 +257,8 @@ public abstract class State implements Cloneable, Serializable {
       if (completed) {
         // keep track of when the submodule exited, in case it was "rewinding time" when it completed
         if (person.history.get(0).exited == null) {
-          // temporary hack. figure out why we need this for the unit tests
+          // this happens when the patient dies in the submodule, so processing is going to stop anyway
+          // but just to be safe and not crash, we'll assume we exited at the current timestep
           this.submoduleExited = time;
         } else {
           this.submoduleExited = person.history.get(0).exited;

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -251,7 +251,10 @@ public abstract class State implements Cloneable, Serializable {
 
       if (completed) {
         // add the history from the submodule to this module's history, at the front
-        moduleHistory.addAll(0, person.history);
+        if (moduleHistory != person.history) {
+          // if the submodule is a java module, it didn't create its own history
+          moduleHistory.addAll(0, person.history);
+        }
         // clear the submodule history
         person.attributes.remove(submod.name);
         // reset person.history to this module's history

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -14,9 +14,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math.ode.DerivativeException;
 import org.mitre.synthea.engine.Components.Attachment;
 import org.mitre.synthea.engine.Components.Exact;
@@ -257,10 +256,13 @@ public abstract class State implements Cloneable, Serializable {
       boolean completed = submod.process(person, time);
 
       if (completed) {
-        // keep track of when the submodule exited, in case it was "rewinding time" when it completed
+        // keep track of when the submodule exited,
+        // in case it was "rewinding time" when it completed
         if (person.history.get(0).exited == null) {
-          // this happens when the patient dies in the submodule, so processing is going to stop anyway
-          // but just to be safe and not crash, we'll assume we exited at the current timestep
+          // this happens when the patient dies in the submodule,
+          // so processing is going to stop anyway
+          // but just to be safe and not crash,
+          // we'll assume we exited at the current timestep
           this.submoduleExited = time;
         } else {
           this.submoduleExited = person.history.get(0).exited;
@@ -1611,17 +1613,11 @@ public abstract class State implements Cloneable, Serializable {
     protected void validate(Module module, String name) {
       if (exact != null || range != null) {
         // units are required
-        if (unit == null || unit.isEmpty()) {
+        if (StringUtils.isBlank(unit)) {
           throw new RuntimeException(
-              "Observations with numeric quantities must contain units matching pattern [^\\s]+: "
-          + "Module \"" + module.name + "\": State \"" + name + "\": Unit missing or empty");
-        }
-
-        String regex = "[^\\s]+";
-        if (!Pattern.matches(regex, unit)) {
-          throw new RuntimeException(
-              "Observations with numeric quantities must contain units matching pattern [^\\s]+: "
-          + "Module \"" + module.name + "\": State \"" + name + "\": Unit \"" + unit + "\"");
+              "Observations with numeric quantities must contain non-blank units. "
+          + "Module \"" + module.name + "\": State \"" + name
+          + "\": Unit is missing, empty, or all whitespace");
         }
       }
 

--- a/src/main/java/org/mitre/synthea/engine/Transition.java
+++ b/src/main/java/org/mitre/synthea/engine/Transition.java
@@ -283,13 +283,13 @@ public abstract class Transition implements Serializable {
         } else if (currentAttribute.equalsIgnoreCase("time")) {
           // do nothing, we already have it
         } else {
-          String personsAttribute
-              = (String) person.attributes.get(currentAttribute.toLowerCase());
-          if (personsAttribute == null) {
-            throw new RuntimeException("LOOKUP TABLE ERROR: Attribute '"
-                + currentAttribute + "' in CSV table '" + this.lookupTableName
-                + "' does not exist as one of this person's attributes.");
+          if (!person.attributes.containsKey(currentAttribute)) {
+        	throw new RuntimeException("LOOKUP TABLE ERROR: Attribute '"
+        		+ currentAttribute + "' in CSV table '" + this.lookupTableName
+        		+ "' does not exist as one of this person's attributes.");
           }
+          String personsAttribute
+              = person.attributes.get(currentAttribute).toString();
           personsAttributes.add(personsAttribute);
         }
       }

--- a/src/main/java/org/mitre/synthea/engine/Transition.java
+++ b/src/main/java/org/mitre/synthea/engine/Transition.java
@@ -284,9 +284,9 @@ public abstract class Transition implements Serializable {
           // do nothing, we already have it
         } else {
           if (!person.attributes.containsKey(currentAttribute)) {
-        	throw new RuntimeException("LOOKUP TABLE ERROR: Attribute '"
-        		+ currentAttribute + "' in CSV table '" + this.lookupTableName
-        		+ "' does not exist as one of this person's attributes.");
+            throw new RuntimeException("LOOKUP TABLE ERROR: Attribute '"
+                + currentAttribute + "' in CSV table '" + this.lookupTableName
+                + "' does not exist as one of this person's attributes.");
           }
           String personsAttribute
               = person.attributes.get(currentAttribute).toString();

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -139,7 +139,14 @@ public class Utilities {
   public static double convertRiskToTimestep(double risk, double originalPeriodInMS) {
     double currTimeStepInMS = Double.parseDouble(Config.get("generate.timestep"));
 
-    return 1 - Math.pow(1 - risk, currTimeStepInMS / originalPeriodInMS);
+    return convertRiskToTimestep(risk, originalPeriodInMS, currTimeStepInMS);
+  }
+  
+  /**
+   * Calculates 1 - (1-risk)^(newTimeStepInMS/originalPeriodInMS).
+   */
+  public static double convertRiskToTimestep(double risk, double originalPeriodInMS, double newTimeStepInMS) {
+    return 1 - Math.pow(1 - risk, newTimeStepInMS / originalPeriodInMS);
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -145,7 +145,8 @@ public class Utilities {
   /**
    * Calculates 1 - (1-risk)^(newTimeStepInMS/originalPeriodInMS).
    */
-  public static double convertRiskToTimestep(double risk, double originalPeriodInMS, double newTimeStepInMS) {
+  public static double convertRiskToTimestep(double risk, double originalPeriodInMS,
+      double newTimeStepInMS) {
     return 1 - Math.pow(1 - risk, newTimeStepInMS / originalPeriodInMS);
   }
 

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -7,10 +7,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import org.hl7.fhir.r4.model.Patient;
 import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.helpers.Attributes;
 import org.mitre.synthea.helpers.Attributes.Inventory;
@@ -18,7 +16,6 @@ import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.PhysiologyValueGenerator;
 import org.mitre.synthea.helpers.RandomCollection;
 import org.mitre.synthea.helpers.SimpleCSV;
-import org.mitre.synthea.helpers.SimpleYML;
 import org.mitre.synthea.helpers.TrendingValueGenerator;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.input.FixedRecord;
@@ -34,6 +31,7 @@ import org.mitre.synthea.world.concepts.HealthRecord.Code;
 import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
 import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
 import org.mitre.synthea.world.concepts.HealthRecord.Procedure;
+import org.mitre.synthea.world.concepts.Names;
 import org.mitre.synthea.world.concepts.PediatricGrowthTrajectory;
 import org.mitre.synthea.world.concepts.VitalSign;
 import org.mitre.synthea.world.geography.Location;
@@ -57,7 +55,6 @@ public final class LifecycleModule extends Module {
 
   private static RandomCollection<String> sexualOrientationData = loadSexualOrientationData();
 
-  private static SimpleYML names = loadNames();
 
   public LifecycleModule() {
     this.name = "Lifecycle";
@@ -70,18 +67,6 @@ public final class LifecycleModule extends Module {
       return SimpleCSV.parse(data);
     } catch (Exception e) {
       System.err.println("ERROR: unable to load csv: " + filename);
-      e.printStackTrace();
-      throw new ExceptionInInitializerError(e);
-    }
-  }
-
-  private static SimpleYML loadNames() {
-    String filename = "names.yml";
-    try {
-      String namesData = Utilities.readResource(filename);
-      return new SimpleYML(namesData);
-    } catch (Exception e) {
-      System.err.println("ERROR: unable to load yml: " + filename);
       e.printStackTrace();
       throw new ExceptionInInitializerError(e);
     }
@@ -139,27 +124,27 @@ public final class LifecycleModule extends Module {
     attributes.put(Person.BIRTHDATE, time);
     String gender = (String) attributes.get(Person.GENDER);
     String language = (String) attributes.get(Person.FIRST_LANGUAGE);
-    String firstName = fakeFirstName(gender, language, person);
-    String lastName = fakeLastName(language, person);
+    String firstName = Names.fakeFirstName(gender, language, person);
+    String lastName = Names.fakeLastName(language, person);
     if (appendNumbersToNames) {
-      firstName = addHash(firstName);
-      lastName = addHash(lastName);
+      firstName = Names.addHash(firstName);
+      lastName = Names.addHash(lastName);
     }
     attributes.put(Person.FIRST_NAME, firstName);
     attributes.put(Person.LAST_NAME, lastName);
     attributes.put(Person.NAME, firstName + " " + lastName);
 
-    String motherFirstName = fakeFirstName("F", language, person);
-    String motherLastName = fakeLastName(language, person);
+    String motherFirstName = Names.fakeFirstName("F", language, person);
+    String motherLastName = Names.fakeLastName(language, person);
     if (appendNumbersToNames) {
-      motherFirstName = addHash(motherFirstName);
-      motherLastName = addHash(motherLastName);
+      motherFirstName = Names.addHash(motherFirstName);
+      motherLastName = Names.addHash(motherLastName);
     }
     attributes.put(Person.NAME_MOTHER, motherFirstName + " " + motherLastName);
     
-    String fatherFirstName = fakeFirstName("M", language, person);
+    String fatherFirstName = Names.fakeFirstName("M", language, person);
     if (appendNumbersToNames) {
-      fatherFirstName = addHash(fatherFirstName);
+      fatherFirstName = Names.addHash(fatherFirstName);
     }
     // this is anglocentric where the baby gets the father's last name
     attributes.put(Person.NAME_FATHER, fatherFirstName + " " + lastName);
@@ -175,7 +160,7 @@ public final class LifecycleModule extends Module {
     attributes.put(Person.TELECOM, phoneNumber);
 
     boolean hasStreetAddress2 = person.rand() < 0.5;
-    attributes.put(Person.ADDRESS, fakeAddress(hasStreetAddress2, person));
+    attributes.put(Person.ADDRESS, Names.fakeAddress(hasStreetAddress2, person));
 
     // If using FixedRecords, overwrite the person's attributes with the FixedRecord attributes.
     if (person.attributes.get(Person.RECORD_GROUP) != null) {
@@ -273,86 +258,6 @@ public final class LifecycleModule extends Module {
   }
 
   /**
-   * Generate a first name appropriate for a given gender and language.
-   * @param gender Gender of the name, "M" or "F"
-   * @param language Origin language of the name, "english", "spanish"
-   * @param person person to generate a name for.
-   * @return First name.
-   */
-  @SuppressWarnings("unchecked")
-  public static String fakeFirstName(String gender, String language, Person person) {
-    List<String> choices;
-    if ("spanish".equalsIgnoreCase(language)) {
-      choices = (List<String>) names.get("spanish." + gender);
-    } else {
-      choices = (List<String>) names.get("english." + gender);
-    }
-    // pick a random item from the list
-    return choices.get(person.randInt(choices.size()));
-  }
-
-  /**
-   * Generate a surname appropriate for a given language.
-   * @param language Origin language of the name, "english", "spanish"
-   * @param person person to generate a name for.
-   * @return Surname or Family Name.
-   */
-  @SuppressWarnings("unchecked")
-  public static String fakeLastName(String language, Person person) {
-    List<String> choices;
-    if ("spanish".equalsIgnoreCase(language)) {
-      choices = (List<String>) names.get("spanish.family");
-    } else {
-      choices = (List<String>) names.get("english.family");
-    }
-    // pick a random item from the list
-    return choices.get(person.randInt(choices.size()));
-  }
-
-  /**
-   * Generate a Street Address.
-   * @param includeLine2 Whether or not the address should have a second line,
-   *     which can take the form of an apartment, unit, or suite number.
-   * @param person person to generate an address for.
-   * @return First name.
-   */
-  @SuppressWarnings("unchecked")
-  public static String fakeAddress(boolean includeLine2, Person person) {
-    int number = person.randInt(1000) + 100;
-    List<String> n = (List<String>)names.get("english.family");
-    // for now just use family names as the street name.
-    // could expand with a few more but probably not worth it
-    String streetName = n.get(person.randInt(n.size()));
-    List<String> a = (List<String>)names.get("street.type");
-    String streetType = a.get(person.randInt(a.size()));
-    
-    if (includeLine2) {
-      int addtlNum = person.randInt(100);
-      List<String> s = (List<String>)names.get("street.secondary");
-      String addtlType = s.get(person.randInt(s.size()));
-      return number + " " + streetName + " " + streetType + " " + addtlType + " " + addtlNum;
-    } else {
-      return number + " " + streetName + " " + streetType;
-    }
-  }
-
-  /**
-   * Adds a 1- to 3-digit hashcode to the end of the name.
-   * @param name Person's name
-   * @return The name with a hash appended, ex "John123" or "Smith22"
-   */
-  public static String addHash(String name) {
-    // note that this value should be deterministic
-    // It cannot be a random number. It needs to be a hash value or something deterministic.
-    // We do not want John10 and John52 -- we want all the Johns to have the SAME numbers. e.g. All
-    // people named John become John52
-    // Why? Because we do not know how using systems will index names. Say a user of an system
-    // loaded with Synthea data wants to find all the people named John Smith. This will be easier
-    // if John Smith always resolves to John52 Smith32 and not [John52 Smith32, John10 Smith22, ...]
-    return name + Integer.toString(Math.abs(name.hashCode() % 1000));
-  }
-
-  /**
    * Age the patient.
    *
    * @return whether or not the patient should grow
@@ -416,9 +321,9 @@ public final class LifecycleModule extends Module {
               person.attributes.put(Person.MAIDEN_NAME, person.attributes.get(Person.LAST_NAME));
               String firstName = ((String) person.attributes.get(Person.FIRST_NAME));
               String language = (String) person.attributes.get(Person.FIRST_LANGUAGE);
-              String newLastName = fakeLastName(language, person);
+              String newLastName = Names.fakeLastName(language, person);
               if (appendNumbersToNames) {
-                newLastName = addHash(newLastName);
+                newLastName = Names.addHash(newLastName);
               }
               person.attributes.put(Person.LAST_NAME, newLastName);
               person.attributes.put(Person.NAME, firstName + " " + newLastName);

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -49,8 +49,6 @@ public final class LifecycleModule extends Module {
   public static final String QUIT_ALCOHOLISM_AGE = "quit alcoholism age";
   public static final String ADHERENCE_PROBABILITY = "adherence probability";
 
-  public static final boolean appendNumbersToNames =
-      Config.getAsBoolean("generate.append_numbers_to_person_names", false);
   private static final String COUNTRY_CODE = Config.get("generate.geography.country_code");
 
   private static RandomCollection<String> sexualOrientationData = loadSexualOrientationData();
@@ -126,26 +124,15 @@ public final class LifecycleModule extends Module {
     String language = (String) attributes.get(Person.FIRST_LANGUAGE);
     String firstName = Names.fakeFirstName(gender, language, person);
     String lastName = Names.fakeLastName(language, person);
-    if (appendNumbersToNames) {
-      firstName = Names.addHash(firstName);
-      lastName = Names.addHash(lastName);
-    }
     attributes.put(Person.FIRST_NAME, firstName);
     attributes.put(Person.LAST_NAME, lastName);
     attributes.put(Person.NAME, firstName + " " + lastName);
 
     String motherFirstName = Names.fakeFirstName("F", language, person);
     String motherLastName = Names.fakeLastName(language, person);
-    if (appendNumbersToNames) {
-      motherFirstName = Names.addHash(motherFirstName);
-      motherLastName = Names.addHash(motherLastName);
-    }
     attributes.put(Person.NAME_MOTHER, motherFirstName + " " + motherLastName);
     
     String fatherFirstName = Names.fakeFirstName("M", language, person);
-    if (appendNumbersToNames) {
-      fatherFirstName = Names.addHash(fatherFirstName);
-    }
     // this is anglocentric where the baby gets the father's last name
     attributes.put(Person.NAME_FATHER, fatherFirstName + " " + lastName);
 
@@ -322,9 +309,6 @@ public final class LifecycleModule extends Module {
               String firstName = ((String) person.attributes.get(Person.FIRST_NAME));
               String language = (String) person.attributes.get(Person.FIRST_LANGUAGE);
               String newLastName = Names.fakeLastName(language, person);
-              if (appendNumbersToNames) {
-                newLastName = Names.addHash(newLastName);
-              }
               person.attributes.put(Person.LAST_NAME, newLastName);
               person.attributes.put(Person.NAME, firstName + " " + newLastName);
             }

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -31,6 +31,7 @@ import org.mitre.synthea.world.agents.behaviors.ProviderFinderQuality;
 import org.mitre.synthea.world.agents.behaviors.ProviderFinderRandom;
 import org.mitre.synthea.world.concepts.ClinicianSpecialty;
 import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
+import org.mitre.synthea.world.concepts.Names;
 import org.mitre.synthea.world.geography.Demographics;
 import org.mitre.synthea.world.geography.Location;
 import org.mitre.synthea.world.geography.quadtree.QuadTree;
@@ -61,6 +62,9 @@ public class Provider implements QuadTreeElement, Serializable {
       Config.get("generate.providers.selection_behavior", "nearest").toLowerCase();
   private static IProviderFinder providerFinder = buildProviderFinder();
 
+  public static final boolean appendNumbersToNames =
+      Config.getAsBoolean("generate.append_numbers_to_person_names", false);
+  
   public Map<String, Object> attributes;
   public String uuid;
   private String locationUuid;
@@ -473,12 +477,12 @@ public class Provider implements QuadTreeElement, Serializable {
       clinician.attributes.put(Person.ZIP, provider.zip);
       clinician.attributes.put(Person.COORDINATE, provider.coordinates);
 
-      String firstName = LifecycleModule.fakeFirstName(gender, language, doc);
-      String lastName = LifecycleModule.fakeLastName(language, doc);
+      String firstName = Names.fakeFirstName(gender, language, doc);
+      String lastName = Names.fakeLastName(language, doc);
 
-      if (LifecycleModule.appendNumbersToNames) {
-        firstName = LifecycleModule.addHash(firstName);
-        lastName = LifecycleModule.addHash(lastName);
+      if (appendNumbersToNames) {
+        firstName = Names.addHash(firstName);
+        lastName = Names.addHash(lastName);
       }
       clinician.attributes.put(Clinician.FIRST_NAME, firstName);
       clinician.attributes.put(Clinician.LAST_NAME, lastName);

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -24,7 +24,6 @@ import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
-import org.mitre.synthea.modules.LifecycleModule;
 import org.mitre.synthea.world.agents.behaviors.IProviderFinder;
 import org.mitre.synthea.world.agents.behaviors.ProviderFinderNearest;
 import org.mitre.synthea.world.agents.behaviors.ProviderFinderQuality;
@@ -61,9 +60,6 @@ public class Provider implements QuadTreeElement, Serializable {
   public static final String PROVIDER_SELECTION_BEHAVIOR =
       Config.get("generate.providers.selection_behavior", "nearest").toLowerCase();
   private static IProviderFinder providerFinder = buildProviderFinder();
-
-  public static final boolean appendNumbersToNames =
-      Config.getAsBoolean("generate.append_numbers_to_person_names", false);
   
   public Map<String, Object> attributes;
   public String uuid;
@@ -479,11 +475,6 @@ public class Provider implements QuadTreeElement, Serializable {
 
       String firstName = Names.fakeFirstName(gender, language, doc);
       String lastName = Names.fakeLastName(language, doc);
-
-      if (appendNumbersToNames) {
-        firstName = Names.addHash(firstName);
-        lastName = Names.addHash(lastName);
-      }
       clinician.attributes.put(Clinician.FIRST_NAME, firstName);
       clinician.attributes.put(Clinician.LAST_NAME, lastName);
       clinician.attributes.put(Clinician.NAME, firstName + " " + lastName);

--- a/src/main/java/org/mitre/synthea/world/concepts/Names.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/Names.java
@@ -1,0 +1,104 @@
+package org.mitre.synthea.world.concepts;
+
+import java.util.List;
+
+import org.mitre.synthea.helpers.SimpleYML;
+import org.mitre.synthea.helpers.Utilities;
+import org.mitre.synthea.world.agents.Person;
+
+public class Names {
+  
+  private static SimpleYML names = loadNames();
+  
+  private static SimpleYML loadNames() {
+    String filename = "names.yml";
+    try {
+      String namesData = Utilities.readResource(filename);
+      return new SimpleYML(namesData);
+    } catch (Exception e) {
+      System.err.println("ERROR: unable to load yml: " + filename);
+      e.printStackTrace();
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+  
+  /**
+   * Generate a first name appropriate for a given gender and language.
+   * @param gender Gender of the name, "M" or "F"
+   * @param language Origin language of the name, "english", "spanish"
+   * @param person person to generate a name for.
+   * @return First name.
+   */
+  @SuppressWarnings("unchecked")
+  public static String fakeFirstName(String gender, String language, Person person) {
+    List<String> choices;
+    if ("spanish".equalsIgnoreCase(language)) {
+      choices = (List<String>) names.get("spanish." + gender);
+    } else {
+      choices = (List<String>) names.get("english." + gender);
+    }
+    // pick a random item from the list
+    return choices.get(person.randInt(choices.size()));
+  }
+
+  /**
+   * Generate a surname appropriate for a given language.
+   * @param language Origin language of the name, "english", "spanish"
+   * @param person person to generate a name for.
+   * @return Surname or Family Name.
+   */
+  @SuppressWarnings("unchecked")
+  public static String fakeLastName(String language, Person person) {
+    List<String> choices;
+    if ("spanish".equalsIgnoreCase(language)) {
+      choices = (List<String>) names.get("spanish.family");
+    } else {
+      choices = (List<String>) names.get("english.family");
+    }
+    // pick a random item from the list
+    return choices.get(person.randInt(choices.size()));
+  }
+
+  /**
+   * Generate a Street Address.
+   * @param includeLine2 Whether or not the address should have a second line,
+   *     which can take the form of an apartment, unit, or suite number.
+   * @param person person to generate an address for.
+   * @return First name.
+   */
+  @SuppressWarnings("unchecked")
+  public static String fakeAddress(boolean includeLine2, Person person) {
+    int number = person.randInt(1000) + 100;
+    List<String> n = (List<String>)names.get("english.family");
+    // for now just use family names as the street name.
+    // could expand with a few more but probably not worth it
+    String streetName = n.get(person.randInt(n.size()));
+    List<String> a = (List<String>)names.get("street.type");
+    String streetType = a.get(person.randInt(a.size()));
+    
+    if (includeLine2) {
+      int addtlNum = person.randInt(100);
+      List<String> s = (List<String>)names.get("street.secondary");
+      String addtlType = s.get(person.randInt(s.size()));
+      return number + " " + streetName + " " + streetType + " " + addtlType + " " + addtlNum;
+    } else {
+      return number + " " + streetName + " " + streetType;
+    }
+  }
+
+  /**
+   * Adds a 1- to 3-digit hashcode to the end of the name.
+   * @param name Person's name
+   * @return The name with a hash appended, ex "John123" or "Smith22"
+   */
+  public static String addHash(String name) {
+    // note that this value should be deterministic
+    // It cannot be a random number. It needs to be a hash value or something deterministic.
+    // We do not want John10 and John52 -- we want all the Johns to have the SAME numbers. e.g. All
+    // people named John become John52
+    // Why? Because we do not know how using systems will index names. Say a user of an system
+    // loaded with Synthea data wants to find all the people named John Smith. This will be easier
+    // if John Smith always resolves to John52 Smith32 and not [John52 Smith32, John10 Smith22, ...]
+    return name + Integer.toString(Math.abs(name.hashCode() % 1000));
+  }
+}

--- a/src/main/java/org/mitre/synthea/world/concepts/Names.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/Names.java
@@ -2,6 +2,7 @@ package org.mitre.synthea.world.concepts;
 
 import java.util.List;
 
+import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.SimpleYML;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
@@ -22,8 +23,13 @@ public class Names {
     }
   }
   
+  public static final boolean appendNumbersToNames =
+      Config.getAsBoolean("generate.append_numbers_to_person_names", false);
+  
   /**
    * Generate a first name appropriate for a given gender and language.
+   * If `generate.append_numbers_to_person_names` == true, 
+   * then numbers will be appended automatically.
    * @param gender Gender of the name, "M" or "F"
    * @param language Origin language of the name, "english", "spanish"
    * @param person person to generate a name for.
@@ -38,11 +44,19 @@ public class Names {
       choices = (List<String>) names.get("english." + gender);
     }
     // pick a random item from the list
-    return choices.get(person.randInt(choices.size()));
+    String name = choices.get(person.randInt(choices.size()));
+
+    if (appendNumbersToNames) {
+      name = addHash(name);
+    }
+
+    return name;
   }
 
   /**
    * Generate a surname appropriate for a given language.
+   * If `generate.append_numbers_to_person_names` == true, 
+   * then numbers will be appended automatically.
    * @param language Origin language of the name, "english", "spanish"
    * @param person person to generate a name for.
    * @return Surname or Family Name.
@@ -56,7 +70,13 @@ public class Names {
       choices = (List<String>) names.get("english.family");
     }
     // pick a random item from the list
-    return choices.get(person.randInt(choices.size()));
+    String name = choices.get(person.randInt(choices.size()));
+
+    if (appendNumbersToNames) {
+      name = addHash(name);
+    }
+
+    return name;
   }
 
   /**

--- a/src/main/resources/modules/hypothyroidism.json
+++ b/src/main/resources/modules/hypothyroidism.json
@@ -174,8 +174,8 @@
       ],
       "direct_transition": "encounter end",
       "range": {
-        "low": 5,
-        "high": 2
+        "low": 2,
+        "high": 5
       }
     },
     "Synthroid Medication Order": {

--- a/src/main/resources/modules/sepsis.json
+++ b/src/main/resources/modules/sepsis.json
@@ -435,7 +435,7 @@
     "Low_MAP": {
       "type": "Observation",
       "category": "vital-signs",
-      "unit": "",
+      "unit": "mm[Hg]",
       "codes": [
         {
           "system": "LOINC",
@@ -452,7 +452,7 @@
     "Normal_MAP": {
       "type": "Observation",
       "category": "vital-signs",
-      "unit": "",
+      "unit": "mm[Hg]",
       "codes": [
         {
           "system": "LOINC",

--- a/src/main/resources/modules/sepsis.json
+++ b/src/main/resources/modules/sepsis.json
@@ -139,7 +139,7 @@
           }
         },
         {
-          "transition": "Set_Systolic"
+          "transition": "Record_Blood_Pressure"
         }
       ],
       "range": {
@@ -227,7 +227,7 @@
           "distribution": 0.125
         },
         {
-          "transition": "Admit_to_Inpatient",
+          "transition": "Record_Blood_Pressure_2",
           "distribution": 0.875
         }
       ]
@@ -360,7 +360,7 @@
           "display": "4 ML norepinephrine 1 MG/ML Injection"
         }
       ],
-      "direct_transition": "Set_Systolic",
+      "direct_transition": "Record_Blood_Pressure",
       "administration": true,
       "remarks": [
         "Among them, NE remains the most commonly used vasopressor and is recommended as the first-line agent by the Surviving Sepsis Campaign (SSC) experts (2). As a strong α-adrenergic agonist, NE increases blood pressure primarily through its vasoconstrictive properties with little effect on heart rate. Ref: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7333107/#:~:text=Among%20them%2C%20NE%20remains%20the,little%20effect%20on%20heart%20rate.",
@@ -466,26 +466,6 @@
         "high": 100
       }
     },
-    "Set_Diastolic": {
-      "type": "VitalSign",
-      "vital_sign": "Diastolic Blood Pressure",
-      "unit": "mm[Hg]",
-      "direct_transition": "Record_Blood_Pressure",
-      "range": {
-        "low": 40,
-        "high": 120
-      }
-    },
-    "Set_Systolic": {
-      "type": "VitalSign",
-      "vital_sign": "Systolic Blood Pressure",
-      "unit": "mm[Hg]",
-      "direct_transition": "Set_Diastolic",
-      "range": {
-        "low": 40,
-        "high": 120
-      }
-    },
     "Record_Blood_Pressure": {
       "type": "MultiObservation",
       "category": "vital-signs",
@@ -508,7 +488,10 @@
               "display": "Systolic Blood Pressure"
             }
           ],
-          "vital_sign": "Systolic Blood Pressure"
+          "range": {
+            "low": 40,
+            "high": 120
+          }
         },
         {
           "category": "laboratory",
@@ -520,7 +503,10 @@
               "display": "Diastolic Blood Pressure"
             }
           ],
-          "vital_sign": "Diastolic Blood Pressure"
+          "range": {
+            "low": 40,
+            "high": 120
+          }
         }
       ],
       "direct_transition": "Check_ARDS"
@@ -580,6 +566,45 @@
         "high": 40,
         "unit": "years"
       }
+    },
+    "Record_Blood_Pressure_2": {
+      "type": "MultiObservation",
+      "category": "vital-signs",
+      "number_of_observations": 0,
+      "codes": [
+        {
+          "system": "LOINC",
+          "code": "85354-9",
+          "display": "Blood Pressure"
+        }
+      ],
+      "observations": [
+        {
+          "category": "vital-signs",
+          "unit": "mm[Hg]",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "8480-6",
+              "display": "Systolic Blood Pressure"
+            }
+          ],
+          "vital_sign": "Systolic Blood Pressure"
+        },
+        {
+          "category": "laboratory",
+          "unit": "mm[Hg]",
+          "codes": [
+            {
+              "system": "LOINC",
+              "code": "8462-4",
+              "display": "Diastolic Blood Pressure"
+            }
+          ],
+          "vital_sign": "Diastolic Blood Pressure"
+        }
+      ],
+      "direct_transition": "Admit_to_Inpatient"
     }
   }
 }

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -713,7 +713,7 @@ public class StateTest {
     assertTrue(obsValue < 400);
   }
 
-    @Test
+  @Test
   public void observation() throws Exception {
     Module module = TestHelper.getFixture("observation.json");
 
@@ -1828,58 +1828,121 @@ public class StateTest {
 
       assertEquals("Example_Condition", person.history.get(16).name);
       assertEquals("Recursive Calls Submodules Module", person.history.get(16).module.name);
-
+      long previousStateExited = person.history.get(17).exited;
+      long currentStateEntered = person.history.get(16).entered;
+      assertEquals(previousStateExited, currentStateEntered);
+      
       assertEquals("Call_Encounter_Submodule", person.history.get(15).name);
       assertEquals("Recursive Calls Submodules Module", person.history.get(15).module.name);
-
+      previousStateExited = person.history.get(16).exited;
+      currentStateEntered = person.history.get(15).entered;
+      assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Initial", person.history.get(14).name);
       assertEquals("Encounter Submodule Module", person.history.get(14).module.name);
+      // the state being called by the submodule won't necessarily have this property
+      // because submodule.exited gets rewritten to whenever the terminal of the submodule exits
+      // ex. main.CallSubmodule: entered 1/1/2020, exited 12/31/2020
+      //     sub.Initial: entered 1/1/2020 exited 1/1/2020
+      //     sub.Delay: entered 1/1/2020 exited 12/31/2020
+      //     sub.Terminal: entered 12/31/2020 exited 12/31/2020
+      // previousStateExited = person.history.get(15).exited;
+      // currentStateEntered = person.history.get(14).entered;
+      // assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Delay", person.history.get(13).name);
       assertEquals("Encounter Submodule Module", person.history.get(13).module.name);
+      previousStateExited = person.history.get(14).exited;
+      currentStateEntered = person.history.get(13).entered;
+      assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Encounter_In_Submodule", person.history.get(12).name);
       assertEquals("Encounter Submodule Module", person.history.get(12).module.name);
+      previousStateExited = person.history.get(13).exited;
+      currentStateEntered = person.history.get(12).entered;
+      assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Call_MedicationOrder_Submodule", person.history.get(11).name);
       assertEquals("Encounter Submodule Module", person.history.get(11).module.name);
+      previousStateExited = person.history.get(12).exited;
+      currentStateEntered = person.history.get(11).entered;
+      assertEquals(previousStateExited, currentStateEntered);
 
 
       assertEquals("Initial", person.history.get(10).name);
       assertEquals("Medication Submodule Module", person.history.get(10).module.name);
+      // previousStateExited = person.history.get(11).exited;
+      // currentStateEntered = person.history.get(10).entered;
+      // assertEquals(previousStateExited, currentStateEntered);
+      // see notes above for why this property doesn't hold
 
       assertEquals("Examplitis_Medication", person.history.get(9).name);
       assertEquals("Medication Submodule Module", person.history.get(9).module.name);
+      previousStateExited = person.history.get(10).exited;
+      currentStateEntered = person.history.get(9).entered;
+      assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Delay_Yet_Again", person.history.get(8).name);
       assertEquals("Medication Submodule Module", person.history.get(8).module.name);
+      previousStateExited = person.history.get(9).exited;
+      currentStateEntered = person.history.get(8).entered;
+      assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("End_Medication", person.history.get(7).name);
       assertEquals("Medication Submodule Module", person.history.get(7).module.name);
+      previousStateExited = person.history.get(8).exited;
+      currentStateEntered = person.history.get(7).entered;
+      assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Med_Terminal", person.history.get(6).name);
       assertEquals("Medication Submodule Module", person.history.get(6).module.name);
+      previousStateExited = person.history.get(7).exited;
+      currentStateEntered = person.history.get(6).entered;
+      assertEquals(previousStateExited, currentStateEntered);
 
 
       assertEquals("Call_MedicationOrder_Submodule", person.history.get(5).name);
       assertEquals("Encounter Submodule Module", person.history.get(5).module.name);
+      // previousStateExited = person.history.get(6).exited;
+      // currentStateEntered = person.history.get(5).entered;
+      // assertEquals(previousStateExited, currentStateEntered);
+      // note that this is the same state object at position 11 and 5
+      // even though it was only called once it shows up twice
+      // (before and after all of the submodule states)
+      // but the entered & exited times don't line up cleanly
 
       assertEquals("Delay_Some_More", person.history.get(4).name);
       assertEquals("Encounter Submodule Module", person.history.get(4).module.name);
+      previousStateExited = person.history.get(5).exited;
+      currentStateEntered = person.history.get(4).entered;
+      assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Encounter_Terminal", person.history.get(3).name);
       assertEquals("Encounter Submodule Module", person.history.get(3).module.name);
+      previousStateExited = person.history.get(4).exited;
+      currentStateEntered = person.history.get(3).entered;
+      assertEquals(previousStateExited, currentStateEntered);
 
 
       assertEquals("Call_Encounter_Submodule", person.history.get(2).name);
       assertEquals("Recursive Calls Submodules Module", person.history.get(2).module.name);
+      // previousStateExited = person.history.get(3).exited;
+      // currentStateEntered = person.history.get(2).entered;
+      // assertEquals(previousStateExited, currentStateEntered);
+      // see note above, this is the same as position 15 
 
       assertEquals("End_Condition", person.history.get(1).name);
       assertEquals("Recursive Calls Submodules Module", person.history.get(1).module.name);
+      previousStateExited = person.history.get(2).exited;
+      currentStateEntered = person.history.get(1).entered;
+      assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Terminal", person.history.get(0).name);
       assertEquals("Recursive Calls Submodules Module", person.history.get(0).module.name);
+      previousStateExited = person.history.get(1).exited;
+      currentStateEntered = person.history.get(0).entered;
+      assertEquals(previousStateExited, currentStateEntered);
+
     } finally {
       // always clean these up, to ensure they don't get seen by any other tests
       modules.remove("submodules/encounter_submodule");

--- a/src/test/resources/generic/switching_provider.json
+++ b/src/test/resources/generic/switching_provider.json
@@ -36,7 +36,7 @@
     "Very Hungry": {
       "type": "Observation",
       "category": "survey",
-      "unit": "",
+      "unit": "{hunger-scale}",
       "codes": [
         {
           "system": "LOINC",
@@ -53,7 +53,7 @@
     "Not Hungry": {
       "type": "Observation",
       "category": "survey",
-      "unit": "",
+      "unit": "{hunger-scale}",
       "codes": [
         {
           "system": "LOINC",


### PR DESCRIPTION
This PR includes a mishmash of various fixes and tweaks pulled from multiple active working branches, in order to reduce the changes left on those branches to what's really important, and ensure these fixes are available throughout.
Where possible, these commits were cherry-picked from other branches to help git figure out how to merge and rebase later.

Details of changes:

 - `src/main/java/Graphviz.java`: fix a bug in rendering graphviz for modules that use the "Vital Sign" type logic 
 - `src/main/java/org/mitre/synthea/engine/State.java`: 
   1.  allow calling Java modules via the "CallSubmodule" state, and ensure that module history isn't duplicated (this caused an issue when a Java module was called repeatedly and the module history grows exponentially)
   2. fix a bug with Delays occuring inside submodules, where upon returning from the submodule, the parent module wasn't aware of any "time rewinding" that may have occurred. The approach here is to set the exited time of the CallSubmodule state based on the exited time of the previous state from history.
   3. require units on observations with numeric values (if the unit is missing it breaks CCDA)
 - `src/main/java/org/mitre/synthea/engine/Transition.java`: fix a bug involving null attributes in table based transitions
 - `src/main/java/org/mitre/synthea/helpers/Utilities.java`: add a function `convertRiskToTimestep` to allow converting risk between arbitrary timesteps (not just the currently configured `generate.timestep`)
 - `src/main/java/org/mitre/synthea/modules/LifecycleModule.java`, `src/main/java/org/mitre/synthea/world/agents/Provider.java`, `src/main/java/org/mitre/synthea/world/concepts/Names.java`:  remove an implicit and unintended link between the Provider class and the modules by extracting the logic to pick names to a new class. Previously, loading providers would call `LifecycleModule.fakeFirstName` etc, which would require loading the Module class, which spins up all the modules. In most cases there will be no difference, but this can help prevent some weird bugs in certain situations.
 - `src/main/resources/modules/hypothyroidism.json`: fix a range with low/high flipped
 - `src/main/resources/modules/sepsis.json`: replace VitalSign states that were setting Systolic and Diastolic blood pressure, and inadvertently overriding the built-in BloodPressureValueGenerators for blood pressure, causing a patient's BP to fluctuate wildly between 40-120 for the rest of their life. Now the blood pressure observation here uses the original range from the module, but doesn't override the underlying BPVG. Also adds another reading of blood pressure using the patient's regular vital signs, per clinical feedback.

More to come in future PRs:
 - Review a few tweaks made to exporters to support different classes of observation values (booleans, HealthRecord.entrys, etc) -- these work fine in FHIR but CCDA is trickier
 - Break out the metabolic syndrome standards of care module into multiple submodules. No functional changes intended, just for readability and maintainability