### PR TITLE
Add ability to select patients to keep/export using a GMF module

### DIFF
--- a/src/main/java/App.java
+++ b/src/main/java/App.java
@@ -32,6 +32,7 @@ public class App {
     System.out.println("         [-u updatedPopulationSnapshotPath]");
     System.out.println("         [-t updateTimePeriodInDays]");
     System.out.println("         [-f fixedRecordPath]");
+    System.out.println("         [-k keepMatchingPatientsPath]");
     System.out.println("         [--config* value]");
     System.out.println("          * any setting from src/main/resources/synthea.properties");
     System.out.println("Examples:");
@@ -174,6 +175,15 @@ public class App {
             } else {
               throw new FileNotFoundException(String.format(
                   "Specified fixed record file (%s) does not exist", value));
+            }
+          } else if (currArg.equals("-k")) {
+            String value = argsQ.poll();
+            File keepPatientsModule = new File(value);
+            if (keepPatientsModule.exists()) {
+              options.keepPatientsModulePath = keepPatientsModule;
+            } else {
+              throw new FileNotFoundException(String.format(
+                  "Specified keep-patients file (%s) does not exist", value));
             }
           } else if (currArg.startsWith("--")) {
             String configSetting;

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -428,7 +428,6 @@ public class Generator implements RandomNumberGenerator {
   public Person generatePerson(int index, long personSeed) {
 
     Person person = null;
-    long finishTime;
     
     try {
       boolean isAlive = true;
@@ -454,7 +453,7 @@ public class Generator implements RandomNumberGenerator {
 
       do {
         person = createPerson(personSeed, demoAttributes);
-        finishTime = person.lastUpdated + timestep;
+        long finishTime = person.lastUpdated + timestep;
 
         isAlive = person.alive(finishTime);
         providerCount = person.providerCount();
@@ -464,10 +463,6 @@ public class Generator implements RandomNumberGenerator {
 
         if (!patientMeetsCriteria) {
           // rotate the seed so the next attempt gets a consistent but different one
-          System.out.println("no match " + tryNumber++);
-          if (tryNumber > 100) {
-            System.out.println(demoAttributes);
-          }
           personSeed = randomForDemographics.nextLong();
           continue;
           // skip the other stuff if the patient doesn't meet our goals

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -364,7 +364,7 @@ public class Module implements Cloneable, Serializable {
     // looping until module is finished,
     // probably more than one state
     String nextStateName = null;
-    while (current.run(person, time)) {
+    while (current.run(person, time, terminateOnDeath)) {
       Long exited = current.exited;      
       nextStateName = current.transition(person, time);
       // System.out.println(" Transitioning to " + nextStateName);

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -180,7 +180,16 @@ public class Module implements Cloneable, Serializable {
     return loadFile(path, submodule, overrides, false);
   }
 
-  private static Module loadFile(Path path, boolean submodule, Properties overrides,
+  /**
+   * Loads the module defined from the file at the given path.
+   *
+   * @param path Path to the module file
+   * @param submodule whether or not this module is a submodule
+   * @param overrides module overrides to apply
+   * @param localFiles true if the file is external to the src/main/resources folder
+   * @return the loaded Module
+   */
+  public static Module loadFile(Path path, boolean submodule, Properties overrides,
           boolean localFiles) throws Exception {
     System.out.format("Loading %s %s\n", submodule ? "submodule" : "module", path.toString());
     String jsonString = localFiles

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -376,7 +376,7 @@ public class Module implements Cloneable, Serializable {
           return true;
         }
         // This must be a delay state that expired between cycles, so temporarily rewind time
-        if (process(person, exited)) {
+        if (process(person, exited, terminateOnDeath)) {
           // if the patient died during the delay, stop
           if (terminateOnDeath) {
             return true;

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -163,16 +163,20 @@ public abstract class State implements Cloneable, Serializable {
 
   /**
    * Run the state. This processes the state, setting entered and exit times.
+   * This will terminate immediately if the patient is dead and `terminateOnDeath` is true.
    *
    * @param person
    *          the person being simulated
    * @param time
    *          the date within the simulated world
+   * @param terminateOnDeath
+   *          whether to terminate immediately and not process the state if the patient is dead
+   *          (has no effect on patients that are alive)
    * @return `true` if processing should continue to the next state, `false` if the processing
    *         should halt for this time step.
    */
-  public boolean run(Person person, long time) {
-    if (!person.alive(time)) {
+  public boolean run(Person person, long time, boolean terminateOnDeath) {
+    if (terminateOnDeath && !person.alive(time)) {
       return false;
     }
     if (this.entered == null) {

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -89,6 +89,12 @@ generate.only_alive_patients = false
 # If both only_dead_patients and only_alive_patients are set to true,
 # It they will both default back to false
 
+# if criteria are provided, (for example, only_dead_patients, only_alive_patients, or a "patient keep module" with -k flag)
+# this is the maximum number of times synthea will loop over a single slot attempting to produce a matching patient.
+# after this many failed attempts, it will throw an exception.
+# set this to 0 to allow for unlimited attempts (but be aware of the possibility that it will never complete!)
+generate.max_attempts_to_keep_patient = 1000
+
 # if true, tracks and prints out details of transition tables for each module upon completion
 # note that this may significantly slow down processing, and is intended primarily for debugging
 generate.track_detailed_transition_metrics = false

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -33,7 +33,7 @@ public abstract class TestHelper {
   public static Module getFixture(String filename) throws Exception {
     Path modulesFolder = Paths.get("generic");
     Path module = modulesFolder.resolve(filename);
-    return Module.loadFile(module, modulesFolder, null);
+    return Module.loadFile(module, false, null, false);
   }
 
   /**

--- a/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
+++ b/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
@@ -344,4 +344,21 @@ public class GeneratorTest {
       generator.updatePerson(p);
     }
   }
+  
+  @Test
+  public void testKeepPatientsModule() throws Exception {
+    Generator.GeneratorOptions opts = new Generator.GeneratorOptions();
+    opts.population = 5;
+    opts.minAge = 35;
+    opts.maxAge = 75;
+    opts.ageSpecified = true;
+    opts.keepPatientsModulePath = new File("src/test/resources/keep_patients_module/keep.json");
+    // keep module checks that patients have attribute diabetes == true
+    
+    Generator generator = new Generator(opts);
+    for (int i = 0; i < opts.population; i++) {
+      Person p = generator.generatePerson(i);
+      assertTrue((Boolean)p.attributes.get("diabetes"));
+    }
+  }
 }

--- a/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
+++ b/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
@@ -96,6 +96,8 @@ public class GeneratorTest {
     Config.set("generate.only_dead_patients", "true");
     int numberOfPeople = 2;
     Generator generator = new Generator(numberOfPeople);
+    generator.options.ageSpecified = true;
+    generator.options.minAge = 50; // specify a high age to increase exposure to modules that cause death
     generator.run();
     assertEquals(0, generator.stats.get("alive").longValue());
     assertEquals(numberOfPeople, generator.stats.get("dead").longValue());

--- a/src/test/resources/keep_patients_module/keep.json
+++ b/src/test/resources/keep_patients_module/keep.json
@@ -1,0 +1,32 @@
+{
+  "name": "keep",
+  "remarks": [
+    "A blank module"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "transition": "Keep",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "diabetes",
+            "operator": "==",
+            "value": true
+          }
+        },
+        {
+          "transition": "Terminal"
+        }
+      ]
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Keep": {
+      "type": "Terminal"
+    }
+  },
+  "gmf_version": 2
+}


### PR DESCRIPTION
This PR introduces the ability to specify a special GMF module that determines criteria for a patient to be exported.

Because the GMF doesn't have the concept of "returning a value" explicitly, this takes the approach of using a named state to determine whether a patient record should be kept or not. (I don't love magic names, but we already require the "Initial" state name.) If a patient finishes in a Terminal state named "Keep" then the record is kept, otherwise the record is discarded, the seed rotated, and another record is generated and tested.
(Another possible approach, if people don't like requiring a specific name, would be to set a specific attribute to true/false)

Use the feature with `./run_synthea -k (path_to_module_file)`

Note that this uses a reduced version of Module.process to run through the module. The "keep module" should primarily include Initial, Terminal, and Simple states, with transitions using whatever logic to select patients. Use of other state types may produce unexpected results.

Two sample "keep modules":

1. Keep patients with Attribute: diabetes == true
![image](https://user-images.githubusercontent.com/13512036/116620274-9a1b0e00-a90f-11eb-91d0-b1031bb5a3bb.png)
[keep.json.txt](https://github.com/synthetichealth/synthea/files/6401701/keep.json.txt)


2. Keep patients that have an active diagnosis of either diabetes or hypertension:
![image](https://user-images.githubusercontent.com/13512036/116620440-d484ab00-a90f-11eb-97dc-bf8881e0bea6.png)
[keep.json.txt](https://github.com/synthetichealth/synthea/files/6401708/keep.json.txt)


In the future we may want to add some kind of "population attributes" to allow for filtering in the context of the population vs just the individual.

⚠️  IMPORTANT ⚠️ 
It is very easy to build a "keep module" that only keeps impossible patients. (For instance, no patient under the age of 18 can get diabetes in synthea. Trying to generating a population with ages 1-100 where every patient has diabetes will never finish, because if it tries to generate a patient under 18 it will never succeed and keep looping forever as it tries with a different seed. To successfully generate a dataset of "only diabetes", make sure the age range is at least 18+)
Use at your own risk. Make sure the demographics settings that you are using align with the patient characteristics you are expecting.