### PR TITLE
Fix for Delays that could possibly have a negative time

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -483,6 +483,10 @@ public abstract class State implements Cloneable, Serializable {
       if (this.next == null) {
         this.processOnce(person, time);
         this.next = this.endOfDelay(time, person);
+        if (this.next < time) {
+          // Don't allow a negative delay
+          this.next = time;
+        }
       }
 
       return ((time >= this.next) && person.alive(this.next));

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -344,6 +344,38 @@ public class StateTest {
   }
 
   @Test
+  public void gausian_delay_never_negative() throws Exception {
+    Module module = TestHelper.getFixture("gaussian_distro_delay.json");
+
+    // Seconds
+    State delay = module.getState("1 Mean Delay");
+    for (int i = 0; i < 100; i++) {
+      State.Delay daClone = (State.Delay) delay.clone();
+      daClone.entered = time;
+      daClone.process(person, time);
+      assertTrue(daClone.next >= time);
+    }
+  }
+
+  @Test
+  public void gausian_delay_has_correct_mean() throws Exception {
+    Module module = TestHelper.getFixture("gaussian_distro_delay.json");
+
+    long acc = 0;
+    // Seconds
+    State delay = module.getState("10 Mean Delay");
+    for (int i = 0; i < 1000; i++) {
+      State.Delay daClone = (State.Delay) delay.clone();
+      daClone.entered = time;
+      daClone.process(person, time);
+      acc += (daClone.next - time);
+    }
+    long mean = acc / 1000;
+    assertTrue(mean > 9500);
+    assertTrue(mean < 10500);
+  }
+
+  @Test
   public void delay_passes_after_time_range() throws Exception {
     Module module = TestHelper.getFixture("delay.json");
 

--- a/src/test/resources/generic/gaussian_distro_delay.json
+++ b/src/test/resources/generic/gaussian_distro_delay.json
@@ -1,0 +1,36 @@
+{
+  "name": "Gaussian Delay",
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "1 Mean Delay"
+    },
+    "1 Mean Delay": {
+      "type": "Delay",
+      "unit": "seconds",
+      "distribution": {
+        "kind": "GAUSSIAN",
+        "parameters": {
+          "mean": 1,
+          "standardDeviation": 15
+        }
+      },
+      "direct_transition": "10 Mean Delay"
+    },
+    "10 Mean Delay": {
+      "type": "Delay",
+      "unit": "seconds",
+      "distribution": {
+        "kind": "GAUSSIAN",
+        "parameters": {
+          "mean": 10,
+          "standardDeviation": 3
+        }
+      },
+      "direct_transition": "Terminal"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    }
+  }
+}


### PR DESCRIPTION
Now, when a Delayable generates the length of delay, if it would be
negative, it's just set to zero. Essentially the Delay state will
complete at the current time.

Added tests to validate. Also added a test to ensure that Gaussian
delays actually generating values with a distribution mean close
to the specified mean.

Addresses #885 