### PR TITLE
Fix uberJar task.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,7 @@ task uberJar(type: Jar) {
     archiveBaseName = 'synthea-with-dependencies'
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
+    duplicatesStrategy = 'warn'
 }
 
 task concepts(type: JavaExec) {


### PR DESCRIPTION
Fix `:uberJar` gradle task after Gradle 7 upgrade.