### PR TITLE
Update Deploy Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,11 +41,10 @@ jobs:
       - name: Create Release
         id: create_release 
         # note id is referenced below in Deploy uberJar
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: master-branch-latest
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: master-branch-latest
           draft: false
           prerelease: true
                 
@@ -59,6 +58,17 @@ jobs:
           asset_path: build/libs/synthea-with-dependencies.jar
           asset_name: synthea-with-dependencies.jar
           asset_content_type: application/java-archive
+        
+        # it's necessary to add another "publish" after the upload, otherwise the release is always listed as "draft"
+        # see https://github.com/actions/upload-release-asset/issues/34
+      - name: Publish Release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          replacesArtifacts: false
+          tag: master-branch-latest
+          token: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3 


### PR DESCRIPTION
There's currently a bug in the deploy workflow, where the master-branch-latest is left in a "draft" / unpublished state. (People probably haven't noticed since we don't do that many merges to master and I try to manually publish it right away)
While investigating I noticed the actions/create-release action is marked as unmaintained, so I figured it would be good to switch to another action.

This change does 2 things:
1 - switches to using a new release action that is maintained
2 - adds another "publish" step to the workflow, after the uberJar is uploaded, to make sure the release isn't marked as draft