### PR TITLE
Support for de/serializing Random class in GSON

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ jacoco {
 
 dependencies {
   // This dependency is found on compile classpath of this component and consumers.
-  implementation 'com.google.code.gson:gson:2.8.6'
+  implementation 'com.google.code.gson:gson:2.8.7'
   implementation 'com.jayway.jsonpath:json-path:2.4.0'
   implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:5.2.0'
   implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:5.2.0'
@@ -65,9 +65,9 @@ dependencies {
   implementation 'org.springframework:spring-web:5.2.7.RELEASE'
 
   // Java 9 no longer includes these APIs by default
-  implementation 'javax.xml.bind:jaxb-api:2.3.0'
-  implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.0'
-  implementation 'javax.activation:activation:1.1.1'
+  implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+  implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.2'
+  implementation 'javax.activation:javax.activation-api:1.2.0'
 
   // get rid of SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
   // if we switch to a real logging framework we may want to switch this

--- a/src/main/java/org/mitre/synthea/helpers/SerializableTypeAdapter.java
+++ b/src/main/java/org/mitre/synthea/helpers/SerializableTypeAdapter.java
@@ -1,0 +1,58 @@
+package org.mitre.synthea.helpers;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Base64;
+
+/**
+ * The SerializableTypeAdapter is a GSON TypeAdapter used to allow GSON to handle classes
+ * that are Serializable, but can't be instrumented by GSON for whatever reason.
+ * This is primarily used for core Java classes (java.*.*) which as of JDK16 no longer
+ * allow access via reflection. See: https://github.com/google/gson/issues/1216
+ * 
+ * <p>The internal approach is to write the object to a string using ObjectOutputStream,
+ * then base64 it. Reading the object reverses the base64 then turns it back into
+ * an Object via ObjectInputStream.
+ * 
+ * <p>This class is based on StackOverflow answer https://stackoverflow.com/a/33097652
+ *
+ * @param <E> Serializable class that cannot be natively deserialized by Gson.
+ */
+public class SerializableTypeAdapter<E extends Serializable> extends TypeAdapter<E> {
+  
+  @Override
+  public void write(JsonWriter out, E value) throws IOException {
+    // TODO: what if value is null?
+    
+    ByteArrayOutputStream bo = new ByteArrayOutputStream();
+    ObjectOutputStream so = new ObjectOutputStream(bo);
+    so.writeObject(value);
+    so.flush();
+
+    String valueString = new String(Base64.getEncoder().encode(bo.toByteArray()));
+    out.value(valueString);
+  }
+
+  @Override
+  public E read(JsonReader in) throws IOException {
+    String valueString = in.nextString();
+    byte[] b = Base64.getDecoder().decode(valueString.getBytes()); 
+    ByteArrayInputStream bi = new ByteArrayInputStream(b);
+    ObjectInputStream si = new ObjectInputStream(bi);
+    try {
+      @SuppressWarnings("unchecked")
+      E value = (E) si.readObject();
+      return value;
+    } catch (ClassNotFoundException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Calendar;
+import java.util.Random;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -358,6 +359,8 @@ public class Utilities {
       .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
       .registerTypeAdapterFactory(InnerClassTypeAdapterFactory.of(Logic.class,"condition_type"))
       .registerTypeAdapterFactory(InnerClassTypeAdapterFactory.of(State.class, "type"))
+      // as of JDK16, GSON can no longer handle certain sdk classes
+      .registerTypeAdapter(Random.class, new SerializableTypeAdapter<Random>())
       .create();
   }
 


### PR DESCRIPTION
This PR fixes #897 and makes Synthea work in Java 16 by introducing a new TypeAdapter for GSON, to allow serializing and deserializing classes that are in core Java packages. (ie, `java.*.*`). In practice it seems like the only core class that we try to serialize is java.util.Random, but I made this generic so that if we need to add more in the future this should make it easy. The basic approach is to leverage the existing java Serializable functionality to write the object to a string, then base64 it. (It turns out for the `java.util.Random` class all the relevant fields are private, so there aren't many other options to serialize it)

Note that I think the only time this will actually get called is when someone does population snapshotting. But we need the TypeAdapter present for loading all the GMF modules, because GSON walks the entire class hierarchy starting from State, and via State.entry you can get to Person.random. If the TypeAdapter for Random isn't present, it will try to create its own via reflection which is no longer possible.

Also I bumped up some of the relevant library versions here just in case that might help too