### PR TITLE
Metadata exporter

### DIFF
--- a/src/main/java/App.java
+++ b/src/main/java/App.java
@@ -76,7 +76,10 @@ public class App {
             options.clinicianSeed = Long.parseLong(value);
           } else if (currArg.equalsIgnoreCase("-r")) {
             String value = argsQ.poll();
-            SimpleDateFormat format = new SimpleDateFormat("YYYYMMDD");
+            // note that Y = "week year" and y = "year" per the formatting guidelines
+            // and D = "day in year" and d = "day in month", so what we actually want is yyyyMMdd
+            // see: https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html
+            SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd");
             format.setTimeZone(TimeZone.getTimeZone("UTC"));
             options.referenceTime = format.parse(value).getTime();
           } else if (currArg.equalsIgnoreCase("-p")) {

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -58,6 +58,11 @@ import org.mitre.synthea.world.geography.Location;
  */
 public class Generator implements RandomNumberGenerator {
 
+  /**
+   * Unique ID for this instance of the Generator. 
+   * Even if the same settings are used multiple times, this ID should be unique.
+   */
+  public final UUID id = UUID.randomUUID();
   public GeneratorOptions options;
   private Random random;
   public long timestep;
@@ -65,7 +70,7 @@ public class Generator implements RandomNumberGenerator {
   public long referenceTime;
   public Map<String, AtomicInteger> stats;
   public Location location;
-  private AtomicInteger totalGeneratedPopulation;
+  public AtomicInteger totalGeneratedPopulation;
   private String logLevel;
   private boolean onlyAlivePatients;
   private boolean onlyDeadPatients;
@@ -130,6 +135,8 @@ public class Generator implements RandomNumberGenerator {
     public File keepPatientsModulePath;
     /** Reference Time when to start Synthea. By default equal to the current system time. */
     public long referenceTime = seed;
+    /** Actual time the run started. */
+    public final long runStartTime = referenceTime;
   }
   
   /**

--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -462,6 +462,14 @@ public abstract class Exporter {
         e.printStackTrace();
       }
     }
+    
+    if (Config.getAsBoolean("exporter.metadata.export", false)) {
+      try {
+        MetadataExporter.exportMetadata(generator);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
 
     closeOpenFiles();
   }

--- a/src/main/java/org/mitre/synthea/export/MetadataExporter.java
+++ b/src/main/java/org/mitre/synthea/export/MetadataExporter.java
@@ -8,7 +8,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -43,8 +45,12 @@ public class MetadataExporter {
     long clinicianSeed = opts.clinicianSeed;
     metadata.put("clinicianSeed", clinicianSeed);
     
-    // reference time
-    long referenceTime = generator.referenceTime;
+    // reference time is expected to be entered on the command line as YYYYMMDD
+    // note that Y = "week year" and y = "year" per the formatting guidelines
+    // and D = "day in year" and d = "day in month", so what we actually want is yyyyMMdd
+    // see: https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html
+    SimpleDateFormat yyyymmdd = new SimpleDateFormat("yyyyMMdd");
+    String referenceTime = yyyymmdd.format(new Date(generator.referenceTime));
     metadata.put("referenceTime", referenceTime);
     
     // - git commit hash of the current running version

--- a/src/main/java/org/mitre/synthea/export/MetadataExporter.java
+++ b/src/main/java/org/mitre/synthea/export/MetadataExporter.java
@@ -1,0 +1,141 @@
+package org.mitre.synthea.export;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.mitre.synthea.engine.Generator;
+import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.Utilities;
+import org.mitre.synthea.world.agents.Payer;
+import org.mitre.synthea.world.agents.Provider;
+
+public class MetadataExporter {
+
+  /**
+   * Export metadata about the current run of Synthea. 
+   * Metadata includes various pieces of information about how the population was generated,
+   * such as version, config settings, and runtime args.
+   * @param generator Generator that was used to generate the population
+   * @throws IOException if an error occurs writing to the output directory
+   */
+  public static void exportMetadata(Generator generator) throws IOException {
+    // use a linked hashmap in an attempt to preserve insertion order. 
+    // ie, most important things at the top/start
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    metadata.put("runID", generator.id);
+    
+    Generator.GeneratorOptions opts = generator.options;
+    
+    // - population seed
+    long seed = opts.seed;
+    metadata.put("seed", seed);
+    
+    // clinician seed
+    long clinicianSeed = opts.clinicianSeed;
+    metadata.put("clinicianSeed", clinicianSeed);
+    
+    // reference time
+    long referenceTime = generator.referenceTime;
+    metadata.put("referenceTime", referenceTime);
+    
+    // - git commit hash of the current running version
+    String version = Utilities.SYNTHEA_VERSION;
+    metadata.put("version", version);
+    
+    // - number of patients, providers, payers generated 
+    // (in case "csv append mode" is on, and someone wants to link patients <--> run. 
+    // I think just these 3 should be enough to identify which run a line from any csv belongs to)
+    int patientCount = generator.totalGeneratedPopulation.get();
+    metadata.put("patientCount", patientCount);
+
+    int providerCount = Provider.getProviderList().size();
+    metadata.put("providerCount", providerCount);
+
+    int payerCount = Payer.getAllPayers().size();
+    metadata.put("payerCount", payerCount);
+
+    
+    // Java version, 
+    String javaVersion = System.getProperty("java.version"); // something like "12" or "1.8.0_201"
+    metadata.put("javaVersion", javaVersion);
+
+    // gradle version maybe
+    
+    
+
+    // Actual Date/Time of execution.
+    String runStartTime = ExportHelper.iso8601Timestamp(opts.runStartTime);
+    metadata.put("runStartTime", runStartTime);
+
+    // Run time, maybe.
+    
+
+    // selected run settings
+    String[] configSettings = {"exporter.years_of_history", };
+    
+    for (String configSetting : configSettings) {
+      metadata.put(configSetting, Config.get(configSetting, ""));
+    }
+    
+    String gender = opts.gender;
+    metadata.put("gender", gender);
+
+    
+    boolean ageSpecified = opts.ageSpecified;
+    int minAge = opts.minAge;
+    int maxAge = opts.maxAge;
+    String age = ageSpecified ? minAge + "-" + maxAge : "";
+    metadata.put("age", age);
+
+    
+    String city = opts.city;
+    metadata.put("city", city);
+
+    String state = opts.state;
+    metadata.put("state", state);
+
+    
+    String modules = opts.enabledModules == null ? "*" : String.join(";", opts.enabledModules);
+    metadata.put("modules", modules);
+
+    Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    String json = gson.toJson(metadata);
+    
+
+    StringBuilder filenameBuilder = new StringBuilder();
+    
+    // make sure everything is filename-safe
+    filenameBuilder.append(runStartTime);
+    filenameBuilder.append('_');
+    
+    // patient count above is the # actually generated.
+    // put in the filename the number they requested
+    int patientRequestCount = opts.population;
+    filenameBuilder.append(patientRequestCount);
+    filenameBuilder.append('_');
+    filenameBuilder.append(state);
+    if (city != null) {
+      filenameBuilder.append('_');
+      filenameBuilder.append(city);
+    }
+    filenameBuilder.append('_');
+    filenameBuilder.append(generator.id);
+    
+    // make sure everything is filename-safe
+    String filename = filenameBuilder.toString().replaceAll("\\W+", "_");
+    File outputDirectory = Exporter.getOutputFolder("metadata", null);
+    outputDirectory.mkdirs();
+    Path outputFile = outputDirectory.toPath().resolve(filename + ".json");
+    
+    Files.write(outputFile, Collections.singleton(json), StandardOpenOption.CREATE_NEW); 
+  }
+}

--- a/src/main/java/org/mitre/synthea/export/MetadataExporter.java
+++ b/src/main/java/org/mitre/synthea/export/MetadataExporter.java
@@ -63,57 +63,49 @@ public class MetadataExporter {
     int payerCount = Payer.getAllPayers().size();
     metadata.put("payerCount", payerCount);
 
-    
     // Java version, 
     String javaVersion = System.getProperty("java.version"); // something like "12" or "1.8.0_201"
     metadata.put("javaVersion", javaVersion);
-
-    // gradle version maybe
-    
-    
 
     // Actual Date/Time of execution.
     String runStartTime = ExportHelper.iso8601Timestamp(opts.runStartTime);
     metadata.put("runStartTime", runStartTime);
 
-    // Run time, maybe.
-    
+    // Run time
+    long runTimeInSeconds = (System.currentTimeMillis() - opts.runStartTime) / 1000;
+    metadata.put("runTimeInSeconds", runTimeInSeconds);
 
     // selected run settings
-    String[] configSettings = {"exporter.years_of_history", };
+    String[] configSettings = { "exporter.years_of_history", };
     
     for (String configSetting : configSettings) {
-      metadata.put(configSetting, Config.get(configSetting, ""));
+      metadata.put(configSetting, Config.get(configSetting));
     }
     
+    // note that nulls don't get exported, so if gender, age, city, etc, aren't specified
+    // then they won't even be in the output file
     String gender = opts.gender;
     metadata.put("gender", gender);
 
-    
     boolean ageSpecified = opts.ageSpecified;
     int minAge = opts.minAge;
     int maxAge = opts.maxAge;
-    String age = ageSpecified ? minAge + "-" + maxAge : "";
+    String age = ageSpecified ? minAge + "-" + maxAge : null;
     metadata.put("age", age);
 
-    
     String city = opts.city;
     metadata.put("city", city);
 
     String state = opts.state;
     metadata.put("state", state);
 
-    
     String modules = opts.enabledModules == null ? "*" : String.join(";", opts.enabledModules);
     metadata.put("modules", modules);
 
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     String json = gson.toJson(metadata);
     
-
     StringBuilder filenameBuilder = new StringBuilder();
-    
-    // make sure everything is filename-safe
     filenameBuilder.append(runStartTime);
     filenameBuilder.append('_');
     
@@ -130,7 +122,7 @@ public class MetadataExporter {
     filenameBuilder.append('_');
     filenameBuilder.append(generator.id);
     
-    // make sure everything is filename-safe
+    // make sure everything is filename-safe, replace "non-word characters" with _
     String filename = filenameBuilder.toString().replaceAll("\\W+", "_");
     File outputDirectory = Exporter.getOutputFolder("metadata", null);
     outputDirectory.mkdirs();

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -9,6 +9,7 @@ exporter.years_of_history = 10
 # split records allows patients to have one record per provider organization
 exporter.split_records = false
 exporter.split_records.duplicate_data = false
+exporter.metadata.export = true
 exporter.ccda.export = false
 exporter.fhir.export = true
 exporter.fhir_stu3.export = false


### PR DESCRIPTION
Currently in the FHIR exporter we include patient seed, population seed, and Synthea version, but these are not available in any other data formats. Rather than add them individually to the other formats, this metadata exporter outputs info about the most recent run as a JSON file.

Notes:
 - I set the new config setting to default to true, because it's a lot better to have it and not need it, than to create a large CSV population and forget the seed you used when you want to recreate it. If people disagree I'm fine disabling it by default though
 - Each run gets a separate metadata file, just to minimize the chance of weirdness in case people have multiple instances running at the same time.
 - The filename is `{timestamp} _ {population size} _ {state} _ { city? } _ {run ID}` to make it more immediately apparent what goes to what, and ensure uniqueness

From the slack channel, 2 earlier suggestions I haven't yet added are gradle version (there doesn't seem to be a trivial way to do it programmatically, so I'll see what out there makes sense) and total run time. 

Any suggestions on additional fields we may want to add here?