### PR TITLE
Only run Slack notification step on CI if the webhook URL is defined

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Slack Notification
         uses: 8398a7/action-slack@v3
-        if: always()
+        if: env.SLACK_WEBHOOK_URL
         with:
           status: custom
           job_name: Java 8

--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -27,7 +27,7 @@ jobs:
   
       - name: Slack Notification
         uses: 8398a7/action-slack@v3
-        if: always()
+        if: env.SLACK_WEBHOOK_URL
         with:
           status: custom
           job_name: Java 16


### PR DESCRIPTION
Quick change to the CI script to only run the slack notification step for PRs/commits, etc, if the webhook URL is configured. Our notifications should still occur for commits and PRs on synthetichealth/synthea, but should no longer fail CI for PRs coming from forks (such as this one) because the webhook URL secret is not passed to forks