### PR TITLE
Performance improvements

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/ExpressedConditionRecord.java
+++ b/src/main/java/org/mitre/synthea/engine/ExpressedConditionRecord.java
@@ -3,10 +3,10 @@ package org.mitre.synthea.engine;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.mitre.synthea.engine.ExpressedSymptom.SymptomInfo;
 import org.mitre.synthea.engine.ExpressedSymptom.SymptomSource;
@@ -140,8 +140,8 @@ public class ExpressedConditionRecord implements Cloneable, Serializable {
      */
     public ModuleConditions(String source) {
       this.source = source;
-      onsetConditions = new ConcurrentHashMap<String, OnsetCondition>();
-      state2conditionMapping = new ConcurrentHashMap<String, String>();
+      onsetConditions = new HashMap<String, OnsetCondition>();
+      state2conditionMapping = new HashMap<String, String>();
     }
     
     /**
@@ -231,7 +231,7 @@ public class ExpressedConditionRecord implements Cloneable, Serializable {
       this.conditionName = name;
       this.onsetTime = onsetTime;
       this.endTime = endTime;
-      this.symptoms = new ConcurrentHashMap<String, List<Integer>>();
+      this.symptoms = new HashMap<String, List<Integer>>();
     }
     
     /**
@@ -295,7 +295,7 @@ public class ExpressedConditionRecord implements Cloneable, Serializable {
   
   public ExpressedConditionRecord(Person person) {
     this.person = person;
-    sources = new ConcurrentHashMap<String, ModuleConditions>();
+    sources = new HashMap<String, ModuleConditions>();
   }
   
   /**
@@ -384,7 +384,7 @@ public class ExpressedConditionRecord implements Cloneable, Serializable {
   public Map<Long, List<ConditionWithSymptoms>> getConditionSymptoms() {
     Map<String, ExpressedSymptom> symptoms = person.getExpressedSymptoms();
     Map<Long, List<ConditionWithSymptoms>> result;
-    result = new ConcurrentHashMap<Long, List<ConditionWithSymptoms>>();    
+    result = new HashMap<Long, List<ConditionWithSymptoms>>();    
     for (String module : sources.keySet()) {
       ModuleConditions moduleConditions = sources.get(module);
       for (String condition : moduleConditions.getOnsetConditions().keySet()) {

--- a/src/main/java/org/mitre/synthea/engine/ExpressedSymptom.java
+++ b/src/main/java/org/mitre/synthea/engine/ExpressedSymptom.java
@@ -114,8 +114,9 @@ public class ExpressedSymptom implements Cloneable, Serializable {
      * Get the current value of the symptom.
      */
     public Integer getCurrentValue() {
-      if (timeInfos.containsKey(lastUpdateTime)) {
-        return timeInfos.get(lastUpdateTime).getValue();
+	  final SymptomInfo timeInfo = timeInfos.get(lastUpdateTime);
+      if (timeInfo != null) {
+        return timeInfo.getValue();
       }
       return null;
     }
@@ -165,12 +166,13 @@ public class ExpressedSymptom implements Cloneable, Serializable {
    */
   public int getSymptom() {
     int max = 0;
-    for (String module : sources.keySet()) {
-      Integer value = sources.get(module).getCurrentValue();
-      Boolean isResolved = sources.get(module).isResolved();
-      if (value != null && value.intValue() > max && !isResolved) {
-        max = value.intValue();
-      }
+    for (SymptomSource module : sources.values()) {
+      if(!module.isResolved()) {
+        Integer value = module.getCurrentValue();
+        if (value != null && value.intValue() > max) {
+          max = value.intValue();
+        }
+	  }
     }
     return max;
   }

--- a/src/main/java/org/mitre/synthea/engine/ExpressedSymptom.java
+++ b/src/main/java/org/mitre/synthea/engine/ExpressedSymptom.java
@@ -1,8 +1,8 @@
 package org.mitre.synthea.engine;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class ExpressedSymptom implements Cloneable, Serializable {
   
@@ -64,7 +64,7 @@ public class ExpressedSymptom implements Cloneable, Serializable {
      */
     public SymptomSource(String source) {
       this.source = source;
-      timeInfos = new ConcurrentHashMap<Long, ExpressedSymptom.SymptomInfo>();
+      timeInfos = new HashMap<Long, ExpressedSymptom.SymptomInfo>();
       resolved = false;
       lastUpdateTime = null;
     }
@@ -134,7 +134,7 @@ public class ExpressedSymptom implements Cloneable, Serializable {
   
   public ExpressedSymptom(String name) {
     this.name = name;  
-    sources = new ConcurrentHashMap<String, SymptomSource>();
+    sources = new HashMap<String, SymptomSource>();
   }
   
   /**

--- a/src/main/java/org/mitre/synthea/engine/Logic.java
+++ b/src/main/java/org/mitre/synthea/engine/Logic.java
@@ -300,7 +300,12 @@ public abstract class Logic implements Serializable {
   public static class And extends GroupedCondition {
     @Override
     public boolean test(Person person, long time) {
-      return conditions.stream().allMatch(c -> c.test(person, time));
+	  for(Logic condition: conditions) {
+		  if (!condition.test(person, time))
+			  return false;
+	  }
+
+	  return true;
     }
   }
 

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math.ode.DerivativeException;
@@ -1724,10 +1725,9 @@ public abstract class State implements Cloneable, Serializable {
       // we need to ensure we deep clone the list
       // (otherwise as this gets passed around, the same objects are used for different patients
       // which causes weird and unexpected results)
-      List<Observation> cloneObs = new ArrayList<>(observations.size());
-      for (Observation o : observations) {
-        cloneObs.add(o.clone());
-      }
+      List<Observation> cloneObs = observations.stream()
+			  .map(Observation::clone)
+			  .collect(Collectors.toCollection(ArrayList::new));
       clone.observations = cloneObs;
       
       return clone;

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -23,6 +23,16 @@ import org.mitre.synthea.engine.State;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 
 public class Utilities {
+
+  private static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
+  
+  private static final ThreadLocal<Calendar> threadLocalCalendar = new ThreadLocal<Calendar>(){
+	  @Override
+	  protected Calendar initialValue() {
+		  return Calendar.getInstance(UTC_TIME_ZONE);
+	  }
+  };
+
   /**
    * Convert a quantity of time in a specified units into milliseconds.
    *
@@ -94,7 +104,7 @@ public class Utilities {
    * Get the year of a Unix timestamp.
    */
   public static int getYear(long time) {
-    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+    Calendar calendar = threadLocalCalendar.get();
     calendar.setTimeInMillis(time);
     return calendar.get(Calendar.YEAR);
   }
@@ -103,7 +113,7 @@ public class Utilities {
    * Get the month of a Unix timestamp.
    */
   public static int getMonth(long time) {
-    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+    Calendar calendar = threadLocalCalendar.get();
     calendar.setTimeInMillis(time);
     return calendar.get(Calendar.MONTH) + 1;
   }
@@ -133,11 +143,20 @@ public class Utilities {
     return retVal;
   }
 
+  private static double timestepCache = Double.NaN;
+  
+  private static double getTimestep() {
+	if(timestepCache == Double.NaN)
+      timestepCache = Double.parseDouble(Config.get("generate.timestep"));
+	
+	return timestepCache;
+  }
+
   /**
    * Calculates 1 - (1-risk)^(currTimeStepInMS/originalPeriodInMS).
    */
   public static double convertRiskToTimestep(double risk, double originalPeriodInMS) {
-    double currTimeStepInMS = Double.parseDouble(Config.get("generate.timestep"));
+    double currTimeStepInMS = getTimestep();
 
     return convertRiskToTimestep(risk, originalPeriodInMS, currTimeStepInMS);
   }

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -602,6 +602,15 @@ public final class LifecycleModule extends Module {
   private static final double[] RESPIRATION_RATE_NORMAL =
       BiometricsConfig.doubles("respiratory.respiration_rate.normal");
 
+  private static long timestepCache = Long.MIN_VALUE;
+  
+  private static long getTimestep() {
+	if(timestepCache == Long.MIN_VALUE)
+      timestepCache = Long.parseLong(Config.get("generate.timestep"));
+	
+	return timestepCache;
+  }
+
   /**
    * Calculate this person's vital signs,
    * based on their conditions, medications, body composition, etc.
@@ -743,7 +752,7 @@ public final class LifecycleModule extends Module {
     person.setVitalSign(VitalSign.CARBON_DIOXIDE, person.rand(CO2_RANGE));
     person.setVitalSign(VitalSign.SODIUM, person.rand(SODIUM_RANGE));
 
-    long timestep = Long.parseLong(Config.get("generate.timestep"));
+    long timestep = getTimestep();
     double heartStart = person.rand(HEART_RATE_NORMAL);
     double heartEnd = person.rand(HEART_RATE_NORMAL);
     person.setVitalSign(VitalSign.HEART_RATE,

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -2,8 +2,6 @@ package org.mitre.synthea.world.agents;
 
 import java.awt.geom.Point2D;
 import java.io.Serializable;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
@@ -497,15 +495,14 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
       default:
         decimalPlaces = 2;
     }
-    Double retVal = value;
-    try {
-      retVal = BigDecimal.valueOf(value)
-              .setScale(decimalPlaces, RoundingMode.HALF_UP)
-              .doubleValue();
+
+	try {
+	  final double factor = Math.pow(10, decimalPlaces);
+	  value = Math.floor(((value * factor * 10) + 5) / 10) / factor;
     } catch (NumberFormatException e) {
       // Ignore, value was NaN or infinity.
     }
-    return retVal;
+    return value;
   }
 
   public void setVitalSign(VitalSign vitalSign, ValueGenerator valueGenerator) {

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.mitre.synthea.engine.ExpressedConditionRecord;
 import org.mitre.synthea.engine.ExpressedSymptom;
@@ -150,17 +149,17 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
   public Person(long seed) {
     this.seed = seed;
     random = new Random(seed);
-    attributes = new ConcurrentHashMap<String, Object>();
-    vitalSigns = new ConcurrentHashMap<VitalSign, ValueGenerator>();
-    symptoms = new ConcurrentHashMap<String, ExpressedSymptom>();
+    attributes = new HashMap<String, Object>();
+    vitalSigns = new HashMap<VitalSign, ValueGenerator>();
+    symptoms = new HashMap<String, ExpressedSymptom>();
     /* initialized the onsetConditions field */
     onsetConditionRecord = new ExpressedConditionRecord(this);
     /* Chronic Medications which will be renewed at each Wellness Encounter */
-    chronicMedications = new ConcurrentHashMap<String, HealthRecord.Medication>();
+    chronicMedications = new HashMap<String, HealthRecord.Medication>();
     hasMultipleRecords =
         Config.getAsBoolean("exporter.split_records", false);
     if (hasMultipleRecords) {
-      records = new ConcurrentHashMap<String, HealthRecord>();
+      records = new HashMap<String, HealthRecord>();
     }
     defaultRecord = new HealthRecord(this);
     lossOfCareEnabled =
@@ -204,11 +203,29 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
     return random.nextInt(bound);
   }
 
+  private boolean haveNextNextGaussian = false;
+  private double nextNextGaussian;
+  
   /**
    * Returns a double from a normal distribution.
    */
   public double randGaussian() {
-    return random.nextGaussian();
+	// See Knuth, ACP, Section 3.4.1 Algorithm C.
+	if (haveNextNextGaussian) {
+		haveNextNextGaussian = false;
+		return nextNextGaussian;
+	} else {
+		double v1, v2, s;
+		do {
+			v1 = 2 * random.nextDouble() - 1; // between -1 and 1
+			v2 = 2 * random.nextDouble() - 1; // between -1 and 1
+			s = v1 * v1 + v2 * v2;
+		} while (s >= 1 || s == 0);
+		double multiplier = Math.sqrt(-2 * Math.log(s)/s);
+		nextNextGaussian = v2 * multiplier;
+		haveNextNextGaussian = true;
+		return v1 * multiplier;
+	}
   }
 
   /**
@@ -324,12 +341,26 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
   /**
    * Returns whether a person is alive at the given time.
    */
-  public boolean alive(long time) {
-    boolean born = attributes.containsKey(Person.BIRTHDATE);
-    Long died = (Long) attributes.get(Person.DEATHDATE);
-    return (born && (died == null || died > time));
-  }
-  
+	private Boolean aliveCacheValue = null;
+	private long aliveCacheTime = Long.MIN_VALUE;
+
+	public boolean alive(long time) {
+		if (aliveCacheTime != time || null == aliveCacheValue) {
+			aliveCacheTime = time;
+			aliveCacheValue = calcAlive(time);
+		}
+		return aliveCacheValue.booleanValue();
+	}
+
+	private boolean calcAlive(long time) {
+		boolean born = attributes.containsKey(Person.BIRTHDATE);
+		if (born) {
+			Long died = (Long) attributes.get(Person.DEATHDATE);
+			return (died == null || died > time);
+		}
+		return false;
+	}
+	  
   /**
   * Get the expressed symptoms.
   */
@@ -389,8 +420,8 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
    */
   public int getSymptom(String type) {
     int max = 0;
-    if (symptoms.containsKey(type)) {
-      ExpressedSymptom expressedSymptom = symptoms.get(type);
+	ExpressedSymptom expressedSymptom = symptoms.get(type);
+	if(null != expressedSymptom){
       max = expressedSymptom.getSymptom();
     }
     return max;

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -245,16 +245,23 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
   /**
    * Returns a person's age in Period form.
    */
-  public Period age(long time) {
-    Period age = Period.ZERO;
+  private Period ageCache = null;
+  private long ageCacheTime = Long.MIN_VALUE;
 
-    if (attributes.containsKey(BIRTHDATE)) {
-      LocalDate now = Instant.ofEpochMilli(time).atZone(timeZone).toLocalDate();
-      LocalDate birthdate = Instant.ofEpochMilli((long) attributes.get(BIRTHDATE))
-          .atZone(timeZone).toLocalDate();
-      age = Period.between(birthdate, now);
+  public Period age(long time) {
+	if(ageCacheTime != time) {
+	  ageCacheTime = time;
+      ageCache = Period.ZERO;
+
+      if (attributes.containsKey(BIRTHDATE)) {
+        LocalDate now = Instant.ofEpochMilli(time).atZone(timeZone).toLocalDate();
+        LocalDate birthdate = Instant.ofEpochMilli((long) attributes.get(BIRTHDATE))
+            .atZone(timeZone).toLocalDate();
+        ageCache = Period.between(birthdate, now);
+      }
     }
-    return age;
+	  
+    return ageCache;
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/world/concepts/GrowthChart.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/GrowthChart.java
@@ -121,17 +121,15 @@ public class GrowthChart implements Serializable {
     return -1 * Math.sqrt(2) * Erf.erfcInv(2 * percentile);
   }
 
+  private static final NormalDistribution NORMAL_DISTRIBUTION = new NormalDistribution();
+
   /**
    * Convert a z-score into a percentile.
    * @param zscore The ZScore to find the percentile for
    * @return percentile - 0.0 - 1.0
    */
   public static double zscoreToPercentile(double zscore) {
-    double percentile = 0;
-
-    NormalDistribution dist = new NormalDistribution();
-    percentile = dist.cumulativeProbability(zscore);
-    return percentile;
+    return NORMAL_DISTRIBUTION.cumulativeProbability(zscore);
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -1126,7 +1126,8 @@ public class HealthRecord implements Serializable {
   }
 
   public boolean medicationActive(String type) {
-    return present.containsKey(type) && ((Medication) present.get(type)).stop == 0L;
+	final Entry medication = present.get(type);
+    return medication != null && ((Medication) medication).stop == 0L;
   }
 
   /**


### PR DESCRIPTION
Reduced runtime by around 30% when tested on two different machines, a 4c/8t laptop, and a 40c/80t server.

 - Added result caching for some slow and frequently used methods.
 - Replaced ConcurrentHashMap usages with HashMap where there are no threads doing concurrent access
 - Build new ConcurrentHashMap's in one go to avoid the synchonizzation cost of adding entries one by one
 - Moved gaussian random number generation inside Person class in order to avoid the synchronized block in the JVM standard library
 - Narrowed synchronized block scope in order to reduce lock contention