### PR TITLE
Add Coverage resource to top level of each generated Patient

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -48,6 +48,8 @@ import org.mitre.synthea.modules.LifecycleModule;
 import org.mitre.synthea.world.agents.Payer;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.CoverageRecord;
+import org.mitre.synthea.world.concepts.CoverageRecord.Plan;
 import org.mitre.synthea.world.concepts.Costs;
 import org.mitre.synthea.world.concepts.VitalSign;
 import org.mitre.synthea.world.geography.Demographics;
@@ -59,7 +61,7 @@ import org.mitre.synthea.world.geography.Location;
 public class Generator implements RandomNumberGenerator {
 
   /**
-   * Unique ID for this instance of the Generator. 
+   * Unique ID for this instance of the Generator.
    * Even if the same settings are used multiple times, this ID should be unique.
    */
   public final UUID id = UUID.randomUUID();
@@ -94,7 +96,7 @@ public class Generator implements RandomNumberGenerator {
    * module. Use "-m filename" on the command line to filter which modules get loaded.
    */
   Predicate<String> modulePredicate;
-  
+
   private static final String TARGET_AGE = "target_age";
 
   /**
@@ -138,7 +140,7 @@ public class Generator implements RandomNumberGenerator {
     /** Actual time the run started. */
     public final long runStartTime = referenceTime;
   }
-  
+
   /**
    * Create a Generator, using all default settings.
    */
@@ -149,7 +151,7 @@ public class Generator implements RandomNumberGenerator {
   /**
    * Create a Generator, with the given population size.
    * All other settings are left as defaults.
-   * 
+   *
    * @param population Target population size
    */
   public Generator(int population) {
@@ -157,11 +159,11 @@ public class Generator implements RandomNumberGenerator {
     options.population = population;
     init();
   }
-  
+
   /**
    * Create a Generator, with the given population size and seed.
    * All other settings are left as defaults.
-   * 
+   *
    * @param population Target population size
    * @param seed Seed used for randomness
    */
@@ -180,7 +182,7 @@ public class Generator implements RandomNumberGenerator {
   public Generator(GeneratorOptions o) {
     this(o, new Exporter.ExporterRuntimeOptions());
   }
-  
+
   /**
    * Create a Generator, with the given options.
    * @param o Desired configuration options
@@ -257,7 +259,7 @@ public class Generator implements RandomNumberGenerator {
       Module.addModules(options.localModuleDir);
     }
     List<String> coreModuleNames = getModuleNames(Module.getModules(path -> false));
-    List<String> moduleNames = getModuleNames(Module.getModules(modulePredicate)); 
+    List<String> moduleNames = getModuleNames(Module.getModules(modulePredicate));
 
     if (options.keepPatientsModulePath != null) {
       try {
@@ -269,7 +271,7 @@ public class Generator implements RandomNumberGenerator {
     }
 
     Costs.loadCostData(); // ensure cost data loads early
-    
+
     String locationName;
     if (options.city == null) {
       locationName = options.state;
@@ -309,7 +311,7 @@ public class Generator implements RandomNumberGenerator {
             .map(m -> m.name)
             .collect(Collectors.toList());
   }
-  
+
   /**
    * Generate the population, using the currently set configuration settings.
    */
@@ -340,12 +342,12 @@ public class Generator implements RandomNumberGenerator {
       if (initialPopulation != null && initialPopulation.size() > 0) {
         // default is to run until current system time.
         if (options.daysToTravelForward > 0) {
-          stop = initialPopulation.get(0).lastUpdated 
+          stop = initialPopulation.get(0).lastUpdated
                   + Utilities.convertTime("days", options.daysToTravelForward);
         }
         for (int i = 0; i < initialPopulation.size(); i++) {
           final int index = i;
-          final Person p = initialPopulation.get(i);        
+          final Person p = initialPopulation.get(i);
           threadPool.submit(() -> updateRecordExportPerson(p, index));
         }
       }
@@ -394,7 +396,7 @@ public class Generator implements RandomNumberGenerator {
   /**
    * Imports the fixed demographics records file when using fixed patient
    * demographics.
-   * 
+   *
    * @return A list of the groups of records imported.
    */
   public List<FixedRecordGroup> importFixedPatientDemographicsFile() {
@@ -416,14 +418,14 @@ public class Generator implements RandomNumberGenerator {
     // Return the record groups.
     return recordGroups;
   }
-  
+
   /**
    * Generate a completely random Person. The returned person will be alive at the end of the
    * simulation. This means that if in the course of the simulation the person dies, a new person
-   * will be started to replace them. 
+   * will be started to replace them.
    * The seed used to generate the person is randomized as well.
    * Note that this method is only used by unit tests.
-   * 
+   *
    * @param index Target index in the whole set of people to generate
    * @return generated Person
    */
@@ -439,7 +441,7 @@ public class Generator implements RandomNumberGenerator {
    * person will be started to replace them. Note also that if the person dies, the seed to produce
    * them can't be re-used (otherwise the new person would die as well) so a new seed is picked,
    * based on the given seed.
-   * 
+   *
    * @param index
    *          Target index in the whole set of people to generate
    * @param personSeed
@@ -449,7 +451,7 @@ public class Generator implements RandomNumberGenerator {
   public Person generatePerson(int index, long personSeed) {
 
     Person person = null;
-    
+
     try {
       int tryNumber = 0; // Number of tries to create these demographics
       Random randomForDemographics = new Random(personSeed);
@@ -477,7 +479,7 @@ public class Generator implements RandomNumberGenerator {
               && tryNumber >= this.maxAttemptsToKeepPatient) {
             // we've tried and failed to produce a patient that meets the criteria
             // throw an exception to halt processing in this slot
-            String msg = "Failed to produce a matching patient after " 
+            String msg = "Failed to produce a matching patient after "
                 + tryNumber + " attempts. "
                 + "Ensure that it is possible for all "
                 + "requested demographics to meet the criteria. "
@@ -543,7 +545,7 @@ public class Generator implements RandomNumberGenerator {
     }
     return person;
   }
-  
+
   /**
    * Helper class to keep track of patient criteria.
    * Caches results in booleans so different combinations are quick to check
@@ -581,7 +583,7 @@ public class Generator implements RandomNumberGenerator {
    * If a patient does not meet the criteria the process will be repeated so a new one is generated
    * @param person the patient to check if we want to export them
    * @param finishTime the time simulation finished
-   * @param index Target index in the whole set of people to generate 
+   * @param index Target index in the whole set of people to generate
    * @param isAlive Whether the patient is alive at end of simulation.
    * @return CriteriaCheck to determine if the patient should be exported/re-simulated
    */
@@ -706,7 +708,7 @@ public class Generator implements RandomNumberGenerator {
    * @param isAlive Whether the person to print is alive.
    */
   private synchronized void writeToConsole(Person person, int index, long time, boolean isAlive) {
-    // this is synchronized to ensure all lines for a single person are always printed 
+    // this is synchronized to ensure all lines for a single person are always printed
     // consecutively
     String deceased = isAlive ? "" : "DECEASED";
     System.out.format("%d -- %s (%d y/o %s) %s, %s %s\n", index + 1,
@@ -795,7 +797,7 @@ public class Generator implements RandomNumberGenerator {
     // Generate the person's age data.
     int targetAge;
     if (options.ageSpecified) {
-      targetAge = 
+      targetAge =
           (int) (options.minAge + ((options.maxAge - options.minAge) * random.nextDouble()));
     } else {
       targetAge = city.pickAge(random);
@@ -804,7 +806,7 @@ public class Generator implements RandomNumberGenerator {
 
     long birthdate = birthdateFromTargetAge(targetAge, random);
     demographicsOutput.put(Person.BIRTHDATE, birthdate);
-    
+
     // Return the generated demographics.
     return demographicsOutput;
   }
@@ -851,7 +853,7 @@ public class Generator implements RandomNumberGenerator {
   private long birthdateFromTargetAge(long targetAge, Random random) {
     long earliestBirthdate = referenceTime - TimeUnit.DAYS.toMillis((targetAge + 1) * 365L + 1);
     long latestBirthdate = referenceTime - TimeUnit.DAYS.toMillis(targetAge * 365L);
-    return 
+    return
         (long) (earliestBirthdate + ((latestBirthdate - earliestBirthdate) * random.nextDouble()));
   }
 
@@ -884,12 +886,12 @@ public class Generator implements RandomNumberGenerator {
 
     totalGeneratedPopulation.incrementAndGet();
   }
-  
+
   private Predicate<String> getModulePredicate() {
     if (options.enabledModules == null) {
       return path -> true;
     }
-    FilenameFilter filenameFilter = new WildcardFileFilter(options.enabledModules, 
+    FilenameFilter filenameFilter = new WildcardFileFilter(options.enabledModules,
         IOCase.INSENSITIVE);
     return path -> filenameFilter.accept(null, path);
   }
@@ -935,12 +937,12 @@ public class Generator implements RandomNumberGenerator {
   public long randLong() {
     return random.nextLong();
   }
-  
+
   /**
    * Return a random UUID.
    */
   public UUID randUUID() {
     return new UUID(randLong(), randLong());
   }
-  
+
 }

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -48,8 +48,6 @@ import org.mitre.synthea.modules.LifecycleModule;
 import org.mitre.synthea.world.agents.Payer;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.agents.Provider;
-import org.mitre.synthea.world.concepts.CoverageRecord;
-import org.mitre.synthea.world.concepts.CoverageRecord.Plan;
 import org.mitre.synthea.world.concepts.Costs;
 import org.mitre.synthea.world.concepts.VitalSign;
 import org.mitre.synthea.world.geography.Demographics;

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -240,7 +240,7 @@ public class FhirR4 {
 
     return mappingTable;
   }
-  
+
   public static FhirContext getContext() {
     return FHIR_CTX;
   }
@@ -309,7 +309,7 @@ public class FhirR4 {
       }
 
       for (CarePlan careplan : encounter.careplans) {
-        BundleEntryComponent careTeamEntry = 
+        BundleEntryComponent careTeamEntry =
                 careTeam(person, personEntry, bundle, encounterEntry, careplan);
         carePlan(person, personEntry, bundle, encounterEntry, encounter.provider, careTeamEntry,
                 careplan);
@@ -318,7 +318,7 @@ public class FhirR4 {
       for (ImagingStudy imagingStudy : encounter.imagingStudies) {
         imagingStudy(person, personEntry, bundle, encounterEntry, imagingStudy);
       }
-      
+
       if (USE_US_CORE_IG) {
         String clinicalNoteText = ClinicalNoteExporter.export(person, encounter);
         boolean lastNote =
@@ -332,6 +332,8 @@ public class FhirR4 {
 
       explanationOfBenefit(personEntry, bundle, encounterEntry, person,
           encounterClaim, encounter);
+
+      coverage(person, personEntry, bundle, encounterClaim, encounter);
     }
 
     if (USE_US_CORE_IG) {
@@ -669,7 +671,7 @@ public class FhirR4 {
 
     return newEntry(bundle, patientResource, (String) person.attributes.get(Person.ID));
   }
-  
+
   /**
    * Map the given Encounter into a FHIR Encounter resource, and add it to the given Bundle.
    *
@@ -731,7 +733,7 @@ public class FhirR4 {
       // no associated provider, patient goes to wellness provider
       provider = person.getProvider(EncounterType.WELLNESS, encounter.start);
     }
-    
+
     if (TRANSACTION_BUNDLE) {
       encounterResource.setServiceProvider(new Reference(
               ExportHelper.buildFhirSearchUrl("Organization", provider.getResourceID())));
@@ -874,7 +876,7 @@ public class FhirR4 {
       Person person, BundleEntryComponent personEntry,
       Bundle bundle, BundleEntryComponent encounterEntry, Claim claim,
       BundleEntryComponent medicationEntry) {
-    
+
     org.hl7.fhir.r4.model.Claim claimResource = new org.hl7.fhir.r4.model.Claim();
     org.hl7.fhir.r4.model.Encounter encounterResource =
         (org.hl7.fhir.r4.model.Encounter) encounterEntry.getResource();
@@ -1031,7 +1033,7 @@ public class FhirR4 {
         claimResource.addDiagnosis(diagnosisComponent);
 
         // update claimItems with diagnosis
-        ItemComponent diagnosisItem = 
+        ItemComponent diagnosisItem =
             new ItemComponent(new PositiveIntType(itemSequence),
                 mapCodeToCodeableConcept(item.codes.get(0), SNOMED_URI));
         diagnosisItem.addDiagnosisSequence(conditionSequence);
@@ -1371,6 +1373,21 @@ public class FhirR4 {
     return newEntry(person, bundle,eob);
   }
 
+  private static BundleEntryComponent coverage(RandomNumberGenerator rand,
+          BundleEntryComponent personEntry,
+          Bundle bundle,
+          BundleEntryComponent claimEntry,
+          Encounter encounter) {
+    Payer payer = encounter.claim.payer;
+    Coverage coverageResource = new Coverage();
+    coverageResource.setStatus(CoverageStatus.ACTIVE);
+    coverageResource.setType(new CodeableConcept().setText(payer.getName()));
+    coverageResource.setBeneficiary(new Reference(personEntry.getFullUrl()));
+    coverageResource.addPayor(new Reference().setDisplay(payer.getName()));
+    BundleEntryComponent coverageEntry = newEntry(rand, bundle, coverageResource);
+    return coverageEntry;
+  }
+
   /**
    * Map the Condition into a FHIR Condition resource, and add it to the given Bundle.
    *
@@ -1381,7 +1398,7 @@ public class FhirR4 {
    * @param condition      The Condition
    * @return The added Entry
    */
-  private static BundleEntryComponent condition(RandomNumberGenerator rand, 
+  private static BundleEntryComponent condition(RandomNumberGenerator rand,
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           HealthRecord.Entry condition) {
     Condition conditionResource = new Condition();
@@ -1649,27 +1666,27 @@ public class FhirR4 {
           + value.getClass().toString() + "; " + value);
     }
   }
-  
+
   /**
    * Maps a Synthea internal SampledData object to the FHIR standard SampledData
    * representation.
-   * 
+   *
    * @param value Synthea internal SampledData instance
    * @param unit Observation unit value
    * @return
    */
   static org.hl7.fhir.r4.model.SampledData mapValueToSampledData(
       Components.SampledData value, String unit) {
-    
+
     org.hl7.fhir.r4.model.SampledData recordData = new org.hl7.fhir.r4.model.SampledData();
     recordData.setOrigin(new Quantity().setValue(value.originValue)
         .setCode(unit).setSystem(UNITSOFMEASURE_URI)
         .setUnit(unit));
-    
+
     // Use the period from the first series. They should all be the same.
     // FHIR output is milliseconds so we need to convert from TimeSeriesData seconds.
     recordData.setPeriod(value.series.get(0).getPeriod() * 1000);
-    
+
     // Set optional fields if they were provided
     if (value.factor != null) {
       recordData.setFactor(value.factor);
@@ -1680,11 +1697,11 @@ public class FhirR4 {
     if (value.upperLimit != null) {
       recordData.setUpperLimit(value.upperLimit);
     }
-    
+
     recordData.setDimensions(value.series.size());
-    
+
     recordData.setData(ExportHelper.sampledDataToValueString(value));
-    
+
     return recordData;
   }
 
@@ -1803,7 +1820,7 @@ public class FhirR4 {
     deviceResource.setPatient(new Reference(personEntry.getFullUrl()));
     return newEntry(rand, bundle, deviceResource);
   }
-  
+
   /**
    * Map the JsonObject for a Supply into a FHIR SupplyDelivery and add it to the Bundle.
    *
@@ -1817,26 +1834,26 @@ public class FhirR4 {
   private static BundleEntryComponent supplyDelivery(RandomNumberGenerator rand,
           BundleEntryComponent personEntry, Bundle bundle, HealthRecord.Supply supply,
           Encounter encounter) {
-   
+
     SupplyDelivery supplyResource = new SupplyDelivery();
     supplyResource.setStatus(SupplyDeliveryStatus.COMPLETED);
     supplyResource.setPatient(new Reference(personEntry.getFullUrl()));
-    
+
     CodeableConcept type = new CodeableConcept();
     type.addCoding()
       .setCode("device")
       .setDisplay("Device")
       .setSystem("http://terminology.hl7.org/CodeSystem/supply-item-type");
     supplyResource.setType(type);
-    
+
     SupplyDeliverySuppliedItemComponent suppliedItem = new SupplyDeliverySuppliedItemComponent();
     suppliedItem.setItem(mapCodeToCodeableConcept(supply.codes.get(0), SNOMED_URI));
     suppliedItem.setQuantity(new Quantity(supply.quantity));
-    
+
     supplyResource.setSuppliedItem(suppliedItem);
-    
+
     supplyResource.setOccurrence(convertFhirDateTime(supply.start, true));
-    
+
     return newEntry(rand, bundle, supplyResource);
   }
 
@@ -1970,7 +1987,7 @@ public class FhirR4 {
       medicationResource.addExtension()
         .setUrl(SHR_EXT + "shr-base-ActionCode-extension")
         .setValue(PRESCRIPTION_OF_DRUG_CC);
-    
+
       medicationResource.setMeta(new Meta()
           .addProfile(SHR_EXT + "shr-medication-MedicationRequested"));
 
@@ -2113,7 +2130,7 @@ public class FhirR4 {
 
   /**
    * Add a MedicationAdministration if needed for the given medication.
-   * 
+   *
    * @param rand              Source of randomness to use when generating ids etc
    * @param personEntry       The Entry for the Person
    * @param bundle            Bundle to add the MedicationAdministration to
@@ -2690,7 +2707,7 @@ public class FhirR4 {
     imagingStudyResource.setNumberOfInstances(totalNumberOfInstances);
     return newEntry(rand, bundle, imagingStudyResource);
   }
-  
+
   /**
    * Map the given Observation with attachment element to a FHIR Media resource, and add it to the
    * given Bundle.
@@ -2723,7 +2740,7 @@ public class FhirR4 {
 
     Attachment content = (Attachment) obs.value;
     org.hl7.fhir.r4.model.Attachment contentResource = new org.hl7.fhir.r4.model.Attachment();
-    
+
     contentResource.setContentType(content.contentType);
     contentResource.setLanguage(content.language);
     if (content.data != null) {
@@ -2736,7 +2753,7 @@ public class FhirR4 {
     if (content.hash != null) {
       contentResource.setHashElement(new org.hl7.fhir.r4.model.Base64BinaryType(content.hash));
     }
-    
+
     mediaResource.setWidth(content.width);
     mediaResource.setHeight(content.height);
 
@@ -2811,7 +2828,7 @@ public class FhirR4 {
     if (USE_US_CORE_IG) {
       location = providerLocation(rand, bundle, provider);
     }
-    
+
     BundleEntryComponent entry = newEntry(bundle, organizationResource, provider.getResourceID());
     // add location to bundle *after* organization to ensure no forward reference
     if (location != null) {
@@ -2820,7 +2837,7 @@ public class FhirR4 {
 
     return entry;
   }
-  
+
   /**
    * Map the Provider into a FHIR Location resource, and add it to the given Bundle.
    *
@@ -3068,7 +3085,7 @@ public class FhirR4 {
     String resourceID = rand.randUUID().toString();
     return newEntry(bundle, resource, resourceID);
   }
-  
+
   /**
    * Helper function to create an Entry for the given Resource within the given Bundle. Sets the
    * resourceID to a random UUID, sets the entry's fullURL to that resourceID, and adds the entry to

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -27,7 +27,7 @@ exporter.practitioner.fhir_stu3.export = false
 exporter.practitioner.fhir_dstu2.export = false
 exporter.encoding = UTF-8
 exporter.csv.export = false
-# if exporter.csv.append_mode = true, then each run will add new data to any existing CSVs. if false, each run will clear out the files and start fresh 
+# if exporter.csv.append_mode = true, then each run will add new data to any existing CSVs. if false, each run will clear out the files and start fresh
 exporter.csv.append_mode = false
 # if exporter.csv.folder_per_run = true, then each run will have CSVs placed into a unique subfolder. if false, each run will only use the top-level csv folder
 exporter.csv.folder_per_run = false
@@ -37,8 +37,8 @@ exporter.csv.folder_per_run = false
 # see list of files at: https://github.com/synthetichealth/synthea/wiki/CSV-File-Data-Dictionary
 # include filenames separated with a comma, ex: patients.csv,procedures.csv,medications.csv
 # NOTE: the csv exporter does not actively delete files, so if Run 1 you included a file, then Run 2 you exclude that file, the version from Run 1 will still be present
-exporter.csv.included_files = 
-exporter.csv.excluded_files = 
+exporter.csv.included_files =
+exporter.csv.excluded_files =
 
 exporter.cpcds.export = false
 exporter.cpcds.append_mode = false
@@ -67,7 +67,7 @@ generate.log_patients.detail = simple
 # options are "none", "simple", or "detailed" (without quotes). defaults to simple if another value is used
 # none = print nothing to the console during generation
 # simple = print patient names once they are generated.
-# detailed = print patient names, atributes, vital signs, etc..  May slow down processing
+# detailed = print patient names, attributes, vital signs, etc..  May slow down processing
 
 generate.timestep = 604800000
 # time is in ms
@@ -87,7 +87,7 @@ generate.lookup_tables = modules/lookup_tables/
 # Set to true if you want every patient to be dead.
 generate.only_dead_patients = false
 # Set to true if you want every patient to be alive.
-generate.only_alive_patients = false
+generate.only_alive_patients = true
 # If both only_dead_patients and only_alive_patients are set to true,
 # It they will both default back to false
 
@@ -141,8 +141,8 @@ generate.birthweights.logging = false
 # receive employer mandated insurance (aka "private" insurance).
 # prior to mandate.year, anyone with income greater than the annual cost of an insurance plan
 # will purchase the insurance.
-generate.insurance.mandate.year = 2006
-generate.insurance.mandate.occupation = 0.2
+generate.insurance.mandate.year = 1900
+generate.insurance.mandate.occupation = 0
 
 # Default Costs, to be used for pricing something that we don't have a specific price for
 # -- $500 for procedures is completely invented

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -87,7 +87,7 @@ generate.lookup_tables = modules/lookup_tables/
 # Set to true if you want every patient to be dead.
 generate.only_dead_patients = false
 # Set to true if you want every patient to be alive.
-generate.only_alive_patients = true
+generate.only_alive_patients = false
 # If both only_dead_patients and only_alive_patients are set to true,
 # It they will both default back to false
 
@@ -141,8 +141,8 @@ generate.birthweights.logging = false
 # receive employer mandated insurance (aka "private" insurance).
 # prior to mandate.year, anyone with income greater than the annual cost of an insurance plan
 # will purchase the insurance.
-generate.insurance.mandate.year = 1900
-generate.insurance.mandate.occupation = 0
+generate.insurance.mandate.year = 2006
+generate.insurance.mandate.occupation = 0.2
 
 # Default Costs, to be used for pricing something that we don't have a specific price for
 # -- $500 for procedures is completely invented


### PR DESCRIPTION
For our needs with the data we were generating, we added a function to create Coverage objects for each Patient that was generated. To do this, we took examples of other resource generation functions and used those to make the coverage() function. We also looked at how Coverage resources were created when they are nested in ExplanationOfBenefits, and used that as a guide. 

From our testing, this is creating multiple valid Coverage resources for each Patient. Another thought we had was to leverage this new resource generation function inside the EoB function for the coverage resources created there, not sure if that would work. 

I did not see a Contributing guide to see details on when to add tests, let me know if there is any other work you would like done to this PR. I wouldn't consider myself a Java expert but happy to make an attempt. Also if this is not something you all are interested in, please close and we will continue to use/maintain our fork. 

CC: @bzimbelman