### PR TITLE
Prevent duplicate codes in HealthRecord Entries

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -836,7 +836,7 @@ public abstract class State implements Cloneable, Serializable {
             ClinicianSpecialty.GENERAL_PRACTICE, null);
         entry = encounter;
         if (codes != null) {
-          encounter.codes.addAll(codes);
+          encounter.mergeCodeList(codes);
         }
         person.setCurrentEncounter(module, encounter);
         encounter.name = this.name;
@@ -906,7 +906,7 @@ public abstract class State implements Cloneable, Serializable {
 
         // Copy over the characteristics from old medication to new medication
         medication.name = chronicMedication.name;
-        medication.codes.addAll(chronicMedication.codes);
+        medication.mergeCodeList(chronicMedication.codes);
         medication.reasons.addAll(chronicMedication.reasons);
         medication.prescriptionDetails = chronicMedication.prescriptionDetails;
         medication.administration = chronicMedication.administration;
@@ -1010,7 +1010,7 @@ public abstract class State implements Cloneable, Serializable {
         // create a temporary coded entry to use for reference in the attribute,
         // which will be replaced if the thing is diagnosed
         HealthRecord.Entry codedEntry = person.record.new Entry(time, codes.get(0).code);
-        codedEntry.codes.addAll(codes);
+        codedEntry.mergeCodeList(codes);
 
         person.attributes.put(assignToAttribute, codedEntry);
       }
@@ -1047,7 +1047,7 @@ public abstract class State implements Cloneable, Serializable {
       entry = person.record.conditionStart(time, primaryCode);
       entry.name = this.name;
       if (codes != null) {
-        entry.codes.addAll(codes);
+        entry.mergeCodeList(codes);
       }
       if (assignToAttribute != null) {
         person.attributes.put(assignToAttribute, entry);
@@ -1123,7 +1123,7 @@ public abstract class State implements Cloneable, Serializable {
       String primaryCode = codes.get(0).code;
       entry = person.record.allergyStart(time, primaryCode);
       entry.name = this.name;
-      entry.codes.addAll(codes);
+      entry.mergeCodeList(codes);
       HealthRecord.Allergy allergy = (HealthRecord.Allergy) entry;
       allergy.allergyType = allergyType;
       allergy.category = category;
@@ -1250,7 +1250,7 @@ public abstract class State implements Cloneable, Serializable {
       Medication medication = person.record.medicationStart(time, primaryCode, chronic);
       entry = medication;
       medication.name = this.name;
-      medication.codes.addAll(codes);
+      medication.mergeCodeList(codes);
 
       if (reason != null) {
         // "reason" is an attribute or stateName referencing a previous conditionOnset state
@@ -1354,7 +1354,7 @@ public abstract class State implements Cloneable, Serializable {
       CarePlan careplan = person.record.careplanStart(time, primaryCode);
       entry = careplan;
       careplan.name = this.name;
-      careplan.codes.addAll(codes);
+      careplan.mergeCodeList(codes);
 
       if (activities != null) {
         careplan.activities.addAll(activities);
@@ -1468,7 +1468,7 @@ public abstract class State implements Cloneable, Serializable {
       HealthRecord.Procedure procedure = person.record.procedure(time, primaryCode);
       entry = procedure;
       procedure.name = this.name;
-      procedure.codes.addAll(codes);
+      procedure.mergeCodeList(codes);
 
       if (reason != null) {
         // "reason" is an attribute or stateName referencing a previous conditionOnset state
@@ -1719,7 +1719,7 @@ public abstract class State implements Cloneable, Serializable {
       HealthRecord.Observation observation = person.record.observation(time, primaryCode, value);
       entry = observation;
       observation.name = this.name;
-      observation.codes.addAll(codes);
+      observation.mergeCodeList(codes);
       observation.category = category;
       observation.unit = unit;
 
@@ -1788,7 +1788,7 @@ public abstract class State implements Cloneable, Serializable {
           person.record.multiObservation(time, primaryCode, observations.size());
       entry = observation;
       observation.name = this.name;
-      observation.codes.addAll(codes);
+      observation.mergeCodeList(codes);
       observation.category = category;
 
       return true;
@@ -1812,7 +1812,7 @@ public abstract class State implements Cloneable, Serializable {
       Report report = person.record.report(time, primaryCode, observations.size());
       entry = report;
       report.name = this.name;
-      report.codes.addAll(codes);
+      report.mergeCodeList(codes);
 
       // increment number of labs by respective provider
       Provider provider;

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1372,7 +1372,7 @@ public abstract class State implements Cloneable, Serializable {
           // the name of the ConditionOnset state (aka "reason")
           for (Entry entry : person.record.present.values()) {
             if (reason.equals(entry.name)) {
-              careplan.reasons.addAll(entry.codes);
+              careplan.mergeReasonList(entry.codes);
             }
           }
         }

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -190,6 +190,42 @@ public class HealthRecord implements Serializable {
     }
   }
 
+  public abstract class EntryWithReasons extends Entry {
+    public List<Code> reasons;
+
+    /**
+     * Constructor for HealthRecord EntryWithReasons.
+     */
+    public EntryWithReasons(long time, String type) {
+      super(time, type);
+      this.reasons = new ArrayList<Code>();
+    }
+
+
+    /**
+     * Merges the passed in code list into the existing list of codes for this entry. If a code in
+     * otherCodes already exists in this.codes, it is skipped, since it already exists in the Entry.
+     * @param otherCodes codes to add to this entry
+     */
+    public void mergeReasonList(List<Code> otherCodes) {
+      otherCodes.forEach(oc -> {
+        if (! this.containsReason(oc.code, oc.system)) {
+          this.codes.add(oc);
+        }
+      });
+    }
+
+    /**
+     * Determines if the given entry contains the provided reason code in its list of reason codes.
+     * @param code clinical term
+     * @param system system for the code
+     * @return true if the code is there
+     */
+    public boolean containsReason(String code, String system) {
+      return this.reasons.stream().anyMatch(c -> code.equals(c.code) && system.equals(c.system));
+    }
+  }
+
   public class Observation extends Entry {
     public Object value;
     public String category;
@@ -219,8 +255,7 @@ public class HealthRecord implements Serializable {
     }
   }
 
-  public class Medication extends Entry {
-    public List<Code> reasons;
+  public class Medication extends EntryWithReasons {
     public Code stopReason;
     public transient JsonObject prescriptionDetails;
     public Claim claim;
@@ -232,7 +267,6 @@ public class HealthRecord implements Serializable {
      */
     public Medication(long time, String type) {
       super(time, type);
-      this.reasons = new ArrayList<Code>();
       // Create a medication claim.
       this.claim = new Claim(this, person);
     }
@@ -275,8 +309,7 @@ public class HealthRecord implements Serializable {
     }
   }
 
-  public class Procedure extends Entry {
-    public List<Code> reasons;
+  public class Procedure extends EntryWithReasons {
     public Provider provider;
     public Clinician clinician;
 
@@ -285,14 +318,12 @@ public class HealthRecord implements Serializable {
      */
     public Procedure(long time, String type) {
       super(time, type);
-      this.reasons = new ArrayList<Code>();
       this.stop = this.start + TimeUnit.MINUTES.toMillis(15);
     }
   }
 
-  public class CarePlan extends Entry {
+  public class CarePlan extends EntryWithReasons {
     public Set<Code> activities;
-    public List<Code> reasons;
     public transient Set<JsonObject> goals;
     public Code stopReason;
 
@@ -302,7 +333,6 @@ public class HealthRecord implements Serializable {
     public CarePlan(long time, String type) {
       super(time, type);
       this.activities = new LinkedHashSet<Code>();
-      this.reasons = new ArrayList<Code>();
       this.goals = new LinkedHashSet<JsonObject>();
     }
 

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -169,6 +169,19 @@ public class HealthRecord implements Serializable {
     }
 
     /**
+     * Merges the passed in code list into the existing list of codes for this entry. If a code in
+     * otherCodes already exists in this.codes, it is skipped, since it already exists in the Entry.
+     * @param otherCodes codes to add to this entry
+     */
+    public void mergeCodeList(List<Code> otherCodes) {
+      otherCodes.forEach(oc -> {
+        if (! this.containsCode(oc.code, oc.system)) {
+          this.codes.add(oc);
+        }
+      });
+    }
+
+    /**
      * Converts the entry to a String.
      */
     @Override

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -255,6 +255,39 @@ public class StateTest {
     assertEquals(time, onsetTime.longValue());
   }
 
+  /**
+   * Previously, if there were multiple calls to ConditionOnset, the condition Entry would contain
+   * multiple Codes, one for each time the ConditionOnset was invoked. This test checks to make
+   * sure that the same code is only added once.
+   * @throws Exception when bad things happen
+   */
+  @Test
+  public void condition_onset_during_encounter_prevent_multiple_coding() throws Exception {
+    Module module = TestHelper.getFixture("condition_onset.json");
+    // The encounter comes first (and add it to history);
+    State encounter = module.getState("ED_Visit");
+
+    assertTrue(encounter.process(person, time));
+    person.history.add(0, encounter);
+
+    // Then appendicitis is diagnosed
+    State appendicitis = module.getState("Appendicitis");
+    assertTrue(appendicitis.process(person, time));
+    // Call the same ConditionOnset
+    assertTrue(appendicitis.process(person, time));
+
+    Encounter enc = person.record.encounters.get(0);
+    assertEquals(1, enc.conditions.get(0).codes.size());
+    Code code = enc.conditions.get(0).codes.get(0);
+    assertEquals("47693006", code.code);
+    assertEquals("Rupture of appendix", code.display);
+    Long onsetTime = person.getOnsetConditionRecord().getConditionLastOnsetTimeFromModule(
+        module.name, code.display
+    );
+    assertTrue(onsetTime != null);
+    assertEquals(time, onsetTime.longValue());
+  }
+
   @Test
   public void allergy_onset() throws Exception {
     // Setup a mock to track calls to the patient record


### PR DESCRIPTION
This PR addresses cases where `HealthRecord.Entry`s can have multiple instances of the same `Code` in their `codes` property. In cases where a `Person` in the simulation passes through the same `ConditionOnset` state multiple times, Synthea will just keep appending the same condition codes to the `Entry`. This change now checks to see if the `Code` already exists in the `Entry`.