### PR TITLE
Allow ISO formatted dates in look up table transitions

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Transition.java
+++ b/src/main/java/org/mitre/synthea/engine/Transition.java
@@ -218,17 +218,7 @@ public abstract class Transition implements Serializable {
           Integer timeIndex = this.attributes.indexOf("time");
           // Remove and parse the age range.
           String value = rowAttributes.remove(timeIndex.intValue());
-          if (!value.contains("-")
-              || value.substring(0, value.indexOf("-")).length() < 1
-              || value.substring(value.indexOf("-") + 1).length() < 1) {
-            throw new RuntimeException(
-                "LOOKUP TABLE '" + fileName
-                    + "' ERROR: Time Range must be in the form: 'timeLow-timeHigh'. Found '"
-                    + value + "'");
-          }
-          timeRange = Range.between(
-              Long.parseLong(value.substring(0, value.indexOf("-"))),
-              Long.parseLong(value.substring(value.indexOf("-") + 1)));
+          timeRange = Utilities.parseDateRange(value);
         }
         // Attributes key to inert into lookup table.
         LookupTableKey attributesLookupKey =

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -345,13 +345,22 @@ public class Utilities {
     return version;
   }
 
+  /**
+   * Parse a range of Synthea timestamps (milliseconds since the epoch) from a String. The string
+   * can be in one of two formats:
+   * "milliseconds start-milliseconds end" example: "1599264000000-1627948800000"
+   * or
+   * "ISO date start-ISO date end" example: "2020-09-05-2021-08-03"
+   * @param range String containing the range
+   * @return A Range with the min and max set to Synthea timestamps, longs containing milliseconds
+   *     since the epoch
+   * @throws IllegalArgumentException If the string is not in one of the expected formats
+   */
   public static Range<Long> parseDateRange(String range) throws IllegalArgumentException {
     if (!range.contains("-")
         || range.substring(0, range.indexOf("-")).length() < 1
         || range.substring(range.indexOf("-") + 1).length() < 1) {
-      throw new IllegalArgumentException(
-          "LOOKUP TABLE '"
-              + "' ERROR: Age Range must be in the form: 'ageLow-ageHigh'. Found '"
+      throw new IllegalArgumentException("Time range format error. Expect low-high. Found '"
               + range + "'");
     }
 

--- a/src/main/java/org/mitre/synthea/helpers/Utilities.java
+++ b/src/main/java/org/mitre/synthea/helpers/Utilities.java
@@ -12,7 +12,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
@@ -348,9 +347,14 @@ public class Utilities {
   /**
    * Parse a range of Synthea timestamps (milliseconds since the epoch) from a String. The string
    * can be in one of two formats:
+   * <p>
    * "milliseconds start-milliseconds end" example: "1599264000000-1627948800000"
    * or
    * "ISO date start-ISO date end" example: "2020-09-05-2021-08-03"
+   * </p><p>
+   * If using the ISO date format, the time range will be from the start of the day at the beginning
+   * of the range until the end of the day for the last day of the range.
+   * </p>
    * @param range String containing the range
    * @return A Range with the min and max set to Synthea timestamps, longs containing milliseconds
    *     since the epoch
@@ -374,8 +378,10 @@ public class Utilities {
       parsedRange = Range.between(
         LocalDate.parse(matcher.group(1), DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay()
             .toInstant(ZoneOffset.UTC).toEpochMilli(),
-        LocalDate.parse(matcher.group(2), DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay()
-            .toInstant(ZoneOffset.UTC).toEpochMilli());
+        // adding a day and subtracting 1 to get the millisecond before midnight at the end of the
+        // range
+        LocalDate.parse(matcher.group(2), DateTimeFormatter.ISO_LOCAL_DATE).plusDays(1)
+            .atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli() - 1);
     } else {
       parsedRange = Range.between(
           Long.parseLong(range.substring(0, range.indexOf("-"))),

--- a/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
@@ -1,5 +1,11 @@
 package org.mitre.synthea.helpers;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.google.gson.JsonPrimitive;
 
 import java.time.LocalDateTime;
@@ -11,7 +17,6 @@ import org.apache.commons.lang3.Range;
 import org.junit.Test;
 import org.mitre.synthea.world.agents.Person;
 
-import static org.junit.Assert.*;
 
 public class UtilitiesTest {
 

--- a/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
@@ -1,15 +1,17 @@
 package org.mitre.synthea.helpers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import com.google.gson.JsonPrimitive;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
+
+import org.apache.commons.lang3.Range;
 import org.junit.Test;
 import org.mitre.synthea.world.agents.Person;
+
+import static org.junit.Assert.*;
 
 public class UtilitiesTest {
 
@@ -220,5 +222,27 @@ public class UtilitiesTest {
     // Trying to parse a non-primitive class type results in an
     // IllegalArgumentException
     Utilities.strToObject(Date.class, "oops");
+  }
+
+  @Test
+  public void parseDateRange() {
+    String testRange = "2020-09-05-2021-08-03";
+    long start = LocalDateTime.of(2020, 9, 5, 0, 0)
+        .toInstant(ZoneOffset.UTC).toEpochMilli();
+    long end = LocalDateTime.of(2021, 8, 3, 0, 0)
+        .toInstant(ZoneOffset.UTC).toEpochMilli();
+    Range<Long> result = Utilities.parseDateRange(testRange);
+    assertEquals(start, (long) result.getMinimum());
+    assertEquals(end, (long) result.getMaximum());
+    testRange = "1599264000000-1627948800000";
+    result = Utilities.parseDateRange(testRange);
+    assertEquals(start, (long) result.getMinimum());
+    assertEquals(end, (long) result.getMaximum());
+    try {
+      Utilities.parseDateRange("silliness");
+      fail("Should not reach here, exception should be thrown.");
+    } catch (IllegalArgumentException iae) {
+      assertNotNull(iae);
+    }
   }
 }

--- a/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/UtilitiesTest.java
@@ -234,12 +234,12 @@ public class UtilitiesTest {
     String testRange = "2020-09-05-2021-08-03";
     long start = LocalDateTime.of(2020, 9, 5, 0, 0)
         .toInstant(ZoneOffset.UTC).toEpochMilli();
-    long end = LocalDateTime.of(2021, 8, 3, 0, 0)
-        .toInstant(ZoneOffset.UTC).toEpochMilli();
+    long end = LocalDateTime.of(2021, 8, 4, 0, 0)
+        .toInstant(ZoneOffset.UTC).toEpochMilli() - 1;
     Range<Long> result = Utilities.parseDateRange(testRange);
     assertEquals(start, (long) result.getMinimum());
     assertEquals(end, (long) result.getMaximum());
-    testRange = "1599264000000-1627948800000";
+    testRange = "1599264000000-1628035199999";
     result = Utilities.parseDateRange(testRange);
     assertEquals(start, (long) result.getMinimum());
     assertEquals(end, (long) result.getMaximum());


### PR DESCRIPTION
Look up table transitions previously allowed for decisions to be made on the time in the simulation. The way that this works is that time ranges can be defined using milliseconds since the epoch. This works, but is not great for human readability.

This PR preserves that capability, but also allows for date ranges to be defined as ISO Dates. This means what was previously:

`1599264000000-1627948800000`

can now be represented as:

`2020-09-05-2021-08-03`

For those who prefer the old format (there is probably someone), it still works.