### PR TITLE
Decrease the time it takes to run the test suite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,9 @@ test {
     // showStandardStreams = true
   }
   maxHeapSize = "6144m"
+  jacoco {
+    excludes = ["org.hl7.*", "com.google.*"]
+  }
 }
 
 buildscript {

--- a/src/test/java/org/mitre/synthea/ParallelTestingService.java
+++ b/src/test/java/org/mitre/synthea/ParallelTestingService.java
@@ -22,10 +22,10 @@ public class ParallelTestingService {
     ExecutorService service = Executors.newFixedThreadPool(6);
     List<String> validationErrors = new ArrayList<>();
     int numberOfPeople = 10;
-    TestHelper.getGeneratedPerson(1);
     List<Future<Exception>> potentialCrashes = new ArrayList<>(10);
+    Person[] people = TestHelper.getGeneratedPeople();
     for (int i = 0; i < numberOfPeople; i++) {
-      Person person = TestHelper.getGeneratedPerson(i);
+      Person person = people[i];
       final int counter = i;
       Future<Exception> maybeCrash = service.submit(() -> {
         long start = System.currentTimeMillis();

--- a/src/test/java/org/mitre/synthea/ParallelTestingService.java
+++ b/src/test/java/org/mitre/synthea/ParallelTestingService.java
@@ -1,0 +1,42 @@
+package org.mitre.synthea;
+
+import org.mitre.synthea.world.agents.Person;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class ParallelTestingService {
+  public static List<String> runInParallel(PersonTester pt) throws Exception {
+    ExecutorService service = Executors.newFixedThreadPool(6);
+    List<String> validationErrors = new ArrayList<>();
+    int numberOfPeople = 10;
+    TestHelper.getGeneratedPerson(1);
+    List<Future<Exception>> potentialCrashes = new ArrayList<>(10);
+    for (int i = 0; i < numberOfPeople; i++) {
+      Person person = TestHelper.getGeneratedPerson(i);
+      Future<Exception> maybeCrash = service.submit(() -> {
+        try {
+          validationErrors.addAll(pt.test(person));
+          return null;
+        } catch (Exception e) {
+          return e;
+        }
+      });
+      potentialCrashes.add(i, maybeCrash);
+    }
+    service.shutdown();
+    service.awaitTermination(1, TimeUnit.HOURS);
+    for (int i = 0; i < potentialCrashes.size(); i++) {
+      Future<Exception> potentalCrash = potentialCrashes.get(i);
+      Exception e = potentalCrash.get();
+      if (e != null) {
+        throw e;
+      }
+    }
+    return validationErrors;
+  }
+}

--- a/src/test/java/org/mitre/synthea/ParallelTestingService.java
+++ b/src/test/java/org/mitre/synthea/ParallelTestingService.java
@@ -1,7 +1,5 @@
 package org.mitre.synthea;
 
-import org.mitre.synthea.world.agents.Person;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -9,7 +7,17 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.mitre.synthea.world.agents.Person;
+
 public class ParallelTestingService {
+  /**
+   * Runs the provided PersonTester in parallel. The PersonTester will be supplied with 10 people.
+   * Tests are run in a fixed thread pool with some of the tests having to wait until the first few
+   * tests complete. Tests can return a List of validation errors (in String form).
+   * @param pt An implementation of PersonTester
+   * @return A list of errors
+   * @throws Exception when bad things happen during the test
+   */
   public static List<String> runInParallel(PersonTester pt) throws Exception {
     ExecutorService service = Executors.newFixedThreadPool(6);
     List<String> validationErrors = new ArrayList<>();

--- a/src/test/java/org/mitre/synthea/ParallelTestingService.java
+++ b/src/test/java/org/mitre/synthea/ParallelTestingService.java
@@ -18,12 +18,20 @@ public class ParallelTestingService {
     List<Future<Exception>> potentialCrashes = new ArrayList<>(10);
     for (int i = 0; i < numberOfPeople; i++) {
       Person person = TestHelper.getGeneratedPerson(i);
+      final int counter = i;
       Future<Exception> maybeCrash = service.submit(() -> {
+        long start = System.currentTimeMillis();
+        System.out.println(String.format("Starting person %d at %d", counter, start));
         try {
           validationErrors.addAll(pt.test(person));
           return null;
         } catch (Exception e) {
           return e;
+        } finally {
+          long end = System.currentTimeMillis();
+          long duration = end - start;
+          System.out.println(String.format("Finished %d at %d, which took %d", counter,
+              end, duration));
         }
       });
       potentialCrashes.add(i, maybeCrash);

--- a/src/test/java/org/mitre/synthea/PersonTester.java
+++ b/src/test/java/org/mitre/synthea/PersonTester.java
@@ -1,9 +1,14 @@
 package org.mitre.synthea;
 
-import org.mitre.synthea.world.agents.Person;
-
 import java.util.List;
 
+import org.mitre.synthea.world.agents.Person;
+
+/**
+ * Single method interface (so it can be implemented using a lambda), for testing people in
+ * parallel. This interface is intended to be used with the ParallelTestingService. It is currently
+ * used for testing various exporters.
+ */
 public interface PersonTester {
   List<String> test(Person person) throws Exception;
 }

--- a/src/test/java/org/mitre/synthea/PersonTester.java
+++ b/src/test/java/org/mitre/synthea/PersonTester.java
@@ -1,0 +1,9 @@
+package org.mitre.synthea;
+
+import org.mitre.synthea.world.agents.Person;
+
+import java.util.List;
+
+public interface PersonTester {
+  List<String> test(Person person) throws Exception;
+}

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -151,6 +151,7 @@ public abstract class TestHelper {
       int numberOfPeople = 10;
       Generator generator = new Generator(numberOfPeople);
       generator.options.overflow = false;
+      exportOff();
       Person[] people = new Person[10];
       for (int i = 0; i < numberOfPeople; i++) {
         people[i] = generator.generatePerson(i);

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -136,6 +136,16 @@ public abstract class TestHelper {
     return Utilities.convertTime("years", numYears);
   }
 
+  /**
+   * This method generates 10 people and then serializes them out into memory as byte arrays. For
+   * tests that need a generated patient, they can call this method to grab a fresh copy of a person
+   * which is rehydrated from the byte array to ensure an unmodified copy of the original. This
+   * eliminates regeneration of people in the test suite for many of the exporters.
+   * @param index which of the 10 people do you want?
+   * @return a person
+   * @throws IOException when there is a problem rehydrating a person
+   * @throws ClassNotFoundException when there is a problem rehydrating a person
+   */
   public static Person getGeneratedPerson(int index) throws IOException, ClassNotFoundException {
     if (serializedPatients == null) {
       int numberOfPeople = 10;

--- a/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
+++ b/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
@@ -323,13 +323,13 @@ public class GeneratorTest {
       return;
     }
 
-    // Get 100 people
+    // Get 10 people
     Generator.GeneratorOptions opts = new Generator.GeneratorOptions();
     opts.population = 1;
     opts.minAge = 50;
     opts.maxAge = 100;
     Generator generator = new Generator(opts);
-    final int NUM_RECS = 100;
+    final int NUM_RECS = 10;
     Person[] people = new Person[NUM_RECS];
     for (int i = 0; i < NUM_RECS; i++) {
       long personSeed = UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE;

--- a/src/test/java/org/mitre/synthea/export/FHIRDSTU2ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRDSTU2ExporterTest.java
@@ -108,12 +108,11 @@ public class FHIRDSTU2ExporterTest {
     List<String> validationErrors = new ArrayList<String>();
 
     int numberOfPeople = 10;
-    Generator generator = new Generator(numberOfPeople);
-    generator.options.overflow = false;
+
     for (int i = 0; i < numberOfPeople; i++) {
       int x = validationErrors.size();
       TestHelper.exportOff();
-      Person person = generator.generatePerson(i);
+      Person person = TestHelper.getGeneratedPerson(i);
       Config.set("exporter.fhir_dstu2.export", "true");
       FhirDstu2.TRANSACTION_BUNDLE = person.randBoolean();
       String fhirJson = FhirDstu2.convertToFHIRJson(person, System.currentTimeMillis());

--- a/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
@@ -14,6 +14,10 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.codec.binary.Base64;
 import org.hl7.fhir.r4.model.Bundle;
@@ -27,6 +31,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mitre.synthea.ParallelTestingService;
 import org.mitre.synthea.TestHelper;
 import org.mitre.synthea.engine.Generator;
 import org.mitre.synthea.engine.Module;
@@ -100,21 +105,16 @@ public class FHIRR4ExporterTest {
     FhirContext ctx = FhirR4.getContext();
     IParser parser = ctx.newJsonParser().setPrettyPrint(true);
     ValidationResources validator = new ValidationResources();
-    List<String> validationErrors = new ArrayList<String>();
 
-    int numberOfPeople = 10;
-    Generator generator = new Generator(numberOfPeople);
-
-    generator.options.overflow = false;
-
-    for (int i = 0; i < numberOfPeople; i++) {
-      int x = validationErrors.size();
+    List<String> errors = ParallelTestingService.runInParallel((person) -> {
+      List<String> validationErrors = new ArrayList<String>();
       TestHelper.exportOff();
-      Person person = generator.generatePerson(i);
       FhirR4.TRANSACTION_BUNDLE = person.randBoolean();
       FhirR4.USE_US_CORE_IG = person.randBoolean();
       FhirR4.USE_SHR_EXTENSIONS = false;
+
       String fhirJson = FhirR4.convertToFHIRJson(person, System.currentTimeMillis());
+
       // Check that the fhirJSON doesn't contain unresolved SNOMED-CT strings
       // (these should have been converted into URIs)
       if (fhirJson.contains("SNOMED-CT")) {
@@ -130,6 +130,7 @@ public class FHIRR4ExporterTest {
       // is impossible.
       // As of 2021-01-05, validating the bundle didn't validate references anyway,
       // but at some point we may want to do that.
+
       Bundle bundle = parser.parseResource(Bundle.class, fhirJson);
       for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
         ValidationResult eresult = validator.validateR4(entry.getResource());
@@ -137,7 +138,7 @@ public class FHIRR4ExporterTest {
           for (SingleValidationMessage emessage : eresult.getMessages()) {
             boolean valid = false;
             if (emessage.getSeverity() == ResultSeverityEnum.INFORMATION
-                    || emessage.getSeverity() == ResultSeverityEnum.WARNING) {
+                || emessage.getSeverity() == ResultSeverityEnum.WARNING) {
               /*
                * Ignore warnings.
                */
@@ -174,8 +175,8 @@ public class FHIRR4ExporterTest {
               valid = true; // ignore this error
             } else if (
                 emessage.getMessage().contains("Unknown extension http://hl7.org/fhir/us/core")
-                || emessage.getMessage().contains("Unknown extension http://synthetichealth")
-                || emessage.getMessage().contains("not be resolved, so has not been checked")) {
+                    || emessage.getMessage().contains("Unknown extension http://synthetichealth")
+                    || emessage.getMessage().contains("not be resolved, so has not been checked")) {
               /*
                * Despite setting instanceValidator.setAnyExtensionsAllowed(true) and
                * instanceValidator.setErrorForUnknownProfiles(false), the FHIR validator still
@@ -191,13 +192,13 @@ public class FHIRR4ExporterTest {
           }
         }
       }
-      int y = validationErrors.size();
-      if (x != y) {
+      if (! validationErrors.isEmpty()) {
         Exporter.export(person, System.currentTimeMillis());
       }
-    }
+      return validationErrors;
+    });
     assertTrue("Validation of exported FHIR bundle failed: "
-        + String.join("|", validationErrors), validationErrors.size() == 0);
+        + String.join("|", errors), errors.size() == 0);
   }
 
   @Test


### PR DESCRIPTION
This PR attempts to reduce the amount of time it takes to run the Synthea test suite. On my machine, it reduces the time by about 2 - 3 minutes. It includes the following changes:

* For exporter tests, 10 people are generated and then serialized out to byte arrays. Each time an exporter test is run, a Person object is rehydrated from the byte array, so the test will get an unmodified copy. This removes several places where the Generator would be spun up and used to create 10 patients
* Some exporter tests are now multithreaded. Export and validation takes place on a separate thread.
* Serialization and deserialization testing in Generator was reduced from 100 people to 10 people

Some things that I tried, but didn't work or hinder greater performance gains:
* Gradle allows for parallel test execution. It's easy to turn on. However, all tests are assigned to threads at the start of the whole test suite. This means that several of the long running tests may all get assigned to the same thread. This would often result in multiple threads sitting idle for a few minutes before all testing wraps up.
* Some things, likely JaCoCo, cause multithreaded performance to be poor. It is likely that there is some sort of lock on test coverage information that holds up parallel performance. In some configurations, Gradle multithreaded testing took longer than single threading. A single patient export takes longer to run in a multithreaded environment than in a single threaded environment, even though there are no obvious resources shared between threads that would fight for locks.

