### PR TITLE
Support java 17

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -3,14 +3,14 @@ on: [push, pull_request]
 jobs:
   check_java_latest:
     runs-on: ubuntu-latest
-    name: Java 16
+    name: Java 17
     
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 16
+          java-version: 17
 
       - name: Gradle cache
         uses: actions/cache@v2
@@ -18,9 +18,9 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-jdk16-${{ hashFiles('**/*.gradle*') }}
+          key: ${{ runner.os }}-gradle-jdk17-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-jdk16
+            ${{ runner.os }}-gradle-jdk17
             
       - name: Compile with Gradle
         run: ./gradlew assemble
@@ -30,8 +30,8 @@ jobs:
         if: env.SLACK_WEBHOOK_URL
         with:
           status: custom
-          job_name: Java 16
-          author_name: Java 16 Build
+          job_name: Java 17
+          author_name: Java 17 Build
           fields: workflow,commit,repo,author,took
           # see https://action-slack.netlify.app/usecase/02-custom for custom payload info
           custom_payload: |

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ checkstyle {
 }
 
 jacoco {
-  toolVersion '0.8.6'
+  toolVersion '0.8.7'
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Java 17 (LTS) was released in September, so we need to support it. Gradle added JDK17 support in 7.3, so this bumps that version and the CI test. From some quick testing it doesn't seem like anything else breaks on java 17 or gradle 7.3, but we should verify more thoroughly before merging