### PR TITLE
Add more usage info to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Generating the population one at a time...
 
 Command-line arguments may be provided to specify a state, city, population size, or seed for randomization.
 ```
-run_synthea [-s seed] [-p populationSize] [-m moduleFilter] [state [city]]
+run_synthea [-s seed] [-p populationSize] [state [city]]
 ```
 
 Full usage info can be printed by passing the `-h` option.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd synthea
 ./gradlew build check test
 ```
 
-### Changing the default properties 
+### Changing the default properties
 
 
 The default properties file values can be found at `src/main/resources/synthea.properties`.
@@ -53,19 +53,46 @@ Generating the population one at a time...
 ```
 
 Command-line arguments may be provided to specify a state, city, population size, or seed for randomization.
-
-Usage is 
 ```
 run_synthea [-s seed] [-p populationSize] [-m moduleFilter] [state [city]]
 ```
-For example:
 
- - `run_synthea Massachusetts`
- - `run_synthea Alaska Juneau`
- - `run_synthea -s 12345`
- - `run_synthea -p 1000`
- - `run_synthea -s 987 Washington Seattle`
- - `run_synthea -s 21 -p 100 Utah "Salt Lake City"`
+Full usage info can be printed by passing the `-h` option.
+```
+$ ./run_synthea -h     
+
+> Task :run
+Usage: run_synthea [options] [state [city]]
+Options: [-s seed]
+         [-cs clinicianSeed]
+         [-p populationSize]
+         [-r referenceDate as YYYYMMDD]
+         [-g gender]
+         [-a minAge-maxAge]
+         [-o overflowPopulation]
+         [-m moduleFileWildcardList]
+         [-c localConfigFilePath]
+         [-d localModulesDirPath]
+         [-i initialPopulationSnapshotPath]
+         [-u updatedPopulationSnapshotPath]
+         [-t updateTimePeriodInDays]
+         [-f fixedRecordPath]
+         [-k keepMatchingPatientsPath]
+         [--config* value]
+          * any setting from src/main/resources/synthea.properties
+
+Examples:
+run_synthea Massachusetts
+run_synthea Alaska Juneau
+run_synthea -s 12345
+run_synthea -p 1000
+run_synthea -s 987 Washington Seattle
+run_synthea -s 21 -p 100 Utah "Salt Lake City"
+run_synthea -g M -a 60-65
+run_synthea -p 10 --exporter.fhir.export true
+run_synthea -m moduleFilename:anotherModule:module*
+run_synthea --exporter.baseDirectory "./output_tx/" Texas
+```
 
 Some settings can be changed in `./src/main/resources/synthea.properties`.
 

--- a/src/main/java/App.java
+++ b/src/main/java/App.java
@@ -39,7 +39,7 @@ public class App {
     System.out.println("run_synthea Massachusetts");
     System.out.println("run_synthea Alaska Juneau");
     System.out.println("run_synthea -s 12345");
-    System.out.println("run_synthea -p 1000)");
+    System.out.println("run_synthea -p 1000");
     System.out.println("run_synthea -s 987 Washington Seattle");
     System.out.println("run_synthea -s 21 -p 100 Utah \"Salt Lake City\"");
     System.out.println("run_synthea -g M -a 60-65");


### PR DESCRIPTION
And cleanup extraneous paren in usage info.

In my particular case, I was looking for an option to generate more patients with the same set of clinicians/providers, which I now assume is the `-cs` option (which wasn't documented here previously).