### PR TITLE
Restore log silencing by default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ bin/**
 /output/
 /out/
 
+**/*.log
+
 # don't commit the autobuilt version file
 src/main/resources/version.txt
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Synthea
-Copyright 2017-2020 The MITRE Corporation
+Copyright 2017-2022 The MITRE Corporation
 
 This material contains prescribable drug codes from RxNorm that are released by
 the National Library of Medicine and is in the public domain.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Generate a list of concepts (used in the records) or attributes (variables on ea
 
 # License
 
-Copyright 2017-2021 The MITRE Corporation
+Copyright 2017-2022 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   // get rid of SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
   // if we switch to a real logging framework we may want to switch this
   implementation "org.slf4j:slf4j-api:1.7.9"
-  // compile "org.slf4j:slf4j-nop:1.6.1" // SLF4J seems to already be provided by org.apache.logging.log4j
+  //implementation "org.slf4j:slf4j-nop:1.7.9" // SLF4J seems to already be provided by org.apache.logging.log4j
   
   // ensure transitive dependencies do not use vulnerable log4j 
   implementation "org.apache.logging.log4j:log4j-core", {

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,1 @@
+<Configuration status="OFF"/>


### PR DESCRIPTION
The PR is a follow up to #969.

That PR ended up generating a new log file: `jsbml.log`.

This PR reverts to the previous behavior where log output is silenced or to the console only.