### PR TITLE
BFD: Exclude claims for encounters outside of the export date range

### DIFF
--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -131,9 +131,8 @@ public abstract class Exporter {
     if (options.deferExports) {
       deferredExports.add(new ImmutablePair<Person, Long>(person, stopTime));
     } else {
-      int yearsOfHistory = Integer.parseInt(Config.get("exporter.years_of_history"));
-      if (yearsOfHistory > 0) {
-        person = filterForExport(person, yearsOfHistory, stopTime);
+      if (options.yearsOfHistory > 0) {
+        person = filterForExport(person, options.yearsOfHistory, stopTime);
       }
       if (!person.alive(stopTime)) {
         filterAfterDeath(person);
@@ -257,7 +256,7 @@ public abstract class Exporter {
     if (Config.getAsBoolean("exporter.bfd.export")) {
       try {
         BB2RIFExporter exporter = BB2RIFExporter.getInstance();
-        exporter.export(person, stopTime);
+        exporter.export(person, stopTime, options.yearsOfHistory);
       } catch (IOException e) {
         e.printStackTrace();
       }


### PR DESCRIPTION
Don't export claims for encounters that finished before the export date range defined by effective time and years of export history.