### PR TITLE
Remove unnecessary assign_to_attribute in switching_provider module

### DIFF
--- a/src/test/resources/generic/switching_provider.json
+++ b/src/test/resources/generic/switching_provider.json
@@ -146,7 +146,6 @@
     },
     "Eater": {
       "type": "ConditionOnset",
-      "assign_to_attribute": "",
       "target_encounter": "",
       "codes": [
         {


### PR DESCRIPTION
See https://github.com/synthetichealth/module-builder/pull/303 for an explanation of why this was there in the first place and what it generates.