### PR TITLE
Better handle blank assign_to_attribute

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -994,15 +994,26 @@ public abstract class State implements Cloneable, Serializable {
   }
 
   /**
+   * Class to handle assign_to_attribute, specifically when it is blank, which used to happen a lot
+   * with the default JSON provided by the Module Builder.
+   */
+  private abstract static class AttributeAssignableState extends State {
+    protected String assignToAttribute;
+
+    protected boolean shouldAssignAttribute() {
+      return (assignToAttribute != null && assignToAttribute.length() > 0);
+    }
+  }
+
+  /**
    * OnsetState is a parent class for ConditionOnset and AllergyOnset, where some common logic can
    * be shared. It is an implementation detail and should never be referenced directly in a JSON
    * module.
    */
-  private abstract static class OnsetState extends State {
+  private abstract static class OnsetState extends AttributeAssignableState {
     public boolean diagnosed;
 
     protected List<Code> codes;
-    protected String assignToAttribute;
     protected String targetEncounter;
 
     public OnsetState clone() {
@@ -1018,7 +1029,7 @@ public abstract class State implements Cloneable, Serializable {
       if (targetEncounter == null || targetEncounter.trim().length() == 0
           || (encounter != null && targetEncounter.equals(encounter.name))) {
         diagnose(person, time);
-      } else if (assignToAttribute != null && codes != null) {
+      } else if (shouldAssignAttribute()) {
         // create a temporary coded entry to use for reference in the attribute,
         // which will be replaced if the thing is diagnosed
         HealthRecord.Entry codedEntry = person.record.new Entry(time, codes.get(0).code);
@@ -1061,7 +1072,7 @@ public abstract class State implements Cloneable, Serializable {
       if (codes != null) {
         entry.mergeCodeList(codes);
       }
-      if (assignToAttribute != null) {
+      if (shouldAssignAttribute()) {
         person.attributes.put(assignToAttribute, entry);
       }
 
@@ -1140,7 +1151,7 @@ public abstract class State implements Cloneable, Serializable {
       allergy.allergyType = allergyType;
       allergy.category = category;
 
-      if (assignToAttribute != null) {
+      if (shouldAssignAttribute()) {
         person.attributes.put(assignToAttribute, entry);
       }
 
@@ -1206,11 +1217,10 @@ public abstract class State implements Cloneable, Serializable {
    * 'administration' field allows for the MedicationOrder to also export a
    * MedicationAdministration into the exported FHIR record.
    */
-  public static class MedicationOrder extends State {
+  public static class MedicationOrder extends AttributeAssignableState {
     private List<Code> codes;
     private String reason;
     private JsonObject prescription; // TODO make this a Component
-    private String assignToAttribute;
     private boolean administration;
     private boolean chronic;
 
@@ -1283,7 +1293,7 @@ public abstract class State implements Cloneable, Serializable {
       medication.prescriptionDetails = prescription;
       medication.administration = administration;
 
-      if (assignToAttribute != null) {
+      if (shouldAssignAttribute()) {
         person.attributes.put(assignToAttribute, medication);
       }
       // increment number of prescriptions prescribed by respective hospital
@@ -1347,12 +1357,11 @@ public abstract class State implements Cloneable, Serializable {
    * for more details. One or more codes describes the care plan and a list of activities describes
    * what the care plan entails.
    */
-  public static class CarePlanStart extends State {
+  public static class CarePlanStart extends AttributeAssignableState {
     private List<Code> codes;
     private List<Code> activities;
     private transient List<JsonObject> goals; // TODO: make this a Component
     private String reason;
-    private String assignToAttribute;
 
     @Override
     public CarePlanStart clone() {
@@ -1389,7 +1398,7 @@ public abstract class State implements Cloneable, Serializable {
           }
         }
       }
-      if (assignToAttribute != null) {
+      if (shouldAssignAttribute()) {
         person.attributes.put(assignToAttribute, careplan);
       }
       return true;
@@ -1520,7 +1529,7 @@ public abstract class State implements Cloneable, Serializable {
       int year = Utilities.getYear(time);
       provider.incrementProcedures(year);
 
-      if (assignToAttribute != null) {
+      if (assignToAttribute != null && assignToAttribute.length() > 0) {
         person.attributes.put(assignToAttribute, procedure);
       }
     }
@@ -2010,11 +2019,10 @@ public abstract class State implements Cloneable, Serializable {
    * and should be added separately. A Device may have a manufacturer or model listed
    * for cases where there is generally only one choice.
    */
-  public static class Device extends State {
+  public static class Device extends AttributeAssignableState {
     public Code code;
     public String manufacturer;
     public String model;
-    public String assignToAttribute;
 
     @Override
     public Device clone() {
@@ -2030,7 +2038,7 @@ public abstract class State implements Cloneable, Serializable {
       device.manufacturer = manufacturer;
       device.model = model;
 
-      if (assignToAttribute != null) {
+      if (shouldAssignAttribute()) {
         person.attributes.put(assignToAttribute, device);
       }
 

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -193,6 +193,8 @@ public class StateTest {
         module.name, conditionDisplay
     );
     assertTrue(onsetTime != null);
+    // Ensure that it ignores the blank assign_to_attribute
+    assertNull(person.attributes.get(""));
     assertEquals(time, onsetTime.longValue());
   }
 
@@ -252,6 +254,7 @@ public class StateTest {
         module.name, code.display
     );
     assertTrue(onsetTime != null);
+    assertNotNull(person.attributes.get("Most Recent ED Visit"));
     assertEquals(time, onsetTime.longValue());
   }
 

--- a/src/test/resources/generic/condition_onset.json
+++ b/src/test/resources/generic/condition_onset.json
@@ -7,6 +7,7 @@
         },
         "Diabetes": {
             "type": "ConditionOnset",
+            "assign_to_attribute" : "",
             "codes": [{
                 "system": "SNOMED-CT",
                 "code": "73211009",


### PR DESCRIPTION
The way that the Module Builder worked, ConditionOnset states would
have a blank assign_to_attribute by default. This would cause a
blank attribute to show up in everyones' records. That has been
addressed in the Module Builder, but this change ensures that the
blank attribute won't be created if older GMF is used.

This is sort of an add on to #989 