### PR TITLE
Stop CardiovascularDiseaseModule from adding multiple codes to the same Entry

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -14,6 +14,7 @@ import org.mitre.synthea.helpers.Attributes.Inventory;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.ClinicianSpecialty;
+import org.mitre.synthea.world.concepts.HealthRecord;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
 import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
@@ -757,7 +758,11 @@ public final class CardiovascularDiseaseModule extends Module {
 
   private static void prescribeMedication(String med, Person person, long time, boolean chronic) {
     Medication entry = person.record.medicationStart(time, med, chronic);
-    entry.codes.add(LOOKUP.get(med));
+    HealthRecord.Code medicationCode = LOOKUP.get(med);
+    if (! entry.containsCode(medicationCode.code, medicationCode.system)) {
+      entry.codes.add(medicationCode);
+    }
+
     // increment number of prescriptions prescribed
     Encounter encounter = (Encounter) person.attributes.get(CVD_ENCOUNTER);
     if (encounter != null) {
@@ -780,7 +785,9 @@ public final class CardiovascularDiseaseModule extends Module {
           && !person.record.present.containsKey(diagnosis)) {
         Code code = LOOKUP.get(diagnosis);
         Entry conditionEntry = person.record.conditionStart(time, code.display);
-        conditionEntry.codes.add(code);
+        if (! conditionEntry.containsCode(code.code, code.system)) {
+          conditionEntry.codes.add(code);
+        }
       }
     }
 


### PR DESCRIPTION
The `CardiovascularDiseaseModule` module will add the same code to an `Entry` multiple times. This is mostly harmless, but will end up with CCDA exports that have multiple translations in code blocks, all with the same code.

This change ensures that codes are added only once.

This PR addresses issue #992 