### PR TITLE
Demographics fix

### DIFF
--- a/src/main/java/org/mitre/synthea/world/geography/Demographics.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Demographics.java
@@ -521,12 +521,7 @@ public class Demographics implements Comparable<Demographics>, Serializable {
    */
   private static void nonZeroDefaults(Map<String, Double> map) {
     // Any null or nan values should be zero
-    for (String key : map.keySet()) {
-      Double value = map.get(key);
-      if (value == null || value.isNaN()) {
-        map.put(key, Double.valueOf(0));
-      }
-    }
+    map.replaceAll((key, value) -> (value == null || value.isNaN()) ? 0.0 : value);
     // Now check if all values are zero
     boolean allZero = true;
     for (Double value : map.values()) {
@@ -535,11 +530,10 @@ public class Demographics implements Comparable<Demographics>, Serializable {
         break;
       }
     }
+    // If all values were zero, apply a uniform distribution.
     if (allZero) {
-      Double value = 1.0 / Double.valueOf(map.size());
-      for (String key : map.keySet()) {
-        map.put(key, value);
-      }
+      Double value = 1.0 / map.size();
+      map.replaceAll((key, oldValue) -> value);
     }
   }
 

--- a/src/main/java/org/mitre/synthea/world/geography/Demographics.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Demographics.java
@@ -252,7 +252,6 @@ public class Demographics implements Comparable<Demographics>, Serializable {
      */
 
     String pickedRange = incomeDistribution.next(random);
-
     String[] range = pickedRange.split("\\.\\.");
     // TODO this seems like it would benefit from better caching
     int low = Integer.parseInt(range[0]) * 1000;
@@ -454,11 +453,14 @@ public class Demographics implements Comparable<Demographics>, Serializable {
       String csvHeader = Integer.toString(i++);
       double percentage = Double.parseDouble(line.get(csvHeader));
       d.ages.put(ageGroup, percentage);
+
     }
+    nonZeroDefaults(d.ages);
 
     d.gender = new HashMap<String, Double>();
     d.gender.put("male", Double.parseDouble(line.get("TOT_MALE")));
     d.gender.put("female", Double.parseDouble(line.get("TOT_FEMALE")));
+    nonZeroDefaults(d.gender);
 
     double percentageTotal = 0;
     d.race = new HashMap<String, Double>();
@@ -480,6 +482,7 @@ public class Demographics implements Comparable<Demographics>, Serializable {
       d.race.put("hawaiian", 0.0);
       d.race.put("other", 0.0);
     }
+    nonZeroDefaults(d.race);
 
     d.income = new HashMap<String, Double>();
     for (String income : CSV_INCOMES) {
@@ -491,6 +494,7 @@ public class Demographics implements Comparable<Demographics>, Serializable {
         d.income.put(income, percentage);
       }
     }
+    nonZeroDefaults(d.income);
 
     d.education = new HashMap<String, Double>();
     for (String education : CSV_EDUCATIONS) {
@@ -502,10 +506,41 @@ public class Demographics implements Comparable<Demographics>, Serializable {
         d.education.put(education.toLowerCase(), percentage);
       }
     }
+    nonZeroDefaults(d.education);
 
     d.ethnicity = Double.parseDouble(line.get(CSV_ETHNICITY));
 
     return d;
+  }
+
+  /**
+   * A distribution with all zero values will cause run-time issues.
+   * If the values are all zero, an equally weighted uniform distribution
+   * will be set.
+   * @param map The map to check.
+   */
+  private static void nonZeroDefaults(Map<String, Double> map) {
+    // Any null or nan values should be zero
+    for (String key : map.keySet()) {
+      Double value = map.get(key);
+      if (value == null || value.isNaN()) {
+        map.put(key, Double.valueOf(0));
+      }
+    }
+    // Now check if all values are zero
+    boolean allZero = true;
+    for (Double value : map.values()) {
+      if (value != 0)  {
+        allZero = false;
+        break;
+      }
+    }
+    if (allZero) {
+      Double value = 1.0 / Double.valueOf(map.size());
+      for (String key : map.keySet()) {
+        map.put(key, value);
+      }
+    }
   }
 
   /**

--- a/src/main/resources/geography/zipcodes.csv
+++ b/src/main/resources/geography/zipcodes.csv
@@ -5660,7 +5660,7 @@
 ,California,CA,Pittsburg,94509,37.996501,-121.812301
 ,California,CA,Pittsburg,94565,38.014576,-121.906255
 ,California,CA,Pixley,93256,35.960636,-119.312992
-,California,CA,"Pi�on Hills",,34.445607,-117.623563
+,California,CA,"Piñon Hills",,34.445607,-117.623563
 ,California,CA,Placentia,92806,33.837959999999995,-117.870494
 ,California,CA,Placentia,92807,33.848733,-117.788357
 ,California,CA,Placentia,92870,33.881158,-117.85478300000001
@@ -36718,9 +36718,9 @@
 ,"New Mexico",NM,"Casa Colorada",,34.550932,-106.73987
 ,New Mexico,NM,Causey,88113,33.772019,-103.085189
 ,New Mexico,NM,Causey,88132,33.907343,-103.166813
-,"New Mexico",NM,"Ca�ada de los Alamos",,35.592655,-105.859754
-,"New Mexico",NM,Ca�on,,35.671759,-106.752682
-,"New Mexico",NM,Ca�ones,,36.176434,-106.419355
+,"New Mexico",NM,"Cañada de los Alamos",,35.592655,-105.859754
+,"New Mexico",NM,Cañon,,35.671759,-106.752682
+,"New Mexico",NM,Cañones,,36.176434,-106.419355
 ,"New Mexico",NM,"Cedar Crest",87008,35.119938,-106.406994
 ,"New Mexico",NM,"Cedar Grove",,35.163489,-106.161268
 ,"New Mexico",NM,"Cedar Hill",,36.929659,-107.889009
@@ -36994,8 +36994,8 @@
 ,New Mexico,NM,Pecos,,35.640493,-105.523041
 ,New Mexico,NM,Peralta,87031,34.599362,-107.206451
 ,New Mexico,NM,Peralta,87042,34.82801,-106.686507
-,"New Mexico",NM,"Pe�a Blanca",,35.570919,-106.331955
-,"New Mexico",NM,Pe�asco,,36.17032,-105.69072
+,"New Mexico",NM,"Peña Blanca",,35.570919,-106.331955
+,"New Mexico",NM,Peñasco,,36.17032,-105.69072
 ,"New Mexico",NM,"Picuris Pueblo",,36.200146,-105.723504
 ,"New Mexico",NM,"Pie Town",87827,34.406825,-108.096748
 ,"New Mexico",NM,Pinehill,87357,34.907890,-108.296747
@@ -57938,7 +57938,7 @@
 ,Texas,TX,Longview,,32.506234,-94.771633
 ,Texas,TX,Loop,79342,32.908208,-102.336600
 ,Texas,TX,Lopezville,,26.245288,-98.153701
-,Texas,TX,Lope�o,,26.711834,-99.100966
+,Texas,TX,Lopeño,,26.711834,-99.100966
 ,Texas,TX,Loraine,79532,32.404869,-100.711396
 ,Texas,TX,Loraine,,32.408651,-100.712515
 ,Texas,TX,Lorena,76630,31.340795,-97.21101
@@ -58826,8 +58826,8 @@
 ,Texas,TX,Saginaw,76131,32.881821,-97.345943
 ,Texas,TX,Saginaw,76179,32.909919,-97.434281
 ,Texas,TX,Salado,76571,30.925739,-97.59865
-,Texas,TX,Saline�o,,26.517553,-99.112058
-,Texas,TX,"Saline�o North",,26.527223,-99.094956
+,Texas,TX,Salineño,,26.517553,-99.112058
+,Texas,TX,"Salineño North",,26.527223,-99.094956
 ,Texas,TX,"Sam Rayburn",,31.077263,-94.025528
 ,Texas,TX,"Sammy Martinez",,26.432851,-98.751298
 ,Texas,TX,Samnorwood,,35.050114,-100.281401


### PR DESCRIPTION
- Fixes a rare exception related to demographic distributions that are all zeroes (e.g., if every income bracket for a location has a zero probability -- then a person cannot exist within any of the income brackets, and a runtime exception is thrown).
- Rather than patch the demographics file, part of this fix is to detect all zero distributions and use a default uniform distribution (which was already being applied in the case where the distributions were null instead of zero). Don't like that? Override the demographics file.
- I also made partial fixes to the demographics file (fixed one county in New Mexico that was especially egregious in this regard).
- One other fix related to Unicode accented n's