### PR TITLE
Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: File a bug report
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        Please note that this template is for bugs only. This is a case where Synthea crashes,
+        behaves in an unexpected way or outputs incorrect information.
+
+        If you have a question about how Synthea works, please visit Synthea Discussions.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      examples:
+        - **OS**: macOS 12.2.1
+        - **Java**: openjdk version 17.0.1
+    value: |
+        - OS:
+        - Java:
+    render: markdown
+  validations:
+    required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/bug-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yml
@@ -20,19 +20,19 @@ body:
       value: "A bug happened!"
     validations:
       required: true
-- type: textarea
-  attributes:
-    label: Environment
-    description: |
-      examples:
-        - **OS**: macOS 12.2.1
-        - **Java**: openjdk version 17.0.1
-    value: |
-        - OS:
-        - Java:
-    render: markdown
-  validations:
-    required: false
+  - type: textarea
+    attributes:
+      label: Environment
+      description: |
+        examples:
+          - **OS**: macOS 12.2.1
+          - **Java**: openjdk version 17.0.1
+      value: |
+          - OS:
+          - Java:
+      render: markdown
+    validations:
+      required: false
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-template.yml
+++ b/.github/ISSUE_TEMPLATE/feature-template.yml
@@ -1,0 +1,24 @@
+name: Feature Request
+description: Request a new feature in Synthea
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+
+        Prior to filling out a feature request, it is recommended to open a Synthea Discussion
+        to ensure that the desired functionality is something that can't be currently achieved
+        with Synthea and that the idea is something that the Synthea team would be willing to
+        incorporate.
+
+        Also, please check the [Contributions to Avoid](https://github.com/synthetichealth/synthea/wiki/Contributing#contributions-to-avoid)
+        section of the Synthea wiki to ensure your idea is something that fits Synthea's scope.
+  - type: textarea
+    id: feature
+    attributes:
+      label: Requested Feature
+      description: New behavior, simulated information or other item you would like in Synthea
+      placeholder: Synthea should add a feature to...
+    validations:
+      required: true


### PR DESCRIPTION
Implement issue templates for Synthea

* Turns off just opening a blank issue
* Makes users select bug or feature request
* Bug template discourages users from asking open questions and points them to discussions
* Feature request points users to discussions first and also the contributions to avoid section of the wiki