### PR TITLE
Add table based transitions to Java Graphviz rendering.

### DIFF
--- a/src/main/java/Graphviz.java
+++ b/src/main/java/Graphviz.java
@@ -251,6 +251,21 @@ public class Graphviz {
           Link link = Factory.to(target).with(Label.of(label));
           links.add(link);
         });
+      } else if (state.has("lookup_table_transition")) {
+        JsonArray distributions = state.get("lookup_table_transition").getAsJsonArray();
+        distributions.forEach(d -> {
+          JsonObject option = d.getAsJsonObject();
+          String destination = option.get("transition").getAsString();
+          double pct = option.get("default_probability").getAsDouble() * 100.0;
+          String label = "See Table (def: " + pct + "%)";
+          Node target = nodeMap.get(destination);
+          if (target == null) {
+            throw new RuntimeException(
+                relativePath + " " + name + " transitioning to unknown state: " + destination);
+          }
+          Link link = Factory.to(target).with(Label.of(label));
+          links.add(link);
+        });
       }
       g = g.with(node.link(links.toArray(new Link[0])));
     }


### PR DESCRIPTION
This PR adds the ability to render table based transitions to the `./gradlew graphviz` task.

The labeling follows the same standard as the Module Builder.

Example rendering:
<img width="736" alt="image" src="https://user-images.githubusercontent.com/1054765/159060507-c99ae7ad-25c7-4ac6-91a6-e444fd549b40.png">

This PR does not address the preexisting overflow/word-wrap issue displayed in the example above.
