### PR TITLE
Blood pressure model with medication impacts

### DIFF
--- a/src/main/resources/htn_drugs.csv
+++ b/src/main/resources/htn_drugs.csv
@@ -1,26 +1,22 @@
-Precise Class,Class,Simple Name,RxNorm,Display,Impact Minimum,Impact Maximum,Available Strengths,Ingredient Code (Allergy),Prescribable,Notes
-Diuretic,Diuretic,Chlorthalidone,197499,chlorthalidone 25 MG Oral Tablet,-11.5,-16.29,25mg,,TRUE,
-Diuretic,Diuretic,Furosemide,313988,furosemide 40 MG Oral Tablet,-11.5,-16.29,20mg;40mg;80mg,,TRUE,
-Diuretic,Diuretic,Spironolactone,313096,spironolactone 25 MG Oral Tablet,-11.5,-16.29,25mg,,TRUE,
-Diuretic,Diuretic,Triamterene/HCTZ,310818,hydroCHLOROthiazide 50 MG / triamterene 75 MG Oral Tablet,-11.5,-16.29,75/50mg,,TRUE,
-Diuretic,Diuretic,Amiloride,977880,aMILoride hydrochloride 5 MG Oral Tablet,-11.5,-16.29,5mg,,TRUE,
-Diuretic,Diuretic,Amiloride/HCTZ,,,-11.5,-16.29,,,FALSE,don't prescribe combos -- makes it more challenging to keep track
-Diuretic,Diuretic,HCTZ,310798,Hydrochlorothiazide 25 MG Oral Tablet,-11.5,-16.29,,,FALSE,used in existing htn module; prescribable false because restricted use
-Ace Inhibitor,ACE or ARB,Lisinopril,314076,lisinopril 10 MG Oral Tablet,-11.5,-16.29,5mg;10mg;20mg;40mg,,TRUE,
-Ace Inhibitor,ACE or ARB,Lisinopril/HCTZ,,,-11.5,-16.29,,,FALSE,don't prescribe combos -- makes it more challenging to keep track
-Angiotensin Receptor Blocker,ACE or ARB,Losartan,979492,losartan potassium 50 MG Oral Tablet,-11.5,-16.29,25mg;50mg;100mg,,TRUE,
-Angiotensin Receptor Blocker,ACE or ARB,Azilsartan,1091646,azilsartan medoxomil 40 MG Oral Tablet,-11.5,-16.29,40mg;90mg,,TRUE,
-Angiotensin Receptor Blocker,ACE or ARB,Azilsartan/chlorthalidone,1235144,azilsartan medoxomil 40 MG / chlorthalidone 12.5 MG Oral Tablet,-11.5,-16.29,40/12.5mg;40/25mg,,TRUE,
-Calcium Channel Blockers,Calcium Channel Blockers,Diltiazem,830877,24 HR dilTIAZem hydrochloride 180 MG Extended Release Oral Tablet,-11.5,-16.29,120mg;180mg;240mg;300mg,,TRUE,
-Calcium Channel Blockers,Calcium Channel Blockers,Amlodipine,197361,amLODIPine 5 MG Oral Tablet,-11.5,-16.29,2.5mg;5mg;10mg,,TRUE,
-Calcium Channel Blockers,Calcium Channel Blockers,Amlodipine,308136,amLODIPine 2.5 MG Oral Tablet,-11.5,-16.29,,,TRUE,used in existing htn module
-Beta Blockers,Beta Blockers,Metoprolol Tartrate,866514,metoprolol tartrate 50 MG Oral Tablet,-11.5,-16.29,25mg;50mg;100mg,,TRUE,
-Beta Blockers,Beta Blockers,Metoprolol ER,866412,24 HR metoprolol succinate 100 MG Extended Release Oral Tablet,-11.5,-16.29,,,FALSE,used in sihd module; restricted use
-Beta Blockers,Beta Blockers,Atenolol,197381,atenolol 50 MG Oral Tablet,-11.5,-16.29,25mg;50mg;100mg,,TRUE,
-Beta Blockers,Beta Blockers,Atenolol/Chlorthalidone,197383,atenolol 50 MG / chlorthalidone 25 MG Oral Tablet,-11.5,-16.29,50/25mg,,FALSE,don't prescribe combos -- makes it more challenging to keep track
-Vasodilators,Vasodilators,Hydralazine,905395,hydrALAZINE hydrochloride 50 MG Oral Tablet,-11.5,-16.29,25mg;50mg;100mg ,,TRUE,
-Vasodilators,Vasodilators,Minoxidil,197987,minoxidil 2.5 MG Oral Tablet,-11.5,-16.29,2.5mg;10mg ,,TRUE,
-Alpha 2 Agonist,Alpha 2 Agonist,Guanfacine,197745,guanFACINE 1 MG Oral Tablet,-11.5,-16.29,1mg;2mg ,,TRUE,
-Alpha Blockers,Alpha Blockers,Doxazosin,197626,doxazosin 2 MG Oral Tablet,-11.5,-16.29,1mg;2mg;4mg;8mg ,,TRUE,
-Potassium Supplements,Potassium Supplements,KCL tablets,,,-11.5,-16.29,20mEq ,,TRUE,
-Potassium Supplements,Potassium Supplements,KCL oral solution (10%),,,-11.5,-16.29,20mEq/15ml,,TRUE,
+Precise Class,Class,Simple Name,RxNorm,Display,Systolic Impact Minimum,Systolic Impact Maximum,Diastolic Impact Minimum,Diastolic Impact Maximum
+Diuretic,Diuretic,Chlorthalidone,197499,chlorthalidone 25 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Diuretic,Diuretic,Furosemide,313988,furosemide 40 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Diuretic,Diuretic,Spironolactone,313096,spironolactone 25 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Diuretic,Diuretic,Triamterene/HCTZ,310818,hydroCHLOROthiazide 50 MG / triamterene 75 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Diuretic,Diuretic,Amiloride,977880,aMILoride hydrochloride 5 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Diuretic,Diuretic,HCTZ,310798,Hydrochlorothiazide 25 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Ace Inhibitor,ACE or ARB,Lisinopril,314076,lisinopril 10 MG Oral Tablet,-11.5,-16.29,-7.2,-13.6
+Angiotensin Receptor Blocker,ACE or ARB,Losartan,979492,losartan potassium 50 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Angiotensin Receptor Blocker,ACE or ARB,Azilsartan,1091646,azilsartan medoxomil 40 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Angiotensin Receptor Blocker,ACE or ARB,Azilsartan/chlorthalidone,1235144,azilsartan medoxomil 40 MG / chlorthalidone 12.5 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Calcium Channel Blockers,Calcium Channel Blockers,Diltiazem,830877,24 HR dilTIAZem hydrochloride 180 MG Extended Release Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Calcium Channel Blockers,Calcium Channel Blockers,Amlodipine,197361,amLODIPine 5 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Calcium Channel Blockers,Calcium Channel Blockers,Amlodipine,308136,amLODIPine 2.5 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Beta Blockers,Beta Blockers,Metoprolol Tartrate,866514,metoprolol tartrate 50 MG Oral Tablet,-11.5,-16.29,-8.7,-15.5
+Beta Blockers,Beta Blockers,Metoprolol ER,866412,24 HR metoprolol succinate 100 MG Extended Release Oral Tablet,-11.5,-16.29,-8.7,-15.5
+Beta Blockers,Beta Blockers,Atenolol,197381,atenolol 50 MG Oral Tablet,-11.5,-16.29,-8.7,-15.5
+Beta Blockers,Beta Blockers,Atenolol/Chlorthalidone,197383,atenolol 50 MG / chlorthalidone 25 MG Oral Tablet,-11.5,-16.29,-8.7,-15.5
+Vasodilators,Vasodilators,Hydralazine,905395,hydrALAZINE hydrochloride 50 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Vasodilators,Vasodilators,Minoxidil,197987,minoxidil 2.5 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Alpha 2 Agonist,Alpha 2 Agonist,Guanfacine,197745,guanFACINE 1 MG Oral Tablet,-11.5,-16.29,-9.3,-11.7
+Alpha Blockers,Alpha Blockers,Doxazosin,197626,doxazosin 2 MG Oral Tablet,-11.5,-16.29,-11.2,-13.8

--- a/src/main/resources/htn_drugs.csv
+++ b/src/main/resources/htn_drugs.csv
@@ -1,0 +1,26 @@
+Precise Class,Class,Simple Name,RxNorm,Display,Impact Minimum,Impact Maximum,Available Strengths,Ingredient Code (Allergy),Prescribable,Notes
+Diuretic,Diuretic,Chlorthalidone,197499,chlorthalidone 25 MG Oral Tablet,-11.5,-16.29,25mg,,TRUE,
+Diuretic,Diuretic,Furosemide,313988,furosemide 40 MG Oral Tablet,-11.5,-16.29,20mg;40mg;80mg,,TRUE,
+Diuretic,Diuretic,Spironolactone,313096,spironolactone 25 MG Oral Tablet,-11.5,-16.29,25mg,,TRUE,
+Diuretic,Diuretic,Triamterene/HCTZ,310818,hydroCHLOROthiazide 50 MG / triamterene 75 MG Oral Tablet,-11.5,-16.29,75/50mg,,TRUE,
+Diuretic,Diuretic,Amiloride,977880,aMILoride hydrochloride 5 MG Oral Tablet,-11.5,-16.29,5mg,,TRUE,
+Diuretic,Diuretic,Amiloride/HCTZ,,,-11.5,-16.29,,,FALSE,don't prescribe combos -- makes it more challenging to keep track
+Diuretic,Diuretic,HCTZ,310798,Hydrochlorothiazide 25 MG Oral Tablet,-11.5,-16.29,,,FALSE,used in existing htn module; prescribable false because restricted use
+Ace Inhibitor,ACE or ARB,Lisinopril,314076,lisinopril 10 MG Oral Tablet,-11.5,-16.29,5mg;10mg;20mg;40mg,,TRUE,
+Ace Inhibitor,ACE or ARB,Lisinopril/HCTZ,,,-11.5,-16.29,,,FALSE,don't prescribe combos -- makes it more challenging to keep track
+Angiotensin Receptor Blocker,ACE or ARB,Losartan,979492,losartan potassium 50 MG Oral Tablet,-11.5,-16.29,25mg;50mg;100mg,,TRUE,
+Angiotensin Receptor Blocker,ACE or ARB,Azilsartan,1091646,azilsartan medoxomil 40 MG Oral Tablet,-11.5,-16.29,40mg;90mg,,TRUE,
+Angiotensin Receptor Blocker,ACE or ARB,Azilsartan/chlorthalidone,1235144,azilsartan medoxomil 40 MG / chlorthalidone 12.5 MG Oral Tablet,-11.5,-16.29,40/12.5mg;40/25mg,,TRUE,
+Calcium Channel Blockers,Calcium Channel Blockers,Diltiazem,830877,24 HR dilTIAZem hydrochloride 180 MG Extended Release Oral Tablet,-11.5,-16.29,120mg;180mg;240mg;300mg,,TRUE,
+Calcium Channel Blockers,Calcium Channel Blockers,Amlodipine,197361,amLODIPine 5 MG Oral Tablet,-11.5,-16.29,2.5mg;5mg;10mg,,TRUE,
+Calcium Channel Blockers,Calcium Channel Blockers,Amlodipine,308136,amLODIPine 2.5 MG Oral Tablet,-11.5,-16.29,,,TRUE,used in existing htn module
+Beta Blockers,Beta Blockers,Metoprolol Tartrate,866514,metoprolol tartrate 50 MG Oral Tablet,-11.5,-16.29,25mg;50mg;100mg,,TRUE,
+Beta Blockers,Beta Blockers,Metoprolol ER,866412,24 HR metoprolol succinate 100 MG Extended Release Oral Tablet,-11.5,-16.29,,,FALSE,used in sihd module; restricted use
+Beta Blockers,Beta Blockers,Atenolol,197381,atenolol 50 MG Oral Tablet,-11.5,-16.29,25mg;50mg;100mg,,TRUE,
+Beta Blockers,Beta Blockers,Atenolol/Chlorthalidone,197383,atenolol 50 MG / chlorthalidone 25 MG Oral Tablet,-11.5,-16.29,50/25mg,,FALSE,don't prescribe combos -- makes it more challenging to keep track
+Vasodilators,Vasodilators,Hydralazine,905395,hydrALAZINE hydrochloride 50 MG Oral Tablet,-11.5,-16.29,25mg;50mg;100mg ,,TRUE,
+Vasodilators,Vasodilators,Minoxidil,197987,minoxidil 2.5 MG Oral Tablet,-11.5,-16.29,2.5mg;10mg ,,TRUE,
+Alpha 2 Agonist,Alpha 2 Agonist,Guanfacine,197745,guanFACINE 1 MG Oral Tablet,-11.5,-16.29,1mg;2mg ,,TRUE,
+Alpha Blockers,Alpha Blockers,Doxazosin,197626,doxazosin 2 MG Oral Tablet,-11.5,-16.29,1mg;2mg;4mg;8mg ,,TRUE,
+Potassium Supplements,Potassium Supplements,KCL tablets,,,-11.5,-16.29,20mEq ,,TRUE,
+Potassium Supplements,Potassium Supplements,KCL oral solution (10%),,,-11.5,-16.29,20mEq/15ml,,TRUE,


### PR DESCRIPTION
One more PR bringing features over from `cabg_cardio_gmf_htn_trial`. This PR reworks the Blood Pressure model to account for hypertension medications having impact. Ultimately I think this kind of thing could be reworked to medications having impact on arbitrary vital signs, but this is a first step.

Medications are defined in file `src/main/resources/htn_drugs.csv` with, as of this writing, more columns and codes than are required, so I may pare that down from what we had previously. Most important are the "code" and "impact minimum" and "impact maximum" columns, which are the RxNorm code and the expected range in mmHg of impact on blood pressure the medication is expected to have. As of now all drugs have impact range -11.5 to -16.29.

The basic approach of the model is:
 - determine baseline blood pressure
 - take into account medications
 - take into account lifestyle changes (CarePlans)

This model caches a number of things to ensure consistency, so that an individual's BP doesn't fluctuate wildly:
 - the final value at a given time, so that subsequent calls at the same timestamp don't have to recalculate
 - the individual's baseline blood pressure depending on hypertension status
 - the impact each drug has on blood pressure for that individual

Note one downside of this change is that in order to get realistic results at the aggregate level, we had to remove the "trending" aspect of the BloodPressureValueGenerator. We can try to reintegrate that but it will take more time and analysis.

Also note that this doesn't take into account the "titration" concept that was introduced in the htn_trial branch, as that concept was not fully fleshed out and very hackish. It worked for a research effort but it's not ready for master.