### PR TITLE
Specialities on encounters

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -819,6 +819,7 @@ public abstract class State implements Cloneable, Serializable {
     private List<Code> codes;
     private String reason;
     private String telemedicinePossibility;
+    private String specialty;
 
     @Override
     public Encounter clone() {
@@ -871,8 +872,12 @@ public abstract class State implements Cloneable, Serializable {
         } else {
           type = EncounterType.fromString(encounterClass);
         }
+        String desiredSpeciality = ClinicianSpecialty.GENERAL_PRACTICE;
+        if (this.specialty != null && !this.specialty.isEmpty()) {
+          desiredSpeciality = this.specialty;
+        }
         HealthRecord.Encounter encounter = EncounterModule.createEncounter(person, time, type,
-            ClinicianSpecialty.GENERAL_PRACTICE, null);
+            desiredSpeciality, null);
         entry = encounter;
         if (codes != null) {
           encounter.mergeCodeList(codes);
@@ -963,7 +968,7 @@ public abstract class State implements Cloneable, Serializable {
         Provider medicationProvider = person.getCurrentProvider(module.name);
         if (medicationProvider == null) {
           // no provider associated with encounter or medication order
-          medicationProvider = person.getProvider(EncounterType.WELLNESS, time);
+          medicationProvider = person.getProvider(EncounterType.WELLNESS, null, time);
         }
         int year = Utilities.getYear(time);
         medicationProvider.incrementPrescriptions(year);
@@ -1332,7 +1337,7 @@ public abstract class State implements Cloneable, Serializable {
       Provider medicationProvider = person.getCurrentProvider(module.name);
       if (medicationProvider == null) {
         // no provider associated with encounter or medication order
-        medicationProvider = person.getProvider(EncounterType.WELLNESS, time);
+        medicationProvider = person.getProvider(EncounterType.WELLNESS, null, time);
       }
 
       int year = Utilities.getYear(time);
@@ -1556,7 +1561,7 @@ public abstract class State implements Cloneable, Serializable {
       if (person.getCurrentProvider(module.name) != null) {
         provider = person.getCurrentProvider(module.name);
       } else { // no provider associated with encounter or procedure
-        provider = person.getProvider(EncounterType.WELLNESS, time);
+        provider = person.getProvider(EncounterType.WELLNESS, null, time);
       }
       int year = Utilities.getYear(time);
       provider.incrementProcedures(year);
@@ -1872,7 +1877,7 @@ public abstract class State implements Cloneable, Serializable {
       if (person.getCurrentProvider(module.name) != null) {
         provider = person.getCurrentProvider(module.name);
       } else { // no provider associated with encounter or procedure
-        provider = person.getProvider(EncounterType.WELLNESS, time);
+        provider = person.getProvider(EncounterType.WELLNESS, null, time);
       }
       int year = Utilities.getYear(time);
       provider.incrementLabs(year);

--- a/src/main/java/org/mitre/synthea/export/BB2RIFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/BB2RIFExporter.java
@@ -867,8 +867,8 @@ public class BB2RIFExporter {
         continue;
       }
       boolean isVirtual = encounter.type.equals(EncounterType.VIRTUAL.toString());
-      boolean isVirtualOutpatient = isVirtual &&
-          (ProviderType.HOSPITAL == encounter.provider.type);
+      boolean isVirtualOutpatient = isVirtual
+          && (ProviderType.HOSPITAL == encounter.provider.type);
       boolean isAmbulatory = encounter.type.equals(EncounterType.AMBULATORY.toString());
       boolean isOutpatient = encounter.type.equals(EncounterType.OUTPATIENT.toString());
       boolean isUrgent = encounter.type.equals(EncounterType.URGENTCARE.toString());

--- a/src/main/java/org/mitre/synthea/export/CCDAExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CCDAExporter.java
@@ -9,6 +9,7 @@ import java.io.StringWriter;
 import org.mitre.synthea.helpers.RandomNumberGenerator;
 
 import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.concepts.HealthRecord;
 import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
 import org.mitre.synthea.world.concepts.RaceAndEthnicity;
 
@@ -102,13 +103,14 @@ public class CCDAExporter {
     person.attributes.put("ethnicity_display_lookup",
         RaceAndEthnicity.LOOK_UP_CDC_ETHNICITY_DISPLAY);
 
-    if (person.attributes.get(Person.PREFERREDYPROVIDER + "wellness") == null) {
+    if (person.preferredProviders.getWellnessProvider() == null) {
       // This person does not have a preferred provider. This happens for veterans at age 20 due to
       // the provider reset and they don't have a provider until their next wellness visit. There
       // may be other cases. This ensures the preferred provider is there for the CCDA template
       Encounter encounter = person.record.lastWellnessEncounter();
       if (encounter != null) {
-        person.attributes.put(Person.PREFERREDYPROVIDER + "wellness", encounter.provider);
+        person.preferredProviders.forceRelationship(HealthRecord.EncounterType.WELLNESS, null,
+            encounter.provider);
       } else {
         throw new IllegalStateException(String.format("Unable to export to CCDA because "
             + "person %s %s has no preferred provider.",
@@ -116,6 +118,8 @@ public class CCDAExporter {
             person.attributes.get(Person.LAST_NAME)));
       }
     }
+
+    person.attributes.put("wellness_provider", person.preferredProviders.getWellnessProvider());
 
     StringWriter writer = new StringWriter();
     try {

--- a/src/main/java/org/mitre/synthea/export/CDWExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CDWExporter.java
@@ -463,7 +463,7 @@ public class CDWExporter {
       return;
     }
     int primarySta3n = -1;
-    Provider provider = person.getProvider(EncounterType.WELLNESS, time);
+    Provider provider = person.getProvider(EncounterType.WELLNESS, null, time);
     if (provider != null) {
       String state = Location.getStateName(provider.state);
       String tz = Location.getTimezoneByState(state);

--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -552,7 +552,7 @@ public class FhirDstu2 {
     Provider provider = encounter.provider;
     if (provider == null) {
       // no associated provider, patient goes to wellness provider
-      provider = person.getProvider(EncounterType.WELLNESS, encounter.start);
+      provider = person.getProvider(EncounterType.WELLNESS, null, encounter.start);
     }
     if (TRANSACTION_BUNDLE) {
       encounterResource.setServiceProvider(new ResourceReferenceDt(

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -730,7 +730,7 @@ public class FhirR4 {
     Provider provider = encounter.provider;
     if (provider == null) {
       // no associated provider, patient goes to wellness provider
-      provider = person.getProvider(EncounterType.WELLNESS, encounter.start);
+      provider = person.getProvider(EncounterType.WELLNESS, null, encounter.start);
     }
 
     if (TRANSACTION_BUNDLE) {
@@ -1913,7 +1913,7 @@ public class FhirR4 {
             : findPractitioner(clinician, bundle);
     Provider providerOrganization = person.record.provider;
     if (providerOrganization == null) {
-      providerOrganization = person.getProvider(EncounterType.WELLNESS, stopTime);
+      providerOrganization = person.getProvider(EncounterType.WELLNESS, null, stopTime);
     }
     String organizationFullUrl = TRANSACTION_BUNDLE
             ? ExportHelper.buildFhirSearchUrl("Organization",

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -679,7 +679,7 @@ public class FhirStu3 {
     Provider provider = encounter.provider;
     if (provider == null) {
       // no associated provider, patient goes to wellness provider
-      provider = person.getProvider(EncounterType.WELLNESS, encounter.start);
+      provider = person.getProvider(EncounterType.WELLNESS, null, encounter.start);
     }
 
     if (TRANSACTION_BUNDLE) {

--- a/src/main/java/org/mitre/synthea/modules/EncounterModule.java
+++ b/src/main/java/org/mitre/synthea/modules/EncounterModule.java
@@ -144,7 +144,7 @@ public final class EncounterModule extends Module {
       encounter.codes.add(code);
     }
     // assign a provider organization
-    Provider prov = person.getProvider(type, null, time);
+    Provider prov = person.getProvider(type, specialty, time);
     prov.incrementEncounters(type, year);
     encounter.provider = prov;
     // assign a clinician

--- a/src/main/java/org/mitre/synthea/modules/EncounterModule.java
+++ b/src/main/java/org/mitre/synthea/modules/EncounterModule.java
@@ -144,7 +144,7 @@ public final class EncounterModule extends Module {
       encounter.codes.add(code);
     }
     // assign a provider organization
-    Provider prov = person.getProvider(type, time);
+    Provider prov = person.getProvider(type, null, time);
     prov.incrementEncounters(type, year);
     encounter.provider = prov;
     // assign a clinician

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -621,7 +621,8 @@ public final class LifecycleModule extends Module {
       // source for the below: https://www.cdc.gov/nchs/data/databriefs/db363-h.pdf
       // NCHS Data Brief - No. 363 - April 2020
       // Total and High-density Lipoprotein Cholesterol in Adults: United States, 2015–2018
-      boolean lowHDL, highTotalChol;
+      boolean lowHDL;
+      boolean highTotalChol;
       if (person.attributes.containsKey("low_hdl")) {
         // cache low or high status, so it's consistent
         lowHDL = (boolean)person.attributes.get("low_hdl");
@@ -635,7 +636,7 @@ public final class LifecycleModule extends Module {
         //   had low high-density lipoprotein cholesterol (HDL-C)."
         double chanceOfLowHDL = female ? .085 : .266;
 
-        lowHDL = person.rand() < chanceOfLowHDL; 
+        lowHDL = person.rand() < chanceOfLowHDL;
 
         person.attributes.put("low_hdl", lowHDL);
 

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -290,9 +290,7 @@ public final class LifecycleModule extends Module {
           if (person.attributes.get("veteran_provider_reset") == null) {
             // reset providers for veterans, they'll switch to VA facilities
             person.attributes.remove(Person.CURRENTPROVIDER);
-            for (EncounterType type : EncounterType.values()) {
-              person.attributes.remove(Person.PREFERREDYPROVIDER + type);
-            }
+
             person.attributes.put("veteran_provider_reset", true);
           }
         }

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -34,6 +34,7 @@ import org.mitre.synthea.world.concepts.HealthRecord;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
 import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
+import org.mitre.synthea.world.concepts.PreferredProviders;
 import org.mitre.synthea.world.concepts.VitalSign;
 import org.mitre.synthea.world.geography.quadtree.QuadTreeElement;
 
@@ -139,6 +140,8 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
   public List<State> history;
   /** Record of insurance coverage. */
   public CoverageRecord coverage;
+  /** A place to maintain preferred providers by encounter type and specialty. */
+  public PreferredProviders preferredProviders;
 
   /**
    * Person constructor.
@@ -166,6 +169,7 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
     }
     record = defaultRecord;
     coverage = new CoverageRecord(this);
+    preferredProviders = new PreferredProviders();
   }
 
   /**
@@ -509,7 +513,7 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
    */
   public Encounter encounterStart(long time, EncounterType type) {
     // Set the record for the current provider as active
-    Provider provider = getProvider(type, time);
+    Provider provider = getProvider(type, null, time);
     record = getHealthRecord(provider, time);
     // Start the encounter
     return record.encounterStart(time, type);
@@ -611,42 +615,24 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
 
   // Providers API -----------------------------------------------------------
   public static final String CURRENTPROVIDER = "currentProvider";
-  public static final String PREFERREDYPROVIDER = "preferredProvider";
 
   /**
    * Get the preferred provider for the specified encounter type. If none is set the
    * provider at the specified time as the preferred provider for this encounter type.
    */
-  public Provider getProvider(EncounterType type, long time) {
-    String key = PREFERREDYPROVIDER + type;
-    if (!attributes.containsKey(key)) {
-      setProvider(type, time);
+  public Provider getProvider(EncounterType type, String speciality, long time) {
+    if (!preferredProviders.doesRelationshipExist(type, speciality)) {
+      setProvider(type, speciality, time);
     }
-    return (Provider) attributes.get(key);
-  }
-
-  /**
-   * Set the preferred provider for the specified encounter type.
-   */
-  public void setProvider(EncounterType type, Provider provider) {
-    if (provider == null) {
-      throw new RuntimeException("Unable to find provider: " + type);
-    }
-    String key = PREFERREDYPROVIDER + type;
-    attributes.put(key, provider);
+    return preferredProviders.get(type, speciality);
   }
 
   /**
    * Set the preferred provider for the specified encounter type to be the provider
    * at the specified time.
    */
-  public void setProvider(EncounterType type, long time) {
-    Provider provider = Provider.findService(this, type, time);
-    if (provider == null && Provider.USE_HOSPITAL_AS_DEFAULT) {
-      // Default to Hospital
-      provider = Provider.findService(this, EncounterType.INPATIENT, time);
-    }
-    setProvider(type, provider);
+  public void setProvider(EncounterType type, String specialty, long time) {
+    preferredProviders.startNewRelationship(this, type, specialty, time);
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -275,7 +275,7 @@ public class Provider implements QuadTreeElement, Serializable {
    * Find specific service provider for the given person.
    * @param person The patient who requires the service.
    * @param service The service required. For example, EncounterType.AMBULATORY.
-   * @param specialty
+   * @param specialty the ClinicianSpecialty required. May be null.
    * @param time The date/time within the simulated world, in milliseconds.
    * @return Service provider or null if none is available.
    */

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -180,6 +180,14 @@ public class Provider implements QuadTreeElement, Serializable {
     return servicesProvided.contains(service);
   }
 
+  public boolean hasSpecialty(String specialty) {
+    return clinicianMap.get(specialty) != null;
+  }
+
+  public boolean canOffer(EncounterType type, String specialty) {
+    return (type == null || hasService(type)) && (specialty == null || hasSpecialty(specialty));
+  }
+
   public void incrementEncounters(EncounterType service, int year) {
     increment(year, ENCOUNTERS);
     increment(year, ENCOUNTERS + "-" + service);
@@ -267,17 +275,19 @@ public class Provider implements QuadTreeElement, Serializable {
    * Find specific service provider for the given person.
    * @param person The patient who requires the service.
    * @param service The service required. For example, EncounterType.AMBULATORY.
+   * @param specialty
    * @param time The date/time within the simulated world, in milliseconds.
    * @return Service provider or null if none is available.
    */
-  public static Provider findService(Person person, EncounterType service, long time) {
+  public static Provider findService(Person person, EncounterType service, String specialty,
+                                     long time) {
     double maxDistance = MAX_PROVIDER_SEARCH_DISTANCE;
     double degrees = 0.125;
     List<Provider> options = null;
     Provider provider = null;
     while (degrees <= maxDistance) {
       options = findProvidersByLocation(person, degrees);
-      provider = providerFinder.find(options, person, service, time);
+      provider = providerFinder.find(options, person, service, specialty, time);
       if (provider != null) {
         return provider;
       }

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/IProviderFinder.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/IProviderFinder.java
@@ -15,8 +15,10 @@ public interface IProviderFinder {
    * @param providers The list of eligible providers.
    * @param person The patient who requires the service.
    * @param service The service required. For example, EncounterType.AMBULATORY.
+   * @param specialty The specialty required. For example, ClinicianSpecialty.INFECTIOUS_DISEASE
    * @param time The date/time within the simulated world, in milliseconds.
    * @return Service provider or null if none is available.
    */
-  public Provider find(List<Provider> providers, Person person, EncounterType service, long time);
+  Provider find(List<Provider> providers, Person person, EncounterType service, String specialty,
+                long time);
 }

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderNearest.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderNearest.java
@@ -15,15 +15,14 @@ import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
 public class ProviderFinderNearest implements IProviderFinder {
 
   @Override
-  public Provider find(List<Provider> providers, Person person, EncounterType service, long time) {
+  public Provider find(List<Provider> providers, Person person, EncounterType service,
+                       String specialty, long time) {
     Stream<Provider> options = providers.stream()
         // Find providers that accept the person
         .filter(p -> p.accepts(person, time));
 
-    // Find providers with the requested service, if one is given
-    if (service != null) {
-      options = options.filter(p -> p.hasService(service));
-    }
+    // Find providers with the requested service and specialties, if given
+    options = options.filter(p -> p.canOffer(service, specialty));
 
     // If it's not an emergency
     if (service == null

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderQuality.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderQuality.java
@@ -12,13 +12,14 @@ public class ProviderFinderQuality implements IProviderFinder {
   private IProviderFinder nearest = new ProviderFinderNearest();
 
   @Override
-  public Provider find(List<Provider> providers, Person person, EncounterType service, long time) {
+  public Provider find(List<Provider> providers, Person person, EncounterType service,
+                       String specialty, long time) {
     List<Provider> options = new ArrayList<>();
     double bestQuality = Double.NEGATIVE_INFINITY;
 
     for (Provider provider : providers) {
       if (provider.accepts(person, time)
-          && (provider.hasService(service) || service == null)) {
+          && (provider.canOffer(service, specialty))) {
         if (provider.quality > bestQuality) {
           options.clear();
           options.add(provider);
@@ -34,7 +35,7 @@ public class ProviderFinderQuality implements IProviderFinder {
     } else if (options.size() == 1) {
       return options.get(0);
     } else {
-      return nearest.find(options, person, service, time);
+      return nearest.find(options, person, service, specialty, time);
     }
   }
 }

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderRandom.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderRandom.java
@@ -10,7 +10,8 @@ import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
 public class ProviderFinderRandom implements IProviderFinder {
 
   @Override
-  public Provider find(List<Provider> providers, Person person, EncounterType service, long time) {
+  public Provider find(List<Provider> providers, Person person, EncounterType service,
+                       String specialty, long time) {
     List<Provider> options = new ArrayList<Provider>();
 
     for (Provider provider : providers) {

--- a/src/main/java/org/mitre/synthea/world/concepts/PreferredProviders.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/PreferredProviders.java
@@ -13,7 +13,7 @@ import org.mitre.synthea.world.agents.Provider;
  */
 public class PreferredProviders implements Serializable {
   // The table class does not allow null values for keys
-  private static String NULL_PLACEHOLDER = "*";
+  private static String NULL_PLACEHOLDER = ClinicianSpecialty.GENERAL_PRACTICE;
 
   private Table<HealthRecord.EncounterType, String, Provider> relationships;
 
@@ -31,11 +31,7 @@ public class PreferredProviders implements Serializable {
    * @return true if there is an existing relationship
    */
   public boolean doesRelationshipExist(HealthRecord.EncounterType type, String speciality) {
-    String specialityColumnValue = speciality;
-    if (specialityColumnValue == null) {
-      specialityColumnValue = NULL_PLACEHOLDER;
-    }
-    return relationships.contains(type, specialityColumnValue);
+    return relationships.contains(type, blankSafeSpecialty(speciality));
   }
 
   /**
@@ -45,11 +41,7 @@ public class PreferredProviders implements Serializable {
    * @return the Provider if there is a preferred one or null
    */
   public Provider get(HealthRecord.EncounterType type, String speciality) {
-    String specialityColumnValue = speciality;
-    if (specialityColumnValue == null) {
-      specialityColumnValue = NULL_PLACEHOLDER;
-    }
-    return relationships.get(type, specialityColumnValue);
+    return relationships.get(type, blankSafeSpecialty(speciality));
   }
 
   /**
@@ -70,12 +62,7 @@ public class PreferredProviders implements Serializable {
           time);
     }
 
-    String specialityColumnValue = speciality;
-    if (specialityColumnValue == null) {
-      specialityColumnValue = NULL_PLACEHOLDER;
-    }
-
-    relationships.put(type, specialityColumnValue, provider);
+    relationships.put(type, blankSafeSpecialty(speciality), provider);
 
     return provider;
   }
@@ -96,11 +83,7 @@ public class PreferredProviders implements Serializable {
    */
   public void forceRelationship(HealthRecord.EncounterType type, String speciality,
                                 Provider provider) {
-    String specialityColumnValue = speciality;
-    if (specialityColumnValue == null) {
-      specialityColumnValue = NULL_PLACEHOLDER;
-    }
-    relationships.put(type, specialityColumnValue, provider);
+    relationships.put(type, blankSafeSpecialty(speciality), provider);
   }
 
   /**
@@ -109,11 +92,7 @@ public class PreferredProviders implements Serializable {
    * @param speciality the ClinicalSpecialty, may be null
    */
   public void resetRelationship(HealthRecord.EncounterType type, String speciality) {
-    String specialityColumnValue = speciality;
-    if (specialityColumnValue == null) {
-      specialityColumnValue = NULL_PLACEHOLDER;
-    }
-    relationships.remove(type, specialityColumnValue);
+    relationships.remove(type, blankSafeSpecialty(speciality));
   }
 
   /**
@@ -121,5 +100,13 @@ public class PreferredProviders implements Serializable {
    */
   public void reset() {
     relationships.clear();
+  }
+
+  private String blankSafeSpecialty(String providedSpecialty) {
+    String specialityColumnValue = providedSpecialty;
+    if (specialityColumnValue == null || specialityColumnValue.isEmpty()) {
+      specialityColumnValue = NULL_PLACEHOLDER;
+    }
+    return specialityColumnValue;
   }
 }

--- a/src/main/java/org/mitre/synthea/world/concepts/PreferredProviders.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/PreferredProviders.java
@@ -1,0 +1,78 @@
+package org.mitre.synthea.world.concepts;
+
+import java.io.Serializable;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
+
+public class PreferredProviders implements Serializable {
+  // The table class does not allow null values for keys
+  private static String NULL_PLACEHOLDER = "*";
+
+  private Table<HealthRecord.EncounterType, String, Provider> relationships;
+
+  public PreferredProviders() {
+    this.relationships = HashBasedTable.create();
+  }
+
+  public boolean doesRelationshipExist(HealthRecord.EncounterType type, String speciality) {
+    String specialityColumnValue = speciality;
+    if(specialityColumnValue == null) {
+      specialityColumnValue = NULL_PLACEHOLDER;
+    }
+    return relationships.contains(type, specialityColumnValue);
+  }
+
+  public Provider get(HealthRecord.EncounterType type, String speciality) {
+    String specialityColumnValue = speciality;
+    if(specialityColumnValue == null) {
+      specialityColumnValue = NULL_PLACEHOLDER;
+    }
+    return relationships.get(type, specialityColumnValue);
+  }
+
+  public Provider startNewRelationship(Person person, HealthRecord.EncounterType type,
+                                       String speciality, long time) {
+    Provider provider = Provider.findService(person, type, speciality, time);
+    if (provider == null && Provider.USE_HOSPITAL_AS_DEFAULT) {
+      // Default to Hospital
+      provider = Provider.findService(person, HealthRecord.EncounterType.INPATIENT, speciality, time);
+    }
+
+    String specialityColumnValue = speciality;
+    if(specialityColumnValue == null) {
+      specialityColumnValue = NULL_PLACEHOLDER;
+    }
+
+    relationships.put(type, specialityColumnValue, provider);
+
+    return provider;
+  }
+
+  public Provider getWellnessProvider() {
+    return get(HealthRecord.EncounterType.WELLNESS, null);
+  }
+
+  public void forceRelationship(HealthRecord.EncounterType type, String speciality,
+                                Provider provider) {
+    String specialityColumnValue = speciality;
+    if(specialityColumnValue == null) {
+      specialityColumnValue = NULL_PLACEHOLDER;
+    }
+    relationships.put(type, specialityColumnValue, provider);
+  }
+
+  public void resetRelationship(HealthRecord.EncounterType type, String speciality) {
+    String specialityColumnValue = speciality;
+    if(specialityColumnValue == null) {
+      specialityColumnValue = NULL_PLACEHOLDER;
+    }
+    relationships.remove(type, specialityColumnValue);
+  }
+
+  public void reset() {
+    relationships.clear();
+  }
+}

--- a/src/main/java/org/mitre/synthea/world/concepts/PreferredProviders.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/PreferredProviders.java
@@ -1,48 +1,77 @@
 package org.mitre.synthea.world.concepts;
 
-import java.io.Serializable;
-
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
+
+import java.io.Serializable;
+
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.agents.Provider;
 
+/**
+ * Class for managing the relationships between a Person and their perferred Providers.
+ */
 public class PreferredProviders implements Serializable {
   // The table class does not allow null values for keys
   private static String NULL_PLACEHOLDER = "*";
 
   private Table<HealthRecord.EncounterType, String, Provider> relationships;
 
+  /**
+   * Create a new PreferredProviders object.
+   */
   public PreferredProviders() {
     this.relationships = HashBasedTable.create();
   }
 
+  /**
+   * Checks to see if a relationship exists for a particular EncounterType and Specialty.
+   * @param type the EncounterType
+   * @param speciality the ClinicianSpecialty, may be null
+   * @return true if there is an existing relationship
+   */
   public boolean doesRelationshipExist(HealthRecord.EncounterType type, String speciality) {
     String specialityColumnValue = speciality;
-    if(specialityColumnValue == null) {
+    if (specialityColumnValue == null) {
       specialityColumnValue = NULL_PLACEHOLDER;
     }
     return relationships.contains(type, specialityColumnValue);
   }
 
+  /**
+   * Return the preferred Provider for a particular EncounterType and Specialty.
+   * @param type the EncounterType
+   * @param speciality the ClinicianSpecialty, may be null
+   * @return the Provider if there is a preferred one or null
+   */
   public Provider get(HealthRecord.EncounterType type, String speciality) {
     String specialityColumnValue = speciality;
-    if(specialityColumnValue == null) {
+    if (specialityColumnValue == null) {
       specialityColumnValue = NULL_PLACEHOLDER;
     }
     return relationships.get(type, specialityColumnValue);
   }
 
+  /**
+   * Creates a new preferred Provider for the supplied Person by using the provider finder
+   * infrastructure. Will replace the existing preferred Provider if one is there.
+   * @param person to find a preferred Provider for
+   * @param type the EncounterType
+   * @param speciality the ClinicianSpecialty, may be null
+   * @param time in the simulation
+   * @return the new preferred Provider
+   */
   public Provider startNewRelationship(Person person, HealthRecord.EncounterType type,
                                        String speciality, long time) {
     Provider provider = Provider.findService(person, type, speciality, time);
     if (provider == null && Provider.USE_HOSPITAL_AS_DEFAULT) {
       // Default to Hospital
-      provider = Provider.findService(person, HealthRecord.EncounterType.INPATIENT, speciality, time);
+      provider = Provider.findService(person, HealthRecord.EncounterType.INPATIENT, speciality,
+          time);
     }
 
     String specialityColumnValue = speciality;
-    if(specialityColumnValue == null) {
+    if (specialityColumnValue == null) {
       specialityColumnValue = NULL_PLACEHOLDER;
     }
 
@@ -51,27 +80,45 @@ public class PreferredProviders implements Serializable {
     return provider;
   }
 
+  /**
+   * Gets the preferred wellness Provider.
+   * @return the Provider if there is one or null
+   */
   public Provider getWellnessProvider() {
     return get(HealthRecord.EncounterType.WELLNESS, null);
   }
 
+  /**
+   * Force a specific preferred Provider without going through the provider finder infrastructure.
+   * @param type the EncounterType
+   * @param speciality the ClinicianSpecialty, may be null
+   * @param provider the Provider who will now be preferred, like it or not
+   */
   public void forceRelationship(HealthRecord.EncounterType type, String speciality,
                                 Provider provider) {
     String specialityColumnValue = speciality;
-    if(specialityColumnValue == null) {
+    if (specialityColumnValue == null) {
       specialityColumnValue = NULL_PLACEHOLDER;
     }
     relationships.put(type, specialityColumnValue, provider);
   }
 
+  /**
+   * Remove the preferred provider for a specific EncounterType and ClinicianSpecialty.
+   * @param type the EncounterType
+   * @param speciality the ClinicalSpecialty, may be null
+   */
   public void resetRelationship(HealthRecord.EncounterType type, String speciality) {
     String specialityColumnValue = speciality;
-    if(specialityColumnValue == null) {
+    if (specialityColumnValue == null) {
       specialityColumnValue = NULL_PLACEHOLDER;
     }
     relationships.remove(type, specialityColumnValue);
   }
 
+  /**
+   * Remove all preferred provider relationships.
+   */
   public void reset() {
     relationships.clear();
   }

--- a/src/main/resources/templates/ccda/ccda.ftl
+++ b/src/main/resources/templates/ccda/ccda.ftl
@@ -57,13 +57,13 @@
       </assignedAuthoringDevice>
       <representedOrganization>
         <id nullFlavor="NA"/>
-        <name>${preferredProviderwellness.name?replace("&", "&amp;")}</name>
+        <name>${wellness_provider.name?replace("&", "&amp;")}</name>
         <telecom nullFlavor="NA"/>
         <addr>
-          <streetAddressLine>${preferredProviderwellness.address?replace("&", "&amp;")}</streetAddressLine>
-          <city>${preferredProviderwellness.city}</city>
-          <state>${preferredProviderwellness.state}</state>
-          <postalCode>${preferredProviderwellness.zip}</postalCode>
+          <streetAddressLine>${wellness_provider.address?replace("&", "&amp;")}</streetAddressLine>
+          <city>${wellness_provider.city}</city>
+          <state>${wellness_provider.state}</state>
+          <postalCode>${wellness_provider.zip}</postalCode>
         </addr>
       </representedOrganization>
     </assignedAuthor>
@@ -72,13 +72,13 @@
     <assignedCustodian>
       <representedCustodianOrganization>
         <id nullFlavor="NA"/>
-        <name>${preferredProviderwellness.name?replace("&", "&amp;")}</name>
+        <name>${wellness_provider.name?replace("&", "&amp;")}</name>
         <telecom nullFlavor="NA"/>
         <addr>
-          <streetAddressLine>${preferredProviderwellness.address?replace("&", "&amp;")}</streetAddressLine>
-          <city>${preferredProviderwellness.city}</city>
-          <state>${preferredProviderwellness.state}</state>
-          <postalCode>${preferredProviderwellness.zip}</postalCode>
+          <streetAddressLine>${wellness_provider.address?replace("&", "&amp;")}</streetAddressLine>
+          <city>${wellness_provider.city}</city>
+          <state>${wellness_provider.state}</state>
+          <postalCode>${wellness_provider.zip}</postalCode>
         </addr>
       </representedCustodianOrganization>
     </assignedCustodian>

--- a/src/test/java/org/mitre/synthea/engine/LogicTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LogicTest.java
@@ -54,12 +54,12 @@ public class LogicTest {
     Provider mock = Mockito.mock(Provider.class);
     Mockito.when(mock.getResourceID()).thenReturn("Mock-Provider");
     for (EncounterType type : EncounterType.values()) {
-      person.setProvider(type, mock);
+      person.preferredProviders.forceRelationship(type, null, mock);
     }
 
     mock = Mockito.mock(Provider.class);
     Mockito.when(mock.getResourceID()).thenReturn("Mock-Emergency");
-    person.setProvider(EncounterType.EMERGENCY, mock);
+    person.preferredProviders.forceRelationship(EncounterType.EMERGENCY, null, mock);
     person.attributes.put(Person.BIRTHDATE, 0L);
     time = System.currentTimeMillis();
     // Ensure Person's Payer is not null.

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -75,10 +75,10 @@ public class StateTest {
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class, withSettings().serializable());
     Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
-    person.setProvider(EncounterType.AMBULATORY, mock);
-    person.setProvider(EncounterType.WELLNESS, mock);
-    person.setProvider(EncounterType.EMERGENCY, mock);
-    person.setProvider(EncounterType.INPATIENT, mock);
+    person.preferredProviders.forceRelationship(EncounterType.AMBULATORY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.EMERGENCY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.INPATIENT, null, mock);
 
     int age = 35;
     time = System.currentTimeMillis();

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -40,6 +40,7 @@ import org.mitre.synthea.modules.WeightLossModule;
 import org.mitre.synthea.world.agents.Payer;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.ClinicianSpecialty;
 import org.mitre.synthea.world.concepts.HealthRecord;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
@@ -2319,5 +2320,19 @@ public class StateTest {
       assertEquals(expectedDisplays[i], code.display);
       assertEquals(expectedQuantities[i], supply.quantity);
     }
+  }
+
+  @Test
+  public void testEncounterSpecialty() throws Exception {
+    Provider mock = Mockito.mock(Provider.class, withSettings().serializable());
+    Mockito.when(mock.getResourceID()).thenReturn("Special-UUID");
+    person.preferredProviders.forceRelationship(EncounterType.AMBULATORY,
+        ClinicianSpecialty.CARDIOLOGY, mock);
+    Module module = TestHelper.getFixture("ahd_with_cardiology.json");
+
+    State encounterState = module.getState("Encounter");
+    assertTrue(encounterState.process(person, time));
+    Encounter encounter = person.getCurrentEncounter(module);
+    assertEquals("Special-UUID", encounter.provider.getResourceID());
   }
 }

--- a/src/test/java/org/mitre/synthea/export/CCDAExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CCDAExporterTest.java
@@ -20,6 +20,7 @@ import org.mitre.synthea.TestHelper;
 import org.mitre.synthea.engine.Generator;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.concepts.HealthRecord;
 
 /**
  * Uses Model Driven Health Tools (MDHT) to validate exported CCDA R2.1.
@@ -71,11 +72,11 @@ public class CCDAExporterTest {
     TestHelper.exportOff();
     Config.set("exporter.ccda.export", "true");
     Optional<Person> personWithWellnessProvider = Arrays.stream(people).filter((person -> {
-      return person.attributes.get(Person.PREFERREDYPROVIDER + "wellness") != null;
+      return person.preferredProviders.getWellnessProvider() != null;
     })).findFirst();
     if (personWithWellnessProvider.isPresent()) {
       Person toExport = personWithWellnessProvider.get();
-      toExport.attributes.remove(Person.PREFERREDYPROVIDER + "wellness");
+      toExport.preferredProviders.resetRelationship(HealthRecord.EncounterType.WELLNESS, null);
       String ccdaXml = CCDAExporter.export(toExport, System.currentTimeMillis());
       InputStream inputStream = IOUtils.toInputStream(ccdaXml, "UTF-8");
       try {

--- a/src/test/java/org/mitre/synthea/export/FHIRDSTU2ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRDSTU2ExporterTest.java
@@ -166,10 +166,10 @@ public class FHIRDSTU2ExporterTest {
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
     Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
-    person.setProvider(EncounterType.AMBULATORY, mock);
-    person.setProvider(EncounterType.WELLNESS, mock);
-    person.setProvider(EncounterType.EMERGENCY, mock);
-    person.setProvider(EncounterType.INPATIENT, mock);
+    person.preferredProviders.forceRelationship(EncounterType.AMBULATORY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.EMERGENCY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.INPATIENT, null, mock);
 
     Long time = System.currentTimeMillis();
     int age = 35;
@@ -230,10 +230,10 @@ public class FHIRDSTU2ExporterTest {
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
     Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
-    person.setProvider(EncounterType.AMBULATORY, mock);
-    person.setProvider(EncounterType.WELLNESS, mock);
-    person.setProvider(EncounterType.EMERGENCY, mock);
-    person.setProvider(EncounterType.INPATIENT, mock);
+    person.preferredProviders.forceRelationship(EncounterType.AMBULATORY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.EMERGENCY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.INPATIENT, null, mock);
 
     Long time = System.currentTimeMillis();
     int age = 35;

--- a/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
@@ -176,10 +176,10 @@ public class FHIRR4ExporterTest {
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
     Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
-    person.setProvider(EncounterType.AMBULATORY, mock);
-    person.setProvider(EncounterType.WELLNESS, mock);
-    person.setProvider(EncounterType.EMERGENCY, mock);
-    person.setProvider(EncounterType.INPATIENT, mock);
+    person.preferredProviders.forceRelationship(EncounterType.AMBULATORY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.EMERGENCY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.INPATIENT, null, mock);
 
     Long time = System.currentTimeMillis();
     int age = 35;
@@ -240,10 +240,10 @@ public class FHIRR4ExporterTest {
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
     Mockito.when(mock.getResourceID()).thenReturn("Mock-Provider");
-    person.setProvider(EncounterType.AMBULATORY, mock);
-    person.setProvider(EncounterType.WELLNESS, mock);
-    person.setProvider(EncounterType.EMERGENCY, mock);
-    person.setProvider(EncounterType.INPATIENT, mock);
+    person.preferredProviders.forceRelationship(EncounterType.AMBULATORY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.EMERGENCY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.INPATIENT, null, mock);
 
     Long time = System.currentTimeMillis();
     int age = 35;

--- a/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
@@ -249,10 +249,10 @@ public class FHIRSTU3ExporterTest {
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
     Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
-    person.setProvider(EncounterType.AMBULATORY, mock);
-    person.setProvider(EncounterType.WELLNESS, mock);
-    person.setProvider(EncounterType.EMERGENCY, mock);
-    person.setProvider(EncounterType.INPATIENT, mock);
+    person.preferredProviders.forceRelationship(EncounterType.AMBULATORY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.EMERGENCY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.INPATIENT, null, mock);
 
     Long time = System.currentTimeMillis();
     int age = 35;
@@ -313,10 +313,10 @@ public class FHIRSTU3ExporterTest {
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
     Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
-    person.setProvider(EncounterType.AMBULATORY, mock);
-    person.setProvider(EncounterType.WELLNESS, mock);
-    person.setProvider(EncounterType.EMERGENCY, mock);
-    person.setProvider(EncounterType.INPATIENT, mock);
+    person.preferredProviders.forceRelationship(EncounterType.AMBULATORY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.EMERGENCY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.INPATIENT, null, mock);
 
     Long time = System.currentTimeMillis();
     int age = 35;

--- a/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
@@ -65,7 +65,8 @@ public class TransitionMetricsTest {
       // seeds chosen by experimentation, to ensure we hit "Pre_Examplitis" at least once
       person = new Person(seed);
       person.attributes.put(Person.GENDER, "M");
-      person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, Mockito.mock(Provider.class));
+      person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null,
+          Mockito.mock(Provider.class));
       time = System.currentTimeMillis();
       person.attributes.put(Person.BIRTHDATE, time);
 

--- a/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
@@ -65,7 +65,7 @@ public class TransitionMetricsTest {
       // seeds chosen by experimentation, to ensure we hit "Pre_Examplitis" at least once
       person = new Person(seed);
       person.attributes.put(Person.GENDER, "M");
-      person.setProvider(EncounterType.WELLNESS, Mockito.mock(Provider.class));
+      person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, Mockito.mock(Provider.class));
       time = System.currentTimeMillis();
       person.attributes.put(Person.BIRTHDATE, time);
 

--- a/src/test/java/org/mitre/synthea/modules/DeathModuleTest.java
+++ b/src/test/java/org/mitre/synthea/modules/DeathModuleTest.java
@@ -37,10 +37,10 @@ public class DeathModuleTest {
     person.history = new LinkedList<>();
     Provider mock = Mockito.mock(Provider.class);
     Mockito.when(mock.getResourceID()).thenReturn("Mock-UUID");
-    person.setProvider(EncounterType.AMBULATORY, mock);
-    person.setProvider(EncounterType.WELLNESS, mock);
-    person.setProvider(EncounterType.EMERGENCY, mock);
-    person.setProvider(EncounterType.INPATIENT, mock);
+    person.preferredProviders.forceRelationship(EncounterType.AMBULATORY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.EMERGENCY, null, mock);
+    person.preferredProviders.forceRelationship(EncounterType.INPATIENT, null, mock);
 
     long birthTime = time - Utilities.convertTime("years", 35);
     person.attributes.put(Person.BIRTHDATE, birthTime);

--- a/src/test/java/org/mitre/synthea/modules/covid/C19ImmunizationModuleTest.java
+++ b/src/test/java/org/mitre/synthea/modules/covid/C19ImmunizationModuleTest.java
@@ -65,8 +65,8 @@ public class C19ImmunizationModuleTest {
     person.attributes.put(C19ImmunizationModule.C19_VACCINE, C19Vaccine.EUASet.PFIZER);
     here.assignPoint(person, "Billerica");
     Provider.loadProviders(here, 1L);
-    person.setProvider(HealthRecord.EncounterType.OUTPATIENT,
-        Provider.findService(person, HealthRecord.EncounterType.OUTPATIENT, decemberFifteenth));
+    person.preferredProviders.forceRelationship(HealthRecord.EncounterType.OUTPATIENT,
+        null, Provider.findService(person, HealthRecord.EncounterType.OUTPATIENT, null, decemberFifteenth));
     Payer.loadPayers(here);
     person.coverage.setPayerAtTime(decemberFifteenth, Payer.getGovernmentPayer("Medicare"));
     C19ImmunizationModule.vaccinate(person, decemberFifteenth, 1);

--- a/src/test/java/org/mitre/synthea/modules/covid/C19ImmunizationModuleTest.java
+++ b/src/test/java/org/mitre/synthea/modules/covid/C19ImmunizationModuleTest.java
@@ -66,7 +66,8 @@ public class C19ImmunizationModuleTest {
     here.assignPoint(person, "Billerica");
     Provider.loadProviders(here, 1L);
     person.preferredProviders.forceRelationship(HealthRecord.EncounterType.OUTPATIENT,
-        null, Provider.findService(person, HealthRecord.EncounterType.OUTPATIENT, null, decemberFifteenth));
+        null, Provider.findService(person, HealthRecord.EncounterType.OUTPATIENT, null,
+            decemberFifteenth));
     Payer.loadPayers(here);
     person.coverage.setPayerAtTime(decemberFifteenth, Payer.getGovernmentPayer("Medicare"));
     C19ImmunizationModule.vaccinate(person, decemberFifteenth, 1);

--- a/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/ProviderTest.java
@@ -94,7 +94,7 @@ public class ProviderTest {
     Provider.loadProviders(location, 1L);
     Person person = new Person(0L);
     location.assignPoint(person, location.randomCityName(person));
-    Provider provider = Provider.findService(person, EncounterType.INPATIENT, 0);
+    Provider provider = Provider.findService(person, EncounterType.INPATIENT, null, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -103,7 +103,7 @@ public class ProviderTest {
     Provider.loadProviders(location, 1L);
     Person person = new Person(0L);
     location.assignPoint(person, location.randomCityName(person));
-    Provider provider = Provider.findService(person, EncounterType.AMBULATORY, 0);
+    Provider provider = Provider.findService(person, EncounterType.AMBULATORY, null, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -112,7 +112,7 @@ public class ProviderTest {
     Provider.loadProviders(location, 1L);
     Person person = new Person(0L);
     location.assignPoint(person, location.randomCityName(person));
-    Provider provider = Provider.findService(person, EncounterType.WELLNESS, 0);
+    Provider provider = Provider.findService(person, EncounterType.WELLNESS, null, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -121,7 +121,7 @@ public class ProviderTest {
     Provider.loadProviders(location, 1L);
     Person person = new Person(0L);
     location.assignPoint(person, location.randomCityName(person));
-    Provider provider = Provider.findService(person, EncounterType.EMERGENCY, 0);
+    Provider provider = Provider.findService(person, EncounterType.EMERGENCY, null, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -135,7 +135,7 @@ public class ProviderTest {
     Provider.loadProviders(capital, 1L);
     Person person = new Person(0L);
     capital.assignPoint(person, capital.randomCityName(person));
-    Provider provider = Provider.findService(person, EncounterType.EMERGENCY, 0);
+    Provider provider = Provider.findService(person, EncounterType.EMERGENCY, null, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -144,7 +144,7 @@ public class ProviderTest {
     Provider.loadProviders(location, 1L);
     Person person = new Person(0L);
     location.assignPoint(person, location.randomCityName(person));
-    Provider provider = Provider.findService(person, EncounterType.URGENTCARE, 0);
+    Provider provider = Provider.findService(person, EncounterType.URGENTCARE, null, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -153,7 +153,7 @@ public class ProviderTest {
     Provider.loadProviders(city, 1L);
     Person person = new Person(0L);
     city.assignPoint(person, city.randomCityName(person));
-    Provider provider = Provider.findService(person, EncounterType.INPATIENT, 0);
+    Provider provider = Provider.findService(person, EncounterType.INPATIENT, null, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -162,7 +162,7 @@ public class ProviderTest {
     Provider.loadProviders(city, 1L);
     Person person = new Person(0L);
     city.assignPoint(person, city.randomCityName(person));
-    Provider provider = Provider.findService(person, EncounterType.AMBULATORY, 0);
+    Provider provider = Provider.findService(person, EncounterType.AMBULATORY, null, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -171,7 +171,7 @@ public class ProviderTest {
     Provider.loadProviders(city, 1L);
     Person person = new Person(0L);
     city.assignPoint(person, city.randomCityName(person));
-    Provider provider = Provider.findService(person, EncounterType.WELLNESS, 0);
+    Provider provider = Provider.findService(person, EncounterType.WELLNESS, null, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -180,7 +180,7 @@ public class ProviderTest {
     Provider.loadProviders(city, 1L);
     Person person = new Person(0L);
     city.assignPoint(person, city.randomCityName(person));
-    Provider provider = Provider.findService(person, EncounterType.EMERGENCY, 0);
+    Provider provider = Provider.findService(person, EncounterType.EMERGENCY, null, 0);
     Assert.assertNotNull(provider);
   }
 
@@ -189,7 +189,7 @@ public class ProviderTest {
     Provider.loadProviders(city, 1L);
     Person person = new Person(0L);
     city.assignPoint(person, city.randomCityName(person));
-    Provider provider = Provider.findService(person, EncounterType.URGENTCARE, 0);
+    Provider provider = Provider.findService(person, EncounterType.URGENTCARE, null, 0);
     Assert.assertNotNull(provider);
   }
 

--- a/src/test/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/behaviors/ProviderFinderTest.java
@@ -41,7 +41,7 @@ public class ProviderFinderTest {
   @Test
   public void testNearest() {
     ProviderFinderNearest finder = new ProviderFinderNearest();
-    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, 0L);
+    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, null, 0L);
     Assert.assertNotNull(provider);
     Assert.assertEquals("1", provider.id);
   }
@@ -54,7 +54,7 @@ public class ProviderFinderTest {
     // Making the test person a veteran, so they will prefer the closest VA facility in a
     // non-emergency situation
     person.attributes.put(Person.VETERAN, "Civil War");
-    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, 0L);
+    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, null, 0L);
     Assert.assertNotNull(provider);
     Assert.assertEquals("2", provider.id);
   }
@@ -67,7 +67,7 @@ public class ProviderFinderTest {
     // Setting the race to white for a test person so that they will not go to an IHS facility in a
     // non-emergency situation
     person.attributes.put(Person.RACE, "white");
-    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, 0L);
+    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, null, 0L);
     Assert.assertNotNull(provider);
     Assert.assertEquals("2", provider.id);
   }
@@ -75,7 +75,7 @@ public class ProviderFinderTest {
   @Test
   public void testAnyNearest() {
     ProviderFinderNearest finder = new ProviderFinderNearest();
-    Provider provider = finder.find(providers, person, null, 0L);
+    Provider provider = finder.find(providers, person, null, null, 0L);
     Assert.assertNotNull(provider);
     Assert.assertEquals("1", provider.id);
   }
@@ -86,7 +86,7 @@ public class ProviderFinderTest {
     List<Provider> options = new ArrayList<Provider>();
     options.addAll(providers);
     options.addAll(providers);
-    Provider provider = finder.find(options, person, EncounterType.WELLNESS, 0L);
+    Provider provider = finder.find(options, person, EncounterType.WELLNESS, null, 0L);
     Assert.assertNotNull(provider);
     Assert.assertEquals("1", provider.id);
   }
@@ -95,14 +95,14 @@ public class ProviderFinderTest {
   public void testNoNearest() {
     ProviderFinderNearest finder = new ProviderFinderNearest();
     List<Provider> options = new ArrayList<Provider>();
-    Provider provider = finder.find(options, person, EncounterType.WELLNESS, 0L);
+    Provider provider = finder.find(options, person, EncounterType.WELLNESS, null, 0L);
     Assert.assertNull(provider);
   }
 
   @Test
   public void testQuality() {
     ProviderFinderQuality finder = new ProviderFinderQuality();
-    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, 0L);
+    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, null, 0L);
     Assert.assertNotNull(provider);
     Assert.assertEquals("3", provider.id);
   }
@@ -110,7 +110,7 @@ public class ProviderFinderTest {
   @Test
   public void testAnyQuality() {
     ProviderFinderQuality finder = new ProviderFinderQuality();
-    Provider provider = finder.find(providers, person, null, 0L);
+    Provider provider = finder.find(providers, person, null, null, 0L);
     Assert.assertNotNull(provider);
     Assert.assertEquals("3", provider.id);
   }
@@ -121,7 +121,7 @@ public class ProviderFinderTest {
     List<Provider> options = new ArrayList<Provider>();
     options.addAll(providers);
     options.addAll(providers);
-    Provider provider = finder.find(options, person, EncounterType.WELLNESS, 0L);
+    Provider provider = finder.find(options, person, EncounterType.WELLNESS, null, 0L);
     Assert.assertNotNull(provider);
     Assert.assertEquals("3", provider.id);
   }
@@ -130,21 +130,21 @@ public class ProviderFinderTest {
   public void testNoQuality() {
     ProviderFinderQuality finder = new ProviderFinderQuality();
     List<Provider> options = new ArrayList<Provider>();
-    Provider provider = finder.find(options, person, EncounterType.WELLNESS, 0L);
+    Provider provider = finder.find(options, person, EncounterType.WELLNESS, null, 0L);
     Assert.assertNull(provider);
   }
 
   @Test
   public void testRandom() {
     ProviderFinderRandom finder = new ProviderFinderRandom();
-    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, 0L);
+    Provider provider = finder.find(providers, person, EncounterType.WELLNESS, null, 0L);
     Assert.assertNotNull(provider);
   }
 
   @Test
   public void testAnyRandom() {
     ProviderFinderRandom finder = new ProviderFinderRandom();
-    Provider provider = finder.find(providers, person, null, 0L);
+    Provider provider = finder.find(providers, person, null, null, 0L);
     Assert.assertNotNull(provider);
   }
 
@@ -152,7 +152,7 @@ public class ProviderFinderTest {
   public void testNoRandom() {
     ProviderFinderRandom finder = new ProviderFinderRandom();
     List<Provider> options = new ArrayList<Provider>();
-    Provider provider = finder.find(options, person, EncounterType.WELLNESS, 0L);
+    Provider provider = finder.find(options, person, EncounterType.WELLNESS, null, 0L);
     Assert.assertNull(provider);
   }
 }

--- a/src/test/java/org/mitre/synthea/world/concepts/LossOfCareHealthRecordTest.java
+++ b/src/test/java/org/mitre/synthea/world/concepts/LossOfCareHealthRecordTest.java
@@ -46,7 +46,7 @@ public class LossOfCareHealthRecordTest {
 
     // Parse out testPrivatePayer's Copay.
     Person person = new Person(0L);
-    person.setProvider(EncounterType.WELLNESS, new Provider());
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, new Provider());
     person.attributes.put(Person.INCOME, 1);
     Encounter encounter = person.encounterStart(time, EncounterType.WELLNESS);
     testPrivatePayerCopay = testPrivatePayer.determineCopay(encounter);
@@ -65,7 +65,7 @@ public class LossOfCareHealthRecordTest {
 
     Person person = new Person(0L);
     person.coverage.setPayerAtTime(time, Payer.noInsurance);
-    person.setProvider(EncounterType.WELLNESS, new Provider());
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, new Provider());
     Code code = new Code("SNOMED-CT","705129","Fake Code");
     // Set person's income to be $1 lower than the cost of encounter
     person.attributes.put(Person.INCOME, (int) defaultEncounterCost - 1);
@@ -93,7 +93,7 @@ public class LossOfCareHealthRecordTest {
   public void personRunsOutOfIncomeDueToCopay() {
     Person person = new Person(0L);
     person.coverage.setPayerAtTime(time, testPrivatePayer);
-    person.setProvider(EncounterType.WELLNESS, new Provider());
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, new Provider());
     Code code = new Code("SNOMED-CT","705129","Fake Code");
 
     // Determine income
@@ -143,7 +143,7 @@ public class LossOfCareHealthRecordTest {
     person.attributes.put(Person.BIRTHDATE, time);
     person.attributes.put(Person.GENDER, "F");
     person.coverage.setPayerAtTime(time, testPrivatePayer);
-    person.setProvider(EncounterType.WELLNESS, new Provider());
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, new Provider());
     Code code = new Code("SNOMED-CT","705129","Fake Code");
     // Set person's income to be $1 lower than the cost of 8 monthly premiums.
     person.attributes.put(Person.INCOME, (int) (testPrivatePayer.getMonthlyPremium() * 8) - 1);
@@ -175,7 +175,7 @@ public class LossOfCareHealthRecordTest {
 
     Person person = new Person(0L);
     person.coverage.setPayerAtTime(time, Payer.noInsurance);
-    person.setProvider(EncounterType.WELLNESS, new Provider());
+    person.preferredProviders.forceRelationship(EncounterType.WELLNESS, null, new Provider());
     Code code = new Code("SNOMED-CT","705129","Fake Code");
     // Set person's income to be $1 lower than the cost of an encounter.
     person.attributes.put(Person.INCOME, (int) defaultEncounterCost - 1);

--- a/src/test/resources/generic/ahd_with_cardiology.json
+++ b/src/test/resources/generic/ahd_with_cardiology.json
@@ -1,0 +1,125 @@
+{
+  "name": "artificial_heart_device_with_cardiology",
+  "remarks": [
+    "Copy of the artifical heart device module, but adds the clinical specialty to the encounter."
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Encounter"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Encounter": {
+      "type": "Encounter",
+      "encounter_class": "ambulatory",
+      "reason": "",
+      "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 440068009,
+          "display": "Home visit for newborn care and assessment (procedure)"
+        }
+      ],
+      "direct_transition": "Necessary_Supplies"
+    },
+    "End_Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Delay"
+    },
+    "Necessary_Supplies": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "quantity": 10000,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 52291003,
+            "display": "Glove, device (physical object)"
+          }
+        },
+        {
+          "quantity": 3000,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 468159004,
+            "display": "Cotton ball (physical object)"
+          }
+        },
+        {
+          "quantity": 98765,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 39802000,
+            "display": "Tongue blade, device (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 788177008,
+            "display": "Examination gown, single-use (physical object)"
+          }
+        }
+      ],
+      "direct_transition": "Artificial_Heart"
+    },
+    "Artificial_Heart": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 13459008,
+        "display": "Temporary artificial heart prosthesis, device (physical object)"
+      },
+      "direct_transition": "End_Encounter",
+      "assign_to_attribute": "artificial_heart",
+      "manufacturer": "SynCardia",
+      "model": "Total Artificial Heart"
+    },
+    "Delay": {
+      "type": "Delay",
+      "exact": {
+        "quantity": 50,
+        "unit": "years"
+      },
+      "distributed_transition": [
+        {
+          "transition": "Remove_Device_By_State",
+          "distribution": 0.4
+        },
+        {
+          "transition": "Remove_Device_By_Code",
+          "distribution": 0.3
+        },
+        {
+          "transition": "Remove_Device_By_Attribute",
+          "distribution": 0.3
+        }
+      ]
+    },
+    "Remove_Device_By_State": {
+      "type": "DeviceEnd",
+      "direct_transition": "Terminal",
+      "device": "Artificial_Heart"
+    },
+    "Remove_Device_By_Code": {
+      "type": "DeviceEnd",
+      "direct_transition": "Terminal",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 13459008,
+          "display": "Temporary artificial heart prosthesis, device (physical object)"
+        }
+      ]
+    },
+    "Remove_Device_By_Attribute": {
+      "type": "DeviceEnd",
+      "direct_transition": "Terminal",
+      "referenced_by_attribute": "artificial_heart"
+    }
+  }
+}


### PR DESCRIPTION
Adds a `specialty` property on the `Encounter` state in GMF. This will require the encounter to happen at a Provider that offers that specialty.

The preferred provider infrastructure has been updated to handle this. People now have a preferred provider by encounter class and specialty.

Checkstyle fixes added in as well. It appears that there are now checkstyle violations on master 😲 