### PR TITLE
Add null check to assignPoint methods.

### DIFF
--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -412,54 +412,6 @@ public class Location implements Serializable {
   }
 
   /**
-   * Assign a geographic location to the given Clinician. Location includes City, State, Zip, and
-   * Coordinate. If cityName is given, then Zip and Coordinate are restricted to valid values for
-   * that city. If cityName is not given, then picks a random city from the list of all cities.
-   *
-   * @param clinician Clinician to assign location information
-   * @param cityName Name of the city, or null to choose one randomly
-   */
-  public void assignPoint(Clinician clinician, String cityName) {
-    List<Place> zipsForCity = null;
-
-    if (cityName == null) {
-      int size = zipCodes.keySet().size();
-      cityName = (String) zipCodes.keySet().toArray()[clinician.randInt(size)];
-    }
-    zipsForCity = zipCodes.get(cityName);
-
-    if (zipsForCity == null) {
-      zipsForCity = zipCodes.get(cityName + " Town");
-    }
-
-    Place place = null;
-    if (zipsForCity != null && zipsForCity.size() == 1) {
-      place = zipsForCity.get(0);
-    } else if (zipsForCity != null) {
-      // pick a random one
-      place = zipsForCity.get(clinician.randInt(zipsForCity.size()));
-    } else {
-      // The place doesn't exist for some reason, pick a random location...
-      String key = (String) zipCodes.keySet().toArray()[clinician.randInt(zipCodes.keySet().size())];
-      place = zipCodes.get(key).get(clinician.randInt(zipCodes.get(key).size()));
-    }
-
-    if (place != null) {
-      // Get the coordinate of the city/town
-      Point2D.Double coordinate = new Point2D.Double();
-      coordinate.setLocation(place.coordinate);
-      // And now perturbate it slightly.
-      // Precision within 0.001 degree is more or less a neighborhood or street.
-      // Precision within 0.01 is a village or town
-      // Precision within 0.1 is a large city
-      double dx = (clinician.rand() * 0.1) - 0.05;
-      double dy = (clinician.rand() * 0.1) - 0.05;
-      coordinate.setLocation(coordinate.x + dx, coordinate.y + dy);
-      clinician.attributes.put(Person.COORDINATE, coordinate);
-    }
-  }
-
-  /**
    * Set social determinants of health attributes on the patient, as defined
    * by the optional social determinants of health county-level file.
    * @param person The person to assign attributes.

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -378,9 +378,9 @@ public class Location implements Serializable {
     }
 
     Place place;
-    if (zipsForCity.size() == 1) {
+    if (zipsForCity != null && zipsForCity.size() == 1) {
       place = zipsForCity.get(0);
-    } else {
+    } else if (zipsForCity != null) {
       String personZip = (String) person.attributes.get(Person.ZIP);
       if (personZip == null) {
         place = zipsForCity.get(person.randInt(zipsForCity.size()));
@@ -390,6 +390,10 @@ public class Location implements Serializable {
             .findFirst()
             .orElse(zipsForCity.get(person.randInt(zipsForCity.size())));
       }
+    } else {
+      // The place doesn't exist for some reason, pick a random location...
+      String key = (String) zipCodes.keySet().toArray()[person.randInt(zipCodes.keySet().size())];
+      place = zipCodes.get(key).get(person.randInt(zipCodes.get(key).size()));
     }
 
     if (place != null) {
@@ -429,11 +433,15 @@ public class Location implements Serializable {
     }
 
     Place place = null;
-    if (zipsForCity.size() == 1) {
+    if (zipsForCity != null && zipsForCity.size() == 1) {
       place = zipsForCity.get(0);
-    } else {
+    } else if (zipsForCity != null) {
       // pick a random one
       place = zipsForCity.get(clinician.randInt(zipsForCity.size()));
+    } else {
+      // The place doesn't exist for some reason, pick a random location...
+      String key = (String) zipCodes.keySet().toArray()[clinician.randInt(zipCodes.keySet().size())];
+      place = zipCodes.get(key).get(clinician.randInt(zipCodes.get(key).size()));
     }
 
     if (place != null) {

--- a/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
+++ b/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
@@ -20,7 +20,7 @@ import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
 
 public class LocationTest {
-
+  private static String locationDoesNotExist = "The Lost City of Atlantis";
   private static String testState = null;
   private static String testTown = null;
   private static Location location = null;
@@ -56,6 +56,26 @@ public class LocationTest {
     List<String> zipcodes = location.getZipCodes(testTown);
     String zipcode = location.getZipCode(testTown, new Person(1));
     Assert.assertTrue(zipcodes.contains(zipcode));
+  }
+
+  @Test
+  public void testLocationWithoutZipCode() {
+    Assert.assertFalse(location.getPopulation(locationDoesNotExist) > 0);
+    List<String> zipcodes = location.getZipCodes(locationDoesNotExist);
+    Assert.assertTrue(zipcodes.size() == 1);
+    Assert.assertTrue(zipcodes.contains("00000"));
+  }
+
+  @Test
+  public void testAssignPointPersonWithLocationThatDoesNotExist() {
+    Person p = new Person(1);
+    String zipcode = location.getZipCode(locationDoesNotExist, p);
+    p.attributes.put(Person.ZIP, zipcode);
+    location.assignPoint(p, locationDoesNotExist);
+    Point2D.Double coord = (Point2D.Double) p.attributes.get(Person.COORDINATE);
+    Assert.assertNotNull(coord);
+    Assert.assertNotNull(coord.x);
+    Assert.assertNotNull(coord.y);
   }
 
   @Test


### PR DESCRIPTION
Meant to address #1046 

Not sure about this "fix" though because it may just mask the fact that a place exists without a corresponding entry in the zip code file.

Which shouldn't happen.