### PR TITLE
Fixes rare issue with weight management regression

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/WeightLossModule.java
+++ b/src/main/java/org/mitre/synthea/modules/WeightLossModule.java
@@ -277,10 +277,16 @@ public final class WeightLossModule extends Module {
     double targetWeight = BMI.weightForHeightAndBMI(height, bmiForPercentileAtTwenty);
     int ageTwenty = 20;
     int lossAndRegressionTotalYears = 7;
-    double weightAtTwenty = BMI.weightForHeightAndBMI(height, pgt.tail().bmi);
     int regressionEndAge = (startAgeInMonths / 12) + lossAndRegressionTotalYears;
-    double percentageElapsed = (person.ageInDecimalYears(time) - ageTwenty)
-        / (regressionEndAge - ageTwenty);
+    int denominator = regressionEndAge - ageTwenty;
+    // This can happen when regression ends at age 20
+    if (denominator == 0) {
+      denominator = 1;
+    }
+
+    double percentageElapsed = (person.ageInDecimalYears(time) - ageTwenty) / denominator;
+
+    double weightAtTwenty = BMI.weightForHeightAndBMI(height, pgt.tail().bmi);
     return weightAtTwenty + (percentageElapsed * (targetWeight - weightAtTwenty));
   }
 


### PR DESCRIPTION
This fix addresses an issue where weight could be calculated as not a number
due to a divide by zero error.

This happened when a person had successful weight management, starting at age
13 and then regressing back to their original weight trajectory. The issue
would happen when attempting to determine what percentage of the "adult"
(after age 20) part of regression had elapsed. Since the adult regression
period was less than one year, it was setting the denominator of the
equation to zero.

The fix now sets this denominator to 1, making the calculation of percentage
elapsed the fraction over age 20 that the person is at the time of the weight
measurement.

Addresses issue #1038 

There are checkstyle issues currently in the master branch that this PR does not address. Those issues are fixed in PR #1047 