### PR TITLE
Fix BP code to be the required code.

### DIFF
--- a/src/main/resources/modules/encounter/vitals.json
+++ b/src/main/resources/modules/encounter/vitals.json
@@ -68,7 +68,7 @@
       "codes": [
         {
           "system": "LOINC",
-          "code": "55284-4",
+          "code": "85354-9",
           "display": "Blood Pressure"
         }
       ],


### PR DESCRIPTION
BP code was incorrect in 1 out of 9 instances in the modules where BP was recorded.

See

- Stackoverflow  thread https://stackoverflow.com/questions/71246204/fhir-to-omop-mapping-question-blood-pressure-systolic-and-diastolic-with-unmapp/71246501#71246501
- FHIR Spec http://hl7.org/fhir/STU3/observation-vitalsigns.html
