### PR TITLE
Fix #1079 multiple administrations.

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1328,7 +1328,7 @@ public abstract class State implements Cloneable, Serializable {
     }
 
     /**
-     * Apply all the various features to the medication
+     * Apply all the various features to the medication.
      * @param person the Person.
      * @param medication the Medication.
      */

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1301,6 +1301,9 @@ public abstract class State implements Cloneable, Serializable {
     @Override
     public boolean process(Person person, long time) {
       String primaryCode = codes.get(0).code;
+      // Check if this person is already on this medication...
+      boolean isAlreadyOnMedication = (person.record.presentOnset(primaryCode) != null);
+
       Medication medication = person.record.medicationStart(time, primaryCode, chronic);
       entry = medication;
       medication.name = this.name;
@@ -1324,6 +1327,9 @@ public abstract class State implements Cloneable, Serializable {
 
       medication.prescriptionDetails = prescription;
       medication.administration = administration;
+      if (medication.administration && !isAlreadyOnMedication) {
+        person.record.medicationEnd(time, primaryCode, null);
+      }
 
       if (shouldAssignAttribute()) {
         person.attributes.put(assignToAttribute, medication);

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -1300,15 +1300,45 @@ public abstract class State implements Cloneable, Serializable {
 
     @Override
     public boolean process(Person person, long time) {
+      Medication medication = null;
+      boolean createPrescription = true;
       String primaryCode = codes.get(0).code;
-      // Check if this person is already on this medication...
-      boolean isAlreadyOnMedication = (person.record.presentOnset(primaryCode) != null);
+      if (this.administration) {
+        medication = person.record.medicationAdministration(time, primaryCode, codes);
+        applyFeatures(person, medication);
 
-      Medication medication = person.record.medicationStart(time, primaryCode, chronic);
+        if (!this.chronic) {
+          createPrescription = false;
+        }
+      }
+      if (createPrescription) {
+        medication = person.record.medicationStart(time, primaryCode, chronic);
+        applyFeatures(person, medication);
+      }
+      // increment number of prescriptions prescribed by respective hospital
+      Provider medicationProvider = person.getCurrentProvider(module.name);
+      if (medicationProvider == null) {
+        // no provider associated with encounter or medication order
+        medicationProvider = person.getProvider(EncounterType.WELLNESS, time);
+      }
+
+      int year = Utilities.getYear(time);
+      medicationProvider.incrementPrescriptions(year);
+      return true;
+    }
+
+    /**
+     * Apply all the various features to the medication
+     * @param person the Person.
+     * @param medication the Medication.
+     */
+    private void applyFeatures(Person person, Medication medication) {
       entry = medication;
       medication.name = this.name;
       medication.mergeCodeList(codes);
-
+      if (shouldAssignAttribute()) {
+        person.attributes.put(assignToAttribute, medication);
+      }
       if (reason != null) {
         // "reason" is an attribute or stateName referencing a previous conditionOnset state
         if (person.attributes.containsKey(reason)) {
@@ -1324,26 +1354,7 @@ public abstract class State implements Cloneable, Serializable {
           }
         }
       }
-
       medication.prescriptionDetails = prescription;
-      medication.administration = administration;
-      if (medication.administration && !isAlreadyOnMedication) {
-        person.record.medicationEnd(time, primaryCode, null);
-      }
-
-      if (shouldAssignAttribute()) {
-        person.attributes.put(assignToAttribute, medication);
-      }
-      // increment number of prescriptions prescribed by respective hospital
-      Provider medicationProvider = person.getCurrentProvider(module.name);
-      if (medicationProvider == null) {
-        // no provider associated with encounter or medication order
-        medicationProvider = person.getProvider(EncounterType.WELLNESS, time);
-      }
-
-      int year = Utilities.getYear(time);
-      medicationProvider.incrementPrescriptions(year);
-      return true;
     }
   }
 

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -1339,6 +1339,7 @@ public class StateTest {
     HealthRecord.Medication medication = (HealthRecord.Medication) person.attributes
         .get("Diabetes Medication");
     assertTrue(medication.administration);
+    assertTrue(medication.stop != 0L);
   }
 
   @Test


### PR DESCRIPTION
There was a bug that multiple medication administrations were not being output on a patient record unless that medication was also ended for each administration.

However, ending the medication after every administration is not a good idea, because that patient could also have an open prescription for that medication.

This fix ensures that MedicationAdministrations and open ongoing prescriptions of the same medications do not conflict, and both are recorded in the output files.

You can replicate the error on `master` and the fix on this branch using the below modules (looking for an annual inpatient encounters called "Dummy Encounter" and Medication/MedicationAdministration named "Administered Injection", "Chronic Injection", and "Administered Chronic Injection").

[medication_administration_example.json.zip](https://github.com/synthetichealth/synthea/files/8805896/medication_administration_example.json.zip)
[medication_administration_example_2.json.zip](https://github.com/synthetichealth/synthea/files/8809570/medication_administration_example_2.json.zip)

