### PR TITLE
Add test for FactTable.getFactByKey

### DIFF
--- a/src/test/java/org/mitre/synthea/helpers/FactTableTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/FactTableTest.java
@@ -37,4 +37,14 @@ public class FactTableTest {
     Assert.assertTrue(output.contains(he + ",He"));
   }
 
+  @Test
+  public void testGetFactByKey() {
+    // Setup a basic fact table with a header.
+    FactTable table = new FactTable();
+    table.setHeader("ID,KEY,NAME,DESCRIPTION");
+    // Insert some facts.
+    int h = table.addFact("H", "Hydrogen,Highly flammable gas");
+    Assert.assertNull(table.getFactByKey("Iwcz&T&5+;N4Sb)kE+#P"));
+  }
+
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `table.getFactByKey("Iwcz&T&5+;N4Sb)kE+#P")` is null when `getFactByKey` is called with the parameter `key = "Iwcz&T&5+;N4Sb)kE+#P"`.
This tests the method [`FactTable.getFactByKey`](https://github.com/synthetichealth/synthea/blob/e5d35d2a9f9cb7193e797bfc292e5f782e436d29/src/main/java/org/mitre/synthea/helpers/FactTable.java#L75).
This test is based on the test [`testFactTable`](https://github.com/synthetichealth/synthea/blob/e5d35d2a9f9cb7193e797bfc292e5f782e436d29/src/test/java/org/mitre/synthea/helpers/FactTableTest.java#L12).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))