### PR TITLE
All cardiology surgeries go to the first hospital.

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -263,6 +263,7 @@ public class Module implements Cloneable, Serializable {
   }
 
   public String name;
+  public String specialty;
   public boolean submodule;
   public Double gmfVersion;
   public List<String> remarks;
@@ -280,6 +281,10 @@ public class Module implements Cloneable, Serializable {
    */
   public Module(JsonObject definition, boolean submodule) throws Exception {
     name = String.format("%s Module", definition.get("name").getAsString());
+
+    if (definition.has("specialty")) {
+      specialty = definition.get("specialty").getAsString();
+    }
 
     if (definition.has("gmf_version")) {
       this.gmfVersion = definition.get("gmf_version").getAsDouble();
@@ -313,6 +318,7 @@ public class Module implements Cloneable, Serializable {
   public Module clone() {
     Module clone = new Module();
     clone.name = this.name;
+    clone.specialty = this.specialty;
     clone.submodule = this.submodule;
     clone.remarks = this.remarks;
     if (this.states != null) {

--- a/src/main/java/org/mitre/synthea/engine/State.java
+++ b/src/main/java/org/mitre/synthea/engine/State.java
@@ -828,8 +828,12 @@ public abstract class State implements Cloneable, Serializable {
         }
       } else {
         EncounterType type = EncounterType.fromString(encounterClass);
+        String specialty = ClinicianSpecialty.GENERAL_PRACTICE;
+        if (this.module.specialty != null) {
+          specialty = this.module.specialty;
+        }
         HealthRecord.Encounter encounter = EncounterModule.createEncounter(person, time, type,
-            ClinicianSpecialty.GENERAL_PRACTICE, null);
+            specialty, null);
         entry = encounter;
         if (codes != null) {
           encounter.codes.addAll(codes);

--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -298,7 +298,7 @@ public class CSVExporter {
     organizations.write("Id,NAME,ADDRESS,CITY,STATE,ZIP,LAT,LON,PHONE,REVENUE,UTILIZATION");
     organizations.write(NEWLINE);
     providers.write("Id,ORGANIZATION,NAME,GENDER,SPECIALITY,ADDRESS,CITY,STATE,ZIP,LAT,LON,"
-        + "UTILIZATION");
+        + "ENCOUNTERS,PROCEDURES");
     providers.write(NEWLINE);
     payers.write("Id,NAME,ADDRESS,CITY,STATE_HEADQUARTERED,ZIP,PHONE,AMOUNT_COVERED,"
         + "AMOUNT_UNCOVERED,REVENUE,COVERED_ENCOUNTERS,UNCOVERED_ENCOUNTERS,COVERED_MEDICATIONS,"
@@ -1120,7 +1120,7 @@ public class CSVExporter {
    * @throws IOException if any IO error occurs
    */
   private void provider(Clinician provider, String orgId) throws IOException {
-    // Id,ORGANIZATION,NAME,GENDER,SPECIALITY,ADDRESS,CITY,STATE,ZIP,UTILIZATION
+    // Id,ORGANIZATION,NAME,GENDER,SPECIALITY,ADDRESS,CITY,STATE,ZIP,ENCOUNTERS,PROCEDURES
 
     StringBuilder s = new StringBuilder();
     s.append(provider.getResourceID()).append(',');
@@ -1133,7 +1133,8 @@ public class CSVExporter {
     }
     s.append(provider.getY()).append(',');
     s.append(provider.getX()).append(',');
-    s.append(provider.getEncounterCount());
+    s.append(provider.getEncounterCount()).append(',');
+    s.append(provider.getProcedureCount());
 
     s.append(NEWLINE);
 

--- a/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterR4.java
@@ -1,6 +1,5 @@
 package org.mitre.synthea.export;
 
-import ca.uhn.fhir.context.FhirContext;
 import com.google.common.collect.Table;
 
 import java.io.File;
@@ -29,6 +28,8 @@ public abstract class FhirPractitionerExporterR4 {
 
   private static final String EXTENSION_URI = 
       "http://synthetichealth.github.io/synthea/utilization-encounters-extension";
+  private static final String PROC_EXTENSION_URI =
+      "http://synthetichealth.github.io/synthea/utilization-procedures-extension";
 
   /**
    * Export the practitioner in FHIR R4 format.
@@ -59,6 +60,11 @@ public abstract class FhirPractitionerExporterR4 {
                 practitioner.addExtension()
                   .setUrl(EXTENSION_URI)
                   .setValue(new IntegerType(doc.getEncounterCount()));
+                if (doc.getProcedureCount() > 0) {
+                  practitioner.addExtension()
+                    .setUrl(PROC_EXTENSION_URI)
+                    .setValue(new IntegerType(doc.getProcedureCount()));
+                }
               }
             }
           }

--- a/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
+++ b/src/main/java/org/mitre/synthea/modules/CardiovascularDiseaseModule.java
@@ -523,7 +523,7 @@ public final class CardiovascularDiseaseModule extends Module {
   private static void beginOrContinueEmergency(Person person, long time, Code code) {
     if (!person.attributes.containsKey(CVD_ENCOUNTER)) {
       Encounter encounter = EncounterModule.createEncounter(person, time, EncounterType.EMERGENCY,
-          ClinicianSpecialty.GENERAL_PRACTICE, code);
+          ClinicianSpecialty.CARDIOLOGY, code);
       person.attributes.put(CVD_ENCOUNTER, encounter);
     }
   }

--- a/src/main/java/org/mitre/synthea/modules/EncounterModule.java
+++ b/src/main/java/org/mitre/synthea/modules/EncounterModule.java
@@ -8,6 +8,7 @@ import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.helpers.Attributes;
 import org.mitre.synthea.helpers.Attributes.Inventory;
 import org.mitre.synthea.helpers.Utilities;
+import org.mitre.synthea.world.agents.Clinician;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.agents.Provider;
 import org.mitre.synthea.world.concepts.ClinicianSpecialty;
@@ -126,7 +127,7 @@ public final class EncounterModule extends Module {
   }
 
   /**
-   * Create an Encounter that is coded, with a provider organzation, and a clinician.
+   * Create an Encounter that is coded, with a provider organization, and a clinician.
    * @param person The patient.
    * @param time The time of the encounter.
    * @param type The type of encounter (e.g. emergency).
@@ -144,7 +145,13 @@ public final class EncounterModule extends Module {
       encounter.codes.add(code);
     }
     // assign a provider organization
-    Provider prov = person.getProvider(type, time);
+    Provider prov = null;
+    if  (specialty.equalsIgnoreCase(ClinicianSpecialty.CARDIOLOGY)) {
+      // Get the first provider in the list that was loaded
+      prov = Provider.getProviderList().get(0);
+    } else {
+      prov = person.getProvider(type, time);
+    }
     prov.incrementEncounters(type, year);
     encounter.provider = prov;
     // assign a clinician

--- a/src/main/java/org/mitre/synthea/modules/PerformAnesthesia.java
+++ b/src/main/java/org/mitre/synthea/modules/PerformAnesthesia.java
@@ -49,7 +49,7 @@ public class PerformAnesthesia extends Module {
   
   static {
     try {
-      // Load the Surgeon File
+      // Load the Anesthetist File
       String anesthetistsCsv = Utilities.readResource("anesthetist_stats.csv");
       List<LinkedHashMap<String,String>> anesthetistsFile = SimpleCSV.parse(anesthetistsCsv);
 
@@ -72,17 +72,17 @@ public class PerformAnesthesia extends Module {
         Provider.getProviderList().add(dummyProvider);
       }
 
-      // Now create a Clinician representing each surgeon...
+      // Now create a Clinician representing each anesthetist...
       Provider provider = Provider.getProviderList().get(0);
       Random clinicianRand = new Random(-9);
       int id = 0;
-      for (String surgeonId : identifierSet) {
+      for (String anesthetistId : identifierSet) {
         Clinician clin = new Clinician(-1, clinicianRand, id++, provider);
 
         clin.attributes.put(Clinician.SPECIALTY, "Anesthesiology");
-        clin.attributes.put(Clinician.FIRST_NAME, surgeonId);
-        clin.attributes.put(Clinician.LAST_NAME, surgeonId);
-        clin.attributes.put(Clinician.NAME, surgeonId);
+        clin.attributes.put(Clinician.FIRST_NAME, anesthetistId);
+        clin.attributes.put(Clinician.LAST_NAME, anesthetistId);
+        clin.attributes.put(Clinician.NAME, anesthetistId);
         clin.attributes.put(Clinician.NAME_PREFIX, "Dr.");
 
         clin.attributes.put(Clinician.GENDER, clinicianRand.nextBoolean() ? "F" : "M");
@@ -93,12 +93,12 @@ public class PerformAnesthesia extends Module {
         clin.attributes.put(Person.ZIP, provider.zip);
         clin.attributes.put(Person.COORDINATE, provider.getLonLat());
 
-        anesthetists.put(surgeonId, clin);
+        anesthetists.put(anesthetistId, clin);
       }
 
       provider.clinicianMap.put(ClinicianSpecialty.ANESTHESIOLOGY, new ArrayList<Clinician>(anesthetists.values()));
       
-      // Finally, go back through the surgeon file data and create distributions
+      // Finally, go back through the anesthetist file data and create distributions
       // for each surgery...
       for (LinkedHashMap<String,String> row : anesthetistsFile) {
         String operation = row.get("new_surgery_col");
@@ -117,7 +117,7 @@ public class PerformAnesthesia extends Module {
         // note that surgeons have different mean times for on/off pump
         
 
-        clin.attributes.put("mean_surgeon_time", mean);
+        clin.attributes.put("mean_anesthesia_time", mean);
         
         RandomCollection<Clinician> clins = anesthetistsBySurgeryType.get(operation);
         
@@ -201,10 +201,12 @@ public class PerformAnesthesia extends Module {
       anesthesiaProc.clinician = anesthetist;
 
       anesthetist.incrementEncounters();
+      anesthetist.incrementProcedures();
       anesthetist.getOrganization().incrementEncounters(EncounterType.INPATIENT, Utilities.getYear(time));
 
       // hack this clinician back onto the record?
-      person.record.currentEncounter(stopTime).clinician = anesthetist;
+      // only do this for the surgeon
+      // person.record.currentEncounter(time).clinician = anesthetist;
 
       String reason = "cardiac_surgery_reason";
 
@@ -242,7 +244,7 @@ public class PerformAnesthesia extends Module {
   public static final double getProcedureDuration(Person person, String cardiacSurgery, Clinician clin, long time) {
     double calculatedBMI = person.getVitalSign(VitalSign.BMI, time);
 
-    double meanSurgeonTime = (double) clin.attributes.get("mean_surgeon_time");
+    double meanSurgeonTime = (double) clin.attributes.get("mean_anesthesia_time");
     
     double gaussianNoise = person.randGaussian();
     

--- a/src/main/java/org/mitre/synthea/world/agents/Clinician.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Clinician.java
@@ -43,6 +43,7 @@ public class Clinician implements Serializable, QuadTreeElement {
   private ArrayList<String> servicesProvided;
   private Provider organization;
   private int encounters;
+  private int procedures;
   public long populationSeed;
 
   /**
@@ -118,6 +119,21 @@ public class Clinician implements Serializable, QuadTreeElement {
     return encounters;
   }
 
+  /**
+   * Increment the number of procedures performed by this Clinician.
+   * @return The incremented number of procedures.
+   */
+  public synchronized int incrementProcedures() {
+    return procedures++;
+  }
+
+  /**
+   * Get the number of procedures performed by this Clinician.
+   * @return The number of procedures.
+   */
+  public int getProcedureCount() {
+    return procedures;
+  }
   public int randInt(int bound) {
     return random.nextInt(bound);
   }

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -496,6 +496,9 @@ public class Provider implements QuadTreeElement, Serializable {
    */
   public Clinician chooseClinicianList(String specialty, RandomNumberGenerator rand) {
     ArrayList<Clinician> clinicians = this.clinicianMap.get(specialty);
+    if (clinicians == null || clinicians.isEmpty()) {
+      clinicians = this.clinicianMap.get(ClinicianSpecialty.GENERAL_PRACTICE);
+    }
     Clinician doc = clinicians.get(rand.randInt(clinicians.size()));
     doc.incrementEncounters();
     return doc;

--- a/src/main/resources/modules/atrial_fibrillation.json
+++ b/src/main/resources/modules/atrial_fibrillation.json
@@ -1,5 +1,6 @@
 {
   "name": "Atrial Fibrillation",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/congestive_heart_failure.json
+++ b/src/main/resources/modules/congestive_heart_failure.json
@@ -1,5 +1,6 @@
 {
   "name": "Congestive Heart Failure",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "states": {
     "Initial": {
       "type": "Initial",

--- a/src/main/resources/modules/heart/acs_anticoagulant.json
+++ b/src/main/resources/modules/heart/acs_anticoagulant.json
@@ -1,5 +1,6 @@
 {
   "name": "acs_anticoagulant",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/heart/acs_antiplatelet.json
+++ b/src/main/resources/modules/heart/acs_antiplatelet.json
@@ -1,5 +1,6 @@
 {
   "name": "acs_antiplatelet",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/heart/acs_arrival_medications.json
+++ b/src/main/resources/modules/heart/acs_arrival_medications.json
@@ -1,5 +1,6 @@
 {
   "name": "acs_arrival_medications",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/heart/acs_discharge_meds.json
+++ b/src/main/resources/modules/heart/acs_discharge_meds.json
@@ -1,5 +1,6 @@
 {
   "name": "acs_discharge_meds",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/heart/avrr/antithrombotic.json
+++ b/src/main/resources/modules/heart/avrr/antithrombotic.json
@@ -1,5 +1,6 @@
 {
   "name": "avrr_antithrombotic",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "AVRr antithrombic submodule."
   ],

--- a/src/main/resources/modules/heart/avrr/intraop_meds_blood.json
+++ b/src/main/resources/modules/heart/avrr/intraop_meds_blood.json
@@ -1,5 +1,6 @@
 {
   "name": "intraop_meds_blood",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "This submodule of Cardiac Surgery models common Labs, Medications, and Blood Components during operation. ",
     "",

--- a/src/main/resources/modules/heart/avrr/outcomes.json
+++ b/src/main/resources/modules/heart/avrr/outcomes.json
@@ -1,5 +1,6 @@
 {
   "name": "outcomes",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "SAVRr outcomes based on operative status."
   ],

--- a/src/main/resources/modules/heart/avrr/preoperative.json
+++ b/src/main/resources/modules/heart/avrr/preoperative.json
@@ -1,5 +1,6 @@
 {
   "name": "preoperative",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "states": {
     "Initial": {
       "type": "Initial",

--- a/src/main/resources/modules/heart/avrr/referral.json
+++ b/src/main/resources/modules/heart/avrr/referral.json
@@ -1,5 +1,6 @@
 {
   "name": "referral",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "AVRr Referral"
   ],

--- a/src/main/resources/modules/heart/avrr/savrr_operation.json
+++ b/src/main/resources/modules/heart/avrr/savrr_operation.json
@@ -1,5 +1,6 @@
 {
   "name": "SAVRr_Operation",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/heart/avrr/savrr_postop.json
+++ b/src/main/resources/modules/heart/avrr/savrr_postop.json
@@ -1,5 +1,6 @@
 {
   "name": "savrr_postop",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "This submodule of Cardiac Surgery models Postoperative ICU and Ward Care."
   ],

--- a/src/main/resources/modules/heart/avrr/sequence.json
+++ b/src/main/resources/modules/heart/avrr/sequence.json
@@ -1,5 +1,6 @@
 {
   "name": "sequence",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "AVRR sequence."
   ],
@@ -260,7 +261,7 @@
         {
           "system": "SNOMED-CT",
           "code": 306185001,
-          "display": "Referral to cardiac surgery service (procedure"
+          "display": "Referral to cardiac surgery service (procedure)"
         }
       ],
       "distribution": {

--- a/src/main/resources/modules/heart/cabg/details.json
+++ b/src/main/resources/modules/heart/cabg/details.json
@@ -1,5 +1,6 @@
 {
   "name": "details",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/heart/cabg/icu_meds_devices.json
+++ b/src/main/resources/modules/heart/cabg/icu_meds_devices.json
@@ -1,5 +1,6 @@
 {
   "name": "icu_meds_devices",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "This submodule of Cardiac Surgery models ICU Medications and Devices. "
   ],

--- a/src/main/resources/modules/heart/cabg/labs_common.json
+++ b/src/main/resources/modules/heart/cabg/labs_common.json
@@ -1,5 +1,6 @@
 {
   "name": "labs_common",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Reuseable lab block."
   ],

--- a/src/main/resources/modules/heart/cabg/operation.json
+++ b/src/main/resources/modules/heart/cabg/operation.json
@@ -1,5 +1,6 @@
 {
   "name": "operation",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "This submodule of Cardiac Surgery models the CABG Operation.",
     " ",

--- a/src/main/resources/modules/heart/cabg/or_intraop.json
+++ b/src/main/resources/modules/heart/cabg/or_intraop.json
@@ -1,5 +1,6 @@
 {
   "name": "or_intraop",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "states": {
     "Initial": {
       "type": "Initial",

--- a/src/main/resources/modules/heart/cabg/or_labs_meds.json
+++ b/src/main/resources/modules/heart/cabg/or_labs_meds.json
@@ -1,5 +1,6 @@
 {
   "name": "or_labs_meds",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "This submodule of Cardiac Surgery models common Labs, Medications, and Blood Components during the CABG Operation. ",
     "",

--- a/src/main/resources/modules/heart/cabg/outcomes.json
+++ b/src/main/resources/modules/heart/cabg/outcomes.json
@@ -1,5 +1,6 @@
 {
   "name": "outcomes",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "CABG outcomes based on operative status."
   ],

--- a/src/main/resources/modules/heart/cabg/postop.json
+++ b/src/main/resources/modules/heart/cabg/postop.json
@@ -1,5 +1,6 @@
 {
   "name": "postop",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "This submodule of Cardiac Surgery models Postoperative ICU and Ward Care."
   ],

--- a/src/main/resources/modules/heart/cabg/postop_blood.json
+++ b/src/main/resources/modules/heart/cabg/postop_blood.json
@@ -1,5 +1,6 @@
 {
   "name": "postop_blood",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "states": {
     "Initial": {
       "type": "Initial",

--- a/src/main/resources/modules/heart/cabg/preoperative.json
+++ b/src/main/resources/modules/heart/cabg/preoperative.json
@@ -1,5 +1,6 @@
 {
   "name": "preoperative",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "This submodule of Cardiac Surgery models Preoperative Testing. The tests completed depend on the schedule priority of the patient and time available before surgery. Labs and imaging are as follows: ",
     "",

--- a/src/main/resources/modules/heart/cabg/referral.json
+++ b/src/main/resources/modules/heart/cabg/referral.json
@@ -1,5 +1,6 @@
 {
   "name": "referral",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "This submodule of Cardiac Surgery models Referral Pathways.",
     "",

--- a/src/main/resources/modules/heart/cabg_sequence.json
+++ b/src/main/resources/modules/heart/cabg_sequence.json
@@ -1,5 +1,6 @@
 {
   "name": "cabg_sequence",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Cardiac Surgery Module General Remarks",
     "",

--- a/src/main/resources/modules/heart/cardiac_labs.json
+++ b/src/main/resources/modules/heart/cardiac_labs.json
@@ -1,5 +1,6 @@
 {
   "name": "cardiac_labs",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Labs used in preoperative testing related to the cardiovascular system."
   ],

--- a/src/main/resources/modules/heart/chf_lab_work.json
+++ b/src/main/resources/modules/heart/chf_lab_work.json
@@ -1,5 +1,6 @@
 {
   "name": "chf_lab_work",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "This submodule captures all the initial lab work based on the STS data dictionary and standard of care.",
     "",

--- a/src/main/resources/modules/heart/chf_lvad.json
+++ b/src/main/resources/modules/heart/chf_lvad.json
@@ -1,5 +1,6 @@
 {
   "name": "chf_lvad",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "LVAD Insertion Surgery"
   ],

--- a/src/main/resources/modules/heart/chf_meds.json
+++ b/src/main/resources/modules/heart/chf_meds.json
@@ -1,5 +1,6 @@
 {
   "name": "chf_meds",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Congestive Heart Failure Medications."
   ],

--- a/src/main/resources/modules/heart/chf_meds_hfmef.json
+++ b/src/main/resources/modules/heart/chf_meds_hfmef.json
@@ -1,5 +1,6 @@
 {
   "name": "chf_meds_HFmEF",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Congestive Heart Failure Medications for HFmEF."
   ],

--- a/src/main/resources/modules/heart/chf_meds_hfref_nyha2.json
+++ b/src/main/resources/modules/heart/chf_meds_hfref_nyha2.json
@@ -1,5 +1,6 @@
 {
   "name": "chf_meds_HFrEF_NYHA2",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Congestive Heart Failure Medications for HFrEF NYHA II."
   ],

--- a/src/main/resources/modules/heart/chf_meds_hfref_nyha3.json
+++ b/src/main/resources/modules/heart/chf_meds_hfref_nyha3.json
@@ -1,5 +1,6 @@
 {
   "name": "chf_meds_HFrEF_NYHA3",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Congestive Heart Failure Medications for HFrEF NYHA III."
   ],

--- a/src/main/resources/modules/heart/chf_meds_hfref_nyha4.json
+++ b/src/main/resources/modules/heart/chf_meds_hfref_nyha4.json
@@ -1,5 +1,6 @@
 {
   "name": "chf_meds_HFrEF_NYHA4",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Congestive Heart Failure Medications for HFrEF NYHA IV."
   ],

--- a/src/main/resources/modules/heart/chf_nyha_panel.json
+++ b/src/main/resources/modules/heart/chf_nyha_panel.json
@@ -1,5 +1,6 @@
 {
   "name": "chf_nyha_panel",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Create NYHA Panel"
   ],

--- a/src/main/resources/modules/heart/chf_transplant.json
+++ b/src/main/resources/modules/heart/chf_transplant.json
@@ -1,5 +1,6 @@
 {
   "name": "chf_transplant",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "CHF Transplant Surgery"
   ],

--- a/src/main/resources/modules/heart/nsteacs_pathway.json
+++ b/src/main/resources/modules/heart/nsteacs_pathway.json
@@ -1,5 +1,6 @@
 {
   "name": "NSTEACS Pathway",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/heart/operative_status.json
+++ b/src/main/resources/modules/heart/operative_status.json
@@ -1,15 +1,12 @@
 {
   "name": "operative_status",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Priority: Refers to a patient’s priority for surgery based upon their clinical status and triage. Priority levels are defined as follows: ",
     "* Priority 1 = Surgery performed within 0-48 hours; the patient has no delay in surgery and/or is actively undergoing resuscitation or extracorporeal membrane oxygenation to sustain life.",
     "* Priority 2 = Surgery performed within <=14 days, often during the same hospitalization to minimize risk of further clinical deterioration.",
     "* Priority 3 = Surgery performed within <=42 days; the patient’s clinical condition is stable over days or weeks prior to the operation, but the procedure should preferentially not be deferred if needed due to increased risk of poor outcome.",
-    "* Priority 4 = Surgery performed within > 42 days; the patient’s clinical condition is stable over days or weeks prior to the operation, but the procedure could be deferred if needed without increased risk of poor outcome.",
-    "",
-    "",
-    "",
-    " "
+    "* Priority 4 = Surgery performed within > 42 days; the patient’s clinical condition is stable over days or weeks prior to the operation, but the procedure could be deferred if needed without increased risk of poor outcome."
   ],
   "states": {
     "Initial": {

--- a/src/main/resources/modules/heart/or_blood.json
+++ b/src/main/resources/modules/heart/or_blood.json
@@ -1,5 +1,6 @@
 {
   "name": "or_blood",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "states": {
     "Initial": {
       "type": "Initial",

--- a/src/main/resources/modules/heart/savrepair/operative_status.json
+++ b/src/main/resources/modules/heart/savrepair/operative_status.json
@@ -1,5 +1,6 @@
 {
   "name": "operative_status",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "SAVRepair_Operative_Status",
     "",
@@ -7,11 +8,7 @@
     "* Priority 1 = Surgery performed within 0-48 hours; the patient has no delay in surgery and/or is actively undergoing resuscitation or extracorporeal membrane oxygenation to sustain life.",
     "* Priority 2 = Surgery performed within <=14 days, often during the same hospitalization to minimize risk of further clinical deterioration.",
     "* Priority 3 = Surgery performed within <=42 days; the patient’s clinical condition is stable over days or weeks prior to the operation, but the procedure should preferentially not be deferred if needed due to increased risk of poor outcome.",
-    "* Priority 4 = Surgery performed within > 42 days; the patient’s clinical condition is stable over days or weeks prior to the operation, but the procedure could be deferred if needed without increased risk of poor outcome.",
-    "",
-    "",
-    "",
-    " "
+    "* Priority 4 = Surgery performed within > 42 days; the patient’s clinical condition is stable over days or weeks prior to the operation, but the procedure could be deferred if needed without increased risk of poor outcome."
   ],
   "states": {
     "Initial": {

--- a/src/main/resources/modules/heart/savreplace/operative_status.json
+++ b/src/main/resources/modules/heart/savreplace/operative_status.json
@@ -1,5 +1,6 @@
 {
   "name": "operative_status",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "SAVReplace_Operative_Status",
     "",
@@ -7,11 +8,7 @@
     "* Priority 1 = Surgery performed within 0-48 hours; the patient has no delay in surgery and/or is actively undergoing resuscitation or extracorporeal membrane oxygenation to sustain life.",
     "* Priority 2 = Surgery performed within <=14 days, often during the same hospitalization to minimize risk of further clinical deterioration.",
     "* Priority 3 = Surgery performed within <=42 days; the patient’s clinical condition is stable over days or weeks prior to the operation, but the procedure should preferentially not be deferred if needed due to increased risk of poor outcome.",
-    "* Priority 4 = Surgery performed within > 42 days; the patient’s clinical condition is stable over days or weeks prior to the operation, but the procedure could be deferred if needed without increased risk of poor outcome.",
-    "",
-    "",
-    "",
-    " "
+    "* Priority 4 = Surgery performed within > 42 days; the patient’s clinical condition is stable over days or weeks prior to the operation, but the procedure could be deferred if needed without increased risk of poor outcome."
   ],
   "states": {
     "Initial": {

--- a/src/main/resources/modules/heart/stemi_fibrinolytic.json
+++ b/src/main/resources/modules/heart/stemi_fibrinolytic.json
@@ -1,5 +1,6 @@
 {
   "name": "stemi_fibrinolytic",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/heart/stemi_pathway.json
+++ b/src/main/resources/modules/heart/stemi_pathway.json
@@ -1,5 +1,6 @@
 {
   "name": "STEMI Pathway",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/heart/tavr/alt_access.json
+++ b/src/main/resources/modules/heart/tavr/alt_access.json
@@ -1,5 +1,6 @@
 {
   "name": "alt_access",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/heart/tavr/operation.json
+++ b/src/main/resources/modules/heart/tavr/operation.json
@@ -1,5 +1,6 @@
 {
   "name": "operation",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Note: the Encounter used for everything here is expected to have been started in the AVRr referral submodule"
   ],

--- a/src/main/resources/modules/heart/tavr/operative_status.json
+++ b/src/main/resources/modules/heart/tavr/operative_status.json
@@ -1,5 +1,6 @@
 {
   "name": "operative_status",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "TAVR_Operative_Status",
     "",
@@ -7,11 +8,7 @@
     "* Priority 1 = Surgery performed within 0-48 hours; the patient has no delay in surgery and/or is actively undergoing resuscitation or extracorporeal membrane oxygenation to sustain life.",
     "* Priority 2 = Surgery performed within <=14 days, often during the same hospitalization to minimize risk of further clinical deterioration.",
     "* Priority 3 = Surgery performed within <=42 days; the patient’s clinical condition is stable over days or weeks prior to the operation, but the procedure should preferentially not be deferred if needed due to increased risk of poor outcome.",
-    "* Priority 4 = Surgery performed within > 42 days; the patient’s clinical condition is stable over days or weeks prior to the operation, but the procedure could be deferred if needed without increased risk of poor outcome.",
-    "",
-    "",
-    "",
-    " "
+    "* Priority 4 = Surgery performed within > 42 days; the patient’s clinical condition is stable over days or weeks prior to the operation, but the procedure could be deferred if needed without increased risk of poor outcome."
   ],
   "states": {
     "Initial": {

--- a/src/main/resources/modules/heart/tavr/outcomes.json
+++ b/src/main/resources/modules/heart/tavr/outcomes.json
@@ -1,5 +1,6 @@
 {
   "name": "outcomes",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "TAVR outcomes based on operative status."
   ],

--- a/src/main/resources/modules/heart/tavr/postop.json
+++ b/src/main/resources/modules/heart/tavr/postop.json
@@ -1,5 +1,6 @@
 {
   "name": "postop",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "This submodule of Cardiac Surgery models Postoperative ICU and Ward Care."
   ],

--- a/src/main/resources/modules/heart/vhd_risks.json
+++ b/src/main/resources/modules/heart/vhd_risks.json
@@ -1,5 +1,6 @@
 {
   "name": "vhd_risks",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Valvular Heart Disease (VHD) Risk model.",
     "",

--- a/src/main/resources/modules/myocardial_infarction.json
+++ b/src/main/resources/modules/myocardial_infarction.json
@@ -1,5 +1,6 @@
 {
   "name": "Myocardial Infarction",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/stable_ischemic_heart_disease.json
+++ b/src/main/resources/modules/stable_ischemic_heart_disease.json
@@ -1,5 +1,6 @@
 {
   "name": "Stable Ischemic Heart Disease",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "states": {
     "Initial": {
       "type": "Initial",

--- a/src/main/resources/modules/stroke.json
+++ b/src/main/resources/modules/stroke.json
@@ -1,5 +1,6 @@
 {
   "name": "Stroke",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "A blank module"
   ],

--- a/src/main/resources/modules/vhd_aortic.json
+++ b/src/main/resources/modules/vhd_aortic.json
@@ -1,5 +1,6 @@
 {
   "name": "vhd_aortic",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Aortic Valvular Heart Disease (VHD) Progression model."
   ],

--- a/src/main/resources/modules/vhd_mitral.json
+++ b/src/main/resources/modules/vhd_mitral.json
@@ -1,5 +1,6 @@
 {
   "name": "vhd_mitral",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Mitral Valvular Heart Disease (VHD) Progression model."
   ],

--- a/src/main/resources/modules/vhd_pulmonic.json
+++ b/src/main/resources/modules/vhd_pulmonic.json
@@ -1,5 +1,6 @@
 {
   "name": "vhd_pulmonic",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Pulmonic Valvular Heart Disease (VHD) Progression model."
   ],

--- a/src/main/resources/modules/vhd_tricuspid.json
+++ b/src/main/resources/modules/vhd_tricuspid.json
@@ -1,5 +1,6 @@
 {
   "name": "vhd_tricuspid",
+  "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "Tricuspid Valvular Heart Disease (VHD) Progression model."
   ],


### PR DESCRIPTION
This is somewhat of a hack.

- All heart-related modules have a new GMF attribute `specialty` that lists the specialty for the entire module, which all are the same in this case, `CARDIOVASCULAR DISEASE (CARDIOLOGY)` (which corresponds to the `ClinicianSpecialty.CARDIAC_SURGERY` constant).
- This specialty is used when the module creates an encounter in order to override organization selection. It will choose the first organization, which should be the first hospital.
- I also changed the static surgeon loading, because each Java Module was overwriting the list of clinicians at the organization, which was adversely effecting export.
  - Duration calculations were unaffected because each module keeps its own private internal list of clinicians. But at export time, only one of those clinician lists was being exported, the rest were being ignored.
- Finally, ⚠️ I changed the CABG Java module to pull from `surgeon_stats_new.csv` rather than `surgeon_stats.csv`, which has slightly different numbers. All the other Java modules were using `surgeon_stats_new.csv` so it seemed like an oversight. ⚠️ 
