### PR TITLE
CCDA Export Failures Again...

### DIFF
--- a/src/test/java/org/mitre/synthea/FailedExportHelper.java
+++ b/src/test/java/org/mitre/synthea/FailedExportHelper.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -50,5 +51,23 @@ public class FailedExportHelper {
     Path jsonFile = Paths.get(directory, String.format("%s.%s.json", id, exporterName));
     String json = JSONExporter.export(person);
     Files.write(jsonFile, json.getBytes());
+  }
+
+  /**
+   * Read failed export files.
+   * @param exporterName "CCDA", "FHIRR4", etc.
+   * @return List of Files, each containing the contents of a failed export file.
+   * @throws IOException when bad things happen
+   */
+  public static List<File> loadFailures(String exporterName) throws IOException {
+    checkExportDirectory();
+    List<File> failures = new ArrayList<File>();
+    Path exportPath = Paths.get(directory);
+    for (File file : exportPath.toFile().listFiles()) {
+      if (file.isFile() && file.getName().endsWith(exporterName)) {
+        failures.add(file);
+      }
+    }
+    return failures;
   }
 }

--- a/src/test/java/org/mitre/synthea/export/CCDAExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CCDAExporterTest.java
@@ -14,6 +14,7 @@ import org.apache.commons.io.IOUtils;
 import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.mdht.uml.cda.util.BasicValidationHandler;
 import org.eclipse.mdht.uml.cda.util.CDAUtil;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,12 +35,16 @@ public class CCDAExporterTest {
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();
 
+  @BeforeClass
+  public static void loadCDAUtils() {
+    CDAUtil.loadPackages();
+  }
+
   @Test
   public void testCCDAExport() throws Exception {
     TestHelper.loadTestProperties();
     Generator.DEFAULT_STATE = Config.get("test_state.default", "Massachusetts");
     Config.set("exporter.baseDirectory", tempFolder.newFolder().toString());
-    CDAUtil.loadPackages();
     List<String> errors = ParallelTestingService.runInParallel((person) -> {
       List<String> validationErrors = new ArrayList<String>();
       TestHelper.exportOff();
@@ -104,7 +109,6 @@ public class CCDAExporterTest {
   public void testFailedCCDAExports() throws Exception {
     System.out.println("Revalidating Failed CCDA Exports...");
     TestHelper.loadTestProperties();
-    CDAUtil.loadPackages();
     List<String> validationErrors = new ArrayList<String>();
     List<File> failures = FailedExportHelper.loadFailures("CCDA");
     for (File failure : failures) {


### PR DESCRIPTION
This PR:

- Adds a disabled `@Ignore` unit test. You can run this unit test locally (after removing the `@Ignore` tag) if you had failed CCDA exports. It will revalidate the failed exports. This is meant as a debugging tool, and not a genuine unit test.
- Consolidates calling `CDAUtil.loadPackages()` once before any unit tests are run... It was only getting called in one test before, which might be OK if they are executed in a predictable order... maybe that helps with the weird "out of memory" issues and class loading issues we've encountered with this library.