### PR TITLE
Avoid NPE on looking up provider location references.

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -874,12 +874,17 @@ public class FhirR4 {
    * @return Location.fullUrl if found, otherwise null.
    */
   private static String findLocationUrl(Provider provider, Bundle bundle) {
+    if (provider == null) {
+      return null;
+    }
     for (BundleEntryComponent entry : bundle.getEntry()) {
       if (entry.getResource().fhirType().equals("Location")) {
         org.hl7.fhir.r4.model.Location location =
             (org.hl7.fhir.r4.model.Location) entry.getResource();
         Reference managingOrg = location.getManagingOrganization();
         if (managingOrg != null
+            && managingOrg.hasIdentifier()
+            && managingOrg.getIdentifier().hasValue()
             && managingOrg.getIdentifier().getValue().equals(provider.getResourceID())) {
           return entry.getFullUrl();
         }


### PR DESCRIPTION
Avoid a rare NPE on FHIR export.

```
org.mitre.synthea.export.FHIRR4ExporterTest > testFHIRR4Export FAILED
    java.lang.NullPointerException
        at org.mitre.synthea.export.FhirR4.findLocationUrl(FhirR4.java:883)
        at org.mitre.synthea.export.FhirR4.encounter(FhirR4.java:773)
        at org.mitre.synthea.export.FhirR4.convertToFHIR(FhirR4.java:268)
        at org.mitre.synthea.export.FhirR4.convertToFHIRJson(FhirR4.java:355)
        at org.mitre.synthea.export.FHIRR4ExporterTest.lambda$testFHIRR4Export$0(FHIRR4ExporterTest.java:114)
```