### PR TITLE
Fix occasional unit test failure.

### DIFF
--- a/src/test/java/org/mitre/synthea/engine/FixedRecordTest.java
+++ b/src/test/java/org/mitre/synthea/engine/FixedRecordTest.java
@@ -55,8 +55,15 @@ public class FixedRecordTest {
     }
 
     // Make sure that the correct number of people were imported from the fixed records.
-    assertEquals(4, generator.internalStore.size());
-    assertEquals(generator.internalStore.size(), rawRecordGroups.size());
+    // Do not count the DECEASED patients.
+    int livingPatients = 0;
+    for (Person p : generator.internalStore) {
+      if (p.alive(System.currentTimeMillis())) {
+        livingPatients += 1;
+      }
+    }
+    assertEquals(4, livingPatients);
+    assertEquals(livingPatients, rawRecordGroups.size());
 
     // Check that each person has HealthRecords that match their fixed demographic records.
     for (int p = 0; p < generator.internalStore.size(); p++) {

--- a/src/test/java/org/mitre/synthea/engine/FixedRecordTest.java
+++ b/src/test/java/org/mitre/synthea/engine/FixedRecordTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -45,7 +46,6 @@ public class FixedRecordTest {
 
   @Test
   public void fixedDemographicsImportTest() {
-
     // List of raw RecordGroups imported directly from the input file for later comparison.
     List<FixedRecordGroup> rawRecordGroups = generator.importFixedPatientDemographicsFile();
 
@@ -56,19 +56,19 @@ public class FixedRecordTest {
 
     // Make sure that the correct number of people were imported from the fixed records.
     // Do not count the DECEASED patients.
-    int livingPatients = 0;
+    List<Person> livingPatients = new ArrayList<Person>();
     for (Person p : generator.internalStore) {
       if (p.alive(System.currentTimeMillis())) {
-        livingPatients += 1;
+        livingPatients.add(p);
       }
     }
-    assertEquals(4, livingPatients);
-    assertEquals(livingPatients, rawRecordGroups.size());
+    assertEquals(4, livingPatients.size());
+    assertEquals(livingPatients.size(), rawRecordGroups.size());
 
     // Check that each person has HealthRecords that match their fixed demographic records.
-    for (int p = 0; p < generator.internalStore.size(); p++) {
+    for (int p = 0; p < livingPatients.size(); p++) {
       // Get the current person and pull their list of records.
-      Person currentPerson = generator.internalStore.get(p);
+      Person currentPerson = livingPatients.get(p);
       FixedRecordGroup recordGroup
           = (FixedRecordGroup) currentPerson.attributes.get(Person.RECORD_GROUP);
       // Make sure the person has the correct number of records.


### PR DESCRIPTION
Fix unit test failure on FixedRecords when it generates someone who dies.

```
org.mitre.synthea.engine.FixedRecordTest > fixedDemographicsImportTest FAILED
    java.lang.AssertionError: expected:<4> but was:<5>
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:645)
        at org.junit.Assert.assertEquals(Assert.java:631)
        at org.mitre.synthea.engine.FixedRecordTest.fixedDemographicsImportTest(FixedRecordTest.java:58)
```

