### PR TITLE
Two more CCDA fixes

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CCDAExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CCDAExporter.java
@@ -114,6 +114,10 @@ public class CCDAExporter {
       // the provider reset and they don't have a provider until their next wellness visit. There
       // may be other cases. This ensures the preferred provider is there for the CCDA template
       Encounter encounter = person.record.lastWellnessEncounter();
+      if (encounter == null) {
+        // If there are absolutely no wellness encounters, then use the last encounter.
+        encounter = person.record.encounters.get(person.record.encounters.size() - 1);
+      }
       if (encounter != null) {
         person.attributes.put(Person.PREFERREDYPROVIDER + "wellness", encounter.provider);
       } else {

--- a/src/main/resources/templates/ccda/social_history_no_current.ftl
+++ b/src/main/resources/templates/ccda/social_history_no_current.ftl
@@ -1,8 +1,8 @@
 <component>
   <!--Social History - CCDA-->
   <section>
-    <templateId root="2.16.840.1.113883.10.20.22.2.17"/>
     <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2015-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.22.2.17"/>
     <!-- Social history section template -->
     <code code="29762-2" codeSystem="2.16.840.1.113883.6.1"/>
     <title>Social History</title>


### PR DESCRIPTION
This PR contains two fixes.

## CCDA Template
The first fix moves a single line in the CCDA template, and addresses the following stack trace when a patient has no documented history of smoking.

```
org.mitre.synthea.export.CCDAExporterTest > testCCDAExport FAILED
    java.lang.AssertionError: Validation of exported CCDA failed: index=41, size=41|Consol Continuity of Care Document (CCD) (V3) SHALL contain  [1..1] component such that it  (CONF:1198-30687, CONF:1198-30688) Conforms to Social History Section (V3) (templateId: 2.16.840.1.113883.10.20.22.2.17:2015-08-01) expected:<0> but was:<2>
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:645)
        at org.mitre.synthea.export.CCDAExporterTest.testCCDAExport(CCDAExporterTest.java:71)
```


I tested the fix with the new `CCDAExporterTest.testFailedCCDAExports()` method.

## Last Provider
The second fix addresses a rare case when a patient has no preferred wellness provider, and no history of any wellness provider, encountered in this stack trace:

```
org.mitre.synthea.export.CCDAExporterTest > testExportWithNoPreferredWellnessProvider FAILED
    java.lang.IllegalStateException: Unable to export to CCDA because person Evangelina20 Jacobson885 has no preferred provider.
        at org.mitre.synthea.export.CCDAExporter.export(CCDAExporter.java:120)
        at org.mitre.synthea.export.CCDAExporterTest.testExportWithNoPreferredWellnessProvider(CCDAExporterTest.java:88)
```
