### PR TITLE
Fixes an issue with fixed records, birthdates and timezones

### DIFF
--- a/src/main/java/org/mitre/synthea/identity/Entity.java
+++ b/src/main/java/org/mitre/synthea/identity/Entity.java
@@ -64,7 +64,7 @@ public class Entity {
       return seeds.get(0);
     }
     LocalDate date = LocalDateTime.from(Instant.ofEpochMilli(timestamp)
-        .atZone(ZoneId.systemDefault())).toLocalDate();
+        .atZone(ZoneId.of("UTC"))).toLocalDate();
     return seedAt(date);
   }
 

--- a/src/test/java/org/mitre/synthea/identity/EntityTest.java
+++ b/src/test/java/org/mitre/synthea/identity/EntityTest.java
@@ -53,5 +53,8 @@ public class EntityTest {
         .atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
     seed = testEntity.seedAt(duringOpenEnd);
     assertEquals("1416", seed.getSeedId());
+    long startOfFirstSeed = -813960000000L;
+    seed = testEntity.seedAt(startOfFirstSeed);
+    assertEquals("5678", seed.getSeedId());
   }
 }


### PR DESCRIPTION
When converting timestamps into LocalDates, the code was using the
local system timezone, when it should be using UTC. This was an issue
for some fixed records with a birthdate that happens in the year
before the start of Daylight Saving Time. This fix switches to using
UTC.