### PR TITLE
Various updates to BFD RIF SNF and HHA exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ src/main/resources/export/external_codes.csv
 src/main/resources/export/snf_pdpm_code_map.json
 src/main/resources/export/snf_pps_code_map.json
 src/main/resources/export/snf_rev_cntr_code_map.json
+src/main/resources/export/hha_rev_cntr_code_map.json
 
 # H2 database files
 **/*.mv.db

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ src/main/resources/export/dme_code_map.json
 src/main/resources/export/hcpcs_code_map.json
 src/main/resources/export/betos_code_map.json
 src/main/resources/export/external_codes.csv
+src/main/resources/export/snf_pdpm_code_map.json
+src/main/resources/export/snf_pps_code_map.json
+src/main/resources/export/snf_rev_cntr_code_map.json
 
 # H2 database files
 **/*.mv.db

--- a/src/main/java/org/mitre/synthea/export/BB2RIFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/BB2RIFExporter.java
@@ -3294,9 +3294,9 @@ public class BB2RIFExporter {
       }
 
       public boolean isContiguous(HealthRecord.Encounter encounter, long maxSeparationTime) {
-        return (encounter.start >= start && encounter.start <= stop + maxSeparationTime) ||
-                (encounter.stop <= stop && encounter.stop >= start - maxSeparationTime) ||
-                (encounter.start <= start && encounter.stop >= stop);
+        return (encounter.start >= start && encounter.start <= stop + maxSeparationTime)
+                || (encounter.stop <= stop && encounter.stop >= start - maxSeparationTime)
+                || (encounter.start <= start && encounter.stop >= stop);
       }
 
       public void addEncounter(HealthRecord.Encounter encounter) {
@@ -3336,7 +3336,9 @@ public class BB2RIFExporter {
 
     public List<ConsolidatedServicePeriod> getPeriods() {
       List<ConsolidatedServicePeriod> servicePeriods = new ArrayList<>();
-      encounters.sort((e1, e2) -> {return (int)(e1.start - e2.start);});
+      encounters.sort((e1, e2) -> {
+        return (int)(e1.start - e2.start);
+      });
       for (HealthRecord.Encounter encounter: encounters) {
         consolidate(encounter, servicePeriods, maxSeparationTime);
       }

--- a/src/main/java/org/mitre/synthea/export/BB2RIFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/BB2RIFExporter.java
@@ -2673,6 +2673,7 @@ public class BB2RIFExporter {
 
       // Use the final encounter in the service period to set all of the remaining field values that
       // are the same for all claim lines
+      // TODO: update ConsolidatedServicePeriods to separate encounters based on provider, clinician
       HealthRecord.Encounter encounter = servicePeriod.getEncounters().get(
               servicePeriod.getEncounters().size() - 1);
       fieldValues.put(HHA.PRVDR_NUM, encounter.provider.id);

--- a/src/main/java/org/mitre/synthea/export/BB2RIFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/BB2RIFExporter.java
@@ -500,7 +500,8 @@ public class BB2RIFExporter {
       }
 
       if (types.isEmpty()) {
-        System.out.printf("BFD RIF unhandled encounter type");
+        System.out.printf("BFD RIF unhandled encounter type (" + encounter.type
+            + ") and provider type (" + encounter.provider.type.toString() + ")");
       }
     }
 

--- a/src/main/java/org/mitre/synthea/helpers/ConsolidatedServicePeriods.java
+++ b/src/main/java/org/mitre/synthea/helpers/ConsolidatedServicePeriods.java
@@ -1,0 +1,109 @@
+package org.mitre.synthea.helpers;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.mitre.synthea.world.concepts.Claim;
+import org.mitre.synthea.world.concepts.HealthRecord;
+
+/**
+ * Utility class to group encounters separated by less than a configurable amount of time.
+ */
+public class ConsolidatedServicePeriods {
+  public static class ConsolidatedServicePeriod {
+    private long start;
+    private long stop;
+    private final List<HealthRecord.Encounter> encounters;
+    private final Claim.ClaimCost totalCost;
+
+    /**
+     * Create a new instance initialized with the time bounds and costs of the supplied encounter.
+     * @param encounter used to initialize the service period
+     */
+    public ConsolidatedServicePeriod(HealthRecord.Encounter encounter) {
+      start = encounter.start;
+      stop = encounter.stop;
+      encounters = new ArrayList<>();
+      encounters.add(encounter);
+      totalCost = new Claim.ClaimCost(encounter.claim.totals);
+    }
+
+    /**
+     * Determines whether the supplied encounter is contiguous (plus or minus the supplied
+     * interval) with this period.
+     * @param encounter the encounter
+     * @param maxSeparationTime maxx allowed separation in milliseconds
+     * @return
+     */
+    public boolean isContiguous(HealthRecord.Encounter encounter, long maxSeparationTime) {
+      return (encounter.start >= start && encounter.start <= stop + maxSeparationTime)
+              || (encounter.stop <= stop && encounter.stop >= start - maxSeparationTime)
+              || (encounter.start <= start && encounter.stop >= stop);
+    }
+
+    /**
+     * Extend the current period to encapsulate the time bounds and costs of the supplied encounter.
+     * @param encounter the encounter
+     */
+    public void addEncounter(HealthRecord.Encounter encounter) {
+      encounters.add(encounter);
+      start = Math.min(start, encounter.start);
+      stop = Math.max(stop, encounter.stop);
+      totalCost.addCosts(encounter.claim.totals);
+    }
+
+    public List<HealthRecord.Encounter> getEncounters() {
+      return encounters;
+    }
+
+    public long getStart() {
+      return start;
+    }
+
+    public long getStop() {
+      return stop;
+    }
+
+    public Claim.ClaimCost getTotalCost() {
+      return totalCost;
+    }
+  }
+
+  private long maxSeparationTime;
+  private List<HealthRecord.Encounter> encounters;
+
+  public ConsolidatedServicePeriods(long maxSeparationTime) {
+    this.maxSeparationTime = maxSeparationTime;
+    encounters = new ArrayList<>();
+  }
+
+  public void addEncounter(HealthRecord.Encounter encounter) {
+    encounters.add(encounter);
+  }
+
+  private static void consolidate(HealthRecord.Encounter encounter,
+          List<ConsolidatedServicePeriod> servicePeriods, long maxSeparationTime) {
+    for (ConsolidatedServicePeriod currentPeriod: servicePeriods) {
+      if (currentPeriod.isContiguous(encounter, maxSeparationTime)) {
+        currentPeriod.addEncounter(encounter);
+        return;
+      }
+    }
+    ConsolidatedServicePeriod period = new ConsolidatedServicePeriod(encounter);
+    servicePeriods.add(period);
+  }
+
+  /**
+   * Create a list of consolidated service periods from the encounters previously added.
+   * @return the list
+   */
+  public List<ConsolidatedServicePeriod> getPeriods() {
+    List<ConsolidatedServicePeriod> servicePeriods = new ArrayList<>();
+    encounters.sort((e1, e2) -> {
+      return (int)(e1.start - e2.start);
+    });
+    for (HealthRecord.Encounter encounter: encounters) {
+      consolidate(encounter, servicePeriods, maxSeparationTime);
+    }
+    return servicePeriods;
+  }
+}

--- a/src/main/java/org/mitre/synthea/helpers/ConsolidatedServicePeriods.java
+++ b/src/main/java/org/mitre/synthea/helpers/ConsolidatedServicePeriods.java
@@ -45,6 +45,7 @@ public class ConsolidatedServicePeriods {
      * @param encounter the encounter
      */
     public void addEncounter(HealthRecord.Encounter encounter) {
+      // TODO: separate encounters by provider, clinician
       encounters.add(encounter);
       start = Math.min(start, encounter.start);
       stop = Math.max(stop, encounter.stop);

--- a/src/main/java/org/mitre/synthea/world/concepts/Claim.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/Claim.java
@@ -19,10 +19,7 @@ public class Claim implements Serializable {
   private static final long serialVersionUID = -3565704321813987656L;
   public static final BigDecimal ZERO_CENTS = BigDecimal.ZERO.setScale(2);
 
-  public class ClaimEntry implements Serializable {
-    private static final long serialVersionUID = 1871121895630816723L;
-    @JSONSkip
-    public Entry entry;
+  public static class ClaimCost {
     /** total cost of the entry. */
     public BigDecimal cost = ZERO_CENTS;
     /** copay paid by patient. */
@@ -39,6 +36,66 @@ public class Claim implements Serializable {
     public BigDecimal paidBySecondaryPayer = ZERO_CENTS;
     /** otherwise paid by patient out of pocket. */
     public BigDecimal patientOutOfPocket = ZERO_CENTS;
+
+    /**
+     * Create a new instance with all costs set to zero.
+     */
+    public ClaimCost() {
+    }
+
+    /**
+     * Create a new instance with the same cost values as the supplied instance.
+     * @param other the instance to copy costs from
+     */
+    public ClaimCost(ClaimCost other) {
+      this.cost = other.cost;
+      this.copayPaidByPatient = other.copayPaidByPatient;
+      this.deductiblePaidByPatient = other.deductiblePaidByPatient;
+      this.adjustment = other.adjustment;
+      this.coinsurancePaidByPayer = other.coinsurancePaidByPayer;
+      this.paidByPayer = other.paidByPayer;
+      this.paidBySecondaryPayer = other.paidBySecondaryPayer;
+      this.patientOutOfPocket = other.patientOutOfPocket;
+    }
+
+    /**
+     * Add the costs from the other entry to this one.
+     * @param other the other claim entry.
+     */
+    public void addCosts(ClaimCost other) {
+      this.cost = this.cost.add(other.cost);
+      this.copayPaidByPatient = this.copayPaidByPatient.add(other.copayPaidByPatient);
+      this.deductiblePaidByPatient
+          = this.deductiblePaidByPatient.add(other.deductiblePaidByPatient);
+      this.adjustment = this.adjustment.add(other.adjustment);
+      this.coinsurancePaidByPayer = this.coinsurancePaidByPayer.add(other.coinsurancePaidByPayer);
+      this.paidByPayer = this.paidByPayer.add(other.paidByPayer);
+      this.paidBySecondaryPayer = this.paidBySecondaryPayer.add(other.paidBySecondaryPayer);
+      this.patientOutOfPocket = this.patientOutOfPocket.add(other.patientOutOfPocket);
+    }
+
+    /**
+     * Returns the amount of coinsurance paid by the patient, either via secondary insurance or out
+     * of pocket.
+     * @return the amount of coinsurance paid
+     */
+    public BigDecimal getCoinsurancePaid() {
+      if (this.paidBySecondaryPayer.compareTo(Claim.ZERO_CENTS) > 0) {
+        return this.paidBySecondaryPayer;
+      } else if (this.coinsurancePaidByPayer.compareTo(Claim.ZERO_CENTS) > 0) {
+        return this.patientOutOfPocket;
+      }
+      return Claim.ZERO_CENTS;
+    }
+  }
+
+  public InsurancePlan plan;
+  public InsurancePlan secondaryPlan;
+
+  public class ClaimEntry extends ClaimCost implements Serializable {
+    private static final long serialVersionUID = 1871121895630816723L;
+    @JSONSkip
+    public Entry entry;
 
     public ClaimEntry(Entry entry) {
       this.entry = entry;
@@ -113,42 +170,9 @@ public class Claim implements Serializable {
         this.patientOutOfPocket = remainingBalance;
         remainingBalance = remainingBalance.subtract(this.patientOutOfPocket);
       }
-
-    }
-
-    /**
-     * Add the costs from the other entry to this one.
-     * @param other the other claim entry.
-     */
-    public void addCosts(ClaimEntry other) {
-      this.cost = this.cost.add(other.cost);
-      this.copayPaidByPatient = this.copayPaidByPatient.add(other.copayPaidByPatient);
-      this.deductiblePaidByPatient
-          = this.deductiblePaidByPatient.add(other.deductiblePaidByPatient);
-      this.adjustment = this.adjustment.add(other.adjustment);
-      this.coinsurancePaidByPayer = this.coinsurancePaidByPayer.add(other.coinsurancePaidByPayer);
-      this.paidByPayer = this.paidByPayer.add(other.paidByPayer);
-      this.paidBySecondaryPayer = this.paidBySecondaryPayer.add(other.paidBySecondaryPayer);
-      this.patientOutOfPocket = this.patientOutOfPocket.add(other.patientOutOfPocket);
-    }
-
-    /**
-     * Returns the amount of coinsurance paid by the patient, either via secondary insurance or out
-     * of pocket.
-     * @return the amount of coinsurance paid
-     */
-    public BigDecimal getCoinsurancePaid() {
-      if (this.paidBySecondaryPayer.compareTo(Claim.ZERO_CENTS) > 0) {
-        return this.paidBySecondaryPayer;
-      } else if (this.coinsurancePaidByPayer.compareTo(Claim.ZERO_CENTS) > 0) {
-        return this.patientOutOfPocket;
-      }
-      return Claim.ZERO_CENTS;
     }
   }
 
-  public InsurancePlan plan;
-  public InsurancePlan secondaryPlan;
   @JSONSkip
   public Person person;
   public ClaimEntry mainEntry;

--- a/src/main/java/org/mitre/synthea/world/concepts/Claim.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/Claim.java
@@ -87,6 +87,30 @@ public class Claim implements Serializable {
       }
       return Claim.ZERO_CENTS;
     }
+
+    /**
+     * Returns the total cost of the Claim, including immunizations/procedures tied to the
+     * encounter.
+     */
+    public BigDecimal getTotalClaimCost() {
+      return cost;
+    }
+
+    public BigDecimal getCoveredCost() {
+      return coinsurancePaidByPayer.add(paidByPayer);
+    }
+
+    public BigDecimal getDeductiblePaid() {
+      return deductiblePaidByPatient;
+    }
+
+    public BigDecimal getCopayPaid() {
+      return copayPaidByPatient;
+    }
+
+    public BigDecimal getPatientCost() {
+      return patientOutOfPocket.add(copayPaidByPatient).add(deductiblePaidByPatient);
+    }
   }
 
   public InsurancePlan plan;
@@ -259,15 +283,15 @@ public class Claim implements Serializable {
    * Returns the total cost that the Payer covered for this claim.
    */
   public BigDecimal getCoveredCost() {
-    return this.totals.coinsurancePaidByPayer.add(this.totals.paidByPayer);
+    return this.totals.getCoveredCost();
   }
 
   public BigDecimal getDeductiblePaid() {
-    return this.totals.deductiblePaidByPatient;
+    return this.totals.getDeductiblePaid();
   }
 
   public BigDecimal getCopayPaid() {
-    return this.totals.copayPaidByPatient;
+    return this.totals.getCopayPaid();
   }
 
   /**
@@ -276,19 +300,13 @@ public class Claim implements Serializable {
    * @return the amount of coinsurance paid
    */
   public BigDecimal getCoinsurancePaid() {
-    if (this.totals.paidBySecondaryPayer.compareTo(Claim.ZERO_CENTS) > 0) {
-      return this.totals.paidBySecondaryPayer;
-    } else if (this.totals.coinsurancePaidByPayer.compareTo(Claim.ZERO_CENTS) > 0) {
-      return this.totals.patientOutOfPocket;
-    }
-    return Claim.ZERO_CENTS;
+    return this.totals.getCoinsurancePaid();
   }
 
   /**
    * Returns the total cost to the patient, including copay, coinsurance, and deductible.
    */
   public BigDecimal getPatientCost() {
-    return this.totals.patientOutOfPocket.add(this.totals.copayPaidByPatient)
-        .add(this.totals.deductiblePaidByPatient);
+    return this.totals.getPatientCost();
   }
 }

--- a/src/main/resources/export/bfd_field_values.tsv
+++ b/src/main/resources/export/bfd_field_values.tsv
@@ -565,7 +565,7 @@ Line	Field	BENEFICIARY	BENEFICIARY_HISTORY	INPATIENT	OUTPATIENT	CARRIER	PDE	DME	
 563	RDS_NOV_IND	Coded	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	TRUE	
 564	RDS_OCT_IND	Coded	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	TRUE	
 565	RDS_SEPT_IND	Coded	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	TRUE	
-566	REV_CNTR	N/A	N/A	"0001 (total charge, lots of alternatives)"	"0001 (total charge, lots of alternatives)"	N/A	N/A	N/A	"0551,0551,0551,0421,0421,0023,0001 (hha codes)"	"0571,0571,0551,0551,0651,0001 (hospice codes)"	"0120,0420,0250,0430,0300 (snf codes)"	FALSE	
+566	REV_CNTR	N/A	N/A	"0001 (total charge, lots of alternatives)"	"0001 (total charge, lots of alternatives)"	N/A	N/A	N/A	"0551,0551,0551,0421,0421,0023,0001 (hha codes)"	"0571,0571,0551,0551,0651,0001 (hospice codes)"	Coded	FALSE	
 567	REV_CNTR_1ST_ANSI_CD	N/A	N/A	N/A		N/A	N/A	N/A		N/A	N/A	TRUE	
 568	REV_CNTR_1ST_MSP_PD_AMT	N/A	N/A	N/A	0	N/A	N/A	N/A	N/A	N/A	N/A	FALSE	
 569	REV_CNTR_2ND_ANSI_CD	N/A	N/A	N/A		N/A	N/A	N/A	N/A	N/A	N/A	TRUE	

--- a/src/main/resources/export/bfd_field_values.tsv
+++ b/src/main/resources/export/bfd_field_values.tsv
@@ -565,7 +565,7 @@ Line	Field	BENEFICIARY	BENEFICIARY_HISTORY	INPATIENT	OUTPATIENT	CARRIER	PDE	DME	
 563	RDS_NOV_IND	Coded	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	TRUE	
 564	RDS_OCT_IND	Coded	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	TRUE	
 565	RDS_SEPT_IND	Coded	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	TRUE	
-566	REV_CNTR	N/A	N/A	"0001 (total charge, lots of alternatives)"	"0001 (total charge, lots of alternatives)"	N/A	N/A	N/A	"0551,0551,0551,0421,0421,0023,0001 (hha codes)"	"0571,0571,0551,0551,0651,0001 (hospice codes)"	"0001,0120,0420,0250,0430,0300 (snf codes)"	FALSE	
+566	REV_CNTR	N/A	N/A	"0001 (total charge, lots of alternatives)"	"0001 (total charge, lots of alternatives)"	N/A	N/A	N/A	"0551,0551,0551,0421,0421,0023,0001 (hha codes)"	"0571,0571,0551,0551,0651,0001 (hospice codes)"	"0120,0420,0250,0430,0300 (snf codes)"	FALSE	
 567	REV_CNTR_1ST_ANSI_CD	N/A	N/A	N/A		N/A	N/A	N/A		N/A	N/A	TRUE	
 568	REV_CNTR_1ST_MSP_PD_AMT	N/A	N/A	N/A	0	N/A	N/A	N/A	N/A	N/A	N/A	FALSE	
 569	REV_CNTR_2ND_ANSI_CD	N/A	N/A	N/A		N/A	N/A	N/A	N/A	N/A	N/A	TRUE	

--- a/src/main/resources/export/bfd_field_values.tsv
+++ b/src/main/resources/export/bfd_field_values.tsv
@@ -565,7 +565,7 @@ Line	Field	BENEFICIARY	BENEFICIARY_HISTORY	INPATIENT	OUTPATIENT	CARRIER	PDE	DME	
 563	RDS_NOV_IND	Coded	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	TRUE	
 564	RDS_OCT_IND	Coded	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	TRUE	
 565	RDS_SEPT_IND	Coded	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	N/A	TRUE	
-566	REV_CNTR	N/A	N/A	"0001 (total charge, lots of alternatives)"	"0001 (total charge, lots of alternatives)"	N/A	N/A	N/A	"0551,0551,0551,0421,0421,0023,0001 (hha codes)"	"0571,0571,0551,0551,0651,0001 (hospice codes)"	"0022,0001,0120 (snf codes)"	FALSE	
+566	REV_CNTR	N/A	N/A	"0001 (total charge, lots of alternatives)"	"0001 (total charge, lots of alternatives)"	N/A	N/A	N/A	"0551,0551,0551,0421,0421,0023,0001 (hha codes)"	"0571,0571,0551,0551,0651,0001 (hospice codes)"	"0001,0120,0420,0250,0430,0300 (snf codes)"	FALSE	
 567	REV_CNTR_1ST_ANSI_CD	N/A	N/A	N/A		N/A	N/A	N/A		N/A	N/A	TRUE	
 568	REV_CNTR_1ST_MSP_PD_AMT	N/A	N/A	N/A	0	N/A	N/A	N/A	N/A	N/A	N/A	FALSE	
 569	REV_CNTR_2ND_ANSI_CD	N/A	N/A	N/A		N/A	N/A	N/A	N/A	N/A	N/A	TRUE	

--- a/src/main/resources/modules/snf/skilled_nursing_facility.json
+++ b/src/main/resources/modules/snf/skilled_nursing_facility.json
@@ -1,7 +1,7 @@
 {
   "name": "Skilled Nursing Facility",
   "remarks": [
-    "Simplified Skilled Nursing Facility module with a regular routine of physical therapy, occupational therapy, social services, medication administration, and dietary counseling."
+    "Simplified Skilled Nursing Facility module with a regular routine of physical therapy, occupational therapy, social services, medication administration, and dietary counseling. Length of stay statistics: https://us.milliman.com/-/media/milliman/pdfs/2021-articles/1-21-21_variation_in_snf_alos_for_medicare_beneficiaries.ashx"
   ],
   "states": {
     "Initial": {
@@ -47,7 +47,7 @@
       "type": "Simple",
       "distributed_transition": [
         {
-          "distribution": 0.35,
+          "distribution": 0.364,
           "transition": "SNF_1-15_Days"
         },
         {
@@ -59,7 +59,7 @@
           "transition": "SNF_31-99_Days"
         },
         {
-          "distribution": 0.02,
+          "distribution": 0.006,
           "transition": "SNF_100_Days"
         }
       ]
@@ -152,11 +152,11 @@
       "type": "Simple",
       "distributed_transition": [
         {
-          "distribution": 0.94,
+          "distribution": 0.1,
           "transition": "Physical_Therapy"
         },
         {
-          "distribution": 0.06,
+          "distribution": 0.9,
           "transition": "Occupational_Therapy_Check"
         }
       ]
@@ -181,11 +181,11 @@
       "type": "Simple",
       "distributed_transition": [
         {
-          "distribution": 0.94,
+          "distribution": 0.1,
           "transition": "Occupational_Therapy"
         },
         {
-          "distribution": 0.06,
+          "distribution": 0.9,
           "transition": "Speech_Language_Therapy_Check"
         }
       ]
@@ -205,11 +205,11 @@
       "type": "Simple",
       "distributed_transition": [
         {
-          "distribution": 0.43,
+          "distribution": 0.05,
           "transition": "Speech_Language_Therapy"
         },
         {
-          "distribution": 0.57,
+          "distribution": 0.95,
           "transition": "NTA_Check"
         }
       ]
@@ -229,11 +229,11 @@
       "type": "Simple",
       "distributed_transition": [
         {
-          "distribution": 0.75,
+          "distribution": 0.25,
           "transition": "Professional_Services_Care"
         },
         {
-          "distribution": 0.25,
+          "distribution": 0.75,
           "transition": "Status_Change_Check"
         }
       ]
@@ -274,7 +274,14 @@
       "direct_transition": "End_Day"
     },
     "End_Day": {
-      "type": "Simple",
+      "type": "Delay",
+      "distribution": {
+        "kind": "EXACT",
+        "parameters": {
+          "value": 1
+        }
+      },
+      "unit": "days",
       "conditional_transition": [
         {
           "transition": "Begin_Day",

--- a/src/test/java/org/mitre/synthea/export/BB2RIFExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/BB2RIFExporterTest.java
@@ -31,8 +31,6 @@ import org.junit.rules.TemporaryFolder;
 import org.mitre.synthea.TestHelper;
 import org.mitre.synthea.engine.Generator;
 import org.mitre.synthea.export.BB2RIFExporter.CodeMapper;
-import org.mitre.synthea.export.BB2RIFExporter.ConsolidatedServicePeriods;
-import org.mitre.synthea.export.BB2RIFExporter.ConsolidatedServicePeriods.ConsolidatedServicePeriod;
 import org.mitre.synthea.export.BB2RIFExporter.HICN;
 import org.mitre.synthea.export.BB2RIFExporter.MBI;
 import org.mitre.synthea.export.BB2RIFExporter.StaticFieldConfig;
@@ -432,29 +430,5 @@ public class BB2RIFExporterTest {
     instant = pointInTime.atStartOfDay(ZoneId.systemDefault()).toInstant();
     timeInMillis = instant.toEpochMilli();
     assertFalse(period.covers(timeInMillis));
-  }
-
-  @Test
-  public void testEncounterConsolidation() {
-    Person person = new Person(System.currentTimeMillis());
-    long now = Instant.now().toEpochMilli();
-    person.record.encounterStart(now, HealthRecord.EncounterType.HOME);
-    person.record.encounterStart(now + Utilities.convertTime("days", 3),
-            HealthRecord.EncounterType.HOME);
-    person.record.encounterStart(now + Utilities.convertTime("days", 2),
-            HealthRecord.EncounterType.HOME);
-    person.record.encounterStart(now + Utilities.convertTime("days", 6),
-            HealthRecord.EncounterType.HOME);
-
-    ConsolidatedServicePeriods consolidated =
-            new ConsolidatedServicePeriods(Utilities.convertTime("days", 2));
-    for (HealthRecord.Encounter encounter: person.record.encounters) {
-      consolidated.addEncounter(encounter);
-    }
-
-    List<ConsolidatedServicePeriod> periods = consolidated.getPeriods();
-    assertEquals(2, periods.size());
-    assertEquals(3, periods.get(0).getEncounters().size());
-    assertEquals(1, periods.get(1).getEncounters().size());
   }
 }

--- a/src/test/java/org/mitre/synthea/export/BB2RIFExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/BB2RIFExporterTest.java
@@ -31,6 +31,8 @@ import org.junit.rules.TemporaryFolder;
 import org.mitre.synthea.TestHelper;
 import org.mitre.synthea.engine.Generator;
 import org.mitre.synthea.export.BB2RIFExporter.CodeMapper;
+import org.mitre.synthea.export.BB2RIFExporter.ConsolidatedServicePeriods;
+import org.mitre.synthea.export.BB2RIFExporter.ConsolidatedServicePeriods.ConsolidatedServicePeriod;
 import org.mitre.synthea.export.BB2RIFExporter.HICN;
 import org.mitre.synthea.export.BB2RIFExporter.MBI;
 import org.mitre.synthea.export.BB2RIFExporter.StaticFieldConfig;
@@ -45,6 +47,7 @@ import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.Claim;
+import org.mitre.synthea.world.concepts.HealthRecord;
 
 public class BB2RIFExporterTest {
   /**
@@ -429,5 +432,29 @@ public class BB2RIFExporterTest {
     instant = pointInTime.atStartOfDay(ZoneId.systemDefault()).toInstant();
     timeInMillis = instant.toEpochMilli();
     assertFalse(period.covers(timeInMillis));
+  }
+
+  @Test
+  public void testEncounterConsolidation() {
+    Person person = new Person(System.currentTimeMillis());
+    long now = Instant.now().toEpochMilli();
+    person.record.encounterStart(now, HealthRecord.EncounterType.HOME);
+    person.record.encounterStart(now + Utilities.convertTime("days", 3),
+            HealthRecord.EncounterType.HOME);
+    person.record.encounterStart(now + Utilities.convertTime("days", 2),
+            HealthRecord.EncounterType.HOME);
+    person.record.encounterStart(now + Utilities.convertTime("days", 6),
+            HealthRecord.EncounterType.HOME);
+
+    ConsolidatedServicePeriods consolidated =
+            new ConsolidatedServicePeriods(Utilities.convertTime("days", 2));
+    for (HealthRecord.Encounter encounter: person.record.encounters) {
+      consolidated.addEncounter(encounter);
+    }
+
+    List<ConsolidatedServicePeriod> periods = consolidated.getPeriods();
+    assertEquals(2, periods.size());
+    assertEquals(3, periods.get(0).getEncounters().size());
+    assertEquals(1, periods.get(1).getEncounters().size());
   }
 }

--- a/src/test/java/org/mitre/synthea/export/BB2RIFExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/BB2RIFExporterTest.java
@@ -79,7 +79,7 @@ public class BB2RIFExporterTest {
     Exporter.ExporterRuntimeOptions exportOpts = new Exporter.ExporterRuntimeOptions();
     Generator.GeneratorOptions generatorOpts = new Generator.GeneratorOptions();
     generatorOpts.population = numberOfPeople;
-    generatorOpts.seed = 1010;
+    generatorOpts.seed = 505;
     RandomNumberGenerator rand = new DefaultRandomNumberGenerator(generatorOpts.seed);
     generatorOpts.minAge = 70;
     generatorOpts.maxAge = 80;

--- a/src/test/java/org/mitre/synthea/export/BB2RIFExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/BB2RIFExporterTest.java
@@ -80,7 +80,7 @@ public class BB2RIFExporterTest {
     Exporter.ExporterRuntimeOptions exportOpts = new Exporter.ExporterRuntimeOptions();
     Generator.GeneratorOptions generatorOpts = new Generator.GeneratorOptions();
     generatorOpts.population = numberOfPeople;
-    generatorOpts.seed = 505;
+    generatorOpts.seed = 1010;
     RandomNumberGenerator rand = new DefaultRandomNumberGenerator(generatorOpts.seed);
     generatorOpts.minAge = 70;
     generatorOpts.maxAge = 80;

--- a/src/test/java/org/mitre/synthea/helpers/ConsolidatedServicePeriodsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/ConsolidatedServicePeriodsTest.java
@@ -9,7 +9,7 @@ import org.mitre.synthea.helpers.ConsolidatedServicePeriods.ConsolidatedServiceP
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.HealthRecord;
 
-public class ConsolodatedServicePeriodsTest {
+public class ConsolidatedServicePeriodsTest {
   @Test
   public void testEncounterConsolidation() {
     Person person = new Person(System.currentTimeMillis());

--- a/src/test/java/org/mitre/synthea/helpers/ConsolodatedServicePeriodsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/ConsolodatedServicePeriodsTest.java
@@ -1,0 +1,36 @@
+package org.mitre.synthea.helpers;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.Test;
+import org.mitre.synthea.helpers.ConsolidatedServicePeriods.ConsolidatedServicePeriod;
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.concepts.HealthRecord;
+
+public class ConsolodatedServicePeriodsTest {
+  @Test
+  public void testEncounterConsolidation() {
+    Person person = new Person(System.currentTimeMillis());
+    long now = Instant.now().toEpochMilli();
+    person.record.encounterStart(now, HealthRecord.EncounterType.HOME);
+    person.record.encounterStart(now + Utilities.convertTime("days", 3),
+            HealthRecord.EncounterType.HOME);
+    person.record.encounterStart(now + Utilities.convertTime("days", 2),
+            HealthRecord.EncounterType.HOME);
+    person.record.encounterStart(now + Utilities.convertTime("days", 6),
+            HealthRecord.EncounterType.HOME);
+
+    ConsolidatedServicePeriods consolidated =
+            new ConsolidatedServicePeriods(Utilities.convertTime("days", 2));
+    for (HealthRecord.Encounter encounter: person.record.encounters) {
+      consolidated.addEncounter(encounter);
+    }
+
+    List<ConsolidatedServicePeriod> periods = consolidated.getPeriods();
+    assertEquals(2, periods.size());
+    assertEquals(3, periods.get(0).getEncounters().size());
+    assertEquals(1, periods.get(1).getEncounters().size());
+  }
+}


### PR DESCRIPTION
Note that there are three new mapping files (available on the file share) utilized by this PR.

1. Fix a bug where all procedures would happen in one day
2. Reduce probability of various procedures during SNF stay
3. RIF revenue center codes are now mapped from procedure codes
4. Update BFD RIF SNF exporter so that claim lines without HCPCS codes are not skipped (matches real data)
5. Add mappings to SNF PPS and PDPM codes to better match real data
6. Centralize logic that determines which events map to which BFD RIF claim files