### PR TITLE
Add default value for exporter.encoding in code.

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CDWExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CDWExporter.java
@@ -148,7 +148,7 @@ public class CDWExporter {
   /**
    * Charset for specifying the character set of the output files.
    */
-  private Charset charset = Charset.forName(Config.get("exporter.encoding"));
+  private Charset charset = Charset.forName(Config.get("exporter.encoding", "UTF-8"));
 
   /**
    * System-dependent string for a line break. (\n on Mac, *nix, \r\n on Windows)

--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -147,7 +147,7 @@ public class CSVExporter {
   /**
    * Charset for specifying the character set of the output files.
    */
-  private Charset charset = Charset.forName(Config.get("exporter.encoding"));
+  private Charset charset = Charset.forName(Config.get("exporter.encoding", "UTF-8"));
 
   /**
    * System-dependent string for a line break. (\n on Mac, *nix, \r\n on Windows)

--- a/src/main/java/org/mitre/synthea/export/SymptomCSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/SymptomCSVExporter.java
@@ -33,7 +33,7 @@ public class SymptomCSVExporter {
   /**
    * Charset for specifying the character set of the output files.
    */
-  private Charset charset = Charset.forName(Config.get("exporter.encoding"));
+  private Charset charset = Charset.forName(Config.get("exporter.encoding", "UTF-8"));
 
   /**
    * System-dependent string for a line break. (\n on Mac, *nix, \r\n on Windows)


### PR DESCRIPTION
Fixes #1131 and #1130.

Adds default value for `exporter.encoding` in the code.

This is important for when a `synthea.properties` file does not specify a value, which causes the effected exporters to fail. This can happen with synthea-international configurations, for example.