### PR TITLE
Add Identifier to Patient Home Location

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -170,7 +170,7 @@ public class FhirR4 {
   private static final String UNITSOFMEASURE_URI = "http://unitsofmeasure.org";
   private static final String DICOM_DCM_URI = "http://dicom.nema.org/resources/ontology/DCM";
   private static final String MEDIA_TYPE_URI = "http://terminology.hl7.org/CodeSystem/media-type";
-  private static final String SYNTHEA_IDENTIFIER = "https://github.com/synthetichealth/synthea";
+  protected static final String SYNTHEA_IDENTIFIER = "https://github.com/synthetichealth/synthea";
 
   @SuppressWarnings("rawtypes")
   private static final Map raceEthnicityCodes = loadRaceEthnicityCodes();

--- a/src/main/java/org/mitre/synthea/export/FhirR4PatientHome.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4PatientHome.java
@@ -2,6 +2,7 @@ package org.mitre.synthea.export;
 
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.codesystems.LocationPhysicalType;
 import org.mitre.synthea.world.agents.Person;
@@ -34,6 +35,9 @@ public class FhirR4PatientHome {
       // Not really generating a random UUID. Given that this is not tied to a particular provider
       // or person, this just makes up a person with a hardcoded random seed.
       patientHome.setId(new Person(1).randUUID().toString());
+      Identifier identifier = patientHome.addIdentifier();
+      identifier.setSystem(FhirR4.SYNTHEA_IDENTIFIER);
+      identifier.setValue(patientHome.getId());
     }
     return patientHome;
   }


### PR DESCRIPTION
This PR fixes #1146 by adding an `Identifier` to the patient's home `Location` so it can be referenced by identifier.