### PR TITLE
FIPS County (CSV Exporter) and SSA County (RIF Exporter)

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -767,7 +767,7 @@ public class Generator {
     // Pull the person's location data.
     demographicsOutput.put(Person.CITY, city.city);
     demographicsOutput.put(Person.STATE, city.state);
-    demographicsOutput.put("county", city.county);
+    demographicsOutput.put(Person.COUNTY, city.county);
 
     // Generate the person's race data based on their location.
     String race = city.pickRace(random);

--- a/src/main/java/org/mitre/synthea/export/BB2RIFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/BB2RIFExporter.java
@@ -492,8 +492,13 @@ public class BB2RIFExporter {
               getBB2SexCode((String)person.attributes.get(Person.GENDER)));
       String zipCode = (String)person.attributes.get(Person.ZIP);
       fieldValues.put(BENEFICIARY.BENE_ZIP_CD, zipCode);
-      fieldValues.put(BENEFICIARY.BENE_COUNTY_CD,
-              locationMapper.zipToCountyCode(zipCode));
+      String countyCode = locationMapper.zipToCountyCode(zipCode);
+      if (countyCode == null) {
+        countyCode = locationMapper.stateCountyNameToCountyCode(
+            (String)person.attributes.get(Person.STATE),
+            (String)person.attributes.get(Person.COUNTY), person);
+      }
+      fieldValues.put(BENEFICIARY.BENE_COUNTY_CD, countyCode);
       for (int i = 0; i < monthCount; i++) {
         fieldValues.put(BB2RIFStructure.beneficiaryFipsStateCntyFields[i],
             locationMapper.zipToFipsCountyCode(zipCode));

--- a/src/main/java/org/mitre/synthea/export/CPCDSExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CPCDSExporter.java
@@ -300,12 +300,12 @@ public class CPCDSExporter {
     } else {
       s.append(',');
     }
-    s.append(person.attributes.getOrDefault("county", "")).append(',');
+    s.append(person.attributes.getOrDefault(Person.COUNTY, "")).append(',');
     s.append(person.attributes.getOrDefault(Person.STATE, "")).append(',');
     s.append(person.attributes.getOrDefault("country", "United States")).append(',');
     s.append(person.attributes.getOrDefault(Person.ZIP, "")).append(',');
 
-    s.append(person.attributes.getOrDefault("county", "")).append(',');
+    s.append(person.attributes.getOrDefault(Person.COUNTY, "")).append(',');
     s.append(person.attributes.getOrDefault(Person.STATE, "")).append(',');
     s.append(person.attributes.getOrDefault("country", "United States")).append(',');
     s.append(person.attributes.getOrDefault(Person.ZIP, ""));

--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -178,7 +178,6 @@ public class CSVExporter {
 
       if (Config.getAsBoolean("exporter.csv.folder_per_run")) {
         // we want a folder per run, so name it based on the timestamp
-        // TODO: do we want to consider names based on the current generation options?
         String timestamp = ExportHelper.iso8601Timestamp(System.currentTimeMillis());
         String subfolderName = timestamp.replaceAll("\\W+", "_"); // make sure it's filename-safe
         outputDirectory = outputDirectory.resolve(subfolderName);
@@ -297,7 +296,8 @@ public class CSVExporter {
   private void writeCSVHeaders() throws IOException {
     patients.write("Id,BIRTHDATE,DEATHDATE,SSN,DRIVERS,PASSPORT,"
         + "PREFIX,FIRST,LAST,SUFFIX,MAIDEN,MARITAL,RACE,ETHNICITY,GENDER,BIRTHPLACE,"
-        + "ADDRESS,CITY,STATE,COUNTY,ZIP,LAT,LON,HEALTHCARE_EXPENSES,HEALTHCARE_COVERAGE,INCOME");
+        + "ADDRESS,CITY,STATE,COUNTY,FIPS,ZIP,LAT,LON,"
+        + "HEALTHCARE_EXPENSES,HEALTHCARE_COVERAGE,INCOME");
     patients.write(NEWLINE);
     allergies.write("START,STOP,PATIENT,ENCOUNTER,CODE,SYSTEM,DESCRIPTION,TYPE,CATEGORY,"
         + "REACTION1,DESCRIPTION1,SEVERITY1,REACTION2,DESCRIPTION2,SEVERITY2");
@@ -591,7 +591,7 @@ public class CSVExporter {
   private String patient(Person person, long time) throws IOException {
     // Id,BIRTHDATE,DEATHDATE,SSN,DRIVERS,PASSPORT,PREFIX,
     // FIRST,LAST,SUFFIX,MAIDEN,MARITAL,RACE,ETHNICITY,GENDER,BIRTHPLACE,ADDRESS
-    // CITY,STATE,COUNTY,ZIP,LAT,LON,HEALTHCARE_EXPENSES,HEALTHCARE_COVERAGE,INCOME
+    // CITY,STATE,COUNTY,FIPS,ZIP,LAT,LON,HEALTHCARE_EXPENSES,HEALTHCARE_COVERAGE,INCOME
     String personID = (String) person.attributes.get(Person.ID);
 
     // check if we've already exported this patient demographic data yet,
@@ -626,7 +626,8 @@ public class CSVExporter {
         Person.ADDRESS,
         Person.CITY,
         Person.STATE,
-        "county",
+        Person.COUNTY,
+        Person.FIPS,
         Person.ZIP,
     }) {
       String value = (String) person.attributes.getOrDefault(attribute, "");

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -164,9 +164,11 @@ public final class LifecycleModule extends Module {
     String city = (String) attributes.get(Person.CITY);
     Location location = (Location) attributes.get(Person.LOCATION);
     if (location != null) {
-      // should never happen in practice, but can happen in unit tests
+      // A null location should never happen in practice, but can happen in unit tests
       location.assignPoint(person, city);
-      person.attributes.put(Person.ZIP, location.getZipCode(city, person));
+      String zipCode = location.getZipCode(city, person);
+      person.attributes.put(Person.ZIP, zipCode);
+      person.attributes.put(Person.FIPS, Location.getFipsCodeByZipCode(zipCode));
       String[] birthPlace;
       if ("english".equalsIgnoreCase((String) attributes.get(Person.FIRST_LANGUAGE))) {
         birthPlace = location.randomBirthPlace(person);

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -61,8 +61,10 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
   public static final String ID = "id";
   public static final String ADDRESS = "address";
   public static final String CITY = "city";
+  public static final String COUNTY = "county";
   public static final String STATE = "state";
   public static final String ZIP = "zip";
+  public static final String FIPS = "fips";
   public static final String BIRTHPLACE = "birthplace";
   public static final String BIRTH_CITY = "birth_city";
   public static final String BIRTH_STATE = "birth_state";

--- a/src/main/java/org/mitre/synthea/world/geography/CMSStateCodeMapper.java
+++ b/src/main/java/org/mitre/synthea/world/geography/CMSStateCodeMapper.java
@@ -5,9 +5,10 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
-import org.mitre.synthea.world.agents.Person;
 
 /**
  * Utility class for converting between state names and abbreviations and CMS provider state codes.
@@ -232,7 +233,8 @@ public class CMSStateCodeMapper {
    * @param countyName The name of the county.
    * @return The SSA county code.
    */
-  public String stateCountyNameToCountyCode(String state, String countyName, Person person) {
+  public String stateCountyNameToCountyCode(String state, String countyName,
+      RandomNumberGenerator rand) {
     String ssaCounty = null;
     String abbrv = stateToAbbrev.get(state);
     Map<String, String> stateData = ssaStateCountyNameCountyCode.get(abbrv);
@@ -242,7 +244,7 @@ public class CMSStateCodeMapper {
       if (ssaCounty == null) {
         // TODO ideally, we'd search by Lat/Lon and pick the closest county
         // instead, we pick a random county within the state
-        int index = person.randInt(stateData.keySet().size());
+        int index = rand.randInt(stateData.keySet().size());
         key = (String) stateData.keySet().toArray()[index];
         ssaCounty = stateData.get(key);
       }

--- a/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
+++ b/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
@@ -67,6 +67,21 @@ public class LocationTest {
   }
 
   @Test
+  public void testLocationWithFipsCode() {
+    Assert.assertTrue(location.getPopulation(testTown) > 0);
+    List<String> zipcodes = location.getZipCodes(testTown);
+    Assert.assertFalse(Location.getFipsCodeByZipCode(zipcodes.get(0)).isEmpty());
+  }
+
+  @Test
+  public void testLocationWithoutFipsCode() {
+    List<String> zipcodes = location.getZipCodes(locationDoesNotExist);
+    Assert.assertTrue(zipcodes.size() == 1);
+    Assert.assertTrue(zipcodes.contains("00000"));
+    Assert.assertTrue(Location.getFipsCodeByZipCode(zipcodes.get(0)).isEmpty());
+  }
+
+  @Test
   public void testAssignPointPersonWithLocationThatDoesNotExist() {
     Person p = new Person(1);
     String zipcode = location.getZipCode(locationDoesNotExist, p);


### PR DESCRIPTION
- Update CSV exporter to include patient FIPS county code and more frequently populate the zip code.
   - Addresses #1124 
- Fixes SSA County code default value (the default was `22090`)  to try county name matching or picking a county within the correct state.
   - Before this fix, approximately 200+ county codes would be the default in 10,000.
   - With just county name looked up, usage of the default code drops from ~200+ to ~30 in 10,000.
   - The last ~30 or so now default to a random county in the correct state.
