### PR TITLE
Modify RIF tests so there are always DME claims.

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,0 +1,1 @@
+disableTools = [ "refactor-first" ]

--- a/src/test/java/org/mitre/synthea/export/BB2RIFExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/BB2RIFExporterTest.java
@@ -9,6 +9,7 @@ import static org.mitre.synthea.world.agents.Person.INCOME_LEVEL;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.net.URI;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,6 +31,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mitre.synthea.TestHelper;
 import org.mitre.synthea.engine.Generator;
+import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.export.BB2RIFExporter.CodeMapper;
 import org.mitre.synthea.export.BB2RIFExporter.HICN;
 import org.mitre.synthea.export.BB2RIFExporter.MBI;
@@ -45,9 +47,32 @@ import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.Claim;
-import org.mitre.synthea.world.concepts.HealthRecord;
 
 public class BB2RIFExporterTest {
+
+  public class MockMapper extends BB2RIFExporter.CodeMapper {
+    public MockMapper() {
+      super("MOCK_MAPPING_FILE_THAT_DOES_NOT_EXIST.JSON");
+    }
+
+    public boolean canMap(String codeToMap) {
+      return true;
+    }
+
+    public boolean hasMap() {
+      return true;
+    }
+
+    public String map(String codeToMap, String bfdCodeType, RandomNumberGenerator rand,
+        boolean stripDots) {
+      if (bfdCodeType.equalsIgnoreCase("code")) {
+        return "XXXX";
+      } else {
+        return "R";
+      }
+    }
+  }
+
   /**
    * Temporary folder for any exported files, guaranteed to be deleted at the end of the test.
    */
@@ -76,6 +101,11 @@ public class BB2RIFExporterTest {
 
   @Test
   public void testBB2Export() throws Exception {
+    BB2RIFExporter.getInstance().dmeCodeMapper = new MockMapper();
+
+    URI uri = BB2RIFExporterTest.class.getResource("/module").toURI();
+    File file = new File(uri);
+    Module.addModules(file);
     int numberOfPeople = 10;
     Exporter.ExporterRuntimeOptions exportOpts = new Exporter.ExporterRuntimeOptions();
     Generator.GeneratorOptions generatorOpts = new Generator.GeneratorOptions();

--- a/src/test/java/org/mitre/synthea/export/BB2RIFExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/BB2RIFExporterTest.java
@@ -63,6 +63,14 @@ public class BB2RIFExporterTest {
       return true;
     }
 
+    /**
+     * Get one of the BFD codes for the supplied Synthea code.
+     * @param codeToMap the Synthea code to look for
+     * @param bfdCodeType the type of BFD code to map to
+     * @param rand a source of random numbers used to pick one of the list of BFD codes
+     * @param stripDots whether to remove dots in codes (e.g. J39.45 -> J3945)
+     * @return the BFD code or null if the code can't be mapped
+     */
     public String map(String codeToMap, String bfdCodeType, RandomNumberGenerator rand,
         boolean stripDots) {
       if (bfdCodeType.equalsIgnoreCase("code")) {

--- a/src/test/resources/module/hearing.json
+++ b/src/test/resources/module/hearing.json
@@ -1,0 +1,90 @@
+{
+  "name": "Hearing",
+  "remarks": [
+    "One in eight people in the United States (13 percent, or 30 million) aged 12 years or older has hearing loss in both ears, based on standard hearing examinations. About 2 percent of adults aged 45 to 54 have disabling hearing loss. The rate increases to 8.5 percent for adults aged 55 to 64.",
+    "cite: https://www.nidcd.nih.gov/health/statistics/quick-statistics-hearing"
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Initial Delay"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Hearing Aid": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 6012004,
+        "display": "Hearing aid, device (physical object)"
+      },
+      "direct_transition": "End Encounter"
+    },
+    "Hearing Disorder": {
+      "type": "ConditionOnset",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 128540005,
+          "display": "Hearing disorder (disorder)"
+        }
+      ],
+      "direct_transition": "Hearing Aid"
+    },
+    "Wellness": {
+      "type": "Encounter",
+      "telemedicine_possibility": "none",
+      "direct_transition": "Hearing Examination",
+      "wellness": true
+    },
+    "Initial Delay": {
+      "type": "Delay",
+      "distribution": {
+        "kind": "UNIFORM",
+        "parameters": {
+          "high": 64,
+          "low": 55
+        }
+      },
+      "unit": "years",
+      "direct_transition": "Wellness"
+    },
+    "End Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Repeated Delay"
+    },
+    "Repeated Delay": {
+      "type": "Delay",
+      "distribution": {
+        "kind": "UNIFORM",
+        "parameters": {
+          "high": 16,
+          "low": 8
+        }
+      },
+      "unit": "months",
+      "direct_transition": "Wellness"
+    },
+    "Hearing Examination": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 398171003,
+          "display": "Hearing examination (procedure)"
+        }
+      ],
+      "distribution": {
+        "kind": "UNIFORM",
+        "parameters": {
+          "high": 60,
+          "low": 30
+        }
+      },
+      "unit": "minutes",
+      "direct_transition": "Hearing Disorder"
+    }
+  },
+  "gmf_version": 2
+}


### PR DESCRIPTION
Modify RIF tests so there are always DME claims.

- Adds a hearing aid module for only the unit tests.
- Adds a mock DME mapper class to ensure the hearing aid claim is exported regardless of the presence of mapping files.
- Ignore sonatype-lift complaints about "God Classes" -- we hear you, now go away.