### PR TITLE
DME Data Ratio Changes

### DIFF
--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -475,6 +475,7 @@ public abstract class Exporter {
         exporter.exportNPIs();
         exporter.exportManifest();
         exporter.exportEndState();
+        exporter.displayMissingDmeCodes();
       } catch (IOException e) {
         e.printStackTrace();
       }

--- a/src/main/resources/modules/copd.json
+++ b/src/main/resources/modules/copd.json
@@ -1121,7 +1121,7 @@
           "distribution": 0.35
         },
         {
-          "transition": "End_COPD_Followup_Enc1",
+          "transition": "Wheelchair Check",
           "distribution": 0.52
         }
       ]
@@ -1133,7 +1133,7 @@
         "code": 464173000,
         "display": "Portable oxygen concentrator (physical object)"
       },
-      "direct_transition": "End_COPD_Followup_Enc1"
+      "direct_transition": "Wheelchair Check"
     },
     "Portable_Gaseous_Oxygen": {
       "type": "Device",
@@ -1142,7 +1142,7 @@
         "code": 261323006,
         "display": "Portable oxygen cylinder (physical object)"
       },
-      "direct_transition": "End_COPD_Followup_Enc1"
+      "direct_transition": "Wheelchair Check"
     },
     "Oxygen Systems": {
       "type": "Simple",
@@ -1174,8 +1174,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": 336621006,
-          "display": "Oxygen concentrator (physical object)"
+          "code": 261323006,
+          "display": "Portable oxygen cylinder (physical object)"
         }
       ]
     },
@@ -1200,6 +1200,24 @@
           "display": "Home nebulizer (physical object)"
         }
       ]
+    },
+    "Wheelchair Check": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Wheelchair",
+          "distribution": 0.02
+        },
+        {
+          "transition": "End_COPD_Followup_Enc1",
+          "distribution": 0.98
+        }
+      ]
+    },
+    "Wheelchair": {
+      "type": "CallSubmodule",
+      "submodule": "dme/wheelchair",
+      "direct_transition": "End_COPD_Followup_Enc1"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/copd.json
+++ b/src/main/resources/modules/copd.json
@@ -13,7 +13,9 @@
     "The National Health Interview Survey reports the prevalence of emphysema",
     "at 18 cases per 1000 persons and chronic bronchitis at 34 cases per 1000 persons",
     "The term COPD was first used in the 1960s https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2706597/ ",
-    "the terms bronchitis and emphysema have been around longer"
+    "the terms bronchitis and emphysema have been around longer",
+    "Oxygen Concentrators: \"States also varied significantly in the number of oxygen concentrators prescribed, ranging from 0.51% to 8.20% of the local Medicare population.\" -- doi:10.1001/jamanetworkopen.2021.29967",
+    "DME based on analysis of 898K oxygen-related claim lines."
   ],
   "states": {
     "Initial": {
@@ -1029,18 +1031,28 @@
         "Ardestani ME, Abbaszadeh M. The association between forced expiratory volume in one second (FEV1) and pulse oximetric measurements of arterial oxygen saturation (SpO2) in the patients with COPD: A preliminary study. J Res Med Sci. 2014;19(3):257-261.",
         "The study may demonstrate that oxygen saturation measured by pulse oximetry appears to be independent of the degree of airways obstruction as quantified by the FEV1; although further evidence needs to be assessed these preliminary findings."
       ],
-      "conditional_transition": [
+      "complex_transition": [
         {
-          "transition": "Oxygen System",
           "condition": {
             "condition_type": "Attribute",
             "attribute": "smoker",
             "operator": "==",
             "value": true
-          }
+          },
+          "distributions": [],
+          "transition": "Oxygen Systems"
         },
         {
-          "transition": "End_COPD_Followup_Enc1"
+          "distributions": [
+            {
+              "transition": "Oxygen Systems",
+              "distribution": 0.08
+            },
+            {
+              "transition": "End_COPD_Followup_Enc1",
+              "distribution": 0.9199999999999999
+            }
+          ]
         }
       ]
     },
@@ -1066,7 +1078,7 @@
           "display": "albuterol 5 MG/ML Inhalation Solution"
         }
       ],
-      "direct_transition": "Nebulizer",
+      "direct_transition": "End Previous Nebulizer",
       "reason": "copd_variant",
       "chronic": true,
       "prescription": {
@@ -1099,7 +1111,95 @@
         "code": 336621006,
         "display": "Oxygen concentrator (physical object)"
       },
+      "distributed_transition": [
+        {
+          "transition": "End_Portable_Oxygen_System",
+          "distribution": 0.13
+        },
+        {
+          "transition": "End_Previous_Gaseous_Oxygen",
+          "distribution": 0.35
+        },
+        {
+          "transition": "End_COPD_Followup_Enc1",
+          "distribution": 0.52
+        }
+      ]
+    },
+    "Portable_Oxygen_System": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 464173000,
+        "display": "Portable oxygen concentrator (physical object)"
+      },
       "direct_transition": "End_COPD_Followup_Enc1"
+    },
+    "Portable_Gaseous_Oxygen": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 261323006,
+        "display": "Portable oxygen cylinder (physical object)"
+      },
+      "direct_transition": "End_COPD_Followup_Enc1"
+    },
+    "Oxygen Systems": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "End_Previous_Gaseous_Oxygen",
+          "distribution": 0.073
+        },
+        {
+          "transition": "End Previous Oxygen System",
+          "distribution": 0.927
+        }
+      ]
+    },
+    "End Previous Oxygen System": {
+      "type": "DeviceEnd",
+      "direct_transition": "Oxygen System",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 336621006,
+          "display": "Oxygen concentrator (physical object)"
+        }
+      ]
+    },
+    "End_Previous_Gaseous_Oxygen": {
+      "type": "DeviceEnd",
+      "direct_transition": "Portable_Gaseous_Oxygen",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 336621006,
+          "display": "Oxygen concentrator (physical object)"
+        }
+      ]
+    },
+    "End_Portable_Oxygen_System": {
+      "type": "DeviceEnd",
+      "direct_transition": "Portable_Oxygen_System",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 464173000,
+          "display": "Portable oxygen concentrator (physical object)"
+        }
+      ]
+    },
+    "End Previous Nebulizer": {
+      "type": "DeviceEnd",
+      "direct_transition": "Nebulizer",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 170615005,
+          "display": "Home nebulizer (physical object)"
+        }
+      ]
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/dme/wheelchair.json
+++ b/src/main/resources/modules/dme/wheelchair.json
@@ -1,0 +1,73 @@
+{
+  "name": "wheelchair",
+  "remarks": [
+    "Assigns a manual or power wheelchair and optional accessory according to probabilities calculated from ~500K wheelchair claim lines."
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "End Previous Wheelchair"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "New Wheelchair": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 228869008,
+        "display": "Manual wheelchair (physical object)"
+      },
+      "direct_transition": "Accessory Check",
+      "assign_to_attribute": "wheelchair"
+    },
+    "End Previous Wheelchair": {
+      "type": "CallSubmodule",
+      "submodule": "dme/wheelchair_end",
+      "distributed_transition": [
+        {
+          "transition": "New Wheelchair",
+          "distribution": 0.86
+        },
+        {
+          "transition": "New Power Wheelchair",
+          "distribution": 0.14
+        }
+      ]
+    },
+    "New Power Wheelchair": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 705427004,
+        "display": "Power-assisted wheelchair (physical object)"
+      },
+      "direct_transition": "Accessory Check",
+      "assign_to_attribute": "wheelchair"
+    },
+    "Accessory Check": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Wheelchair Accessory",
+          "distribution": 0.73
+        },
+        {
+          "transition": "Terminal",
+          "distribution": 0.27
+        }
+      ]
+    },
+    "Wheelchair Accessory": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 705417005,
+        "display": "Wheelchair accessory (physical object)"
+      },
+      "direct_transition": "Terminal",
+      "assign_to_attribute": "wheelchair_accessory"
+    }
+  },
+  "gmf_version": 2
+}

--- a/src/main/resources/modules/dme/wheelchair_end.json
+++ b/src/main/resources/modules/dme/wheelchair_end.json
@@ -1,0 +1,26 @@
+{
+  "name": "wheelchair_end",
+  "remarks": [
+    "Submodule to stop wheelchair and accessory devices."
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "End Wheelchair"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "End Wheelchair": {
+      "type": "DeviceEnd",
+      "direct_transition": "End Accessory",
+      "referenced_by_attribute": "wheelchair"
+    },
+    "End Accessory": {
+      "type": "DeviceEnd",
+      "direct_transition": "Terminal",
+      "referenced_by_attribute": "wheelchair_accessory"
+    }
+  },
+  "gmf_version": 2
+}

--- a/src/main/resources/modules/encounter/fall_risk_screening.json
+++ b/src/main/resources/modules/encounter/fall_risk_screening.json
@@ -82,6 +82,16 @@
                         "display": "Closed fracture of hip"
                       }
                     ]
+                  },
+                  {
+                    "condition_type": "Active Condition",
+                    "codes": [
+                      {
+                        "system": "SNOMED-CT",
+                        "code": "64859006",
+                        "display": "Osteoporosis (disorder)"
+                      }
+                    ]
                   }
                 ]
               },

--- a/src/main/resources/modules/hospice_treatment.json
+++ b/src/main/resources/modules/hospice_treatment.json
@@ -136,7 +136,16 @@
           "display": "Development of individualized plan of care (procedure)"
         }
       ],
-      "direct_transition": "Begin_Day"
+      "distributed_transition": [
+        {
+          "transition": "Assign DME",
+          "distribution": 0.5
+        },
+        {
+          "transition": "Begin_Day",
+          "distribution": 0.5
+        }
+      ]
     },
     "Begin_Day": {
       "type": "Counter",
@@ -169,7 +178,7 @@
       },
       "conditional_transition": [
         {
-          "transition": "Alive Check",
+          "transition": "End Bed",
           "condition": {
             "condition_type": "Attribute",
             "attribute": "hospice_days",
@@ -274,6 +283,78 @@
       "attribute": "hospice",
       "direct_transition": "Wait for Hospice",
       "value": false
+    },
+    "Assign DME": {
+      "type": "Simple",
+      "direct_transition": "Bed"
+    },
+    "Bed": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 91537007,
+        "display": "Hospital bed, device (physical object)"
+      },
+      "direct_transition": "Lift Check"
+    },
+    "Lift": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 706112002,
+        "display": "Patient lifting system (physical object)"
+      },
+      "direct_transition": "Commode Check"
+    },
+    "Commode": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 360008003,
+        "display": "Commode (physical object)"
+      },
+      "direct_transition": "Begin_Day"
+    },
+    "Lift Check": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Lift",
+          "distribution": 0.24
+        },
+        {
+          "transition": "Commode Check",
+          "distribution": 0.76
+        }
+      ]
+    },
+    "Commode Check": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Commode",
+          "distribution": 0.21
+        },
+        {
+          "transition": "Begin_Day",
+          "distribution": 0.79
+        }
+      ]
+    },
+    "End Bed": {
+      "type": "DeviceEnd",
+      "direct_transition": "End Lift",
+      "device": "Bed"
+    },
+    "End Lift": {
+      "type": "DeviceEnd",
+      "device": "Lift",
+      "direct_transition": "End Commode"
+    },
+    "End Commode": {
+      "type": "DeviceEnd",
+      "device": "Commode",
+      "direct_transition": "Alive Check"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/injuries.json
+++ b/src/main/resources/modules/injuries.json
@@ -468,7 +468,7 @@
           "display": "Chronic paralysis due to lesion of spinal cord"
         }
       ],
-      "direct_transition": "Spinal_Surgery"
+      "direct_transition": "Wheelchair for Spine"
     },
     "No_Spinal_Cord_Damage": {
       "type": "ConditionOnset",
@@ -555,7 +555,7 @@
         "cord damage and survived, his/her chronic paralysis will persist for life."
       ],
       "referenced_by_attribute": "spinal_injury",
-      "direct_transition": "End_Spinal_Injury_Followup"
+      "direct_transition": "End Wheelchair for Spine"
     },
     "End_Spinal_Injury_Followup": {
       "type": "EncounterEnd",
@@ -1280,7 +1280,16 @@
           ]
         }
       ],
-      "direct_transition": "Crutches"
+      "distributed_transition": [
+        {
+          "transition": "Wheelchair for Ankle",
+          "distribution": 0.88
+        },
+        {
+          "transition": "Crutches",
+          "distribution": 0.12
+        }
+      ]
     },
     "Broken_Rib": {
       "type": "ConditionOnset",
@@ -1372,7 +1381,20 @@
           ]
         }
       ],
-      "direct_transition": "Broken_Bone_Surgery"
+      "distributed_transition": [
+        {
+          "transition": "Wheelchair for Hip",
+          "distribution": 0.88
+        },
+        {
+          "transition": "Crutches_2",
+          "distribution": 0.06
+        },
+        {
+          "transition": "Walker",
+          "distribution": 0.06
+        }
+      ]
     },
     "Broken_Bone_Immobilization": {
       "type": "Procedure",
@@ -1652,7 +1674,7 @@
           "display": "Encounter for 'check-up'"
         }
       ],
-      "direct_transition": "End Crutches"
+      "direct_transition": "End DME"
     },
     "End_Broken_Bone_Injury": {
       "type": "ConditionEnd",
@@ -2769,18 +2791,8 @@
         "code": 363753007,
         "display": "Crutches (physical object)"
       },
-      "direct_transition": "Broken_Bone_Immobilization"
-    },
-    "End Crutches": {
-      "type": "DeviceEnd",
-      "direct_transition": "End_Broken_Bone_Injury",
-      "codes": [
-        {
-          "system": "SNOMED-CT",
-          "code": 363753007,
-          "display": "Crutches (physical object)"
-        }
-      ]
+      "direct_transition": "Broken_Bone_Immobilization",
+      "assign_to_attribute": "injury_dme"
     },
     "SNF_0": {
       "type": "CallSubmodule",
@@ -2811,6 +2823,77 @@
       "type": "CallSubmodule",
       "submodule": "snf/skilled_nursing_facility",
       "direct_transition": "Burn_Recovery_Period"
+    },
+    "Crutches_2": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 363753007,
+        "display": "Crutches (physical object)"
+      },
+      "direct_transition": "Broken_Bone_Surgery",
+      "assign_to_attribute": "injury_dme"
+    },
+    "Walker": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 705406009,
+        "display": "Walker (physical object)"
+      },
+      "direct_transition": "Broken_Bone_Surgery",
+      "assign_to_attribute": "injury_dme"
+    },
+    "End DME": {
+      "type": "DeviceEnd",
+      "codes": [],
+      "referenced_by_attribute": "injury_dme",
+      "conditional_transition": [
+        {
+          "transition": "End_DME",
+          "condition": {
+            "condition_type": "Or",
+            "conditions": [
+              {
+                "condition_type": "PriorState",
+                "name": "Wheelchair for Hip"
+              },
+              {
+                "condition_type": "PriorState",
+                "name": "Wheelchair for Ankle"
+              }
+            ]
+          }
+        },
+        {
+          "transition": "End_Broken_Bone_Injury"
+        }
+      ]
+    },
+    "Wheelchair for Ankle": {
+      "type": "CallSubmodule",
+      "submodule": "dme/wheelchair",
+      "direct_transition": "Broken_Bone_Immobilization"
+    },
+    "Wheelchair for Hip": {
+      "type": "CallSubmodule",
+      "submodule": "dme/wheelchair",
+      "direct_transition": "Broken_Bone_Surgery"
+    },
+    "Wheelchair for Spine": {
+      "type": "CallSubmodule",
+      "submodule": "dme/wheelchair",
+      "direct_transition": "Spinal_Surgery"
+    },
+    "End Wheelchair for Spine": {
+      "type": "CallSubmodule",
+      "submodule": "dme/wheelchair_end",
+      "direct_transition": "End_Spinal_Injury_Followup"
+    },
+    "End_DME": {
+      "type": "CallSubmodule",
+      "submodule": "dme/wheelchair_end",
+      "direct_transition": "End_Broken_Bone_Injury"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/metabolic_syndrome/dme_supplies.json
+++ b/src/main/resources/modules/metabolic_syndrome/dme_supplies.json
@@ -1,0 +1,113 @@
+{
+  "name": "dme_supplies",
+  "remarks": [
+    "DME Supply module for metabolic syndrome based on sample of approximately 3/4 million CMS DME claims."
+  ],
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "direct_transition": "Strip Check"
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Glucose_Test_Strips": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "quantity": 50,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 337388004,
+            "display": "Blood glucose testing strips (physical object)"
+          }
+        }
+      ],
+      "direct_transition": "Even More Strips"
+    },
+    "Lancets": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "quantity": 100,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 1137596000,
+            "display": "Blood lancet (physical object)"
+          }
+        }
+      ],
+      "direct_transition": "Calibrator Solution Check"
+    },
+    "Calibrator Solution": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "quantity": 100,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 8537005,
+            "display": "Solution (substance)"
+          }
+        }
+      ],
+      "direct_transition": "Terminal",
+      "remarks": [
+        "Normal, low and high calibrator solution / chips"
+      ]
+    },
+    "Strip Check": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Glucose_Test_Strips",
+          "distribution": 0.7514
+        },
+        {
+          "transition": "Lancet Check",
+          "distribution": 0.24860000000000015
+        }
+      ]
+    },
+    "Lancet Check": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Lancets",
+          "distribution": 0.2856
+        },
+        {
+          "transition": "Calibrator Solution Check",
+          "distribution": 0.7144
+        }
+      ]
+    },
+    "Calibrator Solution Check": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Calibrator Solution",
+          "distribution": 0.032
+        },
+        {
+          "transition": "Terminal",
+          "distribution": 0.968
+        }
+      ]
+    },
+    "Even More Strips": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Glucose_Test_Strips",
+          "distribution": 0.0303
+        },
+        {
+          "transition": "Lancet Check",
+          "distribution": 0.9697
+        }
+      ]
+    }
+  },
+  "gmf_version": 2
+}

--- a/src/main/resources/modules/metabolic_syndrome_care.json
+++ b/src/main/resources/modules/metabolic_syndrome_care.json
@@ -440,7 +440,7 @@
     "Prescribe_Medications": {
       "type": "CallSubmodule",
       "submodule": "metabolic_syndrome/medications",
-      "direct_transition": "Glucose_Test_Strips"
+      "direct_transition": "DME and Supplies"
     },
     "Check_Complications": {
       "type": "Simple",
@@ -729,18 +729,9 @@
       },
       "direct_transition": "Prescribe_Medications"
     },
-    "Glucose_Test_Strips": {
-      "type": "SupplyList",
-      "supplies": [
-        {
-          "quantity": 50,
-          "code": {
-            "system": "SNOMED-CT",
-            "code": 337388004,
-            "display": "Blood glucose testing strips (physical object)"
-          }
-        }
-      ],
+    "DME and Supplies": {
+      "type": "CallSubmodule",
+      "submodule": "metabolic_syndrome/dme_supplies",
       "direct_transition": "Check_Complications"
     }
   },

--- a/src/main/resources/modules/metabolic_syndrome_care.json
+++ b/src/main/resources/modules/metabolic_syndrome_care.json
@@ -435,12 +435,12 @@
         "based on https://github.com/clinical-cloud/sample-careplans"
       ],
       "reason": "diabetes_stage",
-      "direct_transition": "Prescribe_Medications"
+      "direct_transition": "Glucose_Monitor"
     },
     "Prescribe_Medications": {
       "type": "CallSubmodule",
       "submodule": "metabolic_syndrome/medications",
-      "direct_transition": "Check_Complications"
+      "direct_transition": "Glucose_Test_Strips"
     },
     "Check_Complications": {
       "type": "Simple",
@@ -719,6 +719,29 @@
     "End_Wellness_Encounter": {
       "type": "EncounterEnd",
       "direct_transition": "Wellness_Encounter"
+    },
+    "Glucose_Monitor": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 337414009,
+        "display": "Blood glucose meter (physical object)"
+      },
+      "direct_transition": "Prescribe_Medications"
+    },
+    "Glucose_Test_Strips": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "quantity": 50,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 337388004,
+            "display": "Blood glucose testing strips (physical object)"
+          }
+        }
+      ],
+      "direct_transition": "Check_Complications"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/osteoarthritis.json
+++ b/src/main/resources/modules/osteoarthritis.json
@@ -124,7 +124,7 @@
           "display": "Heat therapy"
         }
       ],
-      "direct_transition": "OA_Pain_Medication"
+      "direct_transition": "Assign DME"
     },
     "OA_Pain_Medication": {
       "type": "MedicationOrder",
@@ -428,6 +428,62 @@
         "low": 5,
         "high": 10
       }
+    },
+    "Assign DME": {
+      "type": "Simple",
+      "complex_transition": [
+        {
+          "condition": {
+            "condition_type": "Or",
+            "conditions": [
+              {
+                "condition_type": "PriorState",
+                "name": "OA_Of_The_Hip"
+              },
+              {
+                "condition_type": "PriorState",
+                "name": "OA_Of_The_Knee"
+              }
+            ]
+          },
+          "distributions": [
+            {
+              "transition": "Wheelchair",
+              "distribution": 0.54
+            },
+            {
+              "transition": "Walker",
+              "distribution": 0.46
+            }
+          ]
+        },
+        {
+          "distributions": [],
+          "transition": "OA_Pain_Medication"
+        }
+      ],
+      "remarks": [
+        "Based on sample from CMS claims."
+      ]
+    },
+    "Wheelchair": {
+      "type": "CallSubmodule",
+      "submodule": "dme/wheelchair",
+      "direct_transition": "Finish DME"
+    },
+    "Walker": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 705406009,
+        "display": "Walker (physical object)"
+      },
+      "assign_to_attribute": "osteoarthritis_dme",
+      "direct_transition": "Finish DME"
+    },
+    "Finish DME": {
+      "type": "Simple",
+      "direct_transition": "OA_Pain_Medication"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/sleep_apnea.json
+++ b/src/main/resources/modules/sleep_apnea.json
@@ -324,7 +324,7 @@
     },
     "End 2nd Encounter": {
       "type": "EncounterEnd",
-      "direct_transition": "Terminal"
+      "direct_transition": "Wellness Encounter"
     },
     "Sleep Apnea Care Plan": {
       "type": "CarePlanStart",
@@ -379,16 +379,16 @@
             ]
           },
           "distributions": [],
-          "transition": "Home CPAP Unit"
+          "transition": "Set Device CPAP"
         },
         {
           "distributions": [
             {
-              "transition": "Home CPAP Unit",
+              "transition": "Set Device CPAP",
               "distribution": 0.8
             },
             {
-              "transition": "Intraoral Appliance",
+              "transition": "Set_Device_Oral_Appliance",
               "distribution": 0.2
             }
           ]
@@ -402,7 +402,7 @@
         "code": 272265001,
         "display": "Appliance for sleep apnea (physical object)"
       },
-      "direct_transition": "End 2nd Encounter"
+      "direct_transition": "Set Visit Count"
     },
     "Home CPAP Unit": {
       "type": "Device",
@@ -413,11 +413,11 @@
       },
       "distributed_transition": [
         {
-          "transition": "Face Mask",
+          "transition": "Oral_Mask_Supplies",
           "distribution": 0.5
         },
         {
-          "transition": "Nasal Mask",
+          "transition": "Nasal Mask Supplies",
           "distribution": 0.5
         }
       ]
@@ -584,24 +584,6 @@
       "unit": "hours",
       "direct_transition": "Sleep Apnea"
     },
-    "Nasal Mask": {
-      "type": "Device",
-      "code": {
-        "system": "SNOMED-CT",
-        "code": 442398003,
-        "display": "Nasal mask (physical object)"
-      },
-      "direct_transition": "End 2nd Encounter"
-    },
-    "Face Mask": {
-      "type": "Device",
-      "code": {
-        "system": "SNOMED-CT",
-        "code": 704718009,
-        "display": "CPAP/BPAP oral mask (physical object)"
-      },
-      "direct_transition": "End 2nd Encounter"
-    },
     "Follow Up": {
       "type": "Encounter",
       "encounter_class": "inpatient",
@@ -614,6 +596,403 @@
         }
       ],
       "direct_transition": "Return Home Sleep Device"
+    },
+    "Wellness Encounter": {
+      "type": "Encounter",
+      "reason": "",
+      "telemedicine_possibility": "none",
+      "wellness": true,
+      "direct_transition": "Assessment Check"
+    },
+    "Set Device CPAP": {
+      "type": "SetAttribute",
+      "attribute": "sleep_apnea_treatment",
+      "direct_transition": "Home CPAP Unit",
+      "value": "cpap"
+    },
+    "Set_Device_Oral_Appliance": {
+      "type": "SetAttribute",
+      "attribute": "sleep_apnea_treatment",
+      "direct_transition": "Intraoral Appliance",
+      "value": "oral_appliance"
+    },
+    "CPAP Renewal": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "transition": "Stop previous CPAP unit",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "years_until_sleep_apnea_renewal",
+            "operator": "<=",
+            "value": 0
+          }
+        },
+        {
+          "transition": "CPAP Supply Renewal"
+        }
+      ]
+    },
+    "Oral Appliance Renewal": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "transition": "Stop previous oral device",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "years_until_sleep_apnea_renewal",
+            "operator": "<=",
+            "value": 0
+          }
+        },
+        {
+          "transition": "Reset Counter"
+        }
+      ]
+    },
+    "End Wellness Visit": {
+      "type": "EncounterEnd",
+      "direct_transition": "Wellness Encounter"
+    },
+    "Periodic Assessment": {
+      "type": "Procedure",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 103750000,
+          "display": "Sleep apnea assessment (procedure)"
+        }
+      ],
+      "distribution": {
+        "kind": "UNIFORM",
+        "parameters": {
+          "high": 30,
+          "low": 10
+        }
+      },
+      "unit": "minutes",
+      "reason": "Sleep Disorder",
+      "direct_transition": "Device Renewal Check"
+    },
+    "Device Check": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "transition": "CPAP Renewal",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "sleep_apnea_treatment",
+            "operator": "==",
+            "value": "cpap"
+          }
+        },
+        {
+          "transition": "Oral Appliance Renewal",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "sleep_apnea_treatment",
+            "operator": "==",
+            "value": "oral_appliance"
+          }
+        },
+        {
+          "transition": "Reset Counter"
+        }
+      ]
+    },
+    "Assessment Check": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Periodic Assessment",
+          "distribution": 0.8
+        },
+        {
+          "transition": "Device Renewal Check",
+          "distribution": 0.2
+        }
+      ]
+    },
+    "Set Visit Count": {
+      "type": "SetAttribute",
+      "attribute": "years_until_sleep_apnea_renewal",
+      "direct_transition": "End 2nd Encounter",
+      "value": 5
+    },
+    "Decrement Counter": {
+      "type": "Counter",
+      "attribute": "years_until_sleep_apnea_renewal",
+      "action": "decrement",
+      "direct_transition": "Device Check"
+    },
+    "Device Renewal Check": {
+      "type": "Simple",
+      "direct_transition": "Decrement Counter"
+    },
+    "Reset Counter": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "transition": "Reset_Visit_Count",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "years_until_sleep_apnea_renewal",
+            "operator": "<=",
+            "value": 0
+          }
+        },
+        {
+          "transition": "End Wellness Visit"
+        }
+      ]
+    },
+    "Reset_Visit_Count": {
+      "type": "SetAttribute",
+      "attribute": "years_until_sleep_apnea_renewal",
+      "value": 5,
+      "direct_transition": "End Wellness Visit"
+    },
+    "Home_CPAP_Unit": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 702172008,
+        "display": "Home continuous positive airway pressure unit (physical object)"
+      },
+      "distributed_transition": [
+        {
+          "distribution": 0.5
+        },
+        {
+          "distribution": 0.5
+        }
+      ],
+      "direct_transition": "Stop_previous_humidifier"
+    },
+    "Intraoral_Appliance": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 272265001,
+        "display": "Appliance for sleep apnea (physical object)"
+      },
+      "direct_transition": "Reset Counter"
+    },
+    "Humidifier": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 706180003,
+        "display": "Respiratory humidifier (physical object)"
+      },
+      "direct_transition": "Set Visit Count"
+    },
+    "Nasal Mask Supplies": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 467645007,
+            "display": "Continuous positive airway pressure nasal oxygen cannula (physical object)"
+          }
+        },
+        {
+          "quantity": 5,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 972002,
+            "display": "Air filter, device (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 463659001,
+            "display": "Medical air low pressure tubing (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 706226000,
+            "display": "Continuous positive airway pressure/Bilevel positive airway pressure mask (physical object)"
+          }
+        }
+      ],
+      "direct_transition": "Humidifier"
+    },
+    "Oral_Mask_Supplies": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 704718009,
+            "display": "CPAP/BPAP oral mask (physical object)"
+          }
+        },
+        {
+          "quantity": 5,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 972002,
+            "display": "Air filter, device (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 463659001,
+            "display": "Medical air low pressure tubing (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 706226000,
+            "display": "Continuous positive airway pressure/Bilevel positive airway pressure mask (physical object)"
+          }
+        }
+      ],
+      "direct_transition": "Humidifier"
+    },
+    "CPAP Supply Renewal": {
+      "type": "Simple",
+      "distributed_transition": [
+        {
+          "transition": "Nasal_Mask_Supplies",
+          "distribution": 0.5
+        },
+        {
+          "transition": "Oral_Mask_Supplies_2",
+          "distribution": 0.5
+        }
+      ]
+    },
+    "Nasal_Mask_Supplies": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 467645007,
+            "display": "Continuous positive airway pressure nasal oxygen cannula (physical object)"
+          }
+        },
+        {
+          "quantity": 5,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 972002,
+            "display": "Air filter, device (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 463659001,
+            "display": "Medical air low pressure tubing (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 706226000,
+            "display": "Continuous positive airway pressure/Bilevel positive airway pressure mask (physical object)"
+          }
+        }
+      ],
+      "direct_transition": "Reset Counter"
+    },
+    "Oral_Mask_Supplies_2": {
+      "type": "SupplyList",
+      "supplies": [
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 704718009,
+            "display": "CPAP/BPAP oral mask (physical object)"
+          }
+        },
+        {
+          "quantity": 5,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 972002,
+            "display": "Air filter, device (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 463659001,
+            "display": "Medical air low pressure tubing (physical object)"
+          }
+        },
+        {
+          "quantity": 1,
+          "code": {
+            "system": "SNOMED-CT",
+            "code": 706226000,
+            "display": "Continuous positive airway pressure/Bilevel positive airway pressure mask (physical object)"
+          }
+        }
+      ],
+      "direct_transition": "Reset Counter"
+    },
+    "Humidifier_2": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 706180003,
+        "display": "Respiratory humidifier (physical object)"
+      },
+      "direct_transition": "CPAP Supply Renewal"
+    },
+    "Stop previous oral device": {
+      "type": "DeviceEnd",
+      "direct_transition": "Intraoral_Appliance",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 272265001,
+          "display": "Appliance for sleep apnea (physical object)"
+        }
+      ]
+    },
+    "Stop previous CPAP unit": {
+      "type": "DeviceEnd",
+      "direct_transition": "Home_CPAP_Unit",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 702172008,
+          "display": "Home continuous positive airway pressure unit (physical object)"
+        }
+      ]
+    },
+    "Stop_previous_humidifier": {
+      "type": "DeviceEnd",
+      "direct_transition": "Humidifier_2",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 706180003,
+          "display": "Respiratory humidifier (physical object)"
+        }
+      ]
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/snf/skilled_nursing_facility.json
+++ b/src/main/resources/modules/snf/skilled_nursing_facility.json
@@ -117,7 +117,7 @@
           "display": "Initial patient assessment (procedure)"
         }
       ],
-      "direct_transition": "Development_of_Individualized_Care_Plan"
+      "direct_transition": "Facility_Wheelchair"
     },
     "Development_of_Individualized_Care_Plan": {
       "type": "Procedure",
@@ -317,7 +317,7 @@
           "display": "Discharge from skilled nursing facility (procedure)"
         }
       ],
-      "direct_transition": "End Encounter"
+      "direct_transition": "Return_Wheelchair"
     },
     "Terminal": {
       "type": "Terminal"
@@ -325,6 +325,21 @@
     "End Encounter": {
       "type": "EncounterEnd",
       "direct_transition": "Terminal"
+    },
+    "Facility_Wheelchair": {
+      "type": "Device",
+      "code": {
+        "system": "SNOMED-CT",
+        "code": 228869008,
+        "display": "Manual wheelchair (physical object)"
+      },
+      "direct_transition": "Development_of_Individualized_Care_Plan",
+      "assign_to_attribute": "snf_wheelchair"
+    },
+    "Return_Wheelchair": {
+      "type": "DeviceEnd",
+      "referenced_by_attribute": "snf_wheelchair",
+      "direct_transition": "End Encounter"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/total_joint_replacement.json
+++ b/src/main/resources/modules/total_joint_replacement.json
@@ -160,7 +160,16 @@
         "quantity": 1,
         "unit": "months"
       },
-      "direct_transition": "End_Post_Op_CarePlan"
+      "distributed_transition": [
+        {
+          "transition": "DME End",
+          "distribution": 0.99
+        },
+        {
+          "transition": "End_Post_Op_CarePlan",
+          "distribution": 0.01
+        }
+      ]
     },
     "End_Post_Op_CarePlan": {
       "type": "CarePlanEnd",
@@ -324,6 +333,16 @@
       "attribute": "home_health",
       "direct_transition": "Delay_For_Recovery",
       "value": true
+    },
+    "DME End": {
+      "type": "DeviceEnd",
+      "direct_transition": "End Wheelchair",
+      "referenced_by_attribute": "osteoarthritis_dme"
+    },
+    "End Wheelchair": {
+      "type": "CallSubmodule",
+      "submodule": "dme/wheelchair_end",
+      "direct_transition": "End_Post_Op_CarePlan"
     }
   },
   "gmf_version": 1


### PR DESCRIPTION
Adjustments to DME Data Ratios; see #1150.

The following adjustments are approximations based on observed claims data:

- Adds DME states back into metabolic syndrome care module.
  - Blood glucose monitors, calibration solution, testing strips, lancets.
- Adds Oxygen concentrators and portable concentrators into COPD with "DeviceEnd" states.
- Adds additional DME supplies to Sleep Apnea, regular supplies at Wellness visits, and device replacement every 5 years.
  - masks, respiratory humidifiers, air filters, tubing
- Skilled nursing facility
  - wheelchairs
- Added crutches and wheelchairs for broken ankles and hips.
- Added osteoporosis as a fall risk.
- Assign wheelchair or walker for osteoarthritis
- Total joint replacement resolves DME for 99%
- Assigns wheelchairs for some COPD patients who use oxygen
- Assigns beds and other items to some hospice patients
- Adjusts the DME warning messages to be less obnoxious.

Other high-impact changes that are not included: DME charges related to medication administration.