### PR TITLE
FHIR export resource type filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ dependencies {
   implementation files('lib/sbscl/SimulationCoreLibrary_v1.5_slim.jar')
   implementation 'org.sbml.jsbml:jsbml:1.6.1', {
       exclude group:'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
+      exclude group:'junit', module: 'junit'
   }
   implementation 'org.apache.commons:commons-math:2.2'
 

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -421,7 +421,7 @@ public class FhirR4 {
       }
     }
 
-    if (USE_US_CORE_IG) {
+    if (USE_US_CORE_IG && shouldExport("Provenance")) {
       // Add Provenance to the Bundle
       provenance(bundle, person, stopTime);
     }

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -11,9 +11,12 @@ import com.google.gson.JsonObject;
 import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -191,6 +194,56 @@ public class FhirR4 {
   private static final Table<String, String, String> US_CORE_MAPPING =
       loadMapping("us_core_mapping.csv");
 
+  private static final HashSet<String> includedResources = new HashSet<>();
+  private static final HashSet<String> excludedResources = new HashSet<>();
+
+  static {
+    reloadIncludeExclude();
+  }
+
+  static void reloadIncludeExclude() {
+    includedResources.clear();
+    excludedResources.clear();
+    String includedResourcesStr = Config.get("exporter.fhir.included_resources", "").trim();
+    String excludedResourcesStr = Config.get("exporter.fhir.excluded_resources", "").trim();
+
+    List<String> includedResourcesList = Collections.emptyList();
+    List<String> excludedResourcesList = Collections.emptyList();
+
+    if (!includedResourcesStr.isEmpty() && !excludedResourcesStr.isEmpty()) {
+      System.err.println(
+          "FHIR exporter: Included and Excluded resource settings are both set -- ignoring both");
+    } else if (!includedResourcesStr.isEmpty()) {
+      includedResourcesList = propStringToList(includedResourcesStr);
+    } else if (!excludedResourcesStr.isEmpty()) {
+      excludedResourcesList = propStringToList(excludedResourcesStr);
+    }
+
+    includedResources.addAll(includedResourcesList);
+    excludedResources.addAll(excludedResourcesList);
+  }
+
+  static boolean shouldExport(String resourceType) {
+    return (includedResources.isEmpty() || includedResources.contains(resourceType))
+            && !excludedResources.contains(resourceType);
+  }
+
+  /**
+   * Helper function to convert a string of resource type names
+   *  from synthea.properties into a list of FHIR ResourceTypes.
+   * @param propString String directly from Config, ex "Patient,Condition , Procedure"
+   * @return normalized list of filenames as strings
+   */
+  private static List<String> propStringToList(String propString) {
+    List<String> files = Arrays.asList(propString.split(","));
+    // normalize filenames by trimming
+    files = files.stream().map(f ->  f.trim()).collect(Collectors.toList());
+
+    // TODO: convert these into FHIR resource enums
+
+    return files;
+  }
+
   @SuppressWarnings("rawtypes")
   private static Map loadRaceEthnicityCodes() {
     String filename = "race_ethnicity_codes.json";
@@ -267,72 +320,105 @@ public class FhirR4 {
     for (Encounter encounter : person.record.encounters) {
       BundleEntryComponent encounterEntry = encounter(person, personEntry, bundle, encounter);
 
-      for (HealthRecord.Entry condition : encounter.conditions) {
-        condition(person, personEntry, bundle, encounterEntry, condition);
+      if (shouldExport("Condition")) {
+        for (HealthRecord.Entry condition : encounter.conditions) {
+          condition(person, personEntry, bundle, encounterEntry, condition);
+        }
       }
 
-      for (HealthRecord.Allergy allergy : encounter.allergies) {
-        allergy(person, personEntry, bundle, encounterEntry, allergy);
+      if (shouldExport("AllergyIntolerance")) {
+        for (HealthRecord.Allergy allergy : encounter.allergies) {
+          allergy(person, personEntry, bundle, encounterEntry, allergy);
+        }
       }
+
+      final boolean shouldExportMedia = shouldExport("Media");
+      final boolean shouldExportObservation = shouldExport("Observation");
 
       for (Observation observation : encounter.observations) {
         // If the Observation contains an attachment, use a Media resource, since
         // Observation resources in v4 don't support Attachments
         if (observation.value instanceof Attachment) {
-          media(person, personEntry, bundle, encounterEntry, observation);
-        } else {
+          if (shouldExportMedia) {
+            media(person, personEntry, bundle, encounterEntry, observation);
+          }
+        } else if (shouldExportObservation) {
           observation(person, personEntry, bundle, encounterEntry, observation);
         }
       }
 
-      for (Procedure procedure : encounter.procedures) {
-        procedure(person, personEntry, bundle, encounterEntry, procedure);
+      if (shouldExport("Procedure")) {
+        for (Procedure procedure : encounter.procedures) {
+          procedure(person, personEntry, bundle, encounterEntry, procedure);
+        }
       }
 
-      for (HealthRecord.Device device : encounter.devices) {
-        device(person, personEntry, bundle, device);
+      if (shouldExport("Device")) {
+        for (HealthRecord.Device device : encounter.devices) {
+          device(person, personEntry, bundle, device);
+        }
       }
 
-      for (HealthRecord.Supply supply : encounter.supplies) {
-        supplyDelivery(person, personEntry, bundle, supply, encounter);
+      if (shouldExport("SupplyDelivery")) {
+        for (HealthRecord.Supply supply : encounter.supplies) {
+          supplyDelivery(person, personEntry, bundle, supply, encounter);
+        }
       }
 
-      for (Medication medication : encounter.medications) {
-        medicationRequest(person, personEntry, bundle, encounterEntry, encounter, medication);
+      if (shouldExport("MedicationRequest")) {
+        for (Medication medication : encounter.medications) {
+          medicationRequest(person, personEntry, bundle, encounterEntry, encounter, medication);
+        }
       }
 
-      for (HealthRecord.Entry immunization : encounter.immunizations) {
-        immunization(person, personEntry, bundle, encounterEntry, immunization);
+      if (shouldExport("Immunization")) {
+        for (HealthRecord.Entry immunization : encounter.immunizations) {
+          immunization(person, personEntry, bundle, encounterEntry, immunization);
+        }
       }
 
-      for (Report report : encounter.reports) {
-        report(person, personEntry, bundle, encounterEntry, report);
+      if (shouldExport("DiagnosticReport")) {
+        for (Report report : encounter.reports) {
+          report(person, personEntry, bundle, encounterEntry, report);
+        }
       }
 
-      for (CarePlan careplan : encounter.careplans) {
-        BundleEntryComponent careTeamEntry =
-                careTeam(person, personEntry, bundle, encounterEntry, careplan);
-        carePlan(person, personEntry, bundle, encounterEntry, encounter.provider, careTeamEntry,
-                careplan);
+      if (shouldExport("CarePlan")) {
+        final boolean shouldExportCareTeam = shouldExport("CareTeam");
+        for (CarePlan careplan : encounter.careplans) {
+          BundleEntryComponent careTeamEntry = null;
+
+          if (shouldExportCareTeam) {
+            careTeamEntry = careTeam(person, personEntry, bundle, encounterEntry, careplan);
+          }
+          carePlan(person, personEntry, bundle, encounterEntry, encounter.provider, careTeamEntry,
+                  careplan);
+        }
       }
 
-      for (ImagingStudy imagingStudy : encounter.imagingStudies) {
-        imagingStudy(person, personEntry, bundle, encounterEntry, imagingStudy);
+      if (shouldExport("ImagingStudy")) {
+        for (ImagingStudy imagingStudy : encounter.imagingStudies) {
+          imagingStudy(person, personEntry, bundle, encounterEntry, imagingStudy);
+        }
       }
 
-      if (USE_US_CORE_IG) {
+      if (USE_US_CORE_IG && shouldExport("DiagnosticReport")) {
         String clinicalNoteText = ClinicalNoteExporter.export(person, encounter);
         boolean lastNote =
             (encounter == person.record.encounters.get(person.record.encounters.size() - 1));
         clinicalNote(person, personEntry, bundle, encounterEntry, clinicalNoteText, lastNote);
       }
 
-      // one claim per encounter
-      BundleEntryComponent encounterClaim =
-          encounterClaim(person, personEntry, bundle, encounterEntry, encounter);
+      if (shouldExport("Claim")) {
+        // one claim per encounter
+        BundleEntryComponent encounterClaim =
+            encounterClaim(person, personEntry, bundle, encounterEntry, encounter);
 
-      explanationOfBenefit(personEntry, bundle, encounterEntry, person,
-          encounterClaim, encounter, encounter.claim);
+        if (shouldExport("ExplanationOfBenefit")) {
+          explanationOfBenefit(personEntry, bundle, encounterEntry, person,
+              encounterClaim, encounter, encounter.claim);
+        }
+      }
     }
 
     if (USE_US_CORE_IG) {
@@ -2073,7 +2159,7 @@ public class FhirR4 {
     CodeableConcept medicationCodeableConcept = mapCodeToCodeableConcept(code, system);
     medicationResource.setMedication(medicationCodeableConcept);
 
-    if (USE_US_CORE_IG && medication.administration) {
+    if (USE_US_CORE_IG && medication.administration && shouldExport("Medication")) {
       // Occasionally, rather than use medication codes, we want to use a Medication
       // Resource. We only want to do this when we use US Core, to make sure we
       // sometimes produce a resource for the us-core-medication profile, and the
@@ -2194,12 +2280,15 @@ public class FhirR4 {
     }
 
     BundleEntryComponent medicationEntry = newEntry(person, bundle, medicationResource);
-    // create new claim for medication
-    medicationClaim(person, personEntry, bundle, encounterEntry, encounter,
-        medication.claim, medicationEntry, medicationCodeableConcept);
+
+    if (shouldExport("Claim")) {
+      // create new claim for medication
+      medicationClaim(person, personEntry, bundle, encounterEntry, encounter,
+          medication.claim, medicationEntry, medicationCodeableConcept);
+    }
 
     // Create new administration for medication, if needed
-    if (medication.administration) {
+    if (medication.administration && shouldExport("MedicationAdministration")) {
       medicationAdministration(person, personEntry, bundle, encounterEntry, medication,
               medicationResource);
     }
@@ -2324,10 +2413,14 @@ public class FhirR4 {
     reportResource.setEncounter(new Reference(encounterEntry.getFullUrl()));
     reportResource.setEffective(convertFhirDateTime(report.start, true));
     reportResource.setIssued(new Date(report.start));
-    for (Observation observation : report.observations) {
-      Reference reference = new Reference(observation.fullUrl);
-      reference.setDisplay(observation.codes.get(0).display);
-      reportResource.addResult(reference);
+
+    if (shouldExport("Observation")) {
+      // if observations are not exported, we can't reference them
+      for (Observation observation : report.observations) {
+        Reference reference = new Reference(observation.fullUrl);
+        reference.setDisplay(observation.codes.get(0).display);
+        reportResource.addResult(reference);
+      }
     }
 
     return newEntry(rand, bundle, reportResource);
@@ -2345,7 +2438,7 @@ public class FhirR4 {
    * @param currentNote If this is the most current note.
    * @return The entry for the DocumentReference.
    */
-  private static BundleEntryComponent clinicalNote(RandomNumberGenerator rand,
+  private static void clinicalNote(RandomNumberGenerator rand,
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           String clinicalNoteText, boolean currentNote) {
     // We'll need the encounter...
@@ -2380,40 +2473,42 @@ public class FhirR4 {
         .setData(clinicalNoteText.getBytes(java.nio.charset.StandardCharsets.UTF_8));
     newEntry(rand, bundle, reportResource);
 
-    // Add a DocumentReference
-    DocumentReference documentReference = new DocumentReference();
-    if (USE_US_CORE_IG) {
-      Meta meta = new Meta();
-      meta.addProfile(
-          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference");
-      documentReference.setMeta(meta);
-    }
-    if (currentNote) {
-      documentReference.setStatus(DocumentReferenceStatus.CURRENT);
-    } else {
-      documentReference.setStatus(DocumentReferenceStatus.SUPERSEDED);
-    }
-    documentReference.addIdentifier()
-      .setSystem("urn:ietf:rfc:3986")
-      .setValue("urn:uuid:" + reportResource.getId());
-    documentReference.setType(reportResource.getCategoryFirstRep());
-    documentReference.addCategory(new CodeableConcept(
-        new Coding("http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
-            "clinical-note", "Clinical Note")));
-    documentReference.setSubject(new Reference(personEntry.getFullUrl()));
-    documentReference.setDate(encounter.getPeriod().getStart());
-    documentReference.addAuthor(reportResource.getPerformerFirstRep());
-    documentReference.setCustodian(encounter.getServiceProvider());
-    documentReference.addContent()
-        .setAttachment(reportResource.getPresentedFormFirstRep())
-        .setFormat(
-          new Coding("http://ihe.net/fhir/ValueSet/IHE.FormatCode.codesystem",
-              "urn:ihe:iti:xds:2017:mimeTypeSufficient", "mimeType Sufficient"));
-    documentReference.setContext(new DocumentReferenceContextComponent()
-        .addEncounter(reportResource.getEncounter())
-        .setPeriod(encounter.getPeriod()));
+    if (shouldExport("DocumentReference")) {
+      // Add a DocumentReference
+      DocumentReference documentReference = new DocumentReference();
+      if (USE_US_CORE_IG) {
+        Meta meta = new Meta();
+        meta.addProfile(
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference");
+        documentReference.setMeta(meta);
+      }
+      if (currentNote) {
+        documentReference.setStatus(DocumentReferenceStatus.CURRENT);
+      } else {
+        documentReference.setStatus(DocumentReferenceStatus.SUPERSEDED);
+      }
+      documentReference.addIdentifier()
+        .setSystem("urn:ietf:rfc:3986")
+        .setValue("urn:uuid:" + reportResource.getId());
+      documentReference.setType(reportResource.getCategoryFirstRep());
+      documentReference.addCategory(new CodeableConcept(
+          new Coding("http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
+              "clinical-note", "Clinical Note")));
+      documentReference.setSubject(new Reference(personEntry.getFullUrl()));
+      documentReference.setDate(encounter.getPeriod().getStart());
+      documentReference.addAuthor(reportResource.getPerformerFirstRep());
+      documentReference.setCustodian(encounter.getServiceProvider());
+      documentReference.addContent()
+          .setAttachment(reportResource.getPresentedFormFirstRep())
+          .setFormat(
+            new Coding("http://ihe.net/fhir/ValueSet/IHE.FormatCode.codesystem",
+                "urn:ihe:iti:xds:2017:mimeTypeSufficient", "mimeType Sufficient"));
+      documentReference.setContext(new DocumentReferenceContextComponent()
+          .addEncounter(reportResource.getEncounter())
+          .setPeriod(encounter.getPeriod()));
 
-    return newEntry(rand, bundle, documentReference);
+      newEntry(rand, bundle, documentReference);
+    }
   }
 
   /**
@@ -2446,7 +2541,9 @@ public class FhirR4 {
     careplanResource.setIntent(CarePlanIntent.ORDER);
     careplanResource.setSubject(new Reference(personEntry.getFullUrl()));
     careplanResource.setEncounter(new Reference(encounterEntry.getFullUrl()));
-    careplanResource.addCareTeam(new Reference(careTeamEntry.getFullUrl()));
+    if (careTeamEntry != null) {
+      careplanResource.addCareTeam(new Reference(careTeamEntry.getFullUrl()));
+    }
 
     Code code = carePlan.codes.get(0);
     careplanResource.addCategory(mapCodeToCodeableConcept(code, SNOMED_URI));

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -18,6 +18,12 @@ exporter.fhir.use_shr_extensions = false
 exporter.fhir.use_us_core_ig = true
 exporter.fhir.transaction_bundle = true
 exporter.fhir.bulk_data = false
+# included_ and excluded_resources list out the resource types to include/exclude in the csv exporters.
+# only one of these may be set at a time, if both are set then both will be ignored.
+# if neither is set, then all resource types will be included.
+# note the Patient and Encounter resources will always be included, even if specifically listed as excluded here
+exporter.fhir.included_resources =
+exporter.fhir.excluded_resources =
 exporter.groups.fhir.export = false
 exporter.hospital.fhir.export = true
 exporter.hospital.fhir_stu3.export = false

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -108,6 +108,8 @@ public abstract class TestHelper {
     Config.set("exporter.fhir_dstu2.export", "false");
     Config.set("exporter.fhir.transaction_bundle", "false");
     Config.set("exporter.fhir.bulk_data", "false");
+    Config.set("exporter.fhir.included_resources", "");
+    Config.set("exporter.fhir.excluded_resources", "");
     Config.set("exporter.groups.fhir.export", "false");
     Config.set("exporter.hospital.fhir.export", "false");
     Config.set("exporter.hospital.fhir_stu3.export", "false");

--- a/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
@@ -305,21 +305,19 @@ public class FHIRR4ExporterTest {
     Config.set("exporter.fhir.excluded_resources", "");
     FhirR4.reloadIncludeExclude();
 
-    assertTrue(FhirR4.shouldExport("MedicationRequest"));
-    assertTrue(FhirR4.shouldExport("Procedure"));
-    assertTrue(FhirR4.shouldExport("Condition"));
-    assertTrue(FhirR4.shouldExport("NotEvenARealResourceType"));
+    assertTrue(FhirR4.shouldExport(org.hl7.fhir.r4.model.MedicationRequest.class));
+    assertTrue(FhirR4.shouldExport(org.hl7.fhir.r4.model.Procedure.class));
+    assertTrue(FhirR4.shouldExport(org.hl7.fhir.r4.model.Condition.class));
 
     // a few items included, all others excluded
     Config.set("exporter.fhir.included_resources", "MedicationRequest, Procedure");
     Config.set("exporter.fhir.excluded_resources", "");
     FhirR4.reloadIncludeExclude();
 
-    assertTrue(FhirR4.shouldExport("MedicationRequest"));
-    assertTrue(FhirR4.shouldExport("Procedure"));
+    assertTrue(FhirR4.shouldExport(org.hl7.fhir.r4.model.MedicationRequest.class));
+    assertTrue(FhirR4.shouldExport(org.hl7.fhir.r4.model.Procedure.class));
 
-    assertFalse(FhirR4.shouldExport("Condition"));
-    assertFalse(FhirR4.shouldExport("NotEvenARealResourceType"));
+    assertFalse(FhirR4.shouldExport(org.hl7.fhir.r4.model.Condition.class));
 
 
     // a few items excluded, all others included
@@ -327,11 +325,10 @@ public class FHIRR4ExporterTest {
     Config.set("exporter.fhir.excluded_resources", "MedicationRequest,Procedure");
     FhirR4.reloadIncludeExclude();
 
-    assertFalse(FhirR4.shouldExport("MedicationRequest"));
-    assertFalse(FhirR4.shouldExport("Procedure"));
+    assertFalse(FhirR4.shouldExport(org.hl7.fhir.r4.model.MedicationRequest.class));
+    assertFalse(FhirR4.shouldExport(org.hl7.fhir.r4.model.Procedure.class));
 
-    assertTrue(FhirR4.shouldExport("Condition"));
-    assertTrue(FhirR4.shouldExport("NotEvenARealResourceType"));
+    assertTrue(FhirR4.shouldExport(org.hl7.fhir.r4.model.Condition.class));
 
 
     // both set in config == both disabled == allow everything
@@ -339,10 +336,9 @@ public class FHIRR4ExporterTest {
     Config.set("exporter.fhir.excluded_resources", "MedicationRequest ,Procedure");
     FhirR4.reloadIncludeExclude();
 
-    assertTrue(FhirR4.shouldExport("MedicationRequest"));
-    assertTrue(FhirR4.shouldExport("Procedure"));
-    assertTrue(FhirR4.shouldExport("Condition"));
-    assertTrue(FhirR4.shouldExport("NotEvenARealResourceType"));
+    assertTrue(FhirR4.shouldExport(org.hl7.fhir.r4.model.MedicationRequest.class));
+    assertTrue(FhirR4.shouldExport(org.hl7.fhir.r4.model.Procedure.class));
+    assertTrue(FhirR4.shouldExport(org.hl7.fhir.r4.model.Condition.class));
   }
 
   @Test
@@ -400,7 +396,7 @@ public class FHIRR4ExporterTest {
   @Test
   public void testFHIRExportExcludes() throws Exception {
     Config.set("exporter.fhir.included_resources", "");
-    Config.set("exporter.fhir.excluded_resources", "MedicationRequest,Procedure,Observaton");
+    Config.set("exporter.fhir.excluded_resources", "MedicationRequest,Procedure,Observation");
     FhirR4.reloadIncludeExclude();
 
     Person p = new Person(0L);


### PR DESCRIPTION
Addresses #1104

Adds new config settings to support filtering the resource types that are exported in the FHIR exporter, by either an include list or exclude list. (Similar to the existing feature for CSVs)
This approach checks each resource type before instantiating the relevant HAPI resource class.

A few notes on current status:
 - this leaves the Patient and Encounter resources as always included, even if specifically excluded, primarily because of the number of changes it would require.  
 - this doesn't currently attempt to be "friendly" and include related resources, for example a DiagnosticReport will reference Observations, but if you include DiagnosticReport without including Observation, you will get a DiagnosticReport with no outgoing references. 
 - this is only FHIR R4, but I'd like to get any feedback before applying this to the other exporters. (Or maybe we don't even want to spend time on the DSTU2 and STU3 exporters anymore?)
 - I'd also like to explore some changes to work with resource type enums instead of strings

This also includes a tweak to build.gradle to fix some error messages I was seeing in Eclipse. The issue was that JSBCL includes JUnit 4.10 as a transitive dependency, but we use JUnit 4.13 as a direct dependency for tests. Eclipse was getting confused and using JUnit 4.10 at compile time and it didn't recognize some method calls. The tweak removes the transitive dependency on JUnit from JSBCL because I don't think there's any need for the main build to include JUnit.