### PR TITLE
RIF Hospice Consolidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ src/main/resources/export/snf_pdpm_code_map.json
 src/main/resources/export/snf_pps_code_map.json
 src/main/resources/export/snf_rev_cntr_code_map.json
 src/main/resources/export/hha_rev_cntr_code_map.json
+src/main/resources/export/hospice_rev_cntr_code_map.json
 
 # H2 database files
 **/*.mv.db

--- a/build.gradle
+++ b/build.gradle
@@ -114,8 +114,10 @@ dependencies {
   implementation 'org.jfree:jfreechart:1.5.3'
 
   // Use JUnit test framework
-  testImplementation('junit:junit:4.13.2') {
-    force = true
+  testImplementation('junit:junit') {
+    version {
+      strictly '4.13.2'
+    }
   }
   testImplementation 'org.mockito:mockito-core:4.7.0'
   testImplementation 'org.powermock:powermock-module-junit4:2.0.9'

--- a/src/main/java/org/mitre/synthea/export/rif/BB2RIFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/BB2RIFExporter.java
@@ -78,6 +78,7 @@ public class BB2RIFExporter {
   final CodeMapper snfPDPMMapper;
   final CodeMapper snfRevCntrMapper;
   final CodeMapper hhaRevCntrMapper;
+  final CodeMapper hospiceRevCntrMapper;
   final Map<String, RandomCollection<String>> externalCodes;
   final Map<String, String> missingDmeCodes;
   final CMSStateCodeMapper locationMapper;
@@ -106,6 +107,7 @@ public class BB2RIFExporter {
     snfPDPMMapper = new CodeMapper("export/snf_pdpm_code_map.json");
     snfRevCntrMapper = new CodeMapper("export/snf_rev_cntr_code_map.json");
     hhaRevCntrMapper = new CodeMapper("export/hha_rev_cntr_code_map.json");
+    hospiceRevCntrMapper = new CodeMapper("export/hospice_rev_cntr_code_map.json");
     locationMapper = new CMSStateCodeMapper();
     externalCodes = loadExternalCodes();
     try {

--- a/src/main/java/org/mitre/synthea/export/rif/ConsolidatedClaimLines.java
+++ b/src/main/java/org/mitre/synthea/export/rif/ConsolidatedClaimLines.java
@@ -69,7 +69,7 @@ public class ConsolidatedClaimLines extends Claim.ClaimCost {
   public ConsolidatedClaimLines() {
     // use a sorted map to ensure we always emit claim lines in the same order
     uniqueLineItems = new TreeMap<>();
-  } // use a sorted map to ensure we always emit claim lines in the same order
+  }
 
   /**
    * Add a claim to the set of consolidated claim lines. Creates a new claim line if the

--- a/src/main/java/org/mitre/synthea/export/rif/HospiceExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/HospiceExporter.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.mitre.synthea.export.ExportHelper;
 import org.mitre.synthea.world.agents.PayerManager;
 import org.mitre.synthea.world.agents.Person;
@@ -43,198 +44,218 @@ public class HospiceExporter extends RIFExporter {
         continue;
       }
 
-      // Use the active condition diagnoses to enter mapped values
-      // into the diagnoses codes.
+      // Map active conditions at time of encounter
       List<String> mappedDiagnosisCodes = getDiagnosesCodes(person, encounter.stop);
       if (mappedDiagnosisCodes.isEmpty()) {
         continue; // skip this encounter
       }
 
-      long claimId = RIFExporter.nextClaimId.getAndDecrement();
-      long claimGroupId = RIFExporter.nextClaimGroupId.getAndDecrement();
-      long fiDocId = RIFExporter.nextFiDocCntlNum.getAndDecrement();
-      fieldValues.clear();
-      exporter.staticFieldConfig.setValues(fieldValues, BB2RIFStructure.HOSPICE.class, person);
-
-      fieldValues.put(BB2RIFStructure.HOSPICE.BENE_ID,
-              (String)person.attributes.get(RIFExporter.BB2_BENE_ID));
-      fieldValues.put(BB2RIFStructure.HOSPICE.CLM_ID, "" + claimId);
-      fieldValues.put(BB2RIFStructure.HOSPICE.CLM_GRP_ID, "" + claimGroupId);
-      fieldValues.put(BB2RIFStructure.HOSPICE.FI_DOC_CLM_CNTL_NUM, "" + fiDocId);
-      fieldValues.put(BB2RIFStructure.HOSPICE.CLM_FROM_DT,
-              RIFExporter.bb2DateFromTimestamp(encounter.start));
-      fieldValues.put(BB2RIFStructure.HOSPICE.CLM_HOSPC_START_DT_ID,
-              RIFExporter.bb2DateFromTimestamp(encounter.start));
-      fieldValues.put(BB2RIFStructure.HOSPICE.CLM_THRU_DT,
-              RIFExporter.bb2DateFromTimestamp(encounter.stop));
-      fieldValues.put(BB2RIFStructure.HOSPICE.NCH_WKLY_PROC_DT,
-              RIFExporter.bb2DateFromTimestamp(ExportHelper.nextFriday(encounter.stop)));
-      fieldValues.put(BB2RIFStructure.HOSPICE.PRVDR_NUM, encounter.provider.cmsProviderNum);
-      fieldValues.put(BB2RIFStructure.HOSPICE.AT_PHYSN_NPI, encounter.clinician.npi);
-      fieldValues.put(BB2RIFStructure.HOSPICE.RNDRNG_PHYSN_NPI, encounter.clinician.npi);
-      fieldValues.put(BB2RIFStructure.HOSPICE.ORG_NPI_NUM, encounter.provider.npi);
-      fieldValues.put(BB2RIFStructure.HOSPICE.CLM_PMT_AMT,
-              String.format("%.2f", encounter.claim.getTotalClaimCost()));
-      if (encounter.claim.plan == PayerManager.getGovernmentPayer(PayerManager.MEDICARE)
-          .getGovernmentPayerPlan()) {
-        fieldValues.put(BB2RIFStructure.HOSPICE.NCH_PRMRY_PYR_CLM_PD_AMT, "0");
-      } else {
-        fieldValues.put(BB2RIFStructure.HOSPICE.NCH_PRMRY_PYR_CLM_PD_AMT,
-                String.format("%.2f", encounter.claim.getTotalCoveredCost()));
-      }
-      fieldValues.put(BB2RIFStructure.HOSPICE.PRVDR_STATE_CD,
-              exporter.locationMapper.getStateCode(encounter.provider.state));
-      // PTNT_DSCHRG_STUS_CD: 1=home, 2=transfer, 3=SNF, 20=died, 30=still here
-      // NCH_PTNT_STUS_IND_CD: A = Discharged, B = Died, C = Still a patient
-      String dischargeStatus = null;
-      String patientStatus = null;
-      String dischargeDate = null;
-      if (encounter.ended) {
-        dischargeStatus = "1"; // TODO 2=transfer if the next encounter is also inpatient
-        patientStatus = "A"; // discharged
-        dischargeDate = RIFExporter.bb2DateFromTimestamp(ExportHelper.nextFriday(encounter.stop));
-      } else {
-        dischargeStatus = "30"; // the patient is still here
-        patientStatus = "C"; // still a patient
-      }
-      if (!person.alive(encounter.stop)) {
-        dischargeStatus = "20"; // the patient died before the encounter ended
-        patientStatus = "B"; // died
-        dischargeDate = RIFExporter.bb2DateFromTimestamp(ExportHelper.nextFriday(encounter.stop));
-      }
-      fieldValues.put(BB2RIFStructure.HOSPICE.PTNT_DSCHRG_STUS_CD, dischargeStatus);
-      fieldValues.put(BB2RIFStructure.HOSPICE.NCH_PTNT_STATUS_IND_CD, patientStatus);
-      if (dischargeDate != null) {
-        fieldValues.put(BB2RIFStructure.HOSPICE.NCH_BENE_DSCHRG_DT, dischargeDate);
-      }
-      fieldValues.put(BB2RIFStructure.HOSPICE.CLM_TOT_CHRG_AMT,
-              String.format("%.2f", encounter.claim.getTotalClaimCost()));
-      fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_TOT_CHRG_AMT,
-          String.format("%.2f", encounter.claim.getTotalCoveredCost()));
-      fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_NCVRD_CHRG_AMT,
-          String.format("%.2f", encounter.claim.getTotalPatientCost()));
-      fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_PMT_AMT_AMT,
-          String.format("%.2f", encounter.claim.getTotalCoveredCost()));
-      fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_PRVDR_PMT_AMT,
-              String.format("%.2f", encounter.claim.getTotalCoveredCost()));
-
-      if (encounter.reason != null) {
-        // If the encounter has a recorded reason, enter the mapped
-        // values into the principle diagnoses code.
-        if (exporter.conditionCodeMapper.canMap(encounter.reason.code)) {
-          String icdCode = exporter.conditionCodeMapper.map(encounter.reason.code, person, true);
-          fieldValues.put(BB2RIFStructure.HOSPICE.PRNCPAL_DGNS_CD, icdCode);
-        }
-      }
-
-      int smallest = Math.min(mappedDiagnosisCodes.size(),
-              BB2RIFStructure.hospiceDxFields.length);
-      for (int i = 0; i < smallest; i++) {
-        BB2RIFStructure.HOSPICE[] dxField = BB2RIFStructure.hospiceDxFields[i];
-        fieldValues.put(dxField[0], mappedDiagnosisCodes.get(i));
-        fieldValues.put(dxField[1], "0"); // 0=ICD10
-      }
-      if (!fieldValues.containsKey(BB2RIFStructure.HOSPICE.PRNCPAL_DGNS_CD)) {
-        fieldValues.put(BB2RIFStructure.HOSPICE.PRNCPAL_DGNS_CD, mappedDiagnosisCodes.get(0));
-      }
-
-      // Check for external code...
-      exporter.setExternalCode(person, fieldValues,
-          BB2RIFStructure.HOSPICE.PRNCPAL_DGNS_CD, BB2RIFStructure.HOSPICE.ICD_DGNS_E_CD1,
-          BB2RIFStructure.HOSPICE.ICD_DGNS_E_VRSN_CD1);
-      exporter.setExternalCode(person, fieldValues,
-          BB2RIFStructure.HOSPICE.PRNCPAL_DGNS_CD, BB2RIFStructure.HOSPICE.FST_DGNS_E_CD,
-          BB2RIFStructure.HOSPICE.FST_DGNS_E_VRSN_CD);
-
       int days = (int) ((encounter.stop - encounter.start) / (1000 * 60 * 60 * 24));
       if (days <= 0) {
         days = 1;
       }
-      fieldValues.put(BB2RIFStructure.HOSPICE.CLM_UTLZTN_DAY_CNT, "" + days);
-      int coinDays = days -  21; // first 21 days no coinsurance
-      if (coinDays < 0) {
-        coinDays = 0;
-      }
-      fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_UNIT_CNT, "" + days);
-      fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_RATE_AMT,
-          String.format("%.2f", encounter.claim.getTotalClaimCost()
-                  .divide(BigDecimal.valueOf(days), RoundingMode.HALF_EVEN)
-                  .setScale(2, RoundingMode.HALF_EVEN)));
-      String revCenter = fieldValues.get(BB2RIFStructure.HOSPICE.REV_CNTR);
 
+      fieldValues.clear();
+      exporter.staticFieldConfig.setValues(fieldValues, BB2RIFStructure.HOSPICE.class, person);
+      setClaimLevelValues(fieldValues, mappedDiagnosisCodes, days, person, encounter);
+
+      String initialRandomRevCenter = fieldValues.get(BB2RIFStructure.HOSPICE.REV_CNTR);
+      final String PHARMACY_REV_CENTER = "0250";
+      final String MED_ADMIN_CODE = "T1502";
+      ConsolidatedClaimLines consolidatedClaimLines = new ConsolidatedClaimLines();
+      for (Claim.ClaimEntry lineItem : encounter.claim.items) {
+        if (lineItem.entry instanceof HealthRecord.Procedure) {
+          String hcpcsCode = null;
+          for (HealthRecord.Code code : lineItem.entry.codes) {
+            if (exporter.hcpcsCodeMapper.canMap(code.code)) {
+              hcpcsCode = exporter.hcpcsCodeMapper.map(code.code, person, true);
+              break; // take the first mappable code for each procedure
+            }
+          }
+          consolidatedClaimLines.addClaimLine(hcpcsCode, initialRandomRevCenter, lineItem,
+                  encounter);
+        } else if (lineItem.entry instanceof HealthRecord.Medication) {
+          HealthRecord.Medication med = (HealthRecord.Medication) lineItem.entry;
+          if (med.administration) {
+            consolidatedClaimLines.addClaimLine(MED_ADMIN_CODE, PHARMACY_REV_CENTER, lineItem,
+                    encounter);
+          }
+        }
+      }
+
+      // Synchronize to ensure all claim lines are grouped togther in output file
       synchronized (exporter.rifWriters.getOrCreateWriter(BB2RIFStructure.HOSPICE.class)) {
         int claimLine = 1;
-        for (Claim.ClaimEntry lineItem : encounter.claim.items) {
-          String hcpcsCode = null;
-          if (lineItem.entry instanceof HealthRecord.Procedure) {
-            for (HealthRecord.Code code : lineItem.entry.codes) {
-              if (exporter.hcpcsCodeMapper.canMap(code.code)) {
-                hcpcsCode = exporter.hcpcsCodeMapper.map(code.code, person, true);
-                break; // take the first mappable code for each procedure
-              }
-            }
-            fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR, revCenter);
-            fieldValues.remove(BB2RIFStructure.HOSPICE.REV_CNTR_NDC_QTY);
-            fieldValues.remove(BB2RIFStructure.HOSPICE.REV_CNTR_NDC_QTY_QLFR_CD);
-          } else if (lineItem.entry instanceof HealthRecord.Medication) {
-            HealthRecord.Medication med = (HealthRecord.Medication) lineItem.entry;
-            if (med.administration) {
-              hcpcsCode = "T1502";  // Administration of medication
-              // Pharmacy-general classification
-              fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR, "0250");
-              fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_NDC_QTY, "1"); // 1 Unit
+        for (ConsolidatedClaimLines.ConsolidatedClaimLine lineItem:
+                consolidatedClaimLines.getLines()) {
+          fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_DT,
+                  RIFExporter.bb2DateFromTimestamp(lineItem.getStart()));
+          fieldValues.put(BB2RIFStructure.HOSPICE.HCPCS_CD, lineItem.getCode());
+          fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR, lineItem.getRevCntr());
+          int revCntrCount = lineItem.getCount();
+          switch (lineItem.getCode()) {
+            case MED_ADMIN_CODE:
+              fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_NDC_QTY,
+                      Integer.toString(revCntrCount));
               fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_NDC_QTY_QLFR_CD, "UN"); // Unit
-            }
+              fieldValues.remove(BB2RIFStructure.HOSPICE.REV_CNTR_UNIT_CNT);
+              break;
+            default:
+              fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_UNIT_CNT,
+                      Integer.toString(revCntrCount));
+              fieldValues.remove(BB2RIFStructure.HOSPICE.REV_CNTR_NDC_QTY);
+              fieldValues.remove(BB2RIFStructure.HOSPICE.REV_CNTR_NDC_QTY_QLFR_CD);
+              break;
           }
-          if (hcpcsCode == null) {
-            continue;
-          }
-
+          setClaimLineCosts(fieldValues, lineItem, revCntrCount);
           fieldValues.put(BB2RIFStructure.HOSPICE.CLM_LINE_NUM, Integer.toString(claimLine++));
-          fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_DT,
-                  RIFExporter.bb2DateFromTimestamp(lineItem.entry.start));
-          fieldValues.put(BB2RIFStructure.HOSPICE.HCPCS_CD, hcpcsCode);
-          fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_RATE_AMT,
-              String.format("%.2f", lineItem.cost
-                      .divide(BigDecimal.valueOf(Integer.max(1, days)), RoundingMode.HALF_EVEN)
-                      .setScale(2, RoundingMode.HALF_EVEN)));
-          fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_PMT_AMT_AMT,
-              String.format("%.2f", lineItem.coinsurancePaidByPayer.add(lineItem.paidByPayer)));
-          fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_TOT_CHRG_AMT,
-              String.format("%.2f", lineItem.cost));
-          fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_NCVRD_CHRG_AMT,
-              String.format("%.2f", lineItem.copayPaidByPatient
-              .add(lineItem.deductiblePaidByPatient).add(lineItem.patientOutOfPocket)));
-          if (lineItem.patientOutOfPocket.compareTo(Claim.ZERO_CENTS) == 0
-                  && lineItem.deductiblePaidByPatient.compareTo(Claim.ZERO_CENTS) == 0) {
-            // Not subject to deductible or coinsurance
-            fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_DDCTBL_COINSRNC_CD, "3");
-          } else if (lineItem.patientOutOfPocket.compareTo(Claim.ZERO_CENTS) > 0
-                  && lineItem.deductiblePaidByPatient.compareTo(Claim.ZERO_CENTS) > 0) {
-            // Subject to deductible and coinsurance
-            fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_DDCTBL_COINSRNC_CD, "0");
-          } else if (lineItem.patientOutOfPocket.compareTo(Claim.ZERO_CENTS) == 0) {
-            // Not subject to deductible
-            fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_DDCTBL_COINSRNC_CD, "1");
-          } else {
-            // Not subject to coinsurance
-            fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_DDCTBL_COINSRNC_CD, "2");
-          }
           exporter.rifWriters.writeValues(BB2RIFStructure.HOSPICE.class, fieldValues);
         }
 
-        if (claimLine == 1) {
-          // If claimLine still equals 1, then no line items were successfully added.
-          // Add a single top-level entry.
-          fieldValues.put(BB2RIFStructure.HOSPICE.CLM_LINE_NUM, Integer.toString(claimLine));
-          fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_DT,
-                  RIFExporter.bb2DateFromTimestamp(encounter.start));
-          fieldValues.put(BB2RIFStructure.HOSPICE.HCPCS_CD, "S9126"); // hospice per diem
-          exporter.rifWriters.writeValues(BB2RIFStructure.HOSPICE.class, fieldValues);
-        }
+        // Add a total charge entry
+        setClaimLineCosts(fieldValues, consolidatedClaimLines, 1);
+        fieldValues.put(BB2RIFStructure.HOSPICE.CLM_LINE_NUM, Integer.toString(claimLine++));
+        fieldValues.remove(BB2RIFStructure.HOSPICE.HCPCS_CD);
+        fieldValues.remove(BB2RIFStructure.HOSPICE.AT_PHYSN_NPI);
+        fieldValues.remove(BB2RIFStructure.HOSPICE.RNDRNG_PHYSN_NPI);
+        fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR, "0001"); // Total charge
+        fieldValues.remove(BB2RIFStructure.HOSPICE.REV_CNTR_NDC_QTY);
+        fieldValues.remove(BB2RIFStructure.HOSPICE.REV_CNTR_UNIT_CNT);
+        fieldValues.remove(BB2RIFStructure.HOSPICE.REV_CNTR_RATE_AMT);
+        fieldValues.remove(BB2RIFStructure.HOSPICE.REV_CNTR_NDC_QTY_QLFR_CD);
+        fieldValues.remove(BB2RIFStructure.HOSPICE.REV_CNTR_DDCTBL_COINSRNC_CD);
+        exporter.rifWriters.writeValues(BB2RIFStructure.HOSPICE.class, fieldValues);
       }
       claimCount++;
     }
     return claimCount;
+  }
+
+  private static void setClaimLineCosts(Map<BB2RIFStructure.HOSPICE, String> fieldValues,
+          Claim.ClaimCost lineItem, int count) {
+    fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_RATE_AMT,
+            String.format("%.2f", lineItem.cost
+                    .divide(BigDecimal.valueOf(Integer.max(1, count)), RoundingMode.HALF_EVEN)
+                    .setScale(2, RoundingMode.HALF_EVEN)));
+    fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_PMT_AMT_AMT,
+            String.format("%.2f", lineItem.coinsurancePaidByPayer.add(lineItem.paidByPayer)));
+    fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_PRVDR_PMT_AMT,
+            String.format("%.2f", lineItem.coinsurancePaidByPayer.add(lineItem.paidByPayer)));
+    fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_TOT_CHRG_AMT,
+            String.format("%.2f", lineItem.cost));
+    fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_NCVRD_CHRG_AMT,
+            String.format("%.2f", lineItem.copayPaidByPatient
+                    .add(lineItem.deductiblePaidByPatient).add(lineItem.patientOutOfPocket)));
+    if (lineItem.patientOutOfPocket.compareTo(Claim.ZERO_CENTS) == 0
+            && lineItem.deductiblePaidByPatient.compareTo(Claim.ZERO_CENTS) == 0) {
+      // Not subject to deductible or coinsurance
+      fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_DDCTBL_COINSRNC_CD, "3");
+    } else if (lineItem.patientOutOfPocket.compareTo(Claim.ZERO_CENTS) > 0
+            && lineItem.deductiblePaidByPatient.compareTo(Claim.ZERO_CENTS) > 0) {
+      // Subject to deductible and coinsurance
+      fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_DDCTBL_COINSRNC_CD, "0");
+    } else if (lineItem.patientOutOfPocket.compareTo(Claim.ZERO_CENTS) == 0) {
+      // Not subject to deductible
+      fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_DDCTBL_COINSRNC_CD, "1");
+    } else {
+      // Not subject to coinsurance
+      fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_DDCTBL_COINSRNC_CD, "2");
+    }
+  }
+
+  private void setClaimLevelValues(Map<BB2RIFStructure.HOSPICE, String> fieldValues,
+          List<String> mappedDiagnosisCodes, int days, Person person,
+          HealthRecord.Encounter encounter) {
+    fieldValues.put(BB2RIFStructure.HOSPICE.BENE_ID,
+            (String)person.attributes.get(RIFExporter.BB2_BENE_ID));
+    long claimId = RIFExporter.nextClaimId.getAndDecrement();
+    fieldValues.put(BB2RIFStructure.HOSPICE.CLM_ID, "" + claimId);
+    long claimGroupId = RIFExporter.nextClaimGroupId.getAndDecrement();
+    fieldValues.put(BB2RIFStructure.HOSPICE.CLM_GRP_ID, "" + claimGroupId);
+    long fiDocId = RIFExporter.nextFiDocCntlNum.getAndDecrement();
+    fieldValues.put(BB2RIFStructure.HOSPICE.FI_DOC_CLM_CNTL_NUM, "" + fiDocId);
+    fieldValues.put(BB2RIFStructure.HOSPICE.CLM_FROM_DT,
+            RIFExporter.bb2DateFromTimestamp(encounter.start));
+    fieldValues.put(BB2RIFStructure.HOSPICE.CLM_HOSPC_START_DT_ID,
+            RIFExporter.bb2DateFromTimestamp(encounter.start));
+    fieldValues.put(BB2RIFStructure.HOSPICE.CLM_THRU_DT,
+            RIFExporter.bb2DateFromTimestamp(encounter.stop));
+    fieldValues.put(BB2RIFStructure.HOSPICE.NCH_WKLY_PROC_DT,
+            RIFExporter.bb2DateFromTimestamp(ExportHelper.nextFriday(encounter.stop)));
+    fieldValues.put(BB2RIFStructure.HOSPICE.PRVDR_NUM, encounter.provider.cmsProviderNum);
+    fieldValues.put(BB2RIFStructure.HOSPICE.AT_PHYSN_NPI, encounter.clinician.npi);
+    fieldValues.put(BB2RIFStructure.HOSPICE.RNDRNG_PHYSN_NPI, encounter.clinician.npi);
+    fieldValues.put(BB2RIFStructure.HOSPICE.ORG_NPI_NUM, encounter.provider.npi);
+    fieldValues.put(BB2RIFStructure.HOSPICE.CLM_PMT_AMT,
+            String.format("%.2f", encounter.claim.getTotalClaimCost()));
+    if (encounter.claim.plan == PayerManager.getGovernmentPayer(PayerManager.MEDICARE)
+        .getGovernmentPayerPlan()) {
+      fieldValues.put(BB2RIFStructure.HOSPICE.NCH_PRMRY_PYR_CLM_PD_AMT, "0");
+    } else {
+      fieldValues.put(BB2RIFStructure.HOSPICE.NCH_PRMRY_PYR_CLM_PD_AMT,
+              String.format("%.2f", encounter.claim.getTotalCoveredCost()));
+    }
+    fieldValues.put(BB2RIFStructure.HOSPICE.PRVDR_STATE_CD,
+            exporter.locationMapper.getStateCode(encounter.provider.state));
+    // PTNT_DSCHRG_STUS_CD: 1=home, 2=transfer, 3=SNF, 20=died, 30=still here
+    // NCH_PTNT_STUS_IND_CD: A = Discharged, B = Died, C = Still a patient
+    String dischargeStatus = null;
+    String patientStatus = null;
+    String dischargeDate = null;
+    if (encounter.ended) {
+      dischargeStatus = "1"; // TODO 2=transfer if the next encounter is also inpatient
+      patientStatus = "A"; // discharged
+      dischargeDate = RIFExporter.bb2DateFromTimestamp(ExportHelper.nextFriday(encounter.stop));
+    } else {
+      dischargeStatus = "30"; // the patient is still here
+      patientStatus = "C"; // still a patient
+    }
+    if (!person.alive(encounter.stop)) {
+      dischargeStatus = "20"; // the patient died before the encounter ended
+      patientStatus = "B"; // died
+      dischargeDate = RIFExporter.bb2DateFromTimestamp(ExportHelper.nextFriday(encounter.stop));
+    }
+    fieldValues.put(BB2RIFStructure.HOSPICE.PTNT_DSCHRG_STUS_CD, dischargeStatus);
+    fieldValues.put(BB2RIFStructure.HOSPICE.NCH_PTNT_STATUS_IND_CD, patientStatus);
+    if (dischargeDate != null) {
+      fieldValues.put(BB2RIFStructure.HOSPICE.NCH_BENE_DSCHRG_DT, dischargeDate);
+    }
+    fieldValues.put(BB2RIFStructure.HOSPICE.CLM_TOT_CHRG_AMT,
+            String.format("%.2f", encounter.claim.getTotalClaimCost()));
+
+    if (encounter.reason != null) {
+      // If the encounter has a recorded reason, enter the mapped
+      // values into the principle diagnoses code.
+      if (exporter.conditionCodeMapper.canMap(encounter.reason.code)) {
+        String icdCode = exporter.conditionCodeMapper.map(encounter.reason.code, person, true);
+        fieldValues.put(BB2RIFStructure.HOSPICE.PRNCPAL_DGNS_CD, icdCode);
+      }
+    }
+
+    int smallest = Math.min(mappedDiagnosisCodes.size(),
+            BB2RIFStructure.hospiceDxFields.length);
+    for (int i = 0; i < smallest; i++) {
+      BB2RIFStructure.HOSPICE[] dxField = BB2RIFStructure.hospiceDxFields[i];
+      fieldValues.put(dxField[0], mappedDiagnosisCodes.get(i));
+      fieldValues.put(dxField[1], "0"); // 0=ICD10
+    }
+    if (!fieldValues.containsKey(BB2RIFStructure.HOSPICE.PRNCPAL_DGNS_CD)) {
+      fieldValues.put(BB2RIFStructure.HOSPICE.PRNCPAL_DGNS_CD, mappedDiagnosisCodes.get(0));
+    }
+
+    // Check for external code...
+    exporter.setExternalCode(person, fieldValues,
+        BB2RIFStructure.HOSPICE.PRNCPAL_DGNS_CD, BB2RIFStructure.HOSPICE.ICD_DGNS_E_CD1,
+        BB2RIFStructure.HOSPICE.ICD_DGNS_E_VRSN_CD1);
+    exporter.setExternalCode(person, fieldValues,
+        BB2RIFStructure.HOSPICE.PRNCPAL_DGNS_CD, BB2RIFStructure.HOSPICE.FST_DGNS_E_CD,
+        BB2RIFStructure.HOSPICE.FST_DGNS_E_VRSN_CD);
+
+    fieldValues.put(BB2RIFStructure.HOSPICE.CLM_UTLZTN_DAY_CNT, "" + days);
+    fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_UNIT_CNT, "" + days);
+    fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_RATE_AMT,
+        String.format("%.2f", encounter.claim.getTotalClaimCost()
+                .divide(BigDecimal.valueOf(days), RoundingMode.HALF_EVEN)
+                .setScale(2, RoundingMode.HALF_EVEN)));
   }
 }

--- a/src/main/java/org/mitre/synthea/export/rif/HospiceExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/HospiceExporter.java
@@ -35,7 +35,6 @@ public class HospiceExporter extends RIFExporter {
    */
   long export(Person person, long startTime, long stopTime) throws IOException {
     long claimCount = 0;
-    HashMap<BB2RIFStructure.HOSPICE, String> fieldValues = new HashMap<>();
     for (HealthRecord.Encounter encounter : person.record.encounters) {
       if (encounter.stop < startTime || encounter.stop < CLAIM_CUTOFF) {
         continue;
@@ -55,7 +54,7 @@ public class HospiceExporter extends RIFExporter {
         days = 1;
       }
 
-      fieldValues.clear();
+      HashMap<BB2RIFStructure.HOSPICE, String> fieldValues = new HashMap<>();
       exporter.staticFieldConfig.setValues(fieldValues, BB2RIFStructure.HOSPICE.class, person);
       setClaimLevelValues(fieldValues, mappedDiagnosisCodes, days, person, encounter);
 
@@ -252,10 +251,5 @@ public class HospiceExporter extends RIFExporter {
         BB2RIFStructure.HOSPICE.FST_DGNS_E_VRSN_CD);
 
     fieldValues.put(BB2RIFStructure.HOSPICE.CLM_UTLZTN_DAY_CNT, "" + days);
-    fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_UNIT_CNT, "" + days);
-    fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_RATE_AMT,
-        String.format("%.2f", encounter.claim.getTotalClaimCost()
-                .divide(BigDecimal.valueOf(days), RoundingMode.HALF_EVEN)
-                .setScale(2, RoundingMode.HALF_EVEN)));
   }
 }

--- a/src/main/java/org/mitre/synthea/export/rif/SNFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/SNFExporter.java
@@ -6,6 +6,7 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.mitre.synthea.export.ExportHelper;
 import org.mitre.synthea.world.agents.PayerManager;
 import org.mitre.synthea.world.agents.Person;
@@ -303,12 +304,12 @@ public class SNFExporter extends RIFExporter {
           }
 
           fieldValues.put(BB2RIFStructure.SNF.CLM_LINE_NUM, Integer.toString(claimLine++));
-          setSNFClaimLineCosts(fieldValues, lineItem, Integer.max(1, revCntrCount));
+          setClaimLineCosts(fieldValues, lineItem, Integer.max(1, revCntrCount));
           exporter.rifWriters.writeValues(BB2RIFStructure.SNF.class, fieldValues);
         }
 
-        // Add a total charge etry
-        setSNFClaimLineCosts(fieldValues, consolidatedClaimLines, 1);
+        // Add a total charge entry
+        setClaimLineCosts(fieldValues, consolidatedClaimLines, 1);
         fieldValues.put(BB2RIFStructure.SNF.CLM_LINE_NUM, Integer.toString(claimLine++));
         fieldValues.remove(BB2RIFStructure.SNF.HCPCS_CD);
         fieldValues.remove(BB2RIFStructure.SNF.AT_PHYSN_NPI);
@@ -327,7 +328,7 @@ public class SNFExporter extends RIFExporter {
     return claimCount;
   }
 
-  private static void setSNFClaimLineCosts(HashMap<BB2RIFStructure.SNF, String> fieldValues,
+  private static void setClaimLineCosts(Map<BB2RIFStructure.SNF, String> fieldValues,
           Claim.ClaimCost lineItem, int count) {
     fieldValues.put(BB2RIFStructure.SNF.REV_CNTR_RATE_AMT,
             String.format("%.2f", lineItem.cost
@@ -354,6 +355,4 @@ public class SNFExporter extends RIFExporter {
       fieldValues.put(BB2RIFStructure.SNF.REV_CNTR_DDCTBL_COINSRNC_CD, "2");
     }
   }
-
-
 }

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -162,7 +162,7 @@ public class Location implements Serializable {
         Map<String, Double> determinants = socialDeterminantsOfHealth.get(county);
         for (String determinant : determinants.keySet()) {
           Double probability = determinants.get(determinant);
-          Double sum = averages.getOrDefault(determinant, new Double(0));
+          Double sum = averages.getOrDefault(determinant, 0.0);
           averages.put(determinant, probability + sum);
         }
       }


### PR DESCRIPTION
- Break up RIF `HospiceExporter.export` function to make the flow clearer
- Break up RIF `SNFExporter.export` function to make the flow clearer
- Add claim line consolidation to Hospice export to reduce the number of claim lines per claim
- Fix deprecation warning re `new Double(0.0)`
- Fix gradle deprecation warning re dependency version fixing

Note: requires new hospice_rev_cntr_code_map.json file available from the usual places.