### PR TITLE
Restore slack notifications on failed builds

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -27,7 +27,7 @@ jobs:
   
       - name: Slack Notification
         uses: 8398a7/action-slack@v3
-        if: env.SLACK_WEBHOOK_URL
+        if: always() && env.SLACK_WEBHOOK_URL
         with:
           status: custom
           job_name: Java 17
@@ -77,7 +77,7 @@ jobs:
 
       - name: Slack Notification
         uses: 8398a7/action-slack@v3
-        if: env.SLACK_WEBHOOK_URL
+        if: always() && env.SLACK_WEBHOOK_URL
         with:
           status: custom
           job_name: Java 11


### PR DESCRIPTION
I noticed a while ago that our internal slack notification hasn't reported build failures in a long time. This was because of my previous PR #920 where I had changed the logic to not run if there was no slack webhook url configured (so that it wouldn't fail 100% of the time on forks). But removing the `always()` meant that if a previous step failed, it wouldn't run the slack notification step.

The correct logic should be to combine both the `always()` check and the slack webhook url check