### PR TITLE
Add exponential distribution for Length of Stay

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Distribution.java
+++ b/src/main/java/org/mitre/synthea/engine/Distribution.java
@@ -50,8 +50,8 @@ public class Distribution implements Serializable {
         break;
       case EXPONENTIAL:
         double average = this.parameters.get("mean");
-        double lambda = (1 / average);
-        value = 1 + Math.log(1 - person.rand()) / (-1 * lambda);
+        double lambda = (1.0d / average);
+        value = 1.0d + Math.log(1.0d - person.rand()) / (-1.0d * lambda);
         break;
       default:
         value = -1;

--- a/src/main/java/org/mitre/synthea/engine/Distribution.java
+++ b/src/main/java/org/mitre/synthea/engine/Distribution.java
@@ -11,7 +11,7 @@ import org.mitre.synthea.world.agents.Person;
  */
 public class Distribution implements Serializable {
   public enum Kind {
-    EXACT, GAUSSIAN, UNIFORM
+    EXACT, GAUSSIAN, UNIFORM, EXPONENTIAL
   }
 
   public Kind kind;
@@ -48,6 +48,11 @@ public class Distribution implements Serializable {
           }
         }
         break;
+      case EXPONENTIAL:
+        double average = this.parameters.get("mean");
+        double lambda = (1 / average);
+        value = 1 + Math.log(1 - person.rand()) / (-1 * lambda);
+        break;
       default:
         value = -1;
     }
@@ -74,6 +79,8 @@ public class Distribution implements Serializable {
       case GAUSSIAN:
         return this.parameters.containsKey("mean")
             && this.parameters.containsKey("standardDeviation");
+      case EXPONENTIAL:
+        return this.parameters.containsKey("mean");
       default:
         return false;
     }

--- a/src/main/resources/modules/anemia/anemia_sub.json
+++ b/src/main/resources/modules/anemia/anemia_sub.json
@@ -6,7 +6,7 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "Anemia"
+      "direct_transition": "End Any Active Encounter Just In Case"
     },
     "Anemia": {
       "type": "ConditionOnset",
@@ -63,7 +63,7 @@
       ],
       "conditional_transition": [
         {
-          "transition": "End_Initial_Encounter",
+          "transition": "Delay",
           "condition": {
             "condition_type": "And",
             "conditions": [
@@ -87,7 +87,7 @@
           }
         },
         {
-          "transition": "End_Initial_Encounter",
+          "transition": "Delay",
           "condition": {
             "condition_type": "And",
             "conditions": [
@@ -111,13 +111,9 @@
           }
         },
         {
-          "transition": "Administer_Medications_2"
+          "transition": "Administer_Medications"
         }
       ]
-    },
-    "End_Initial_Encounter": {
-      "type": "EncounterEnd",
-      "direct_transition": "Delay"
     },
     "Male": {
       "type": "Simple",
@@ -181,7 +177,7 @@
         "high": 60,
         "unit": "minutes"
       },
-      "direct_transition": "End Transfusion_Encounter"
+      "direct_transition": "End Encounter After Transfusion"
     },
     "Peripheral_Blood_Smear": {
       "type": "Procedure",
@@ -227,7 +223,7 @@
           "distribution": 0.1
         },
         {
-          "transition": "End_Consult_Referral to_Experts_Encounter",
+          "transition": "End Encounter After Medication Rx",
           "distribution": 0.8
         }
       ]
@@ -247,7 +243,7 @@
           "distribution": 0.1
         },
         {
-          "transition": "End_Consult_Referral to_Experts_Encounter",
+          "transition": "End Encounter After Medication Rx",
           "distribution": 0.9
         }
       ]
@@ -261,20 +257,7 @@
           "display": "Vitamin B 12 5 MG/ML Injectable Solution"
         }
       ],
-      "direct_transition": "End_Consult_Referral to_Experts_Encounter"
-    },
-    "Transfusion_Encounter": {
-      "type": "Encounter",
-      "encounter_class": "inpatient",
-      "reason": "anemia",
-      "codes": [
-        {
-          "system": "SNOMED-CT",
-          "code": 185347001,
-          "display": "Encounter for problem (procedure)"
-        }
-      ],
-      "direct_transition": "Transfusion"
+      "direct_transition": "End Encounter After Medication Rx"
     },
     "Anemia_Encounter": {
       "type": "Encounter",
@@ -303,58 +286,6 @@
         }
       ],
       "reason": "anemia"
-    },
-    "Administer_Medications_2": {
-      "type": "Simple",
-      "distributed_transition": [
-        {
-          "transition": "Iron_Supplement_2",
-          "distribution": 0.1
-        },
-        {
-          "transition": "Vitamin_B12_Booster",
-          "distribution": 0.1
-        },
-        {
-          "transition": "End_Anemia_Encounter",
-          "distribution": 0.8
-        }
-      ]
-    },
-    "Iron_Supplement_2": {
-      "type": "MedicationOrder",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": 310325,
-          "display": "ferrous sulfate 325 MG Oral Tablet"
-        }
-      ],
-      "distributed_transition": [
-        {
-          "transition": "Vitamin_B12_Booster",
-          "distribution": 0.1
-        },
-        {
-          "transition": "End_Anemia_Encounter",
-          "distribution": 0.9
-        }
-      ]
-    },
-    "Vitamin_B12_Booster": {
-      "type": "MedicationOrder",
-      "codes": [
-        {
-          "system": "RxNorm",
-          "code": 2001499,
-          "display": "Vitamin B 12 5 MG/ML Injectable Solution"
-        }
-      ],
-      "direct_transition": "End_Anemia_Encounter"
-    },
-    "End_Anemia_Encounter": {
-      "type": "EncounterEnd",
-      "direct_transition": "Terminal"
     },
     "CBC_Panel_F_Routine": {
       "type": "DiagnosticReport",
@@ -1072,10 +1003,6 @@
         }
       ]
     },
-    "End Transfusion_Encounter": {
-      "type": "EncounterEnd",
-      "direct_transition": "Delay_One_Day"
-    },
     "Consult_Referral_to_Experts_Encounter": {
       "type": "Encounter",
       "encounter_class": "ambulatory",
@@ -1104,10 +1031,6 @@
         }
       ]
     },
-    "End_Consult_Referral to_Experts_Encounter": {
-      "type": "EncounterEnd",
-      "direct_transition": "Terminal"
-    },
     "Collect_Social_and_Nutrition_History": {
       "type": "Simple",
       "remarks": [
@@ -1121,7 +1044,7 @@
         "quantity": 1,
         "unit": "hours"
       },
-      "direct_transition": "Transfusion_Encounter"
+      "direct_transition": "Transfusion"
     },
     "Blood_Panel_M_Routine": {
       "type": "DiagnosticReport",
@@ -1216,6 +1139,18 @@
         "unit": "days"
       },
       "direct_transition": "Consult_Referral_to_Experts_Encounter"
+    },
+    "End Any Active Encounter Just In Case": {
+      "type": "EncounterEnd",
+      "direct_transition": "Anemia"
+    },
+    "End Encounter After Transfusion": {
+      "type": "EncounterEnd",
+      "direct_transition": "Delay_One_Day"
+    },
+    "End Encounter After Medication Rx": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/breast_cancer.json
+++ b/src/main/resources/modules/breast_cancer.json
@@ -1308,7 +1308,7 @@
     },
     "Regular Mammogram Visit": {
       "type": "Encounter",
-      "encounter_class": "ambulatory",
+      "encounter_class": "inpatient",
       "codes": [
         {
           "system": "SNOMED-CT",

--- a/src/main/resources/modules/breast_cancer.json
+++ b/src/main/resources/modules/breast_cancer.json
@@ -438,7 +438,7 @@
           "display": "Stage group.clinical Cancer"
         }
       ],
-      "direct_transition": "Delay for Analysis of Possible Treatments",
+      "direct_transition": "End the Initial Encounter",
       "value_code": {
         "system": "SNOMED-CT",
         "code": 258228008,
@@ -539,7 +539,7 @@
         "code": 258224005,
         "display": "Stage 3 (qualifier value)"
       },
-      "direct_transition": "Delay for Analysis of Possible Treatments"
+      "direct_transition": "End the Initial Encounter"
     },
     "Stage I": {
       "type": "Observation",
@@ -557,7 +557,7 @@
         "code": 258215001,
         "display": "Stage 1 (qualifier value)"
       },
-      "direct_transition": "Delay for Analysis of Possible Treatments"
+      "direct_transition": "End the Initial Encounter"
     },
     "IIIB": {
       "type": "Observation",
@@ -843,7 +843,7 @@
         "code": 258219007,
         "display": "Stage 2 (qualifier value)"
       },
-      "direct_transition": "Delay for Analysis of Possible Treatments"
+      "direct_transition": "End the Initial Encounter"
     },
     "Stage II Treatment": {
       "type": "Simple",
@@ -1303,7 +1303,7 @@
     "Treatment Successful": {
       "type": "SetAttribute",
       "attribute": "breast_cancer_survival",
-      "direct_transition": "End the Initial Encounter",
+      "direct_transition": "Sit-Down with Oncologist to Discuss Treatment Options",
       "value": "yes"
     },
     "Regular Mammogram Visit": {
@@ -2104,7 +2104,7 @@
           "distribution": 0.3
         },
         {
-          "transition": "End the Initial Encounter",
+          "transition": "Sit-Down with Oncologist to Discuss Treatment Options",
           "distribution": 0.7
         }
       ]
@@ -2118,12 +2118,12 @@
     "Hospice Reason": {
       "type": "SetAttribute",
       "attribute": "hospice_reason",
-      "direct_transition": "End the Initial Encounter",
+      "direct_transition": "Sit-Down with Oncologist to Discuss Treatment Options",
       "value_attribute": "breast_cancer_condition"
     },
     "End the Initial Encounter": {
       "type": "EncounterEnd",
-      "direct_transition": "Sit-Down with Oncologist to Discuss Treatment Options"
+      "direct_transition": "Delay for Analysis of Possible Treatments"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/breast_cancer.json
+++ b/src/main/resources/modules/breast_cancer.json
@@ -1303,7 +1303,7 @@
     "Treatment Successful": {
       "type": "SetAttribute",
       "attribute": "breast_cancer_survival",
-      "direct_transition": "Sit-Down with Oncologist to Discuss Treatment Options",
+      "direct_transition": "End the Initial Encounter",
       "value": "yes"
     },
     "Regular Mammogram Visit": {
@@ -2104,7 +2104,7 @@
           "distribution": 0.3
         },
         {
-          "transition": "Sit-Down with Oncologist to Discuss Treatment Options",
+          "transition": "End the Initial Encounter",
           "distribution": 0.7
         }
       ]
@@ -2118,8 +2118,12 @@
     "Hospice Reason": {
       "type": "SetAttribute",
       "attribute": "hospice_reason",
-      "direct_transition": "Sit-Down with Oncologist to Discuss Treatment Options",
+      "direct_transition": "End the Initial Encounter",
       "value_attribute": "breast_cancer_condition"
+    },
+    "End the Initial Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Sit-Down with Oncologist to Discuss Treatment Options"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/breast_cancer.json
+++ b/src/main/resources/modules/breast_cancer.json
@@ -1308,7 +1308,7 @@
     },
     "Regular Mammogram Visit": {
       "type": "Encounter",
-      "encounter_class": "inpatient",
+      "encounter_class": "ambulatory",
       "codes": [
         {
           "system": "SNOMED-CT",

--- a/src/main/resources/modules/cystic_fibrosis.json
+++ b/src/main/resources/modules/cystic_fibrosis.json
@@ -1722,7 +1722,7 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": 16602611000119108,
+          "code": "16602611000119108",
           "display": "Awaiting transplantation of lung (situation)"
         }
       ],

--- a/src/main/resources/modules/home_hospice_snf.json
+++ b/src/main/resources/modules/home_hospice_snf.json
@@ -665,19 +665,6 @@
           }
         },
         {
-          "transition": "Heart Disease",
-          "condition": {
-            "condition_type": "Active Condition",
-            "codes": [
-              {
-                "system": "SNOMED-CT",
-                "code": 53741008,
-                "display": "Coronary Heart Disease"
-              }
-            ]
-          }
-        },
-        {
           "transition": "CF",
           "condition": {
             "condition_type": "Attribute",
@@ -739,7 +726,7 @@
     "Alzheimers": {
       "type": "SetAttribute",
       "attribute": "hospice_reason",
-      "direct_transition": "COPD",
+      "direct_transition": "Initiate Hospice",
       "value_attribute": "Type of Alzheimer's"
     },
     "COPD": {
@@ -753,16 +740,6 @@
       "attribute": "hospice_reason",
       "value_attribute": "chf",
       "direct_transition": "Initiate Hospice"
-    },
-    "Heart Disease": {
-      "type": "SetAttribute",
-      "attribute": "hospice_reason",
-      "direct_transition": "Initiate Hospice",
-      "value_code": {
-        "system": "SNOMED",
-        "code": "53741008",
-        "display": "Coronary Heart Disease"
-      }
     },
     "CKD": {
       "type": "SetAttribute",

--- a/src/main/resources/modules/hospice_treatment.json
+++ b/src/main/resources/modules/hospice_treatment.json
@@ -25,74 +25,29 @@
       "reason": "hospice_reason"
     },
     "Determine_LOS": {
-      "type": "Simple",
-      "distributed_transition": [
+      "type": "SetAttribute",
+      "attribute": "hospice_days",
+      "distribution": {
+        "kind": "EXPONENTIAL",
+        "round": true,
+        "parameters": {
+          "mean": 22.7
+        }
+      },
+      "conditional_transition": [
         {
-          "distribution": 0.26,
-          "transition": "LOS_1-7_Days"
+          "transition": "Max Length of Stay",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "hospice_days",
+            "operator": ">",
+            "value": 240
+          }
         },
         {
-          "distribution": 0.35,
-          "transition": "LOS_8-60_Days"
-        },
-        {
-          "distribution": 0.07,
-          "transition": "LOS_61-90_Days"
-        },
-        {
-          "distribution": 0.11,
-          "transition": "LOS_91-180_Days"
-        },
-        {
-          "distribution": 0.21,
-          "transition": "LOS_181-240_Days"
+          "transition": "Certification_Procedure"
         }
       ]
-    },
-    "LOS_1-7_Days": {
-      "type": "SetAttribute",
-      "attribute": "hospice_days",
-      "direct_transition": "Certification_Procedure",
-      "range": {
-        "high": 7,
-        "low": 1
-      }
-    },
-    "LOS_8-60_Days": {
-      "type": "SetAttribute",
-      "attribute": "hospice_days",
-      "direct_transition": "Certification_Procedure",
-      "range": {
-        "high": 60,
-        "low": 8
-      }
-    },
-    "LOS_61-90_Days": {
-      "type": "SetAttribute",
-      "attribute": "hospice_days",
-      "direct_transition": "Certification_Procedure",
-      "range": {
-        "high": 90,
-        "low": 61
-      }
-    },
-    "LOS_91-180_Days": {
-      "type": "SetAttribute",
-      "attribute": "hospice_days",
-      "direct_transition": "Certification_Procedure",
-      "range": {
-        "high": 180,
-        "low": 91
-      }
-    },
-    "LOS_181-240_Days": {
-      "type": "SetAttribute",
-      "attribute": "hospice_days",
-      "direct_transition": "Certification_Procedure",
-      "range": {
-        "high": 240,
-        "low": 181
-      }
     },
     "Certification_Procedure": {
       "type": "Procedure",
@@ -355,6 +310,12 @@
       "type": "DeviceEnd",
       "device": "Commode",
       "direct_transition": "Alive Check"
+    },
+    "Max Length of Stay": {
+      "type": "SetAttribute",
+      "attribute": "hospice_days",
+      "direct_transition": "Certification_Procedure",
+      "value": 240
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/hospice_treatment.json
+++ b/src/main/resources/modules/hospice_treatment.json
@@ -21,8 +21,21 @@
           "display": "Admission to hospice (procedure)"
         }
       ],
-      "direct_transition": "Determine_LOS",
-      "reason": "hospice_reason"
+      "reason": "hospice_reason",
+      "conditional_transition": [
+        {
+          "transition": "Stay Until Death",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "days_until_death",
+            "operator": "<",
+            "value": 30
+          }
+        },
+        {
+          "transition": "Determine_LOS"
+        }
+      ]
     },
     "Determine_LOS": {
       "type": "SetAttribute",
@@ -137,7 +150,7 @@
           "condition": {
             "condition_type": "Attribute",
             "attribute": "hospice_days",
-            "operator": "<",
+            "operator": "<=",
             "value": 0
           }
         },
@@ -316,6 +329,12 @@
       "attribute": "hospice_days",
       "direct_transition": "Certification_Procedure",
       "value": 240
+    },
+    "Stay Until Death": {
+      "type": "SetAttribute",
+      "attribute": "hospice_days",
+      "direct_transition": "Certification_Procedure",
+      "value_attribute": "days_until_death"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/prescribing_opioids_for_chronic_pain_and_treatment_of_oud.json
+++ b/src/main/resources/modules/prescribing_opioids_for_chronic_pain_and_treatment_of_oud.json
@@ -1342,7 +1342,7 @@
           "display": "Pain intensity, Enjoyment of life, General activity (PEG) 3 item pain scale"
         }
       ],
-      "direct_transition": "Addiction",
+      "direct_transition": "End follow up with positive test",
       "observations": [
         {
           "category": "survey",
@@ -1554,7 +1554,7 @@
           "display": "Drugs of abuse 5 panel - Urine by Screen method"
         }
       ],
-      "direct_transition": "Addiction",
+      "direct_transition": "End initial encounter with positive result",
       "value_code": {
         "system": "SNOMED-CT",
         "code": 10828004,
@@ -3197,6 +3197,15 @@
       ],
       "reason": "Condition_OUD_2",
       "direct_transition": "End_Encounter_OUD_Treatment_Cont"
+    },
+    "End follow up with positive test": {
+      "type": "EncounterEnd",
+      "direct_transition": "Addiction"
+    },
+    "End initial encounter with positive result": {
+      "type": "EncounterEnd",
+      "direct_transition": "Addiction"
     }
-  }
+  },
+  "gmf_version": 2
 }

--- a/src/main/resources/modules/snf/skilled_nursing_facility.json
+++ b/src/main/resources/modules/snf/skilled_nursing_facility.json
@@ -44,58 +44,29 @@
       ]
     },
     "Determine_LOS": {
-      "type": "Simple",
-      "distributed_transition": [
+      "type": "SetAttribute",
+      "attribute": "snf_days",
+      "distribution": {
+        "kind": "EXPONENTIAL",
+        "round": true,
+        "parameters": {
+          "mean": 18.7
+        }
+      },
+      "conditional_transition": [
         {
-          "distribution": 0.364,
-          "transition": "SNF_1-15_Days"
+          "transition": "Max Length of Stay",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "snf_days",
+            "operator": ">",
+            "value": 100
+          }
         },
         {
-          "distribution": 0.34,
-          "transition": "SNF_16-30_Days"
-        },
-        {
-          "distribution": 0.29,
-          "transition": "SNF_31-99_Days"
-        },
-        {
-          "distribution": 0.006,
-          "transition": "SNF_100_Days"
+          "transition": "History_Physical_Exam"
         }
       ]
-    },
-    "SNF_1-15_Days": {
-      "type": "SetAttribute",
-      "attribute": "snf_days",
-      "range": {
-        "high": 15,
-        "low": 1
-      },
-      "direct_transition": "History_Physical_Exam"
-    },
-    "SNF_16-30_Days": {
-      "type": "SetAttribute",
-      "attribute": "snf_days",
-      "range": {
-        "high": 30,
-        "low": 16
-      },
-      "direct_transition": "History_Physical_Exam"
-    },
-    "SNF_31-99_Days": {
-      "type": "SetAttribute",
-      "attribute": "snf_days",
-      "range": {
-        "high": 99,
-        "low": 31
-      },
-      "direct_transition": "History_Physical_Exam"
-    },
-    "SNF_100_Days": {
-      "type": "SetAttribute",
-      "attribute": "snf_days",
-      "value": 100,
-      "direct_transition": "History_Physical_Exam"
     },
     "History_Physical_Exam": {
       "type": "Procedure",
@@ -340,6 +311,12 @@
       "type": "DeviceEnd",
       "referenced_by_attribute": "snf_wheelchair",
       "direct_transition": "End Encounter"
+    },
+    "Max Length of Stay": {
+      "type": "SetAttribute",
+      "attribute": "snf_days",
+      "value": 100,
+      "direct_transition": "History_Physical_Exam"
     }
   },
   "gmf_version": 1

--- a/src/test/java/org/mitre/synthea/engine/DistributionTest.java
+++ b/src/test/java/org/mitre/synthea/engine/DistributionTest.java
@@ -21,6 +21,17 @@ public class DistributionTest {
   }
 
   @Test
+  public void testValidateExponential() {
+    Distribution d = new Distribution();
+    d.kind = Distribution.Kind.EXPONENTIAL;
+    assertFalse(d.validate());
+    HashMap<String, Double> parameters = new HashMap();
+    parameters.put("mean", 5.3d);
+    d.parameters = parameters;
+    assertTrue(d.validate());
+  }
+
+  @Test
   public void testRounding() {
     Distribution d = new Distribution();
     d.kind = Distribution.Kind.UNIFORM;


### PR DESCRIPTION
This pull request adds the [exponential distribution](https://en.wikipedia.org/wiki/Exponential_distribution) [Wikipedia] to the list of available distributions.

This distribution can be used for determining "length of stay", for instance.

Addresses #1168 for the purposes of #1169, #1170, #1171 

