### PR TITLE
Allow config settings that are usually in resources to reference any file location

### DIFF
--- a/src/main/java/Graphviz.java
+++ b/src/main/java/Graphviz.java
@@ -84,7 +84,7 @@ public class Graphviz {
     System.out.format("Loading %s\n", path.toString());
     String moduleRelativePath = modulesFolder.getParent().relativize(path).toString();
     JsonReader reader = new JsonReader(new StringReader(
-             Utilities.readResource(moduleRelativePath)));
+             Utilities.readResourceOrPath(moduleRelativePath)));
     JsonObject object = JsonParser.parseReader(reader).getAsJsonObject();
     reader.close();
     return object;

--- a/src/main/java/org/mitre/synthea/engine/Transition.java
+++ b/src/main/java/org/mitre/synthea/engine/Transition.java
@@ -271,7 +271,7 @@ public abstract class Transition implements Serializable {
       String fileName = Config.get("generate.lookup_tables") + lookupTableName;
       List<? extends Map<String, String>> lookupTable = null;
       try {
-        String csv = Utilities.readResourceAndStripBOM(fileName);
+        String csv = Utilities.readResource(fileName, true, true);
         lookupTable = SimpleCSV.parse(csv);
       } catch (IOException e) {
         e.printStackTrace();

--- a/src/main/java/org/mitre/synthea/modules/covid/C19VaccineAgeDistributions.java
+++ b/src/main/java/org/mitre/synthea/modules/covid/C19VaccineAgeDistributions.java
@@ -121,7 +121,7 @@ public class C19VaccineAgeDistributions {
     String fileName = Config.get("generate.lookup_tables") + DOSE_RATES_FILE;
     List<? extends Map<String, String>> rawRates = null;
     try {
-      String csv = Utilities.readResourceAndStripBOM(fileName);
+      String csv = Utilities.readResource(fileName, true, true);
       rawRates = SimpleCSV.parse(csv);
     } catch (IOException e) {
       e.printStackTrace();

--- a/src/main/java/org/mitre/synthea/world/agents/PayerManager.java
+++ b/src/main/java/org/mitre/synthea/world/agents/PayerManager.java
@@ -123,7 +123,7 @@ public class PayerManager {
   private static void loadPayers(Location location, String fileName) throws IOException {
     PayerManager.loadNoInsurance();
 
-    String resource = Utilities.readResourceAndStripBOM(fileName);
+    String resource = Utilities.readResource(fileName, true, true);
     Iterator<? extends Map<String, String>> csv = SimpleCSV.parseLineByLine(resource);
 
     while (csv.hasNext()) {
@@ -156,7 +156,7 @@ public class PayerManager {
     String fileName = Config.get("generate.payers.insurance_plans.default_file");
     Iterator<? extends Map<String, String>> csv = null;
     try {
-      String resource = Utilities.readResourceAndStripBOM(fileName);
+      String resource = Utilities.readResource(fileName, true, true);
       csv = SimpleCSV.parseLineByLine(resource);
     } catch (IOException e) {
       e.printStackTrace();

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -449,7 +449,7 @@ public class Provider implements QuadTreeElement, Serializable {
       return;
     }
 
-    String resource = Utilities.readResourceOrPath(filename);
+    String resource = Utilities.readResource(filename, true, true);
     Iterator<? extends Map<String,String>> csv = SimpleCSV.parseLineByLine(resource);
 
     while (csv.hasNext()) {

--- a/src/main/java/org/mitre/synthea/world/agents/Provider.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Provider.java
@@ -434,7 +434,7 @@ public class Provider implements QuadTreeElement, Serializable {
    * THIS method is for loading providers and generating clinicians with specific specialties
    *
    * @param location the state being loaded
-   * @param filename Location of the file, relative to src/main/resources
+   * @param filename Location of the file
    * @param providerType ProviderType
    * @param servicesProvided Set of services provided by these facilities
    * @param random Source of randomness for provider generation
@@ -449,7 +449,7 @@ public class Provider implements QuadTreeElement, Serializable {
       return;
     }
 
-    String resource = Utilities.readResource(filename);
+    String resource = Utilities.readResourceOrPath(filename);
     Iterator<? extends Map<String,String>> csv = SimpleCSV.parseLineByLine(resource);
 
     while (csv.hasNext()) {

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/IncomeSpenddownEligibility.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/IncomeSpenddownEligibility.java
@@ -39,7 +39,7 @@ public class IncomeSpenddownEligibility implements IPlanEligibility {
     String resource = null;
     Iterator<? extends Map<String, String>> csv = null;
     try {
-      resource = Utilities.readResource(fileName);
+      resource = Utilities.readResource(fileName, true, true);
       csv = SimpleCSV.parseLineByLine(resource);
     } catch (IOException e) {
       throw new RuntimeException("There was an issue reading the file '"

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/PlanEligibilityFinder.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/PlanEligibilityFinder.java
@@ -53,7 +53,7 @@ public class PlanEligibilityFinder {
     String resource = null;
     Iterator<? extends Map<String, String>> csv = null;
     try {
-      resource = Utilities.readResourceAndStripBOM(fileName);
+      resource = Utilities.readResource(fileName, true, true);
       csv = SimpleCSV.parseLineByLine(resource);
     } catch (IOException e) {
       e.printStackTrace();

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/PovertyMultiplierFileEligibility.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/PovertyMultiplierFileEligibility.java
@@ -68,7 +68,7 @@ public class PovertyMultiplierFileEligibility implements IPlanEligibility {
     String resource = null;
     Iterator<? extends Map<String, String>> csv = null;
     try {
-      resource = Utilities.readResource(fileName);
+      resource = Utilities.readResource(fileName, true, true);
       csv = SimpleCSV.parseLineByLine(resource);
     } catch (IOException e) {
       e.printStackTrace();

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/QualifyingAttributesEligibility.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/QualifyingAttributesEligibility.java
@@ -74,7 +74,7 @@ public class QualifyingAttributesEligibility implements IPlanEligibility {
     String resource = null;
     Iterator<? extends Map<String, String>> csv = null;
     try {
-      resource = Utilities.readResourceAndStripBOM(fileName);
+      resource = Utilities.readResource(fileName, true, true);
       csv = SimpleCSV.parseLineByLine(resource);
     } catch (IOException e) {
       throw new RuntimeException("There was an issue reading the file '"

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/QualifyingConditionCodesEligibility.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/QualifyingConditionCodesEligibility.java
@@ -53,7 +53,7 @@ public class QualifyingConditionCodesEligibility implements IPlanEligibility {
   private static List<String> buildQualifyingConditionsFile(String fileName) {
     String resource = null;
     try {
-      resource = Utilities.readResourceAndStripBOM(fileName);
+      resource = Utilities.readResource(fileName, true, true);
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/src/main/java/org/mitre/synthea/world/concepts/BirthStatistics.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/BirthStatistics.java
@@ -57,7 +57,7 @@ public class BirthStatistics {
     String filename = Config.get("generate.birthweights.default_file");
     List<? extends Map<String,String>> csv = null;
     try {
-      String resource = Utilities.readResource(filename);
+      String resource = Utilities.readResource(filename, true, true);
       csv = SimpleCSV.parse(resource);
     } catch (Exception e) {
       System.err.println("Failed to load default birth weight file!");

--- a/src/main/java/org/mitre/synthea/world/concepts/Costs.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/Costs.java
@@ -175,7 +175,7 @@ public class Costs {
    */
   private static Map<String, CostData> parseCsvToMap(String filename) {
     try {
-      String rawData = Utilities.readResource(filename);
+      String rawData = Utilities.readResourceAndStripBOM(filename);
       List<LinkedHashMap<String, String>> lines = SimpleCSV.parse(rawData);
 
       Map<String, CostData> costMap = new HashMap<>();
@@ -208,7 +208,7 @@ public class Costs {
 
   private static Map<String, Double> parseAdjustmentFactors(String resource) {
     try {
-      String rawData = Utilities.readResource(resource);
+      String rawData = Utilities.readResourceAndStripBOM(resource);
       List<LinkedHashMap<String, String>> lines = SimpleCSV.parse(rawData);
 
       Map<String, Double> costMap = new HashMap<>();
@@ -232,7 +232,7 @@ public class Costs {
 
   private static Map<String, Double> parseEncounterAdjustmentFactors(String resource) {
     try {
-      String rawData = Utilities.readResource(resource);
+      String rawData = Utilities.readResourceAndStripBOM(resource);
       List<LinkedHashMap<String, String>> lines = SimpleCSV.parse(rawData);
 
       Map<String, Double> costMap = new HashMap<>();

--- a/src/main/java/org/mitre/synthea/world/geography/Demographics.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Demographics.java
@@ -385,7 +385,7 @@ public class Demographics implements Comparable<Demographics>, Serializable {
   public static Table<String, String, Demographics> load(String state)
       throws IOException {
     String filename = Config.get("generate.demographics.default_file");
-    String csv = Utilities.readResource(filename);
+    String csv = Utilities.readResource(filename, true, true);
 
     List<? extends Map<String,String>> demographicsCsv = SimpleCSV.parse(csv);
 

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -104,7 +104,7 @@ public class Location implements Serializable {
     String filename = null;
     try {
       filename = Config.get("generate.geography.zipcodes.default_file");
-      String csv = Utilities.readResource(filename);
+      String csv = Utilities.readResource(filename, true, true);
       List<? extends Map<String,String>> ziplist = SimpleCSV.parse(csv);
 
       zipCodes = new HashMap<>();
@@ -130,7 +130,7 @@ public class Location implements Serializable {
     try {
       filename = Config.get("generate.geography.sdoh.default_file",
         "geography/sdoh.csv");
-      String csv = Utilities.readResource(filename);
+      String csv = Utilities.readResource(filename, true, true);
       List<? extends Map<String,String>> sdohList = SimpleCSV.parse(csv);
 
       for (Map<String,String> line : sdohList) {
@@ -405,7 +405,7 @@ public class Location implements Serializable {
     String filename = null;
     try {
       filename = Config.get("generate.geography.zipcodes.default_file");
-      String csv = Utilities.readResource(filename);
+      String csv = Utilities.readResourceOrPath(filename);
       List<? extends Map<String,String>> ziplist = SimpleCSV.parse(csv);
 
       for (Map<String,String> line : ziplist) {
@@ -466,7 +466,7 @@ public class Location implements Serializable {
     String filename = null;
     try {
       filename = Config.get("generate.geography.timezones.default_file");
-      String csv = Utilities.readResource(filename);
+      String csv = Utilities.readResourceOrPath(filename);
       List<? extends Map<String,String>> tzlist = SimpleCSV.parse(csv);
 
       for (Map<String,String> line : tzlist) {
@@ -502,7 +502,7 @@ public class Location implements Serializable {
   protected static Map<String, List<String>> loadCitiesByLanguage(String resource) {
     Map<String, List<String>> foreignPlacesOfBirth = new HashMap<>();
     try {
-      String json = Utilities.readResource(resource);
+      String json = Utilities.readResourceOrPath(resource);
       foreignPlacesOfBirth = new Gson().fromJson(json, HashMap.class);
     } catch (Exception e) {
       System.err.println("ERROR: unable to load foreign places of birth");

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -405,7 +405,7 @@ public class Location implements Serializable {
     String filename = null;
     try {
       filename = Config.get("generate.geography.zipcodes.default_file");
-      String csv = Utilities.readResourceOrPath(filename);
+      String csv = Utilities.readResource(filename, true, true);
       List<? extends Map<String,String>> ziplist = SimpleCSV.parse(csv);
 
       for (Map<String,String> line : ziplist) {
@@ -466,7 +466,7 @@ public class Location implements Serializable {
     String filename = null;
     try {
       filename = Config.get("generate.geography.timezones.default_file");
-      String csv = Utilities.readResourceOrPath(filename);
+      String csv = Utilities.readResource(filename, true, true);
       List<? extends Map<String,String>> tzlist = SimpleCSV.parse(csv);
 
       for (Map<String,String> line : tzlist) {

--- a/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
+++ b/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
@@ -102,11 +102,11 @@ public class LocationTest {
   @Test
   public void testAllDemographicsHaveLocations() throws Exception {
     String demoFileContents =
-        Utilities.readResourceOrPath(Config.get("generate.demographics.default_file"));
+        Utilities.readResource(Config.get("generate.demographics.default_file"), true, true);
     List<LinkedHashMap<String, String>> demographics = SimpleCSV.parse(demoFileContents);
 
     String zipFileContents =
-        Utilities.readResourceOrPath(Config.get("generate.geography.zipcodes.default_file"));
+        Utilities.readResource(Config.get("generate.geography.zipcodes.default_file"), true, true);
     List<LinkedHashMap<String, String>> zips = SimpleCSV.parse(zipFileContents);
 
     // parse all the locations from the zip codes and put them in a a set.

--- a/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
+++ b/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
@@ -102,11 +102,11 @@ public class LocationTest {
   @Test
   public void testAllDemographicsHaveLocations() throws Exception {
     String demoFileContents =
-        Utilities.readResource(Config.get("generate.demographics.default_file"));
+        Utilities.readResourceOrPath(Config.get("generate.demographics.default_file"));
     List<LinkedHashMap<String, String>> demographics = SimpleCSV.parse(demoFileContents);
 
     String zipFileContents =
-        Utilities.readResource(Config.get("generate.geography.zipcodes.default_file"));
+        Utilities.readResourceOrPath(Config.get("generate.geography.zipcodes.default_file"));
     List<LinkedHashMap<String, String>> zips = SimpleCSV.parse(zipFileContents);
 
     // parse all the locations from the zip codes and put them in a a set.


### PR DESCRIPTION
Addresses #1224 

As of today we have a number of config settings which implicitly point to locations under `src/main/resources`, but there's no technical reason they necessarily have to. But as shown in the linked issue, if you try to point to an absolute file path somewhere else, it doesn't work.

This PR refactors the `Utilities.readResource` family of methods into 4:

`Utilities.readResource(String, boolean, boolean)`:
  Method containing all the logic and configurability. Allow for optionally reading from different locations and optionally stripping BOM.

`Utilities.readResource(String)`:
  Default method to match the previous implementation, calls the above with the options set to false.

`Utilities.readResourceOrPath(String)`:
  Method to allow for reading from either src/main/resources, or from a free path on the filesystem. Calls `readResource(filename, false, true)`

`Utilities.readResourceAndStripBOM(String)`:
  Method to allow for reading from only src/main/resources, and strips BOM if present. Calls `readResource(filename, true, false)`


Then I updated references to these methods by the following rules:

1. If the file we read is a CSV, we should strip BOM.
2. If the file we read comes from a config setting, we should allow free paths. (Aka, if the file path is hardcoded, don't bother allowing free paths)
3. If both the above are true, use `Utilities.readResource(String, boolean, boolean)`
4. If neither is true, use `Utilities.readResource(String)` to minimize the number of changes
5. Otherwise use the appropriate named method for clarity

Note: I have not yet tested this with all combinations, such as via gradle vs via uberJar, on Mac vs Linux vs Windows, etc. We should confirm this with as many combinations as we can think of.