### PR TITLE
BFD missing code map report

### DIFF
--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -476,7 +476,7 @@ public abstract class Exporter {
         exporter.exportNPIs();
         exporter.exportManifest();
         exporter.exportEndState();
-        exporter.displayMissingDmeCodes();
+        exporter.exportMissingCodes();
       } catch (IOException e) {
         e.printStackTrace();
       }

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -1675,18 +1675,20 @@ public class FhirR4 {
             new AllergyIntolerance.AllergyIntoleranceReactionComponent();
         reactionComponent.addManifestation(mapCodeToCodeableConcept(manifestation, SNOMED_URI));
         HealthRecord.ReactionSeverity severity = allergy.reactions.get(manifestation);
-        switch (severity) {
-          case MILD:
-            reactionComponent.setSeverity(AllergyIntolerance.AllergyIntoleranceSeverity.MILD);
-            break;
-          case MODERATE:
-            reactionComponent.setSeverity(AllergyIntolerance.AllergyIntoleranceSeverity.MODERATE);
-            break;
-          case SEVERE:
-            reactionComponent.setSeverity(AllergyIntolerance.AllergyIntoleranceSeverity.SEVERE);
-            break;
-          default:
-            // do nothing
+        if (severity != null) {
+          switch (severity) {
+            case MILD:
+              reactionComponent.setSeverity(AllergyIntolerance.AllergyIntoleranceSeverity.MILD);
+              break;
+            case MODERATE:
+              reactionComponent.setSeverity(AllergyIntolerance.AllergyIntoleranceSeverity.MODERATE);
+              break;
+            case SEVERE:
+              reactionComponent.setSeverity(AllergyIntolerance.AllergyIntoleranceSeverity.SEVERE);
+              break;
+            default:
+              // do nothing
+          }
         }
         allergyResource.addReaction(reactionComponent);
       });

--- a/src/main/java/org/mitre/synthea/export/rif/BB2RIFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/BB2RIFExporter.java
@@ -6,12 +6,14 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.MissingResourceException;
@@ -319,18 +321,24 @@ public class BB2RIFExporter {
    */
   public void exportMissingCodes() throws IOException {
     if (Config.getAsBoolean("exporter.bfd.export_missing_codes", true)) {
+      List<Map<String, String>> allMissingCodes = new LinkedList<>();
+      allMissingCodes.addAll(conditionCodeMapper.getMissingCodes());
+      allMissingCodes.addAll(medicationCodeMapper.getMissingCodes());
+      allMissingCodes.addAll(drgCodeMapper.getMissingCodes());
+      allMissingCodes.addAll(dmeCodeMapper.getMissingCodes());
+      allMissingCodes.addAll(hcpcsCodeMapper.getMissingCodes());
+      allMissingCodes.addAll(betosCodeMapper.getMissingCodes());
+      allMissingCodes.addAll(snfPPSMapper.getMissingCodes());
+      allMissingCodes.addAll(snfPDPMMapper.getMissingCodes());
+      allMissingCodes.addAll(snfRevCntrMapper.getMissingCodes());
+      allMissingCodes.addAll(hhaRevCntrMapper.getMissingCodes());
+      allMissingCodes.addAll(hospiceRevCntrMapper.getMissingCodes());
+
       File outputDir = Exporter.getOutputFolder("bfd", null);
-      conditionCodeMapper.exportMissingCodesToCSV(outputDir);
-      medicationCodeMapper.exportMissingCodesToCSV(outputDir);
-      drgCodeMapper.exportMissingCodesToCSV(outputDir);
-      dmeCodeMapper.exportMissingCodesToCSV(outputDir);
-      hcpcsCodeMapper.exportMissingCodesToCSV(outputDir);
-      betosCodeMapper.exportMissingCodesToCSV(outputDir);
-      snfPPSMapper.exportMissingCodesToCSV(outputDir);
-      snfPDPMMapper.exportMissingCodesToCSV(outputDir);
-      snfRevCntrMapper.exportMissingCodesToCSV(outputDir);
-      hhaRevCntrMapper.exportMissingCodesToCSV(outputDir);
-      hospiceRevCntrMapper.exportMissingCodesToCSV(outputDir);
+      if (!allMissingCodes.isEmpty()) {
+        Files.write(outputDir.toPath().resolve("missing_codes.csv"),
+                SimpleCSV.unparse(allMissingCodes).getBytes());
+      }
     }
   }
 

--- a/src/main/java/org/mitre/synthea/export/rif/BB2RIFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/BB2RIFExporter.java
@@ -80,7 +80,6 @@ public class BB2RIFExporter {
   final CodeMapper hhaRevCntrMapper;
   final CodeMapper hospiceRevCntrMapper;
   final Map<String, RandomCollection<String>> externalCodes;
-  final Map<String, String> missingDmeCodes;
   final CMSStateCodeMapper locationMapper;
   final BeneficiaryExporter beneExp;
   final InpatientExporter inpatientExp;
@@ -122,7 +121,6 @@ public class BB2RIFExporter {
       // and if these do throw ioexceptions there's nothing we can do anyway
       throw new RuntimeException(e);
     }
-    missingDmeCodes = new HashMap<String, String>();
     beneExp = new BeneficiaryExporter(this);
     inpatientExp = new InpatientExporter(this);
     outpatientExp = new OutpatientExporter(this);
@@ -316,14 +314,23 @@ public class BB2RIFExporter {
   }
 
   /**
-   * Display DME codes that were not mappable during export.
+   * Export codes that were not mappable during export.
    * These missing codes might be accidental, they may be intentional.
    */
-  public void displayMissingDmeCodes() {
-    String description;
-    for (String code : missingDmeCodes.keySet()) {
-      description = missingDmeCodes.get(code);
-      System.err.println(" *** Possibly Missing DME Code: " + code + " | " + description);
+  public void exportMissingCodes() throws IOException {
+    if (Config.getAsBoolean("exporter.bfd.export_missing_codes", true)) {
+      File outputDir = Exporter.getOutputFolder("bfd", null);
+      conditionCodeMapper.exportMissingCodesToCSV(outputDir);
+      medicationCodeMapper.exportMissingCodesToCSV(outputDir);
+      drgCodeMapper.exportMissingCodesToCSV(outputDir);
+      dmeCodeMapper.exportMissingCodesToCSV(outputDir);
+      hcpcsCodeMapper.exportMissingCodesToCSV(outputDir);
+      betosCodeMapper.exportMissingCodesToCSV(outputDir);
+      snfPPSMapper.exportMissingCodesToCSV(outputDir);
+      snfPDPMMapper.exportMissingCodesToCSV(outputDir);
+      snfRevCntrMapper.exportMissingCodesToCSV(outputDir);
+      hhaRevCntrMapper.exportMissingCodesToCSV(outputDir);
+      hospiceRevCntrMapper.exportMissingCodesToCSV(outputDir);
     }
   }
 

--- a/src/main/java/org/mitre/synthea/export/rif/CarrierExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/CarrierExporter.java
@@ -159,8 +159,8 @@ public class CarrierExporter extends RIFExporter {
       if (encounter.reason != null) {
         // If the encounter has a recorded reason, enter the mapped
         // values into the principle diagnoses code.
-        if (exporter.conditionCodeMapper.canMap(encounter.reason.code)) {
-          icdReasonCode = exporter.conditionCodeMapper.map(encounter.reason.code, person, true);
+        if (exporter.conditionCodeMapper.canMap(encounter.reason)) {
+          icdReasonCode = exporter.conditionCodeMapper.map(encounter.reason, person, true);
           fieldValues.put(BB2RIFStructure.CARRIER.PRNCPAL_DGNS_CD, icdReasonCode);
           fieldValues.put(BB2RIFStructure.CARRIER.LINE_ICD_DGNS_CD, icdReasonCode);
         }
@@ -195,8 +195,8 @@ public class CarrierExporter extends RIFExporter {
           String ndcCode = "";
           if (lineItem.entry instanceof HealthRecord.Procedure) {
             for (HealthRecord.Code code : lineItem.entry.codes) {
-              if (exporter.hcpcsCodeMapper.canMap(code.code)) {
-                hcpcsCode = exporter.hcpcsCodeMapper.map(code.code, person, true);
+              if (exporter.hcpcsCodeMapper.canMap(code)) {
+                hcpcsCode = exporter.hcpcsCodeMapper.map(code, person, true);
                 break; // take the first mappable code for each procedure
               }
             }
@@ -204,7 +204,7 @@ public class CarrierExporter extends RIFExporter {
             HealthRecord.Medication med = (HealthRecord.Medication) lineItem.entry;
             if (med.administration) {
               hcpcsCode = "T1502";  // Administration of medication
-              ndcCode = exporter.medicationCodeMapper.map(med.codes.get(0).code, person);
+              ndcCode = exporter.medicationCodeMapper.map(med.codes.get(0), person);
             }
           }
           if (icdReasonCode == null) {

--- a/src/main/java/org/mitre/synthea/export/rif/CodeMapper.java
+++ b/src/main/java/org/mitre/synthea/export/rif/CodeMapper.java
@@ -3,16 +3,26 @@ package org.mitre.synthea.export.rif;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+import org.apache.commons.io.FilenameUtils;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.RandomCollection;
 import org.mitre.synthea.helpers.RandomNumberGenerator;
+import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
+import org.mitre.synthea.world.concepts.HealthRecord.Code;
 
 /**
  * Utility class for dealing with code mapping configuration writers.
@@ -23,6 +33,8 @@ class CodeMapper {
   private static final String WEIGHT_KEY = "weight";
   private HashMap<String, RandomCollection<Map<String, String>>> map;
   private boolean mapImported = false;
+  private ConcurrentHashMap<Code, LongAdder> missingCodes;
+  private String mapperName;
 
   /**
    * Create a new CodeMapper for the supplied JSON string.
@@ -42,6 +54,8 @@ class CodeMapper {
    */
   public CodeMapper(String jsonMapResource) {
     requireCodeMaps = Config.getAsBoolean("exporter.bfd.require_code_maps", true);
+    missingCodes = new ConcurrentHashMap<>();
+    mapperName = FilenameUtils.getBaseName(jsonMapResource);
     try {
       // deserialize the JSON code map
       String jsonStr = Utilities.readResource(jsonMapResource);
@@ -81,17 +95,57 @@ class CodeMapper {
    * @return true if the Synthea code can be mapped to BFD, false if not
    */
   public boolean canMap(String codeToMap) {
-    if (map == null) {
-      return false;
-    }
-    return map.containsKey(codeToMap);
+    return canMap(codeToMap, true);
   }
 
   /**
-   * Determines whether this mapper was successfully configured with a code map.
+   * Determines whether this mapper has an entry for the supplied code.
+   * @param codeToMap the Synthea code to look for
+   * @return true if the Synthea code can be mapped to BFD, false if not
+   */
+  public boolean canMap(Code codeToMap) {
+    boolean mappable = canMap(codeToMap.code, false);
+    if (!mappable) {
+      missingCodes.compute(codeToMap, (k, v) -> {
+        if (v == null) {
+          v = new LongAdder();
+        }
+        v.increment();
+        return v;
+      });
+    }
+    return mappable;
+  }
+
+  /**
+   * Determines whether this mapper has an entry for the supplied code.
+   * @param codeToMap the Synthea code to look for
+   * @param logMissing whether to log missing codes or not
+   * @return true if the Synthea code can be mapped to BFD, false if not
+   */
+  private boolean canMap(String codeToMap, boolean logMissing) {
+    if (map == null) {
+      return false;
+    }
+    boolean mappable = map.containsKey(codeToMap);
+    if (!mappable && logMissing) {
+      missingCodes.compute(new Code(null, codeToMap, null), (k, v) -> {
+        if (v == null) {
+          v = new LongAdder();
+        }
+        v.increment();
+        return v;
+      });
+    }
+    return mappable;
+  }
+
+  /**
+   * Determines whether this mapper was successfully configured with a code map. Currently used
+   * in unit tests which may be run both with and without mapping files present.
    * @return true if configured, false otherwise.
    */
-  public boolean hasMap() {
+  boolean hasMap() {
     return mapImported;
   }
 
@@ -111,10 +165,33 @@ class CodeMapper {
    * {@code map(codeToMap, "code", rand)}.
    * @param codeToMap the Synthea code to look for
    * @param rand a source of random numbers used to pick one of the list of BFD codes
+   * @return the BFD code or null if the code can't be mapped
+   */
+  public String map(Code codeToMap, RandomNumberGenerator rand) {
+    return map(codeToMap, "code", rand);
+  }
+
+  /**
+   * Get one of the BFD codes for the supplied Synthea code. Equivalent to
+   * {@code map(codeToMap, "code", rand)}.
+   * @param codeToMap the Synthea code to look for
+   * @param rand a source of random numbers used to pick one of the list of BFD codes
    * @param stripDots whether to remove dots in codes (e.g. J39.45 -> J3945)
    * @return the BFD code or null if the code can't be mapped
    */
   public String map(String codeToMap, RandomNumberGenerator rand, boolean stripDots) {
+    return map(codeToMap, "code", rand, stripDots);
+  }
+
+  /**
+   * Get one of the BFD codes for the supplied Synthea code. Equivalent to
+   * {@code map(codeToMap, "code", rand)}.
+   * @param codeToMap the Synthea code to look for
+   * @param rand a source of random numbers used to pick one of the list of BFD codes
+   * @param stripDots whether to remove dots in codes (e.g. J39.45 -> J3945)
+   * @return the BFD code or null if the code can't be mapped
+   */
+  public String map(Code codeToMap, RandomNumberGenerator rand, boolean stripDots) {
     return map(codeToMap, "code", rand, stripDots);
   }
 
@@ -126,6 +203,17 @@ class CodeMapper {
    * @return the BFD code or null if the code can't be mapped
    */
   public String map(String codeToMap, String bfdCodeType, RandomNumberGenerator rand) {
+    return map(codeToMap, bfdCodeType, rand, false);
+  }
+
+  /**
+   * Get one of the BFD codes for the supplied Synthea code.
+   * @param codeToMap the Synthea code to look for
+   * @param bfdCodeType the type of BFD code to map to
+   * @param rand a source of random numbers used to pick one of the list of BFD codes
+   * @return the BFD code or null if the code can't be mapped
+   */
+  public String map(Code codeToMap, String bfdCodeType, RandomNumberGenerator rand) {
     return map(codeToMap, bfdCodeType, rand, false);
   }
 
@@ -148,6 +236,53 @@ class CodeMapper {
       return code.replaceAll("\\.", "");
     } else {
       return code;
+    }
+  }
+
+  /**
+   * Get one of the BFD codes for the supplied Synthea code.
+   * @param codeToMap the Synthea code to look for
+   * @param bfdCodeType the type of BFD code to map to
+   * @param rand a source of random numbers used to pick one of the list of BFD codes
+   * @param stripDots whether to remove dots in codes (e.g. J39.45 -> J3945)
+   * @return the BFD code or null if the code can't be mapped
+   */
+  public String map(Code codeToMap, String bfdCodeType, RandomNumberGenerator rand,
+          boolean stripDots) {
+    return map(codeToMap.code, bfdCodeType, rand, stripDots);
+  }
+
+  /**
+   * Get the missing code as a list of maps, where each map includes the code, a description, and
+   * the count of times it was requested. Only used by exportMissingCodesToCSV and unit tests.
+   * @return missing code list
+   */
+  List<? extends Map<String, String>> getMissingCodes() {
+    List<Map<String, String>> missingCodeList = new ArrayList<>(missingCodes.size());
+    missingCodes.forEach((code, count) -> {
+      Map<String, String> row = new LinkedHashMap<>();
+      row.put("code", code.code);
+      row.put("description", code.display);
+      row.put("count", count.toString());
+      missingCodeList.add(row);
+    });
+    // sort in decending order by count
+    Collections.sort(missingCodeList, (o1, o2) -> {
+      return (int)(Long.parseLong(o2.get("count")) - Long.parseLong(o1.get("count")));
+    });
+    return missingCodeList;
+  }
+
+  /**
+   * Export a CSV that includes a list of all codes that couldn't be mapped and a count of the
+   * number of time that code was requested.
+   * @param outputDir the directory to write the missing codes CSV to
+   * @throws IOException if something goes wrong
+   */
+  public void exportMissingCodesToCSV(File outputDir) throws IOException {
+    if (!missingCodes.isEmpty()) {
+      Files.write(outputDir.toPath().resolve(mapperName + "_missing_codes.csv"),
+              SimpleCSV.unparse(getMissingCodes()).getBytes());
     }
   }
 }

--- a/src/main/java/org/mitre/synthea/export/rif/DMEExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/DMEExporter.java
@@ -95,8 +95,8 @@ public class DMEExporter extends RIFExporter {
       if (encounter.reason != null) {
         // If the encounter has a recorded reason, enter the mapped
         // values into the principle diagnoses code.
-        if (exporter.conditionCodeMapper.canMap(encounter.reason.code)) {
-          String icdCode = exporter.conditionCodeMapper.map(encounter.reason.code, person, true);
+        if (exporter.conditionCodeMapper.canMap(encounter.reason)) {
+          String icdCode = exporter.conditionCodeMapper.map(encounter.reason, person, true);
           fieldValues.put(BB2RIFStructure.DME.PRNCPAL_DGNS_CD, icdCode);
           fieldValues.put(BB2RIFStructure.DME.LINE_ICD_DGNS_CD, icdCode);
         }
@@ -156,16 +156,14 @@ public class DMEExporter extends RIFExporter {
           } else {
             fieldValues.put(BB2RIFStructure.DME.DMERC_LINE_MTUS_CNT, "");
           }
-          if (!exporter.dmeCodeMapper.canMap(lineItem.entry.codes.get(0).code)) {
-            exporter.missingDmeCodes.put(lineItem.entry.codes.get(0).code,
-                 lineItem.entry.codes.get(0).display);
+          if (!exporter.dmeCodeMapper.canMap(lineItem.entry.codes.get(0))) {
             continue;
           }
           fieldValues.put(BB2RIFStructure.DME.CLM_FROM_DT,
                   RIFExporter.bb2DateFromTimestamp(lineItem.entry.start));
           fieldValues.put(BB2RIFStructure.DME.CLM_THRU_DT,
                   RIFExporter.bb2DateFromTimestamp(lineItem.entry.start));
-          String hcpcsCode = exporter.dmeCodeMapper.map(lineItem.entry.codes.get(0).code, person);
+          String hcpcsCode = exporter.dmeCodeMapper.map(lineItem.entry.codes.get(0), person);
           fieldValues.put(BB2RIFStructure.DME.HCPCS_CD, hcpcsCode);
           if (exporter.betosCodeMapper.canMap(hcpcsCode)) {
             fieldValues.put(BB2RIFStructure.DME.BETOS_CD,
@@ -174,7 +172,7 @@ public class DMEExporter extends RIFExporter {
             fieldValues.put(BB2RIFStructure.DME.BETOS_CD, "");
           }
           fieldValues.put(BB2RIFStructure.DME.LINE_CMS_TYPE_SRVC_CD,
-                  exporter.dmeCodeMapper.map(lineItem.entry.codes.get(0).code,
+                  exporter.dmeCodeMapper.map(lineItem.entry.codes.get(0),
                           BB2RIFStructure.DME.LINE_CMS_TYPE_SRVC_CD.toString().toLowerCase(),
                           person));
           fieldValues.put(BB2RIFStructure.DME.LINE_BENE_PTB_DDCTBL_AMT,

--- a/src/main/java/org/mitre/synthea/export/rif/HHAExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/HHAExporter.java
@@ -91,10 +91,10 @@ public class HHAExporter extends RIFExporter {
           String hcpcsCode = null;
           if (lineItem.entry instanceof HealthRecord.Procedure) {
             for (HealthRecord.Code code : lineItem.entry.codes) {
-              if (exporter.hcpcsCodeMapper.canMap(code.code)) {
-                hcpcsCode = exporter.hcpcsCodeMapper.map(code.code, person, true);
-                if (exporter.hhaRevCntrMapper.canMap(code.code)) {
-                  revCenter = exporter.hhaRevCntrMapper.map(code.code, person);
+              if (exporter.hcpcsCodeMapper.canMap(code)) {
+                hcpcsCode = exporter.hcpcsCodeMapper.map(code, person, true);
+                if (exporter.hhaRevCntrMapper.canMap(code)) {
+                  revCenter = exporter.hhaRevCntrMapper.map(code, person);
                 }
                 break; // take the first mappable code for each procedure
               }
@@ -141,8 +141,8 @@ public class HHAExporter extends RIFExporter {
       if (finalEncounterOfPeriod.reason != null) {
         // If the encounter has a recorded reason, enter the mapped
         // values into the principle diagnoses code.
-        if (exporter.conditionCodeMapper.canMap(finalEncounterOfPeriod.reason.code)) {
-          String icdCode = exporter.conditionCodeMapper.map(finalEncounterOfPeriod.reason.code,
+        if (exporter.conditionCodeMapper.canMap(finalEncounterOfPeriod.reason)) {
+          String icdCode = exporter.conditionCodeMapper.map(finalEncounterOfPeriod.reason,
                   person, true);
           fieldValues.put(BB2RIFStructure.HHA.PRNCPAL_DGNS_CD, icdCode);
         }

--- a/src/main/java/org/mitre/synthea/export/rif/HospiceExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/HospiceExporter.java
@@ -69,8 +69,8 @@ public class HospiceExporter extends RIFExporter {
         if (lineItem.entry instanceof HealthRecord.Procedure) {
           String hcpcsCode = null;
           for (HealthRecord.Code code : lineItem.entry.codes) {
-            if (exporter.hcpcsCodeMapper.canMap(code.code)) {
-              hcpcsCode = exporter.hcpcsCodeMapper.map(code.code, person, true);
+            if (exporter.hcpcsCodeMapper.canMap(code)) {
+              hcpcsCode = exporter.hcpcsCodeMapper.map(code, person, true);
               if (exporter.hospiceRevCntrMapper.canMap(hcpcsCode)) {
                 revCenter = exporter.hospiceRevCntrMapper.map(hcpcsCode, person, true);
               }
@@ -234,8 +234,8 @@ public class HospiceExporter extends RIFExporter {
     if (encounter.reason != null) {
       // If the encounter has a recorded reason, enter the mapped
       // values into the principle diagnoses code.
-      if (exporter.conditionCodeMapper.canMap(encounter.reason.code)) {
-        String icdCode = exporter.conditionCodeMapper.map(encounter.reason.code, person, true);
+      if (exporter.conditionCodeMapper.canMap(encounter.reason)) {
+        String icdCode = exporter.conditionCodeMapper.map(encounter.reason, person, true);
         fieldValues.put(BB2RIFStructure.HOSPICE.PRNCPAL_DGNS_CD, icdCode);
       }
     }

--- a/src/main/java/org/mitre/synthea/export/rif/InpatientExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/InpatientExporter.java
@@ -149,8 +149,8 @@ public class InpatientExporter extends RIFExporter {
       if (encounter.reason != null) {
         // If the encounter has a recorded reason, enter the mapped
         // values into the principle diagnoses code.
-        if (exporter.conditionCodeMapper.canMap(encounter.reason.code)) {
-          icdReasonCode = exporter.conditionCodeMapper.map(encounter.reason.code, person, true);
+        if (exporter.conditionCodeMapper.canMap(encounter.reason)) {
+          icdReasonCode = exporter.conditionCodeMapper.map(encounter.reason, person, true);
           fieldValues.put(BB2RIFStructure.INPATIENT.PRNCPAL_DGNS_CD, icdReasonCode);
           fieldValues.put(BB2RIFStructure.INPATIENT.ADMTG_DGNS_CD, icdReasonCode);
         }
@@ -200,9 +200,9 @@ public class InpatientExporter extends RIFExporter {
         List<String> mappedProcedureCodes = new ArrayList<>();
         for (HealthRecord.Procedure procedure : encounter.procedures) {
           for (HealthRecord.Code code : procedure.codes) {
-            if (exporter.conditionCodeMapper.canMap(code.code)) {
+            if (exporter.conditionCodeMapper.canMap(code)) {
               mappableProcedures.add(procedure);
-              mappedProcedureCodes.add(exporter.conditionCodeMapper.map(code.code, person, true));
+              mappedProcedureCodes.add(exporter.conditionCodeMapper.map(code, person, true));
               break; // take the first mappable code for each procedure
             }
           }
@@ -233,8 +233,8 @@ public class InpatientExporter extends RIFExporter {
           String hcpcsCode = null;
           if (lineItem.entry instanceof HealthRecord.Procedure) {
             for (HealthRecord.Code code : lineItem.entry.codes) {
-              if (exporter.hcpcsCodeMapper.canMap(code.code)) {
-                hcpcsCode = exporter.hcpcsCodeMapper.map(code.code, person, true);
+              if (exporter.hcpcsCodeMapper.canMap(code)) {
+                hcpcsCode = exporter.hcpcsCodeMapper.map(code, person, true);
                 break; // take the first mappable code for each procedure
               }
             }

--- a/src/main/java/org/mitre/synthea/export/rif/OutpatientExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/OutpatientExporter.java
@@ -117,8 +117,8 @@ public class OutpatientExporter extends RIFExporter {
       if (encounter.reason != null) {
         // If the encounter has a recorded reason, enter the mapped
         // values into the principle diagnoses code.
-        if (exporter.conditionCodeMapper.canMap(encounter.reason.code)) {
-          icdReasonCode = exporter.conditionCodeMapper.map(encounter.reason.code, person, true);
+        if (exporter.conditionCodeMapper.canMap(encounter.reason)) {
+          icdReasonCode = exporter.conditionCodeMapper.map(encounter.reason, person, true);
           fieldValues.put(BB2RIFStructure.OUTPATIENT.PRNCPAL_DGNS_CD, icdReasonCode);
         }
       }
@@ -157,9 +157,9 @@ public class OutpatientExporter extends RIFExporter {
         List<String> mappedProcedureCodes = new ArrayList<>();
         for (HealthRecord.Procedure procedure : encounter.procedures) {
           for (HealthRecord.Code code : procedure.codes) {
-            if (exporter.conditionCodeMapper.canMap(code.code)) {
+            if (exporter.conditionCodeMapper.canMap(code)) {
               mappableProcedures.add(procedure);
-              mappedProcedureCodes.add(exporter.conditionCodeMapper.map(code.code, person, true));
+              mappedProcedureCodes.add(exporter.conditionCodeMapper.map(code, person, true));
               break; // take the first mappable code for each procedure
             }
           }
@@ -193,8 +193,8 @@ public class OutpatientExporter extends RIFExporter {
           String hcpcsCode = null;
           if (lineItem.entry instanceof HealthRecord.Procedure) {
             for (HealthRecord.Code code : lineItem.entry.codes) {
-              if (exporter.hcpcsCodeMapper.canMap(code.code)) {
-                hcpcsCode = exporter.hcpcsCodeMapper.map(code.code, person, true);
+              if (exporter.hcpcsCodeMapper.canMap(code)) {
+                hcpcsCode = exporter.hcpcsCodeMapper.map(code, person, true);
                 break; // take the first mappable code for each procedure
               }
             }
@@ -208,7 +208,7 @@ public class OutpatientExporter extends RIFExporter {
               hcpcsCode = "T1502";  // Administration of medication
               // Drugs requiring specific id
               fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR, "0636");
-              String ndcCode = exporter.medicationCodeMapper.map(med.codes.get(0).code, person);
+              String ndcCode = exporter.medicationCodeMapper.map(med.codes.get(0), person);
               fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_IDE_NDC_UPC_NUM, ndcCode);
               fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_NDC_QTY, "1"); // 1 Unit
               fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_NDC_QTY_QLFR_CD, "UN"); // Unit

--- a/src/main/java/org/mitre/synthea/export/rif/PDEExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/PDEExporter.java
@@ -75,13 +75,13 @@ public class PDEExporter extends RIFExporter {
       }
 
       for (HealthRecord.Medication medication : encounter.medications) {
-        if (!exporter.medicationCodeMapper.canMap(medication.codes.get(0).code)) {
+        if (!exporter.medicationCodeMapper.canMap(medication.codes.get(0))) {
           continue; // skip codes that can't be mapped to NDC
         }
         long supplyDaysMax = 90; // TBD - 30, 60, 90 day refil schedules?
         long supplyInterval = supplyDaysMax * 24 * 60 * 60 * 1000;
         long finishTime = medication.stop == 0L ? stopTime : Long.min(medication.stop, stopTime);
-        String medicationCode = exporter.medicationCodeMapper.map(medication.codes.get(0).code,
+        String medicationCode = exporter.medicationCodeMapper.map(medication.codes.get(0),
                 person);
         long time = medication.start;
         int fillNo = 1;

--- a/src/main/java/org/mitre/synthea/export/rif/RIFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/RIFExporter.java
@@ -173,8 +173,8 @@ public abstract class RIFExporter {
       if (encounter.start <= time) {
         for (HealthRecord.Entry dx : encounter.conditions) {
           if (dx.start <= time && (dx.stop == 0L || dx.stop > time)) {
-            if (exporter.conditionCodeMapper.canMap(dx.codes.get(0).code)) {
-              String mapped = exporter.conditionCodeMapper.map(dx.codes.get(0).code, person, true);
+            if (exporter.conditionCodeMapper.canMap(dx.codes.get(0))) {
+              String mapped = exporter.conditionCodeMapper.map(dx.codes.get(0), person, true);
               // Temporarily add the mapped code... we'll remove it later.
               HealthRecord.Code mappedCode = new HealthRecord.Code("ICD10", mapped,
                       dx.codes.get(0).display);

--- a/src/main/java/org/mitre/synthea/export/rif/SNFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/SNFExporter.java
@@ -238,8 +238,8 @@ public class SNFExporter extends RIFExporter {
     if (encounter.reason != null) {
       // If the encounter has a recorded reason, enter the mapped
       // values into the principle diagnoses code.
-      if (exporter.conditionCodeMapper.canMap(encounter.reason.code)) {
-        String icdCode = exporter.conditionCodeMapper.map(encounter.reason.code, person, true);
+      if (exporter.conditionCodeMapper.canMap(encounter.reason)) {
+        String icdCode = exporter.conditionCodeMapper.map(encounter.reason, person, true);
         fieldValues.put(BB2RIFStructure.SNF.PRNCPAL_DGNS_CD, icdCode);
         fieldValues.put(BB2RIFStructure.SNF.ADMTG_DGNS_CD, icdCode);
         if (exporter.drgCodeMapper.canMap(icdCode)) {
@@ -305,9 +305,9 @@ public class SNFExporter extends RIFExporter {
       List<String> mappedProcedureCodes = new ArrayList<>();
       for (HealthRecord.Procedure procedure : encounter.procedures) {
         for (HealthRecord.Code code : procedure.codes) {
-          if (exporter.conditionCodeMapper.canMap(code.code)) {
+          if (exporter.conditionCodeMapper.canMap(code)) {
             mappableProcedures.add(procedure);
-            mappedProcedureCodes.add(exporter.conditionCodeMapper.map(code.code, person, true));
+            mappedProcedureCodes.add(exporter.conditionCodeMapper.map(code, person, true));
             break; // take the first mappable code for each procedure
           }
         }
@@ -344,12 +344,12 @@ public class SNFExporter extends RIFExporter {
         String snfCode = null;
         String revCntr = null;
         for (HealthRecord.Code code : lineItem.entry.codes) {
-          if (exporter.snfRevCntrMapper.canMap(code.code)) {
-            revCntr = exporter.snfRevCntrMapper.map(code.code, person, true);
+          if (exporter.snfRevCntrMapper.canMap(code)) {
+            revCntr = exporter.snfRevCntrMapper.map(code, person, true);
           }
-          if (codeMapper.canMap(code.code)) {
+          if (codeMapper.canMap(code)) {
             if (person.rand() < 0.15) { // Only 15% of SNF claim have a HCPCS code
-              snfCode = codeMapper.map(code.code, person, true);
+              snfCode = codeMapper.map(code, person, true);
               consolidatedClaimLines.addClaimLine(snfCode, revCntr, lineItem, encounter);
             }
             break; // take the first mappable code for each procedure

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -46,6 +47,36 @@ public class HealthRecord implements Serializable {
    * HealthRecord.Code represents a system, code, and display value.
    */
   public static class Code implements Comparable<Code>, Serializable {
+
+    @Override
+    public int hashCode() {
+      int hash = 7;
+      hash = 67 * hash + Objects.hashCode(this.system);
+      hash = 67 * hash + Objects.hashCode(this.code);
+      return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null) {
+        return false;
+      }
+      if (getClass() != obj.getClass()) {
+        return false;
+      }
+      final Code other = (Code) obj;
+      if (!Objects.equals(this.code, other.code)) {
+        return false;
+      }
+      if (!Objects.equals(this.system, other.system)) {
+        return false;
+      }
+      return true;
+    }
+
     /** Code System (e.g. LOINC, RxNorm, SNOMED) identifier (typically a URI) */
     public String system;
     /** The code itself. */
@@ -81,10 +112,6 @@ public class HealthRecord implements Serializable {
       this.system = definition.get("system").getAsString();
       this.code = definition.get("code").getAsString();
       this.display = definition.get("display").getAsString();
-    }
-
-    public boolean equals(Code other) {
-      return this.system.equals(other.system) && this.code.equals(other.code);
     }
 
     public String toString() {

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -55,6 +55,7 @@ exporter.cpcds.single_payer = false
 
 exporter.bfd.export = false
 exporter.bfd.require_code_maps = true
+exporter.bfd.export_missing_codes = true
 exporter.bfd.bene_id_start = -1000000
 exporter.bfd.clm_id_start = -100000000
 exporter.bfd.clm_grp_id_start = -100000000
@@ -241,7 +242,7 @@ generate.payers.insurance_companies.medicaid = Medicaid
 generate.payers.insurance_companies.dual_eligible = Dual Eligible
 # The percentage of a person's income that they are willing to spend on health insurance premiums.
 generate.payers.insurance_plans.income_premium_ratio = 0.13
-# The chance of rejection 
+# The chance of rejection
 # Plan selection behavior
 # How patients select a plan:
 #  best_rates - select plans with best rates for person's existing conditions and medical needs

--- a/src/test/java/org/mitre/synthea/export/rif/BB2RIFExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/rif/BB2RIFExporterTest.java
@@ -31,6 +31,7 @@ import org.mitre.synthea.helpers.DefaultRandomNumberGenerator;
 import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.world.concepts.Claim;
+import org.mitre.synthea.world.concepts.HealthRecord.Code;
 
 public class BB2RIFExporterTest {
 
@@ -39,10 +40,12 @@ public class BB2RIFExporterTest {
       super("MOCK_MAPPING_FILE_THAT_DOES_NOT_EXIST.JSON");
     }
 
-    public boolean canMap(String codeToMap) {
+    @Override
+    public boolean canMap(Code codeToMap) {
       return true;
     }
 
+    @Override
     public boolean hasMap() {
       return true;
     }
@@ -55,7 +58,8 @@ public class BB2RIFExporterTest {
      * @param stripDots whether to remove dots in codes (e.g. J39.45 -> J3945)
      * @return the BFD code or null if the code can't be mapped
      */
-    public String map(String codeToMap, String bfdCodeType, RandomNumberGenerator rand,
+    @Override
+    public String map(Code codeToMap, String bfdCodeType, RandomNumberGenerator rand,
         boolean stripDots) {
       if (bfdCodeType.equalsIgnoreCase("code")) {
         return "XXXX";


### PR DESCRIPTION
Track Synthea codes that can't be mapped to a suitable BFD code and export a CSV report with: map file, code, code description, and number of times the code was requested.