### PR TITLE
Reproducibility fixes

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -66,7 +67,7 @@ public class Module implements Cloneable, Serializable {
   private static final Map<String, ModuleSupplier> modules = loadModules();
 
   private static Map<String, ModuleSupplier> loadModules() {
-    Map<String, ModuleSupplier> retVal = new ConcurrentHashMap<>();
+    Map<String, ModuleSupplier> retVal = new TreeMap<>();
     int submoduleCount = 0;
 
     retVal.put("Lifecycle", new ModuleSupplier(new LifecycleModule()));

--- a/src/main/java/org/mitre/synthea/export/ExportHelper.java
+++ b/src/main/java/org/mitre/synthea/export/ExportHelper.java
@@ -11,12 +11,14 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.UUID;
 
 import org.hl7.fhir.dstu3.model.Condition;
 import org.mitre.synthea.engine.Components.Attachment;
 import org.mitre.synthea.engine.Components.SampledData;
 import org.mitre.synthea.helpers.TimeSeriesData;
 import org.mitre.synthea.world.agents.Clinician;
+import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.HealthRecord;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 import org.mitre.synthea.world.concepts.HealthRecord.Observation;
@@ -286,6 +288,47 @@ public abstract class ExportHelper {
       return String.format("%s?identifier=%s|%s", "Practitioner",
               "http://hl7.org/fhir/sid/us-npi", clinician.npi);
     }
+  }
+
+  /**
+   * Construct a consistent UUID based on the given Person, timestamp, and a key.
+   * This method allows you to get the same UUID for a concept at a given point in time,
+   * when that concept does not map cleanly 1:1 to an object in the Synthea model.
+   * IMPORTANT: this is NOT random but attempts to minimize the likelihood of collisions.
+   */
+  public static final String buildUUID(Person person, long timestamp, String key) {
+    return buildUUID(person.getSeed(), timestamp, key);
+  }
+
+  /**
+   * Construct a consistent UUID based on the given seed, timestamp, and a key.
+   * This method allows you to get the same UUID for a concept at a given point in time,
+   * when that concept does not map cleanly 1:1 to an object in the Synthea model.
+   * IMPORTANT: this is NOT random but attempts to minimize the likelihood of collisions.
+   */
+  public static final String buildUUID(long personSeed, long timestamp, String key) {
+    long mostSigBits = personSeed;
+    long leastSigBits = timestamp;
+
+    // the UUID is just the hex encoding of a 128bit number (represented in java as 2 64bit longs)
+    // so the person seed and timestamp are enough to get us "something", but we can mix it up
+    // to enable variety using the key. to make it numeric just get the hashCode
+    int keyHash = key.hashCode();
+
+    // first add the key to each long
+    mostSigBits = mostSigBits + keyHash;
+    leastSigBits = leastSigBits + keyHash;
+
+    // because the hashCode is an int, it didn't add anything in the upper bits of the long
+    // reverse the hashCode to get the upper bits
+    mostSigBits = mostSigBits + Long.reverse(keyHash);
+    leastSigBits = leastSigBits + Long.reverse(keyHash);
+
+    // finally rotate the bits just to get a little more variance in the characters
+    mostSigBits = Long.rotateLeft(mostSigBits, keyHash);
+    leastSigBits = Long.rotateLeft(leastSigBits, keyHash);
+
+    return new UUID(mostSigBits, leastSigBits).toString();
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterR4.java
@@ -52,7 +52,7 @@ public abstract class FhirPractitionerExporterR4 {
             ArrayList<Clinician> docs = clinicians.get(specialty);
             for (Clinician doc : docs) {
               if (doc.getEncounterCount() > 0) {
-                BundleEntryComponent entry = FhirR4.practitioner(rand, bundle, doc);
+                BundleEntryComponent entry = FhirR4.practitioner(bundle, doc);
                 Practitioner practitioner = (Practitioner) entry.getResource();
                 practitioner.addExtension()
                   .setUrl(EXTENSION_URI)

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -2667,11 +2667,6 @@ public class FhirR4 {
       BundleEntryComponent personEntry, long carePlanStart,
       CodeableConcept goalStatus, JsonObject goal) {
 
-    // note: this ID logic assumes the person will not have 2 careplans
-    // that start at the same timestep with the same code
-    String resourceID = ExportHelper.buildUUID(person, carePlanStart,
-        "CareGoal for CarePlan " + goalStatus.getCodingFirstRep().getCode());
-
     Goal goalResource = new Goal();
     if (USE_US_CORE_IG) {
       Meta meta = new Meta();
@@ -2681,7 +2676,6 @@ public class FhirR4 {
     }
     goalResource.setLifecycleStatus(GoalLifecycleStatus.ACCEPTED);
     goalResource.setAchievementStatus(goalStatus);
-    goalResource.setId(resourceID);
     goalResource.setSubject(new Reference(personEntry.getFullUrl()));
 
     if (goal.has("text")) {
@@ -2739,6 +2733,11 @@ public class FhirR4 {
         }
       }
     }
+
+    // note: this ID logic assumes the person will not have 2 careplans
+    // that start at the same timestep with the same description
+    String resourceID = ExportHelper.buildUUID(person, carePlanStart,
+        "CareGoal for " + goalResource.getDescription());
 
     return newEntry(bundle, goalResource, resourceID);
   }

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -2452,7 +2452,7 @@ public class FhirR4 {
    * Add a clinical note to the Bundle, which adds both a DocumentReference and a
    * DiagnosticReport.
    *
-   * @param Person         The Person
+   * @param person         The Person
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the Report to
    * @param encounterEntry Current Encounter entry

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.hl7.fhir.r4.model.Address;
@@ -137,7 +138,6 @@ import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 import org.mitre.synthea.engine.Components;
 import org.mitre.synthea.engine.Components.Attachment;
 import org.mitre.synthea.helpers.Config;
-import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.identity.Entity;
@@ -330,13 +330,13 @@ public class FhirR4 {
 
       if (shouldExport(Condition.class)) {
         for (HealthRecord.Entry condition : encounter.conditions) {
-          condition(person, personEntry, bundle, encounterEntry, condition);
+          condition(personEntry, bundle, encounterEntry, condition);
         }
       }
 
       if (shouldExport(AllergyIntolerance.class)) {
         for (HealthRecord.Allergy allergy : encounter.allergies) {
-          allergy(person, personEntry, bundle, encounterEntry, allergy);
+          allergy(personEntry, bundle, encounterEntry, allergy);
         }
       }
 
@@ -348,28 +348,28 @@ public class FhirR4 {
         // Observation resources in v4 don't support Attachments
         if (observation.value instanceof Attachment) {
           if (shouldExportMedia) {
-            media(person, personEntry, bundle, encounterEntry, observation);
+            media(personEntry, bundle, encounterEntry, observation);
           }
         } else if (shouldExportObservation) {
-          observation(person, personEntry, bundle, encounterEntry, observation);
+          observation(personEntry, bundle, encounterEntry, observation);
         }
       }
 
       if (shouldExport(org.hl7.fhir.r4.model.Procedure.class)) {
         for (Procedure procedure : encounter.procedures) {
-          procedure(person, personEntry, bundle, encounterEntry, procedure);
+          procedure(personEntry, bundle, encounterEntry, procedure);
         }
       }
 
       if (shouldExport(Device.class)) {
         for (HealthRecord.Device device : encounter.devices) {
-          device(person, personEntry, bundle, device);
+          device(personEntry, bundle, device);
         }
       }
 
       if (shouldExport(SupplyDelivery.class)) {
         for (HealthRecord.Supply supply : encounter.supplies) {
-          supplyDelivery(person, personEntry, bundle, supply, encounter);
+          supplyDelivery(personEntry, bundle, supply, encounter);
         }
       }
 
@@ -381,13 +381,13 @@ public class FhirR4 {
 
       if (shouldExport(Immunization.class)) {
         for (HealthRecord.Entry immunization : encounter.immunizations) {
-          immunization(person, personEntry, bundle, encounterEntry, immunization);
+          immunization(personEntry, bundle, encounterEntry, immunization);
         }
       }
 
       if (shouldExport(DiagnosticReport.class)) {
         for (Report report : encounter.reports) {
-          report(person, personEntry, bundle, encounterEntry, report);
+          report(personEntry, bundle, encounterEntry, report);
         }
       }
 
@@ -406,7 +406,7 @@ public class FhirR4 {
 
       if (shouldExport(org.hl7.fhir.r4.model.ImagingStudy.class)) {
         for (ImagingStudy imagingStudy : encounter.imagingStudies) {
-          imagingStudy(person, personEntry, bundle, encounterEntry, imagingStudy);
+          imagingStudy(personEntry, bundle, encounterEntry, imagingStudy);
         }
       }
 
@@ -855,7 +855,7 @@ public class FhirR4 {
       if (providerFullUrl != null) {
         encounterResource.setServiceProvider(new Reference(providerFullUrl));
       } else {
-        BundleEntryComponent providerOrganization = provider(person, bundle, provider);
+        BundleEntryComponent providerOrganization = provider(bundle, provider);
         encounterResource.setServiceProvider(new Reference(providerOrganization.getFullUrl()));
       }
     }
@@ -896,7 +896,7 @@ public class FhirR4 {
         if (practitionerFullUrl != null) {
           encounterResource.addParticipant().setIndividual(new Reference(practitionerFullUrl));
         } else {
-          BundleEntryComponent practitioner = practitioner(person, bundle, encounter.clinician);
+          BundleEntryComponent practitioner = practitioner(bundle, encounter.clinician);
           encounterResource.addParticipant().setIndividual(
                   new Reference(practitioner.getFullUrl()));
         }
@@ -918,7 +918,7 @@ public class FhirR4 {
       encounterResource.setHospitalization(hospitalization);
     }
 
-    BundleEntryComponent entry = newEntry(person, bundle, encounterResource);
+    BundleEntryComponent entry = newEntry(bundle, encounterResource, encounter.uuid.toString());
     if (USE_US_CORE_IG) {
       // US Core Encounters should have an identifier to support the required
       // Encounter.identifier search parameter
@@ -1085,7 +1085,8 @@ public class FhirR4 {
     moneyResource.setCurrency("USD");
     claimResource.setTotal(moneyResource);
 
-    BundleEntryComponent medicationClaimEntry = newEntry(person, bundle, claimResource);
+    BundleEntryComponent medicationClaimEntry =
+        newEntry(bundle, claimResource, claim.uuid.toString());
 
     explanationOfBenefit(personEntry, bundle, encounterEntry, person,
         medicationClaimEntry, encounter, claim);
@@ -1221,7 +1222,7 @@ public class FhirR4 {
     moneyResource.setValue(encounter.claim.getTotalClaimCost());
     claimResource.setTotal(moneyResource);
 
-    return newEntry(person, bundle, claimResource);
+    return newEntry(bundle, claimResource, encounter.claim.uuid.toString());
   }
 
   /**
@@ -1536,20 +1537,21 @@ public class FhirR4 {
     eob.setPayment(new ExplanationOfBenefit.PaymentComponent()
         .setAmount(payment));
 
-    return newEntry(person, bundle,eob);
+    String uuid = ExportHelper.buildUUID(person, claim.mainEntry.entry.start,
+        "ExplanationOfBenefit for Claim" + claim.uuid);
+    return newEntry(bundle, eob, uuid);
   }
 
   /**
    * Map the Condition into a FHIR Condition resource, and add it to the given Bundle.
    *
-   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         The Bundle to add to
    * @param encounterEntry The current Encounter entry
    * @param condition      The Condition
    * @return The added Entry
    */
-  private static BundleEntryComponent condition(RandomNumberGenerator rand,
+  private static BundleEntryComponent condition(
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           HealthRecord.Entry condition) {
     Condition conditionResource = new Condition();
@@ -1595,24 +1597,22 @@ public class FhirR4 {
       status.getCodingFirstRep().setCode("resolved");
     }
 
-    BundleEntryComponent conditionEntry = newEntry(rand, bundle, conditionResource);
-
+    BundleEntryComponent conditionEntry =
+        newEntry(bundle, conditionResource, condition.uuid.toString());
     condition.fullUrl = conditionEntry.getFullUrl();
-
     return conditionEntry;
   }
 
   /**
    * Map the Condition into a FHIR AllergyIntolerance resource, and add it to the given Bundle.
    *
-   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         The Bundle to add to
    * @param encounterEntry The current Encounter entry
    * @param allergy        The Allergy Entry
    * @return The added Entry
    */
-  private static BundleEntryComponent allergy(RandomNumberGenerator rand,
+  private static BundleEntryComponent allergy(
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           HealthRecord.Allergy allergy) {
 
@@ -1700,7 +1700,7 @@ public class FhirR4 {
           "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance");
       allergyResource.setMeta(meta);
     }
-    BundleEntryComponent allergyEntry = newEntry(rand, bundle, allergyResource);
+    BundleEntryComponent allergyEntry = newEntry(bundle, allergyResource, allergy.uuid.toString());
     allergy.fullUrl = allergyEntry.getFullUrl();
     return allergyEntry;
   }
@@ -1709,14 +1709,13 @@ public class FhirR4 {
   /**
    * Map the given Observation into a FHIR Observation resource, and add it to the given Bundle.
    *
-   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Person Entry
    * @param bundle         The Bundle to add to
    * @param encounterEntry The current Encounter entry
    * @param observation    The Observation
    * @return The added Entry
    */
-  private static BundleEntryComponent observation(RandomNumberGenerator rand,
+  private static BundleEntryComponent observation(
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           Observation observation) {
     org.hl7.fhir.r4.model.Observation observationResource =
@@ -1791,7 +1790,7 @@ public class FhirR4 {
       observationResource.setMeta(meta);
     }
 
-    BundleEntryComponent entry = newEntry(rand, bundle, observationResource);
+    BundleEntryComponent entry = newEntry(bundle, observationResource, observation.uuid.toString());
     observation.fullUrl = entry.getFullUrl();
     return entry;
   }
@@ -1863,14 +1862,13 @@ public class FhirR4 {
   /**
    * Map the given Procedure into a FHIR Procedure resource, and add it to the given Bundle.
    *
-   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Person entry
    * @param bundle         Bundle to add to
    * @param encounterEntry The current Encounter entry
    * @param procedure      The Procedure
    * @return The added Entry
    */
-  private static BundleEntryComponent procedure(RandomNumberGenerator rand,
+  private static BundleEntryComponent procedure(
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           Procedure procedure) {
     org.hl7.fhir.r4.model.Procedure procedureResource = new org.hl7.fhir.r4.model.Procedure();
@@ -1931,22 +1929,21 @@ public class FhirR4 {
       procedureResource.addExtension(performedContext);
     }
 
-    BundleEntryComponent procedureEntry = newEntry(rand, bundle, procedureResource);
+    BundleEntryComponent procedureEntry =
+        newEntry(bundle, procedureResource, procedure.uuid.toString());
     procedure.fullUrl = procedureEntry.getFullUrl();
-
     return procedureEntry;
   }
 
   /**
    * Map the HealthRecord.Device into a FHIR Device and add it to the Bundle.
    *
-   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Person entry.
    * @param bundle         Bundle to add to.
    * @param device         The device to add.
    * @return The added Entry.
    */
-  private static BundleEntryComponent device(RandomNumberGenerator rand,
+  private static BundleEntryComponent device(
           BundleEntryComponent personEntry, Bundle bundle, HealthRecord.Device device) {
     Device deviceResource = new Device();
     if (USE_US_CORE_IG) {
@@ -1974,20 +1971,19 @@ public class FhirR4 {
         .setType(DeviceNameType.USERFRIENDLYNAME);
     deviceResource.setType(mapCodeToCodeableConcept(device.codes.get(0), SNOMED_URI));
     deviceResource.setPatient(new Reference(personEntry.getFullUrl()));
-    return newEntry(rand, bundle, deviceResource);
+    return newEntry(bundle, deviceResource, device.uuid.toString());
   }
 
   /**
    * Map the JsonObject for a Supply into a FHIR SupplyDelivery and add it to the Bundle.
    *
-   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Person entry.
    * @param bundle         Bundle to add to.
    * @param supply         The supplied object to add.
    * @param encounter      The encounter during which the supplies were delivered
    * @return The added Entry.
    */
-  private static BundleEntryComponent supplyDelivery(RandomNumberGenerator rand,
+  private static BundleEntryComponent supplyDelivery(
           BundleEntryComponent personEntry, Bundle bundle, HealthRecord.Supply supply,
           Encounter encounter) {
 
@@ -2010,7 +2006,7 @@ public class FhirR4 {
 
     supplyResource.setOccurrence(convertFhirDateTime(supply.start, true));
 
-    return newEntry(rand, bundle, supplyResource);
+    return newEntry(bundle, supplyResource, supply.uuid.toString());
   }
 
   /**
@@ -2081,10 +2077,15 @@ public class FhirR4 {
     agent.setOnBehalfOf(new Reference()
         .setReference(organizationFullUrl)
         .setDisplay(providerOrganization.name));
-    return newEntry(person, bundle, provenance);
+
+    // NOTE: this assumes only one Provenance per bundle.
+    // If that assumption is ever not true, change the timestamp used and/or key here
+    String uuid = ExportHelper.buildUUID(person, (long) person.attributes.get(Person.BIRTHDATE),
+        "Provenance");
+    return newEntry(bundle, provenance, uuid);
   }
 
-  private static BundleEntryComponent immunization(RandomNumberGenerator rand,
+  private static BundleEntryComponent immunization(
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           HealthRecord.Entry immunization) {
     Immunization immResource = new Immunization();
@@ -2114,7 +2115,8 @@ public class FhirR4 {
       immResource.setLocation(encounterResource.getLocationFirstRep().getLocation());
     }
 
-    BundleEntryComponent immunizationEntry = newEntry(rand, bundle, immResource);
+    BundleEntryComponent immunizationEntry =
+        newEntry(bundle, immResource, immunization.uuid.toString());
     immunization.fullUrl = immunizationEntry.getFullUrl();
 
     return immunizationEntry;
@@ -2186,7 +2188,9 @@ public class FhirR4 {
       drugResource.setMeta(meta);
       drugResource.setCode(medicationCodeableConcept);
       drugResource.setStatus(MedicationStatus.ACTIVE);
-      BundleEntryComponent drugEntry = newEntry(person, bundle, drugResource);
+      String drugUUID = ExportHelper.buildUUID(person, medication.start,
+          "Medication Resource for " + medication.uuid);
+      BundleEntryComponent drugEntry = newEntry(bundle, drugResource, drugUUID);
       medicationResource.setMedication(new Reference(drugEntry.getFullUrl()));
 
       // Set the MedicationRequest.category
@@ -2293,7 +2297,8 @@ public class FhirR4 {
 
     }
 
-    BundleEntryComponent medicationEntry = newEntry(person, bundle, medicationResource);
+    BundleEntryComponent medicationEntry =
+        newEntry(bundle, medicationResource, medication.uuid.toString());
 
     if (shouldExport(org.hl7.fhir.r4.model.Claim.class)) {
       // create new claim for medication
@@ -2313,7 +2318,7 @@ public class FhirR4 {
   /**
    * Add a MedicationAdministration if needed for the given medication.
    *
-   * @param rand              Source of randomness to use when generating ids etc
+   * @param person            The Person
    * @param personEntry       The Entry for the Person
    * @param bundle            Bundle to add the MedicationAdministration to
    * @param encounterEntry    Current Encounter entry
@@ -2322,7 +2327,7 @@ public class FhirR4 {
    * @return The added Entry
    */
   private static BundleEntryComponent medicationAdministration(
-      RandomNumberGenerator rand, BundleEntryComponent personEntry, Bundle bundle,
+      Person person, BundleEntryComponent personEntry, Bundle bundle,
           BundleEntryComponent encounterEntry, Medication medication,
           MedicationRequest medicationRequest) {
 
@@ -2382,7 +2387,10 @@ public class FhirR4 {
       }
     }
 
-    BundleEntryComponent medicationAdminEntry = newEntry(rand, bundle, medicationResource);
+    String medicationAdminUUID = ExportHelper.buildUUID(person, medication.start,
+        "MedicationAdministration for " + medication.uuid);
+    BundleEntryComponent medicationAdminEntry =
+        newEntry(bundle, medicationResource, medicationAdminUUID);
     return medicationAdminEntry;
   }
 
@@ -2394,14 +2402,13 @@ public class FhirR4 {
   /**
    * Map the given Report to a FHIR DiagnosticReport resource, and add it to the given Bundle.
    *
-   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the Report to
    * @param encounterEntry Current Encounter entry
    * @param report         The Report
    * @return The added Entry
    */
-  private static BundleEntryComponent report(RandomNumberGenerator rand,
+  private static BundleEntryComponent report(
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           Report report) {
     DiagnosticReport reportResource = new DiagnosticReport();
@@ -2438,14 +2445,14 @@ public class FhirR4 {
       }
     }
 
-    return newEntry(rand, bundle, reportResource);
+    return newEntry(bundle, reportResource, report.uuid.toString());
   }
 
   /**
    * Add a clinical note to the Bundle, which adds both a DocumentReference and a
    * DiagnosticReport.
    *
-   * @param rand           Source of randomness to use when generating ids etc
+   * @param Person         The Person
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the Report to
    * @param encounterEntry Current Encounter entry
@@ -2453,7 +2460,7 @@ public class FhirR4 {
    * @param currentNote If this is the most current note.
    * @return The entry for the DocumentReference.
    */
-  private static void clinicalNote(RandomNumberGenerator rand,
+  private static void clinicalNote(Person person,
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           String clinicalNoteText, boolean currentNote) {
     // We'll need the encounter...
@@ -2486,7 +2493,10 @@ public class FhirR4 {
     reportResource.addPresentedForm()
         .setContentType("text/plain; charset=utf-8")
         .setData(clinicalNoteText.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-    newEntry(rand, bundle, reportResource);
+
+    String reportUUID = ExportHelper.buildUUID(person, 0,
+        "DiagnosticReport for note " + clinicalNoteText);
+    newEntry(bundle, reportResource, reportUUID);
 
     if (shouldExport(DocumentReference.class)) {
       // Add a DocumentReference
@@ -2522,14 +2532,17 @@ public class FhirR4 {
           .addEncounter(reportResource.getEncounter())
           .setPeriod(encounter.getPeriod()));
 
-      newEntry(rand, bundle, documentReference);
+      String documentUUID = ExportHelper.buildUUID(person, 0,
+          "DocumentReference for note " + clinicalNoteText);
+
+      newEntry(bundle, documentReference, documentUUID);
     }
   }
 
   /**
    * Map the given CarePlan to a FHIR CarePlan resource, and add it to the given Bundle.
    *
-   * @param rand           Source of randomness to use when generating ids etc
+   * @param person         The Person
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the CarePlan to
    * @param encounterEntry Current Encounter entry
@@ -2537,7 +2550,7 @@ public class FhirR4 {
    * @param carePlan       The CarePlan to map to FHIR and add to the bundle
    * @return The added Entry
    */
-  private static BundleEntryComponent carePlan(RandomNumberGenerator rand,
+  private static BundleEntryComponent carePlan(Person person,
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           Provider provider, BundleEntryComponent careTeamEntry, CarePlan carePlan) {
     org.hl7.fhir.r4.model.CarePlan careplanResource = new org.hl7.fhir.r4.model.CarePlan();
@@ -2628,29 +2641,33 @@ public class FhirR4 {
 
     for (JsonObject goal : carePlan.goals) {
       BundleEntryComponent goalEntry =
-          careGoal(rand, bundle, personEntry, carePlan.start, goalStatus, goal);
+          careGoal(person, bundle, personEntry, carePlan.start, goalStatus, goal);
       careplanResource.addGoal().setReference(goalEntry.getFullUrl());
     }
 
     careplanResource.setText(new Narrative().setStatus(NarrativeStatus.GENERATED)
         .setDiv(new XhtmlNode(NodeType.Element).setValue(narrative)));
 
-    return newEntry(rand, bundle, careplanResource);
+    return newEntry(bundle, careplanResource, carePlan.uuid.toString());
   }
 
   /**
    * Map the JsonObject into a FHIR Goal resource, and add it to the given Bundle.
-   * @param rand Source of randomness to use when generating ids etc
+   * @param person The Person
    * @param bundle The Bundle to add to
    * @param goalStatus The GoalStatus
    * @param goal The JsonObject
    * @return The added Entry
    */
   private static BundleEntryComponent careGoal(
-      RandomNumberGenerator rand, Bundle bundle,
+      Person person, Bundle bundle,
       BundleEntryComponent personEntry, long carePlanStart,
       CodeableConcept goalStatus, JsonObject goal) {
-    String resourceID = rand.randUUID().toString();
+
+    // note: this ID logic assumes the person will not have 2 careplans
+    // that start at the same timestep with the same code
+    String resourceID = ExportHelper.buildUUID(person, carePlanStart,
+        "CareGoal for CarePlan " + goalStatus.getCodingFirstRep().getCode());
 
     Goal goalResource = new Goal();
     if (USE_US_CORE_IG) {
@@ -2720,20 +2737,20 @@ public class FhirR4 {
       }
     }
 
-    return newEntry(rand, bundle, goalResource);
+    return newEntry(bundle, goalResource, resourceID);
   }
 
   /**
    * Map the given CarePlan to a FHIR CareTeam resource, and add it to the given Bundle.
    *
-   * @param rand           Source of randomness to use when generating ids etc
+   * @param person         The Person
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the CarePlan to
    * @param encounterEntry Current Encounter entry
    * @param carePlan       The CarePlan to map to FHIR and add to the bundle
    * @return The added Entry
    */
-  private static BundleEntryComponent careTeam(RandomNumberGenerator rand,
+  private static BundleEntryComponent careTeam(Person person,
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           CarePlan carePlan) {
 
@@ -2801,7 +2818,10 @@ public class FhirR4 {
     participant.setMember(encounter.getServiceProvider());
     careTeam.addManagingOrganization(encounter.getServiceProvider());
 
-    return newEntry(rand, bundle, careTeam);
+    String careTeamUUID = ExportHelper.buildUUID(person, carePlan.start,
+        "CareTeam for CarePlan " + carePlan.uuid);
+
+    return newEntry(bundle, careTeam, careTeamUUID);
   }
 
   private static Identifier generateIdentifier(String uid) {
@@ -2815,14 +2835,13 @@ public class FhirR4 {
   /**
    * Map the given ImagingStudy to a FHIR ImagingStudy resource, and add it to the given Bundle.
    *
-   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the ImagingStudy to
    * @param encounterEntry Current Encounter entry
    * @param imagingStudy   The ImagingStudy to map to FHIR and add to the bundle
    * @return The added Entry
    */
-  private static BundleEntryComponent imagingStudy(RandomNumberGenerator rand,
+  private static BundleEntryComponent imagingStudy(
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           ImagingStudy imagingStudy) {
     org.hl7.fhir.r4.model.ImagingStudy imagingStudyResource =
@@ -2900,21 +2919,20 @@ public class FhirR4 {
 
     imagingStudyResource.setSeries(seriesResourceList);
     imagingStudyResource.setNumberOfInstances(totalNumberOfInstances);
-    return newEntry(rand, bundle, imagingStudyResource);
+    return newEntry(bundle, imagingStudyResource, imagingStudy.uuid.toString());
   }
 
   /**
    * Map the given Observation with attachment element to a FHIR Media resource, and add it to the
    * given Bundle.
    *
-   * @param rand           Source of randomness to use when generating ids etc
    * @param personEntry    The Entry for the Person
    * @param bundle         Bundle to add the Media to
    * @param encounterEntry Current Encounter entry
    * @param obs   The Observation to map to FHIR and add to the bundle
    * @return The added Entry
    */
-  private static BundleEntryComponent media(RandomNumberGenerator rand,
+  private static BundleEntryComponent media(
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           Observation obs) {
     org.hl7.fhir.r4.model.Media mediaResource =
@@ -2954,18 +2972,17 @@ public class FhirR4 {
 
     mediaResource.setContent(contentResource);
 
-    return newEntry(rand, bundle, mediaResource);
+    return newEntry(bundle, mediaResource, obs.uuid.toString());
   }
 
   /**
    * Map the Provider into a FHIR Organization resource, and add it to the given Bundle.
    *
-   * @param rand     Source of randomness to use when generating ids etc
    * @param bundle   The Bundle to add to
    * @param provider The Provider
    * @return The added Entry
    */
-  protected static BundleEntryComponent provider(RandomNumberGenerator rand, Bundle bundle,
+  protected static BundleEntryComponent provider(Bundle bundle,
           Provider provider) {
     Organization organizationResource = new Organization();
     if (USE_US_CORE_IG) {
@@ -3021,10 +3038,10 @@ public class FhirR4 {
 
     org.hl7.fhir.r4.model.Location location = null;
     if (USE_US_CORE_IG) {
-      location = providerLocation(rand, bundle, provider);
+      location = providerLocation(bundle, provider);
     }
 
-    BundleEntryComponent entry = newEntry(bundle, organizationResource, provider.getResourceID());
+    BundleEntryComponent entry = newEntry(bundle, organizationResource, provider.uuid);
     // add location to bundle *after* organization to ensure no forward reference
     if (location != null) {
       newEntry(bundle, location, provider.getResourceLocationID());
@@ -3036,12 +3053,11 @@ public class FhirR4 {
   /**
    * Map the Provider into a FHIR Location resource, and add it to the given Bundle.
    *
-   * @param rand     Source of randomness to use when generating ids etc
    * @param bundle   The Bundle to add to
    * @param provider The Provider
    * @return The added Entry or null if the bundle already contains this provider location
    */
-  protected static org.hl7.fhir.r4.model.Location providerLocation(RandomNumberGenerator rand,
+  protected static org.hl7.fhir.r4.model.Location providerLocation(
           Bundle bundle, Provider provider) {
     org.hl7.fhir.r4.model.Location location = new org.hl7.fhir.r4.model.Location();
     if (USE_US_CORE_IG) {
@@ -3092,12 +3108,11 @@ public class FhirR4 {
 
   /**
    * Map the clinician into a FHIR Practitioner resource, and add it to the given Bundle.
-   * @param rand   Source of randomness to use when generating ids etc
    * @param bundle The Bundle to add to
    * @param clinician The clinician
    * @return The added Entry
    */
-  protected static BundleEntryComponent practitioner(RandomNumberGenerator rand, Bundle bundle,
+  protected static BundleEntryComponent practitioner(Bundle bundle,
           Clinician clinician) {
     Practitioner practitionerResource = new Practitioner();
     if (USE_US_CORE_IG) {
@@ -3182,7 +3197,14 @@ public class FhirR4 {
       }
       practitionerRole.addTelecom(practitionerResource.getTelecomFirstRep());
 
-      newEntry(rand, bundle, practitionerRole);
+      // clinicians do not have any associated "individual seed" or "timestamp"
+      // so we'll just re-use the uuid bits
+      UUID origUUID = UUID.fromString(clinician.uuid);
+      String uuid = ExportHelper.buildUUID(origUUID.getLeastSignificantBits(),
+          origUUID.getMostSignificantBits(),
+          "PractitionerRole for Clinician " + origUUID);
+
+      newEntry(bundle, practitionerRole, uuid);
     }
 
     return practitionerEntry;
@@ -3266,23 +3288,7 @@ public class FhirR4 {
 
   /**
    * Helper function to create an Entry for the given Resource within the given Bundle. Sets the
-   * resourceID to a random UUID, sets the entry's fullURL to that resourceID, and adds the entry to
-   * the bundle.
-   *
-   * @param rand     Source of randomness to use when generating ids etc
-   * @param bundle   The Bundle to add the Entry to
-   * @param resource Resource the new Entry should contain
-   * @return the created Entry
-   */
-  private static BundleEntryComponent newEntry(RandomNumberGenerator rand, Bundle bundle,
-          Resource resource) {
-    String resourceID = rand.randUUID().toString();
-    return newEntry(bundle, resource, resourceID);
-  }
-
-  /**
-   * Helper function to create an Entry for the given Resource within the given Bundle. Sets the
-   * resourceID to a random UUID, sets the entry's fullURL to that resourceID, and adds the entry to
+   * resourceID to the given ID, sets the entry's fullURL to that resourceID, and adds the entry to
    * the bundle.
    *
    * @param bundle   The Bundle to add the Entry to

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -1670,7 +1670,9 @@ public class FhirR4 {
     allergyResource.setCode(mapCodeToCodeableConcept(code, SNOMED_URI));
 
     if (allergy.reactions != null) {
-      allergy.reactions.keySet().stream().forEach(manifestation -> {
+      List<Code> sortedReactions = new ArrayList<>(allergy.reactions.keySet());
+      sortedReactions.sort((a,b) -> a.code.compareTo(b.code));
+      sortedReactions.forEach(manifestation -> {
         AllergyIntolerance.AllergyIntoleranceReactionComponent reactionComponent =
             new AllergyIntolerance.AllergyIntoleranceReactionComponent();
         reactionComponent.addManifestation(mapCodeToCodeableConcept(manifestation, SNOMED_URI));

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -2494,8 +2494,11 @@ public class FhirR4 {
         .setContentType("text/plain; charset=utf-8")
         .setData(clinicalNoteText.getBytes(java.nio.charset.StandardCharsets.UTF_8));
 
+    // the note text might be exactly identical for multiple encounters,
+    // so to ensure the UUID is unique use the encounter ID as the key
+    // IMPORTANT: if this function is called more than once per encounter, change here and below!
     String reportUUID = ExportHelper.buildUUID(person, 0,
-        "DiagnosticReport for note " + clinicalNoteText);
+        "DiagnosticReport for note on encounter " + encounter.getId());
     newEntry(bundle, reportResource, reportUUID);
 
     if (shouldExport(DocumentReference.class)) {
@@ -2533,7 +2536,7 @@ public class FhirR4 {
           .setPeriod(encounter.getPeriod()));
 
       String documentUUID = ExportHelper.buildUUID(person, 0,
-          "DocumentReference for note " + clinicalNoteText);
+          "DocumentReference for note on encounter " + encounter.getId());
 
       newEntry(bundle, documentReference, documentUUID);
     }

--- a/src/main/java/org/mitre/synthea/export/HospitalExporterR4.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporterR4.java
@@ -41,7 +41,7 @@ public abstract class HospitalExporterR4 {
         int totalEncounters = utilization.column(Provider.ENCOUNTERS).values().stream()
             .mapToInt(ai -> ai.get()).sum();
         if (totalEncounters > 0) {
-          BundleEntryComponent entry = FhirR4.provider(rand, bundle, h);
+          BundleEntryComponent entry = FhirR4.provider(bundle, h);
           addHospitalExtensions(h, (Organization) entry.getResource());
         }
       }

--- a/src/main/java/org/mitre/synthea/modules/covid/C19Vaccine.java
+++ b/src/main/java/org/mitre/synthea/modules/covid/C19Vaccine.java
@@ -53,7 +53,7 @@ public class C19Vaccine {
             "212", false, 0.071, 0));
 
     List<Pair<EUASet, Double>> pmf = EUAs.entrySet().stream()
-        .map(entry -> new Pair<EUASet, Double>(entry.getKey(), entry.getValue().getUsagePercentage()))
+        .map(entry -> new Pair<>(entry.getKey(), entry.getValue().getUsagePercentage()))
         .collect(Collectors.toList());
 
     shotSelector = new SyncedEnumeratedDistro<EUASet>(pmf);

--- a/src/main/java/org/mitre/synthea/modules/covid/C19Vaccine.java
+++ b/src/main/java/org/mitre/synthea/modules/covid/C19Vaccine.java
@@ -1,7 +1,8 @@
 package org.mitre.synthea.modules.covid;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.apache.commons.math3.util.Pair;
@@ -19,7 +20,7 @@ import org.mitre.synthea.world.agents.Person;
  * </p>
  */
 public class C19Vaccine {
-  public static final HashMap<EUASet, C19Vaccine> EUAs = new HashMap();
+  public static final Map<EUASet, C19Vaccine> EUAs = new TreeMap<>();
   private static SyncedEnumeratedDistro<EUASet> shotSelector;
 
   private String display;
@@ -51,10 +52,11 @@ public class C19Vaccine {
             + "recombinant spike protein-Ad26, preservative free, 0.5 mL",
             "212", false, 0.071, 0));
 
-    List pmf = EUAs.entrySet().stream()
-        .map(entry -> new Pair(entry.getKey(), entry.getValue().getUsagePercentage()))
+    List<Pair<EUASet, Double>> pmf = EUAs.entrySet().stream()
+        .map(entry -> new Pair<EUASet, Double>(entry.getKey(), entry.getValue().getUsagePercentage()))
         .collect(Collectors.toList());
-    shotSelector = new SyncedEnumeratedDistro(pmf);
+
+    shotSelector = new SyncedEnumeratedDistro<EUASet>(pmf);
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/planfinder/PlanFinderPriority.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/planfinder/PlanFinderPriority.java
@@ -1,6 +1,7 @@
 package org.mitre.synthea.world.agents.behaviors.planfinder;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,8 +28,10 @@ public class PlanFinderPriority implements IPlanFinder {
       Set<Integer> eligiblePriorities = eligiblePlans.stream().map(plan ->
           plan.getPayer().getPriority()).collect(Collectors.toSet());
       int maxEligiblePriority = Collections.min(eligiblePriorities);
-      eligiblePlans = eligiblePlans.stream().filter(plan ->
-          plan.getPayer().getPriority() == maxEligiblePriority).collect(Collectors.toList());
+      eligiblePlans = eligiblePlans.stream()
+          .filter(plan -> plan.getPayer().getPriority() == maxEligiblePriority)
+          .sorted(Comparator.comparing(InsurancePlan::toString))
+          .collect(Collectors.toList());
     }
 
     return chooseRandomPlan(eligiblePlans, person);

--- a/src/main/java/org/mitre/synthea/world/concepts/Claim.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/Claim.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.mitre.synthea.export.JSONSkip;
 import org.mitre.synthea.world.agents.PayerManager;
@@ -217,6 +218,7 @@ public class Claim implements Serializable {
   public ClaimEntry mainEntry;
   public List<ClaimEntry> items;
   public ClaimEntry totals;
+  public final UUID uuid;
 
   /**
    * Constructor of a Claim for an Entry.
@@ -249,6 +251,7 @@ public class Claim implements Serializable {
     }
     this.items = new ArrayList<ClaimEntry>();
     this.totals = new ClaimEntry(entry);
+    this.uuid = this.person.randUUID();
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.mitre.synthea.export.JSONSkip;
@@ -124,7 +125,8 @@ public class HealthRecord implements Serializable {
     /** reference to the HealthRecord this entry belongs to. */
     @JSONSkip
     HealthRecord record = HealthRecord.this;
-    public String fullUrl;
+    public final UUID uuid = record.person.randUUID();
+    public String fullUrl; // cache the fullURL used in FHIR exporters
     public String name;
     public long start;
     public long stop;

--- a/src/main/java/org/mitre/synthea/world/concepts/healthinsurance/InsurancePlan.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/healthinsurance/InsurancePlan.java
@@ -277,4 +277,17 @@ public class InsurancePlan implements Serializable {
     return this.defaultCopay.compareTo(BigDecimal.ZERO) > 0;
   }
 
+  @Override
+  public String toString() {
+    // an ugly toString, but the goal is just to have a consistent "thing" to sort by
+    return "InsurancePlan [payer=" + payer.getName()
+        + ", deductible=" + deductible
+        + ", defaultCopay=" + defaultCopay
+        + ", defaultCoinsurance=" + defaultCoinsurance
+        + ", monthlyPremium=" + monthlyPremium
+        + ", medicareSupplement=" + medicareSupplement
+        + ", insuranceStatus=" + insuranceStatus
+        + ", planEligibility=" + planEligibility
+        + ", activeTimeRange=" + activeTimeRange + "]";
+  }
 }


### PR DESCRIPTION
Addresses #1236 and fixes some instances where running the same population multiple times produces different results

Issues identified and fixed so far:

1. The ordering of allergy reactions
2. DocumentReference content and Insurance plan selection

(Essentially both of these are the result of using Sets where order is not guaranteed. The current fix is not ideal, it does some extra sorting at the end, so there may be a more "root" fix further upstream. Note that I was not able to reproduce this second issue when running with only a single thread, which also suggests to me further analysis is required)

3. Resource UUIDs are occasionally different
This is because the UUIDs are generated using the same random number generator as used during generation. When the simulation is re-run with a different end date, the generation process may tick up an extra time stamp and roll a few extra random numbers. The fix here is to essentially remove all randomness from the FhirR4 exporter, done in two ways:
A) Select UUIDs during the generation process, by assigning them to every `HealthRecord.Entry` at creation time
B) For FHIR resources that don't align 1:1 with a synthea model class, use a new method `ExportHelper.buildUUID` to consistently create a UUID based on the Person, time, and a "key" for uniqueness. A few examples are the Provenance added to the end of each Bundle, DiagnosticRequests and DocumentReferences created for clinical notes, and ExplanationOfBenefits.

4. DICOM UIDs are occasionally different
This is because the Series object and the Instances it contains are being unintentionally leaked between patients. (Also doesn't occur when running with only a single thread.) I've put in a fix to ensure objects are always cloned, but I suspect there might be a more minimal fix possible. The "cleanest" would be an extra bit in `ImagingStudy.clone()` to match, for example, `ObservationGroup.clone()` where the observations in a list are individually cloned, but that's tougher in this case because we want certain instances to have a different/random number of objects in the list.

5. Differences across OSes
Observed on MacOS vs a Linux Docker image, likely to occur across other combinations as well. Patients with the same config were producing wildly different results. This was because in a couple places we were selecting a random index based on a HashMap, where sort order is not guaranteed. Seems like order is consistent for a given OS but still we shouldn't even bank on that. I replaced instances of HashMap with TreeMap for a minimal change that should ensure a consistent order.

Not currently implemented as part of this PR, I suggest we implement these separately:
 - FHIR 2 & 3 updates to match R4
 - CSV exporter to use the existing UUIDs
 - Update any other exporter that generates UUIDs
(Do we want these to be part of this PR?)