### PR TITLE
Fix Encounter Leaks

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -277,7 +277,10 @@ public class Module implements Cloneable, Serializable {
 
   public String name;
   public String specialty;
+  /** true if this is a submodule, false otherwise. */
   public boolean submodule;
+  /** if a submodule, the original name of this submodule. Otherwise null. */
+  public String submoduleName;
   public Double gmfVersion;
   public List<String> remarks;
   private Map<String, State> states;
@@ -333,11 +336,18 @@ public class Module implements Cloneable, Serializable {
     clone.name = this.name;
     clone.specialty = this.specialty;
     clone.submodule = this.submodule;
+    if (clone.submodule) {
+      // Only if this is a submodule, it wants to remember its own name.
+      // later, the `name` will be overwritten by the top-level module.
+      clone.submoduleName = clone.name;
+    }
     clone.remarks = this.remarks;
     if (this.states != null) {
       clone.states = new ConcurrentHashMap<String, State>();
       for (String key : this.states.keySet()) {
-        clone.states.put(key, this.states.get(key).clone());
+        State state = this.states.get(key).clone();
+        state.module = clone;
+        clone.states.put(key, state);
       }
     }
     return clone;
@@ -373,18 +383,24 @@ public class Module implements Cloneable, Serializable {
     if (terminateOnDeath && !person.alive(time)) {
       return true;
     }
+    // Possibly reset wellness encounters for this module.
+    String activeKey = EncounterModule.ACTIVE_WELLNESS_ENCOUNTER + " " + this.name;
+    if (!person.attributes.containsKey(activeKey)) {
+      // "false" means the person has not entered (or is still within) a wellness encounter
+      person.attributes.put(activeKey, false);
+    }
     person.history = null;
     // what current state is this person in?
-    if (!person.attributes.containsKey(this.name)) {
+    String historyKey = this.name;
+    if (this.submodule) {
+      historyKey = this.submoduleName;
+    }
+    if (!person.attributes.containsKey(historyKey)) {
       person.history = new LinkedList<State>();
       person.history.add(initialState());
-      person.attributes.put(this.name, person.history);
+      person.attributes.put(historyKey, person.history);
     }
-    person.history = (List<State>) person.attributes.get(this.name);
-    String activeKey = EncounterModule.ACTIVE_WELLNESS_ENCOUNTER + " " + this.name;
-    if (person.attributes.containsKey(EncounterModule.ACTIVE_WELLNESS_ENCOUNTER)) {
-      person.attributes.put(activeKey, true);
-    }
+    person.history = (List<State>) person.attributes.get(historyKey);
     State current = person.history.get(0);
     // System.out.println(" Resuming at " + current.name);
     // process the current state,
@@ -412,7 +428,6 @@ public class Module implements Cloneable, Serializable {
         current = person.history.get(0);
       }
     }
-    person.attributes.remove(activeKey);
     return (current instanceof State.Terminal);
   }
 

--- a/src/main/java/org/mitre/synthea/export/rif/BB2RIFExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/BB2RIFExporter.java
@@ -352,6 +352,9 @@ public class BB2RIFExporter {
   public void export(Person person, long stopTime, int yearsOfHistory) throws IOException {
     Map<EXPORT_SUMMARY, String> exportCounts = new HashMap<>();
     long startTime = stopTime - Utilities.convertTime("years", yearsOfHistory);
+    if (yearsOfHistory == 0) {
+      startTime = (long) person.attributes.get(Person.BIRTHDATE);
+    }
     exportCounts.put(EXPORT_SUMMARY.BENE_ID, beneExp.export(person, startTime, stopTime));
     beneExp.exportHistory(person, startTime, stopTime);
     exportCounts.put(EXPORT_SUMMARY.INPATIENT_CLAIMS,

--- a/src/main/java/org/mitre/synthea/modules/DeathModule.java
+++ b/src/main/java/org/mitre/synthea/modules/DeathModule.java
@@ -34,8 +34,9 @@ public class DeathModule {
 
       Code causeOfDeath = (Code) person.attributes.get(Person.CAUSE_OF_DEATH);
 
+      person.releaseCurrentEncounter(time, "DeathModule");
       Encounter encounter = EncounterModule.createEncounter(person, time, EncounterType.WELLNESS,
-          ClinicianSpecialty.GENERAL_PRACTICE, DEATH_CERTIFICATION);
+          ClinicianSpecialty.GENERAL_PRACTICE, DEATH_CERTIFICATION, "DeathModule");
       encounter.reason = causeOfDeath;
 
       Observation codObs = person.record.observation(time, CAUSE_OF_DEATH_CODE.code, causeOfDeath);
@@ -44,6 +45,10 @@ public class DeathModule {
 
       Report deathCert = person.record.report(time, DEATH_CERTIFICATE.code, 1);
       deathCert.codes.add(DEATH_CERTIFICATE);
+
+      person.record.encounterEnd(time, EncounterType.WELLNESS);
+      // Do NOT release the DeathModule encounter, because no one should
+      // be able to have an encounter after this one.
     }
   }
 

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -576,63 +576,49 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
     return returnValue;
   }
 
-  public static final String CURRENT_ENCOUNTERS = "current-encounters";
+  public static final String CURRENT_ENCOUNTER_MODULE = "current-encounter-module";
 
   /**
-   * Get the current encounter for the specified module or null if none exists.
+   * Get the module with the current encounter or null if no module is
+   * currently in an encounter.
    */
-  @SuppressWarnings("unchecked")
-  public Encounter getCurrentEncounter(Module module) {
-    Map<String, Encounter> moduleToCurrentEncounter
-        = (Map<String, Encounter>) attributes.get(CURRENT_ENCOUNTERS);
-
-    if (moduleToCurrentEncounter == null) {
-      moduleToCurrentEncounter = new HashMap<>();
-      attributes.put(CURRENT_ENCOUNTERS, moduleToCurrentEncounter);
-    }
-
-    return moduleToCurrentEncounter.get(module.name);
+  public String getCurrentEncounterModule() {
+    return (String) attributes.get(CURRENT_ENCOUNTER_MODULE);
   }
 
   /**
-   * Check if there are any current encounters.
-   * @return true if there current encounters, false otherwise
+   * Check if there is a current encounter.
+   * @return true if there is a current encounter, false otherwise.
    */
   public boolean hasCurrentEncounter() {
-    if (attributes != null) {
-      Map<String, Encounter> moduleToCurrentEncounter
-              = (Map<String, Encounter>) attributes.get(CURRENT_ENCOUNTERS);
-
-      if (moduleToCurrentEncounter != null && !moduleToCurrentEncounter.isEmpty()) {
-        // Uncomment the following lines to see which module encounters are blocking the start
-        // of wellness encounters in the encounter module.
-        // System.out.println("Pre-wellness Encounter Check Failed:");
-        // for (String module: moduleToCurrentEncounter.keySet()) {
-        //   Encounter encounter = moduleToCurrentEncounter.get(module);
-        //   System.out.printf("%s, %s\n", module, encounter.codes.get(0).code);
-        // }
-        return true;
-      }
-    }
-    return false;
+    return attributes.containsKey(CURRENT_ENCOUNTER_MODULE);
   }
 
   /**
-   * Set the current encounter for the specified module.
+   * Releases the current encounter reservation.
+   * This always succeeds, so any calls should make sure they are
+   * the owners using 'getCurrentEncounterModule()'.
+   * Currently the parameters are unused.
+   * @param time The time in the simulation.
+   * @param module The name of the module releasing the reservation.
    */
-  @SuppressWarnings("unchecked")
-  public void setCurrentEncounter(Module module, Encounter encounter) {
-    Map<String, Encounter> moduleToCurrentEncounter
-        = (Map<String, Encounter>) attributes.get(CURRENT_ENCOUNTERS);
+  public void releaseCurrentEncounter(long time, String module) {
+    attributes.remove(CURRENT_ENCOUNTER_MODULE);
+  }
 
-    if (moduleToCurrentEncounter == null) {
-      moduleToCurrentEncounter = new HashMap<>();
-      attributes.put(CURRENT_ENCOUNTERS, moduleToCurrentEncounter);
-    }
-    if (encounter == null) {
-      moduleToCurrentEncounter.remove(module.name);
+  /**
+   * Reserve the current Encounter... no other module can run an encounter
+   * (except for Wellness Encounters).
+   * @param time The time in the simulation.
+   * @param module The name of the module making the reservation.
+   * @return true if the encounter is reserved, false otherwise.
+   */
+  public boolean reserveCurrentEncounter(long time, String module) {
+    if (hasCurrentEncounter()) {
+      return false;
     } else {
-      moduleToCurrentEncounter.put(module.name, encounter);
+      attributes.put(CURRENT_ENCOUNTER_MODULE, module);
+      return true;
     }
   }
 

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/DefaultPlanEligibility.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/DefaultPlanEligibility.java
@@ -1,0 +1,14 @@
+package org.mitre.synthea.world.agents.behaviors.planeligibility;
+
+import org.mitre.synthea.world.agents.Person;
+
+/**
+ * DefaultPlanEligibility can be used for the No Insurance plan.
+ * Everyone qualifies.
+ */
+public class DefaultPlanEligibility implements IPlanEligibility {
+  @Override
+  public boolean isPersonEligible(Person person, long time) {
+    return true;
+  }
+}

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/PlanEligibilityFinder.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/planeligibility/PlanEligibilityFinder.java
@@ -9,10 +9,9 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
-import org.mitre.synthea.world.agents.Person;
 
 /**
- * Returns the requested Payer elgibility algorithm. This prevents redundant
+ * Returns the requested Payer eligibility algorithm. This prevents redundant
  * recreations of the same objects over and over.
  */
 public class PlanEligibilityFinder {
@@ -21,34 +20,30 @@ public class PlanEligibilityFinder {
 
   private static final String ELIGIBILITY_NAME = "Name";
   public static final String GENERIC = "GENERIC";
+  public static final IPlanEligibility DEFAULT = new DefaultPlanEligibility();
 
   /**
-   * Returns the correct elgibility algorithm based on the given string.
+   * Returns the correct eligibility algorithm based on the given string.
    * @param eligibility The name of the eligibility type.
    * @return  The requested payer eligibility algorithm.
    */
   public static IPlanEligibility getEligibilityAlgorithm(String eligibility) {
-    String cleanedEigibility = eligibility.replaceAll("\\s", "").toUpperCase();
-    if (planEligibilities.containsKey(cleanedEigibility)) {
-      return planEligibilities.get(cleanedEigibility);
+    String cleanedEligibility = eligibility.replaceAll("\\s", "").toUpperCase();
+    if (cleanedEligibility.equals(GENERIC)) {
+      return DEFAULT;
+    } else if (planEligibilities.containsKey(cleanedEligibility)) {
+      return planEligibilities.get(cleanedEligibility);
     }
-    throw new RuntimeException("Plan eligiblity " + eligibility + " does not exist.");
+    throw new RuntimeException("Plan eligibility " + eligibility + " does not exist.");
   }
 
   /**
-   * Builds the plan eligiblities for the given state and CSV input file.
+   * Builds the plan eligibilities for the given state and CSV input file.
    * @param state The state.
    */
   public static void buildPlanEligibilities(String state, String fileName) {
     planEligibilities = new HashMap<>();
-    // Generic eliigblities always return true.
-    planEligibilities.put(PlanEligibilityFinder.GENERIC, new IPlanEligibility() {
-      @Override
-      public boolean isPersonEligible(Person person, long time) {
-        return true;
-      }
-    });
-    // Build the CSV input eligbility algorithms.
+    // Build the CSV input eligibility algorithms.
     CSVEligibility.buildEligibilityOptions(state);
     String resource = null;
     Iterator<? extends Map<String, String>> csv = null;

--- a/src/main/resources/modules/cerebral_palsy.json
+++ b/src/main/resources/modules/cerebral_palsy.json
@@ -1308,7 +1308,7 @@
         "high": 30,
         "unit": "minutes"
       },
-      "direct_transition": "Living_with_CP"
+      "direct_transition": "End_Cerebral_Palsy_Encounter1"
     },
     "Cerebral_Palsy_Pneumonia": {
       "type": "ConditionOnset",
@@ -1520,13 +1520,17 @@
           "distribution": 0.4
         },
         {
-          "transition": "Terminal",
+          "transition": "End Encounter and Exit",
           "distribution": 0.6000000000000001
         }
       ]
     },
     "Terminal": {
       "type": "Terminal"
+    },
+    "End Encounter and Exit": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
     }
   },
   "remarks": [

--- a/src/main/resources/modules/heart/cabg_sequence.json
+++ b/src/main/resources/modules/heart/cabg_sequence.json
@@ -166,7 +166,7 @@
       "submodule": "heart/cabg/referral",
       "conditional_transition": [
         {
-          "transition": "Terminal",
+          "transition": "End Last Encounter",
           "condition": {
             "condition_type": "Or",
             "conditions": [
@@ -202,16 +202,12 @@
     "Postop ICU and Ward": {
       "type": "CallSubmodule",
       "submodule": "heart/cabg/postop",
-      "direct_transition": "End Operation Encounter"
+      "direct_transition": "End Last Encounter"
     },
     "Deceased": {
       "type": "Death",
-      "direct_transition": "Terminal",
+      "direct_transition": "End Last Encounter",
       "referenced_by_attribute": "cardiac_surgery_reason"
-    },
-    "End Operation Encounter": {
-      "type": "EncounterEnd",
-      "direct_transition": "Terminal"
     },
     "Terminal": {
       "type": "Terminal"
@@ -220,6 +216,10 @@
       "type": "CallSubmodule",
       "submodule": "heart/operative_status",
       "direct_transition": "Set Outcomes"
+    },
+    "End Last Encounter": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/sepsis.json
+++ b/src/main/resources/modules/sepsis.json
@@ -11,12 +11,7 @@
     "References: ",
     "1. Hotchkiss RS, Karl IE. The Pathophysiology and Treatment of Sepsis. N Engl J Med. 2003 Jan 9;348(2):138–50. ",
     "2. \tSurviving Sepsis Campaign: International Guidelines for Mana... : Critical Care Medicine [Internet]. [cited 2020 Oct 16]. Available from: https://journals.lww.com/ccmjournal/Fulltext/2017/03000/Surviving_Sepsis_Campaign___International.15.aspx",
-    "3. \tDellinger RP, Schorr CA, Levy MM. A Users’ Guide to the 2016 Surviving Sepsis Guidelines. Crit Care Med. 2017 Mar;45(3):381–385. ",
-    "",
-    "",
-    "",
-    "",
-    ""
+    "3. \tDellinger RP, Schorr CA, Levy MM. A Users’ Guide to the 2016 Surviving Sepsis Guidelines. Crit Care Med. 2017 Mar;45(3):381–385. "
   ],
   "states": {
     "Initial": {
@@ -255,7 +250,7 @@
         "quantity": 1,
         "unit": "days"
       },
-      "direct_transition": "Terminal",
+      "direct_transition": "End Encounter by Death",
       "remarks": [
         "Overall mortality of sepsis is 12.5% among patients with sepsis. Ref: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6250243/#:~:text=The%20higher%20prevalence%20of%20sepsis,sepsis%20and%20septic%20shock%2C%20respectively."
       ]
@@ -634,6 +629,10 @@
       "direct_transition": "Vancomycin",
       "administration": true,
       "reason": "Sepsis"
+    },
+    "End Encounter by Death": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/vhd_aortic.json
+++ b/src/main/resources/modules/vhd_aortic.json
@@ -122,7 +122,7 @@
       "type": "Simple",
       "conditional_transition": [
         {
-          "transition": "Terminal",
+          "transition": "End Encounter and Exit",
           "condition": {
             "condition_type": "At Least",
             "minimum": 1,
@@ -209,7 +209,7 @@
       "type": "Simple",
       "conditional_transition": [
         {
-          "transition": "Terminal",
+          "transition": "End Encounter and Exit",
           "condition": {
             "condition_type": "At Least",
             "minimum": 1,
@@ -670,6 +670,10 @@
     "Delay 10 years": {
       "type": "Simple",
       "direct_transition": "AVRr Sequence"
+    },
+    "End Encounter and Exit": {
+      "type": "EncounterEnd",
+      "direct_transition": "Terminal"
     }
   },
   "gmf_version": 2

--- a/src/test/java/org/mitre/synthea/TestHelper.java
+++ b/src/test/java/org/mitre/synthea/TestHelper.java
@@ -15,13 +15,20 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 
 import org.mitre.synthea.engine.Generator;
 import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.engine.State;
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.DefaultRandomNumberGenerator;
+import org.mitre.synthea.helpers.RandomNumberGenerator;
 import org.mitre.synthea.helpers.Utilities;
+import org.mitre.synthea.world.agents.Clinician;
 import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.ClinicianSpecialty;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
 
 public abstract class TestHelper {
 
@@ -138,6 +145,23 @@ public abstract class TestHelper {
 
   public static long years(long numYears) {
     return Utilities.convertTime("years", numYears);
+  }
+
+  /**
+   * Create a provider that can assigned to Patients.
+   * @return General practice provider with all services.
+   */
+  public static Provider buildMockProvider() {
+    Provider provider = new Provider();
+    for (EncounterType type : EncounterType.values()) {
+      provider.servicesProvided.add(type);
+    }
+    RandomNumberGenerator rng = new DefaultRandomNumberGenerator(0L);
+    Clinician doc = new Clinician(0L, rng, 0L, provider);
+    ArrayList<Clinician> clinicians = new ArrayList<Clinician>();
+    clinicians.add(doc);
+    provider.clinicianMap.put(ClinicianSpecialty.GENERAL_PRACTICE, clinicians);
+    return provider;
   }
 
   /**

--- a/src/test/java/org/mitre/synthea/engine/LogicTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LogicTest.java
@@ -331,6 +331,11 @@ public class LogicTest {
     person.records = null;
   }
 
+  private void clearRecord(Person person) {
+    person.initializeDefaultHealthRecords();
+    person.releaseCurrentEncounter(0L, null);
+  }
+
   @Test
   public void test_observations() {
 
@@ -341,13 +346,13 @@ public class LogicTest {
     obs.codes.add(mmseCode);
     assertFalse(doTest("mmseObservationGt22"));
 
-    person.record = new HealthRecord(person); // clear it out
+    clearRecord(person);
 
     obs = person.record.observation(time, mmseCode.code, 29);
     obs.codes.add(mmseCode);
     assertTrue(doTest("mmseObservationGt22"));
 
-    person.record = new HealthRecord(person); // clear it out
+    clearRecord(person);
 
     HealthRecord.Code valueCodeFalse = new HealthRecord.Code("LOINC", "72107-8",
         "Other Observation Value");
@@ -356,7 +361,7 @@ public class LogicTest {
     obs.codes.add(mmseCode);
     assertFalse(doTest("ObservationEqValueCode"));
 
-    person.record = new HealthRecord(person); // clear it out
+    clearRecord(person);
 
     HealthRecord.Code valueCodeTrue = new HealthRecord.Code("LOINC", "72107-7",
         "Some Observation Value");
@@ -365,7 +370,7 @@ public class LogicTest {
     obs.codes.add(mmseCode);
     assertTrue(doTest("ObservationEqValueCode"));
 
-    person.record = new HealthRecord(person); // clear it out
+    clearRecord(person);
     assertFalse(doTest("hasDiabetesObservation"));
 
     obs = person.record.observation(time, "Blood Panel", "blah blah");
@@ -379,7 +384,7 @@ public class LogicTest {
 
   @Test
   public void test_condition_condition() {
-    person.record = new HealthRecord(person);
+    clearRecord(person);
     assertFalse(doTest("diabetesConditionTest"));
     assertFalse(doTest("alzheimersConditionTest"));
 
@@ -406,7 +411,7 @@ public class LogicTest {
 
   @Test
   public void test_allergy_condition() {
-    person.record = new HealthRecord(person);
+    clearRecord(person);
     assertFalse(doTest("penicillinAllergyTest"));
 
     HealthRecord.Code penicillinCode = new HealthRecord.Code("RxNorm", "7984",
@@ -427,7 +432,7 @@ public class LogicTest {
     HealthRecord.Code diabetesCode = new HealthRecord.Code("SNOMED-CT", "698360004",
         "Diabetes self management plan");
 
-    person.record = new HealthRecord(person);
+    clearRecord(person);
     assertFalse(doTest("diabetesCarePlanTest"));
     assertFalse(doTest("anginaCarePlanTest"));
 

--- a/src/test/java/org/mitre/synthea/engine/LookupTableTransitionTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LookupTableTransitionTest.java
@@ -23,6 +23,7 @@ import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
 import org.powermock.reflect.Whitebox;
 
 public class LookupTableTransitionTest {
@@ -298,6 +299,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.ETHNICITY, "english");
     person.attributes.put(Person.GENDER, "F");
@@ -322,6 +324,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.ETHNICITY, "english");
     person.attributes.put(Person.GENDER, "F");
@@ -346,6 +349,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.ETHNICITY, "english");
     person.attributes.put(Person.GENDER, "M");
@@ -370,6 +374,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.ETHNICITY, "irish");
     person.attributes.put(Person.GENDER, "M");
@@ -394,6 +399,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.ETHNICITY, "irish");
     person.attributes.put(Person.GENDER, "F");
@@ -418,6 +424,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.ETHNICITY, "italian");
     person.attributes.put(Person.GENDER, "M");
@@ -442,6 +449,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.ETHNICITY, "italian");
     person.attributes.put(Person.GENDER, "F");
@@ -468,6 +476,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     // 'spanish' is not accounted for in lookuptabltitis.csv.
     person.attributes.put(Person.ETHNICITY, "spanish");
@@ -495,6 +504,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.ETHNICITY, "english");
     person.attributes.put(Person.GENDER, "F");
@@ -518,6 +528,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.GENDER, "M");
     person.attributes.put(Person.STATE, "Massachusetts");
@@ -539,6 +550,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.GENDER, "F");
     person.attributes.put(Person.STATE, "Massachusetts");
@@ -560,6 +572,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.GENDER, "M");
     person.attributes.put(Person.STATE, "New Hampshire");
@@ -581,6 +594,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.GENDER, "M");
     person.attributes.put(Person.STATE, "Massachusetts");
@@ -602,6 +616,7 @@ public class LookupTableTransitionTest {
 
     // Create the person with the preset attributes.
     Person person = new Person(0L);
+    person.setProvider(EncounterType.WELLNESS, TestHelper.buildMockProvider());
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.GENDER, "F");
     person.attributes.put(Person.STATE, "Massachusetts");

--- a/src/test/java/org/mitre/synthea/engine/StateTest.java
+++ b/src/test/java/org/mitre/synthea/engine/StateTest.java
@@ -40,6 +40,7 @@ import org.mitre.synthea.modules.WeightLossModule;
 import org.mitre.synthea.world.agents.PayerManager;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.ClinicianSpecialty;
 import org.mitre.synthea.world.concepts.HealthRecord;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
@@ -103,8 +104,14 @@ public class StateTest {
     State.ENABLE_PHYSIOLOGY_STATE = physStateEnabled;
   }
 
-  private void simulateWellnessEncounter(Module module) {
-    person.attributes.put(EncounterModule.ACTIVE_WELLNESS_ENCOUNTER + " " + module.name, true);
+  private void simulateWellnessEncounter(Module module, Person person, long time) {
+    // "true" indicates that we are in a wellness encounter (true)
+    person.attributes.put(EncounterModule.ACTIVE_WELLNESS_ENCOUNTER, true);
+    // "false" indicates that the module has not used its "pass" yet
+    person.attributes.put(EncounterModule.ACTIVE_WELLNESS_ENCOUNTER + " " + module.name, false);
+    EncounterModule.createEncounter(person, time, EncounterType.WELLNESS,
+        ClinicianSpecialty.GENERAL_PRACTICE,
+        EncounterModule.ENCOUNTER_CHECKUP, EncounterModule.NAME);
   }
 
   @Test
@@ -932,7 +939,7 @@ public class StateTest {
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("weeks", 2);
 
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
 
     // Now we should pass through
     assertTrue(encounter.process(person, time));
@@ -951,7 +958,7 @@ public class StateTest {
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
 
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
 
     assertTrue(encounter.process(person, time));
 
@@ -1082,7 +1089,7 @@ public class StateTest {
     time = time + Utilities.convertTime("months", 6);
     // Simulate the wellness encounter by calling perform_encounter
 
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1110,7 +1117,7 @@ public class StateTest {
     State encounter = module.getState("DiagnosisEncounter");
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1152,7 +1159,7 @@ public class StateTest {
     time = time + Utilities.convertTime("months", 6);
     // Simulate the wellness encounter by calling perform_encounter
 
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1189,7 +1196,7 @@ public class StateTest {
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
     // Simulate the wellness encounter by calling perform_encounter
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1225,7 +1232,7 @@ public class StateTest {
     State encounter = module.getState("Wellness_Encounter");
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1261,7 +1268,7 @@ public class StateTest {
     State encounter = module.getState("Wellness_Encounter");
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1299,7 +1306,7 @@ public class StateTest {
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
 
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1328,7 +1335,7 @@ public class StateTest {
     person.attributes.remove("Diabetes Medication");
     Module module = TestHelper.getFixture("medication_order.json");
     State encounter = module.getState("Wellness_Encounter");
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1346,7 +1353,7 @@ public class StateTest {
     person.attributes.remove("Diabetes Medication");
     Module module = TestHelper.getFixture("medication_order.json");
     State encounter = module.getState("Wellness_Encounter");
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1378,7 +1385,7 @@ public class StateTest {
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
 
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1419,7 +1426,7 @@ public class StateTest {
     State encounter = module.getState("Wellness_Encounter");
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1460,7 +1467,7 @@ public class StateTest {
     State encounter = module.getState("Wellness_Encounter");
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1501,7 +1508,7 @@ public class StateTest {
     State encounter = module.getState("Wellness_Encounter");
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1530,7 +1537,7 @@ public class StateTest {
     person.attributes.remove("Diabetes_CarePlan");
     Module module = TestHelper.getFixture("careplan_start.json");
     State encounter = module.getState("Wellness_Encounter");
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1559,7 +1566,7 @@ public class StateTest {
     State encounter = module.getState("Wellness_Encounter");
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1606,7 +1613,7 @@ public class StateTest {
     State encounter = module.getState("Wellness_Encounter");
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     person.history.add(encounter);
 
     // Now process the careplan
@@ -1652,7 +1659,7 @@ public class StateTest {
     State encounter = module.getState("Wellness_Encounter");
     assertFalse(encounter.process(person, time));
     time = time + Utilities.convertTime("months", 6);
-    simulateWellnessEncounter(module);
+    simulateWellnessEncounter(module, person, time);
     assertTrue(encounter.process(person, time));
     person.history.add(encounter);
 
@@ -1888,7 +1895,9 @@ public class StateTest {
             Whitebox.<Map<String, Module.ModuleSupplier>>getInternalState(Module.class, "modules");
     // hack to load these test modules so they can be called by the CallSubmodule state
     Module subModule1 = TestHelper.getFixture("submodules/encounter_submodule.json");
+    subModule1.submodule = true;
     Module subModule2 = TestHelper.getFixture("submodules/medication_submodule.json");
+    subModule2.submodule = true;
     modules.put("submodules/encounter_submodule", new Module.ModuleSupplier(subModule1));
     modules.put("submodules/medication_submodule", new Module.ModuleSupplier(subModule2));
 
@@ -1921,7 +1930,7 @@ public class StateTest {
       assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Initial", person.history.get(14).name);
-      assertEquals("Encounter Submodule Module", person.history.get(14).module.name);
+      assertEquals("Encounter Submodule Module", person.history.get(14).module.submoduleName);
       // the state being called by the submodule won't necessarily have this property
       // because submodule.exited gets rewritten to whenever the terminal of the submodule exits
       // ex. main.CallSubmodule: entered 1/1/2020, exited 12/31/2020
@@ -1933,58 +1942,58 @@ public class StateTest {
       // assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Delay", person.history.get(13).name);
-      assertEquals("Encounter Submodule Module", person.history.get(13).module.name);
+      assertEquals("Encounter Submodule Module", person.history.get(13).module.submoduleName);
       previousStateExited = person.history.get(14).exited;
       currentStateEntered = person.history.get(13).entered;
       assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Encounter_In_Submodule", person.history.get(12).name);
-      assertEquals("Encounter Submodule Module", person.history.get(12).module.name);
+      assertEquals("Encounter Submodule Module", person.history.get(12).module.submoduleName);
       previousStateExited = person.history.get(13).exited;
       currentStateEntered = person.history.get(12).entered;
       assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Call_MedicationOrder_Submodule", person.history.get(11).name);
-      assertEquals("Encounter Submodule Module", person.history.get(11).module.name);
+      assertEquals("Encounter Submodule Module", person.history.get(11).module.submoduleName);
       previousStateExited = person.history.get(12).exited;
       currentStateEntered = person.history.get(11).entered;
       assertEquals(previousStateExited, currentStateEntered);
 
 
       assertEquals("Initial", person.history.get(10).name);
-      assertEquals("Medication Submodule Module", person.history.get(10).module.name);
+      assertEquals("Medication Submodule Module", person.history.get(10).module.submoduleName);
       // previousStateExited = person.history.get(11).exited;
       // currentStateEntered = person.history.get(10).entered;
       // assertEquals(previousStateExited, currentStateEntered);
       // see notes above for why this property doesn't hold
 
       assertEquals("Examplitis_Medication", person.history.get(9).name);
-      assertEquals("Medication Submodule Module", person.history.get(9).module.name);
+      assertEquals("Medication Submodule Module", person.history.get(9).module.submoduleName);
       previousStateExited = person.history.get(10).exited;
       currentStateEntered = person.history.get(9).entered;
       assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Delay_Yet_Again", person.history.get(8).name);
-      assertEquals("Medication Submodule Module", person.history.get(8).module.name);
+      assertEquals("Medication Submodule Module", person.history.get(8).module.submoduleName);
       previousStateExited = person.history.get(9).exited;
       currentStateEntered = person.history.get(8).entered;
       assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("End_Medication", person.history.get(7).name);
-      assertEquals("Medication Submodule Module", person.history.get(7).module.name);
+      assertEquals("Medication Submodule Module", person.history.get(7).module.submoduleName);
       previousStateExited = person.history.get(8).exited;
       currentStateEntered = person.history.get(7).entered;
       assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Med_Terminal", person.history.get(6).name);
-      assertEquals("Medication Submodule Module", person.history.get(6).module.name);
+      assertEquals("Medication Submodule Module", person.history.get(6).module.submoduleName);
       previousStateExited = person.history.get(7).exited;
       currentStateEntered = person.history.get(6).entered;
       assertEquals(previousStateExited, currentStateEntered);
 
 
       assertEquals("Call_MedicationOrder_Submodule", person.history.get(5).name);
-      assertEquals("Encounter Submodule Module", person.history.get(5).module.name);
+      assertEquals("Encounter Submodule Module", person.history.get(5).module.submoduleName);
       // previousStateExited = person.history.get(6).exited;
       // currentStateEntered = person.history.get(5).entered;
       // assertEquals(previousStateExited, currentStateEntered);
@@ -1994,13 +2003,13 @@ public class StateTest {
       // but the entered & exited times don't line up cleanly
 
       assertEquals("Delay_Some_More", person.history.get(4).name);
-      assertEquals("Encounter Submodule Module", person.history.get(4).module.name);
+      assertEquals("Encounter Submodule Module", person.history.get(4).module.submoduleName);
       previousStateExited = person.history.get(5).exited;
       currentStateEntered = person.history.get(4).entered;
       assertEquals(previousStateExited, currentStateEntered);
 
       assertEquals("Encounter_Terminal", person.history.get(3).name);
-      assertEquals("Encounter Submodule Module", person.history.get(3).module.name);
+      assertEquals("Encounter Submodule Module", person.history.get(3).module.submoduleName);
       previousStateExited = person.history.get(4).exited;
       currentStateEntered = person.history.get(3).entered;
       assertEquals(previousStateExited, currentStateEntered);
@@ -2038,6 +2047,7 @@ public class StateTest {
         Whitebox.<Map<String, Module.ModuleSupplier>>getInternalState(Module.class, "modules");
     // hack to load these test modules so they can be called by the CallSubmodule state
     Module subModule = TestHelper.getFixture("submodules/admission.json");
+    subModule.submodule = true;
     modules.put("submodules/admission", new Module.ModuleSupplier(subModule));
 
     try {
@@ -2216,7 +2226,7 @@ public class StateTest {
     State deviceState = module.getState("Artificial_Heart");
     assertTrue(deviceState.process(person, time));
 
-    Encounter encounter = person.getCurrentEncounter(module);
+    Encounter encounter = person.record.currentEncounter(time);
     List<HealthRecord.Device> devices = encounter.devices;
     assertNotNull(devices);
     assertEquals(1, devices.size());
@@ -2245,7 +2255,7 @@ public class StateTest {
     State deviceEndState = module.getState("Remove_Device_By_Attribute");
     assertTrue(deviceEndState.process(person, time));
 
-    Encounter encounter = person.getCurrentEncounter(module);
+    Encounter encounter = person.record.currentEncounter(time);
     List<HealthRecord.Device> devices = encounter.devices;
     HealthRecord.Device device = devices.get(0);
     assertEquals(time, device.stop);
@@ -2264,7 +2274,7 @@ public class StateTest {
     State deviceEndState = module.getState("Remove_Device_By_Code");
     assertTrue(deviceEndState.process(person, time));
 
-    Encounter encounter = person.getCurrentEncounter(module);
+    Encounter encounter = person.record.currentEncounter(time);
     List<HealthRecord.Device> devices = encounter.devices;
     HealthRecord.Device device = devices.get(0);
     assertEquals(time, device.stop);
@@ -2284,7 +2294,7 @@ public class StateTest {
     State deviceEndState = module.getState("Remove_Device_By_State");
     assertTrue(deviceEndState.process(person, time));
 
-    Encounter encounter = person.getCurrentEncounter(module);
+    Encounter encounter = person.record.currentEncounter(time);
     List<HealthRecord.Device> devices = encounter.devices;
     HealthRecord.Device device = devices.get(0);
     assertEquals(time, device.stop);
@@ -2300,7 +2310,7 @@ public class StateTest {
     State supplyListState = module.getState("Necessary_Supplies");
     assertTrue(supplyListState.process(person, time));
 
-    Encounter encounter = person.getCurrentEncounter(module);
+    Encounter encounter = person.record.currentEncounter(time);
     List<HealthRecord.Supply> supplies = encounter.supplies;
     assertNotNull(supplies);
     assertEquals(4, supplies.size());
@@ -2330,7 +2340,7 @@ public class StateTest {
     State supplyListState = module.getState("Vaccine");
     assertTrue(supplyListState.process(person, time));
 
-    Encounter encounter = person.getCurrentEncounter(module);
+    Encounter encounter = person.record.currentEncounter(time);
     List<HealthRecord.Immunization> vaccines = encounter.immunizations;
     assertNotNull(vaccines);
     assertEquals(1, vaccines.size());

--- a/src/test/java/org/mitre/synthea/export/JSONExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/JSONExporterTest.java
@@ -41,7 +41,9 @@ public class JSONExporterTest {
       assertEquals(person.attributes.get(Person.GENDER), gender);
       if (moduleExport) {
         attributes.keySet().forEach((attributeName) -> {
-          if (attributeName.endsWith("Module")) {
+          if (!attributeName.startsWith("active_wellness_encounter")
+              && attributeName.endsWith("Module")) {
+            Object obj = attributes.get(attributeName);
             attributes.get(attributeName).getAsJsonArray().forEach((stateElement) -> {
               if (stateElement.getAsJsonObject().get("state_name") == null) {
                 validationErrors.add(String.format("Module %s does not have a state name in "

--- a/src/test/java/org/mitre/synthea/export/rif/BB2RIFExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/rif/BB2RIFExporterTest.java
@@ -88,7 +88,7 @@ public class BB2RIFExporterTest {
     Generator.DEFAULT_STATE = Config.get("test_state.default", "Massachusetts");
     Config.set("exporter.bfd.export", "true");
     Config.set("exporter.bfd.require_code_maps", "false");
-    Config.set("exporter.bfd.years_of_history", "10");
+    Config.set("exporter.years_of_history", "10");
     Config.set("generate.only_alive_patients", "true");
     exportDir = tempFolder.newFolder();
     Config.set("exporter.baseDirectory", exportDir.toString());

--- a/src/test/java/org/mitre/synthea/modules/QualityOfLifeTest.java
+++ b/src/test/java/org/mitre/synthea/modules/QualityOfLifeTest.java
@@ -8,10 +8,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mitre.synthea.TestHelper;
 import org.mitre.synthea.world.agents.PayerManager;
 import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
 import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
 import org.mitre.synthea.world.concepts.HealthRecord.Entry;
 
 //test calculate, conditionsInYear, weight
@@ -29,6 +32,10 @@ public class QualityOfLifeTest {
   public void init() {
     // Create Person
     person = new Person(0);
+    Provider provider = TestHelper.buildMockProvider();
+    for (EncounterType type : EncounterType.values()) {
+      person.setProvider(type, provider);
+    }
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.attributes.put(Person.INCOME, 1000000);
 
@@ -86,7 +93,7 @@ public class QualityOfLifeTest {
 
     double dalyLiving = qol[0];
     double qalyLiving = qol[1];
-    // All care was recieved so the person recieves least QOL impact.
+    // All care was received so the person receives least QOL impact.
     assertEquals(true, (dalyLiving > 1.2 && dalyLiving < 1.3));
     assertEquals(true, (qalyLiving > 33 && qalyLiving < 34));
   }
@@ -100,7 +107,7 @@ public class QualityOfLifeTest {
 
     double dalyDeceased = qol[0];
     double qalyDeceased = qol[1];
-    // All care was recieved so the person recieves least QOL impact.
+    // All care was received so the person receives least QOL impact.
     assertEquals(true, (dalyDeceased > 53 && dalyDeceased < 54));
     assertEquals(true, (qalyDeceased > 33 && qalyDeceased < 34));
   }

--- a/src/test/java/org/mitre/synthea/world/agents/PayerTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/PayerTest.java
@@ -258,6 +258,10 @@ public class PayerTest {
     person = new Person(0L);
     person.attributes.put(Person.BIRTHDATE, time);
     person.attributes.put(Person.GENDER, "F");
+    Provider provider = TestHelper.buildMockProvider();
+    for (EncounterType type : EncounterType.values()) {
+      person.setProvider(type, provider);
+    }
     person.record.conditionStart(time, "254837009");
     person.attributes.put(Person.OCCUPATION_LEVEL, 1.0);
     // Above Medicaid Income Level.

--- a/src/test/java/org/mitre/synthea/world/concepts/CostsTest.java
+++ b/src/test/java/org/mitre/synthea/world/concepts/CostsTest.java
@@ -5,13 +5,16 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Random;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mitre.synthea.TestHelper;
+import org.mitre.synthea.engine.Generator;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.world.agents.PayerManager;
 import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
 import org.mitre.synthea.world.concepts.HealthRecord.Code;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
 import org.mitre.synthea.world.concepts.HealthRecord.Entry;
 import org.mitre.synthea.world.concepts.HealthRecord.Medication;
 
@@ -26,9 +29,13 @@ public class CostsTest {
   @Before
   public void setup() {
     Costs.loadCostData();
-    person = new Person(System.currentTimeMillis());
     PayerManager.loadNoInsurance();
     time = 0L;
+    person = new Person(System.currentTimeMillis());
+    Provider provider = TestHelper.buildMockProvider();
+    for (EncounterType type : EncounterType.values()) {
+      person.setProvider(type, provider);
+    }
     person.attributes.put(Person.BIRTHDATE, time);
     person.coverage.setPlanToNoInsurance(time);
   }
@@ -49,7 +56,8 @@ public class CostsTest {
     assertTrue(cost <= maxCost);
     assertTrue(cost >= minCost);
 
-    person.attributes.put(Person.STATE, "Massachusetts");
+    String state = Config.get("test_state.default", Generator.DEFAULT_STATE);
+    person.attributes.put(Person.STATE, state);
     double adjFactor = 0.5096;
     cost = Costs.determineCostOfEntry(fakeMedication, person);
     assertTrue(cost <= (maxCost * adjFactor));
@@ -70,7 +78,8 @@ public class CostsTest {
     assertTrue(cost <= maxCost);
     assertTrue(cost >= minCost);
 
-    person.attributes.put(Person.STATE, "Massachusetts");
+    String state = Config.get("test_state.default", Generator.DEFAULT_STATE);
+    person.attributes.put(Person.STATE, state);
     double adjFactor = 0.8183;
     cost = Costs.determineCostOfEntry(fakeDevice, person);
     assertTrue(cost <= (maxCost * adjFactor));
@@ -91,7 +100,8 @@ public class CostsTest {
     assertTrue(cost <= maxCost);
     assertTrue(cost >= minCost);
 
-    person.attributes.put(Person.STATE, "Massachusetts");
+    String state = Config.get("test_state.default", Generator.DEFAULT_STATE);
+    person.attributes.put(Person.STATE, state);
     double adjFactor = 0.8183;
     cost = Costs.determineCostOfEntry(fakeSupply, person);
     assertTrue(cost <= (maxCost * adjFactor));
@@ -116,7 +126,8 @@ public class CostsTest {
     assertTrue(cost <= maxCost);
     assertTrue(cost >= minCost);
     // Now test cost with adjustment factor.
-    person.attributes.put(Person.STATE, "California");
+    String state = Config.get("test_state.alternative", "California");
+    person.attributes.put(Person.STATE, state);
     double adjFactor = 1.0227;
     cost = Costs.determineCostOfEntry(fakeMedication, person);
     assertTrue(cost <= (maxCost * adjFactor));

--- a/src/test/java/org/mitre/synthea/world/concepts/HealthRecordTest.java
+++ b/src/test/java/org/mitre/synthea/world/concepts/HealthRecordTest.java
@@ -22,6 +22,7 @@ import org.mitre.synthea.world.geography.Location;
 
 public class HealthRecordTest {
 
+  Provider provider;
   InsurancePlan noInsurance;
   long time;
 
@@ -30,14 +31,22 @@ public class HealthRecordTest {
    */
   @Before
   public void setup() {
+    provider = TestHelper.buildMockProvider();
     PayerManager.loadPayers(new Location("Massachusetts", null));
     noInsurance = PayerManager.getNoInsurancePlan();
     time = 0L;
   }
 
+  private void setProvider(Person person) {
+    for (EncounterType type : EncounterType.values()) {
+      person.setProvider(type, provider);
+    }
+  }
+
   @Test
   public void testReportAllObs() {
     Person person = new Person(0L);
+    setProvider(person);
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.coverage.setPlanToNoInsurance(time);
     HealthRecord record = new HealthRecord(person);
@@ -57,6 +66,7 @@ public class HealthRecordTest {
   @Test
   public void testReportSomeObs() {
     Person person = new Person(0L);
+    setProvider(person);
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.coverage.setPlanToNoInsurance(time);
     HealthRecord record = new HealthRecord(person);
@@ -75,6 +85,7 @@ public class HealthRecordTest {
   @Test
   public void testReportTooManyObs() {
     Person person = new Person(0L);
+    setProvider(person);
     person.attributes.put(Person.BIRTHDATE, 0L);
     person.coverage.setPlanToNoInsurance(time);
     HealthRecord record = new HealthRecord(person);
@@ -94,6 +105,7 @@ public class HealthRecordTest {
   @Test
   public void testMedicationAdministrationQuantity() {
     Person person = new Person(0L);
+    setProvider(person);
     person.attributes.put(Person.BIRTHDATE, time);
     person.coverage.setPlanToNoInsurance(time);
     Medication med = person.record.medicationStart(time, "foobar", false);
@@ -105,6 +117,7 @@ public class HealthRecordTest {
   @Test
   public void testMedicationPrescriptionQuantity() {
     Person person = new Person(0L);
+    setProvider(person);
     person.attributes.put(Person.BIRTHDATE, time);
     person.coverage.setPlanToNoInsurance(time);
     Medication med = person.record.medicationStart(time, "foobar", true);
@@ -115,9 +128,9 @@ public class HealthRecordTest {
   @Test
   public void testMedicationDetailedQuantity() throws Exception {
     Person person = new Person(0L);
+    setProvider(person);
     person.attributes.put(Person.BIRTHDATE, time);
     person.coverage.setPlanToNoInsurance(time);
-    person.setProvider(EncounterType.WELLNESS, new Provider());
 
     Module module = TestHelper.getFixture("medication_order.json");
 

--- a/src/test/resources/generic/example_module.json
+++ b/src/test/resources/generic/example_module.json
@@ -5,7 +5,6 @@
     "can be cured with Examplitol or an Examplotomy but some never recover."
   ],
   "states": {
-
     "Initial": {
       "type": "Initial",
       "conditional_transition": [
@@ -21,7 +20,6 @@
         }
       ]
     },
-
     "Age_Guard": {
       "type": "Guard",
       "allow": {
@@ -32,16 +30,15 @@
       },
       "distributed_transition": [
         {
-          "distribution": 0.10,
+          "distribution": 0.1,
           "transition": "Pre_Examplitis"
         },
         {
-          "distribution": 0.90,
+          "distribution": 0.9,
           "transition": "Terminal"
         }
       ]
     },
-
     "Pre_Examplitis": {
       "type": "Delay",
       "range": {
@@ -51,7 +48,6 @@
       },
       "direct_transition": "Examplitis"
     },
-
     "Examplitis": {
       "type": "ConditionOnset",
       "target_encounter": "Wellness_Encounter",
@@ -64,13 +60,11 @@
       ],
       "direct_transition": "Wellness_Encounter"
     },
-
     "Wellness_Encounter": {
       "type": "Encounter",
       "wellness": true,
       "direct_transition": "Examplitol"
     },
-
     "Examplitol": {
       "type": "MedicationOrder",
       "reason": "Examplitis",
@@ -81,22 +75,8 @@
           "display": "Examplitol"
         }
       ],
-      "distributed_transition": [
-        {
-          "distribution": 0.2,
-          "transition": "Pre_Examplotomy"
-        },
-        {
-          "distribution": 0.1,
-          "transition": "Last_Days"
-        },
-        {
-          "distribution": 0.7,
-          "transition": "Terminal"
-        }
-      ]
+      "direct_transition": "End Wellness Encounter"
     },
-
     "Pre_Examplotomy": {
       "type": "Delay",
       "range": {
@@ -106,7 +86,6 @@
       },
       "direct_transition": "Examplotomy_Encounter"
     },
-
     "Examplotomy_Encounter": {
       "type": "Encounter",
       "encounter_class": "ambulatory",
@@ -119,7 +98,6 @@
       ],
       "direct_transition": "Examplotomy"
     },
-
     "Examplotomy": {
       "type": "Procedure",
       "duration": {
@@ -137,10 +115,9 @@
       "reason": "Examplitis",
       "direct_transition": "End_Examplotomy_Encounter"
     },
-
     "End_Examplotomy_Encounter": {
-    	"type": "EncounterEnd",
-    	"distributed_transition": [
+      "type": "EncounterEnd",
+      "distributed_transition": [
         {
           "distribution": 0.1,
           "transition": "Death"
@@ -151,24 +128,39 @@
         }
       ]
     },
-
     "Last_Days": {
       "type": "Delay",
       "range": {
-          "low": 8,
-          "high": 20,
-          "unit": "years"
+        "low": 8,
+        "high": 20,
+        "unit": "years"
       },
       "direct_transition": "Death"
     },
-
     "Death": {
       "type": "Death",
       "direct_transition": "Terminal"
     },
-
     "Terminal": {
       "type": "Terminal"
+    },
+    "End Wellness Encounter": {
+      "type": "EncounterEnd",
+      "distributed_transition": [
+        {
+          "distribution": 0.2,
+          "transition": "Pre_Examplotomy"
+        },
+        {
+          "distribution": 0.1,
+          "transition": "Last_Days"
+        },
+        {
+          "distribution": 0.7,
+          "transition": "Terminal"
+        }
+      ]
     }
-  }
+  },
+  "gmf_version": 2
 }


### PR DESCRIPTION
This pull request fixes Encounter Leaks as described in #1221.

With these changes, modules must now "reserve" the "current encounter" and "release" it when finished.

Modules that do not have the current encounter are blocked from starting new encounters. Wellness encounters are still an exception.

This fix also adjusts how submodules are called and tracked. A submodule may impersonate or disguise itself as a parent top-level module in order to interact with the current encounter. It does this by saying it is the parent top-level module when it is asked for its name.