### PR TITLE
UUID recreation on other exporters

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CPCDSExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CPCDSExporter.java
@@ -234,7 +234,7 @@ public class CPCDSExporter {
     long end = 0;
 
     for (Encounter encounter : person.record.encounters) {
-      String encounterID = person.randUUID().toString();
+      String encounterID = encounter.uuid.toString();
       UUID medRecordNumber = person.randUUID();
       CPCDSAttributes encounterAttributes = new CPCDSAttributes(encounter);
 

--- a/src/main/java/org/mitre/synthea/export/CPCDSExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CPCDSExporter.java
@@ -235,7 +235,8 @@ public class CPCDSExporter {
 
     for (Encounter encounter : person.record.encounters) {
       String encounterID = encounter.uuid.toString();
-      UUID medRecordNumber = person.randUUID();
+      String medRecordNumber = ExportHelper.buildUUID(person, encounter.start,
+          "MedRecordNumber for Encounter" + encounterID);
       CPCDSAttributes encounterAttributes = new CPCDSAttributes(encounter);
 
 
@@ -258,8 +259,8 @@ public class CPCDSExporter {
       if (start == 999999999999999999L) {
         start = end;
       }
-      String coverageID = coverage(person, personID, start, end, payerId, type, groupId, groupName,
-              planName, planId);
+      String coverageID = coverage(person, personID, encounterID, start, end, payerId, type,
+          groupId, groupName, planName, planId);
       claim(person, encounter, personID, encounterID, medRecordNumber, encounterAttributes, payerId,
               coverageID);
       hospital(encounter, encounterAttributes, payerName);
@@ -328,18 +329,18 @@ public class CPCDSExporter {
   /**
    * Write a single Coverage CPCDS file.
    *
-   * @param rand        Source of randomness to use when generating ids etc
    * @param personID    ID of the person prescribed the careplan.
    * @param encounterID ID of the encounter where the careplan was prescribed
    * @param careplan    The careplan itself
    * @throws IOException if any IO error occurs
    */
-  private String coverage(RandomNumberGenerator rand, String personID, long start, long stop,
+  private String coverage(Person person, String personID, String encounterID, long start, long stop,
           String payerId, String type, UUID groupId, String groupName, String name,
           String planId) throws IOException {
 
     StringBuilder s = new StringBuilder();
-    String coverageID = rand.randUUID().toString();
+    String coverageID = ExportHelper.buildUUID(person, start,
+        "Coverage ID for Encounter" + encounterID);
     s.append(coverageID).append(',');
     s.append(personID).append(',');
     s.append(personID).append(',');
@@ -384,7 +385,7 @@ public class CPCDSExporter {
    * @throws IOException Throws this exception
    */
   private void claim(RandomNumberGenerator rand, Encounter encounter, String personID,
-          String encounterID, UUID medRecordNumber, CPCDSAttributes attributes, String payerId,
+          String encounterID, String medRecordNumber, CPCDSAttributes attributes, String payerId,
           String coverageID) throws IOException {
 
     StringBuilder s = new StringBuilder();
@@ -402,7 +403,7 @@ public class CPCDSExporter {
         String.valueOf(dateFromTimestamp(encounter.start)),
         String.valueOf(dateFromTimestamp(encounter.stop)),
         personID.toString(),
-        medRecordNumber.toString(),
+        medRecordNumber,
         encounterID,
         "",
         "",
@@ -748,7 +749,7 @@ public class CPCDSExporter {
                   * dayMultiplier.get(duration.get("unit").getAsString());
         }
 
-        UUID rxRef = rand.randUUID();
+        UUID rxRef = medication.uuid;
 
         String[] serviceTypeList = { "01", "04", "06" };
         String serviceType = serviceTypeList[(int) randomLongWithBounds(0, 2)];

--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -471,7 +471,7 @@ public class CSVExporter {
 
     for (Encounter encounter : person.record.encounters) {
 
-      String encounterID = encounter(person, personID, encounter);
+      String encounterID = encounter(personID, encounter);
       String payerID = encounter.claim.plan.getPayer().uuid;
 
       claim(person, encounter.claim, encounter, encounterID, time);
@@ -512,11 +512,11 @@ public class CSVExporter {
       }
 
       for (CarePlan careplan : encounter.careplans) {
-        careplan(person, personID, encounterID, careplan);
+        careplan(personID, encounterID, careplan);
       }
 
       for (ImagingStudy imagingStudy : encounter.imagingStudies) {
-        imagingStudy(person, personID, encounterID, imagingStudy);
+        imagingStudy(personID, encounterID, imagingStudy);
       }
 
       for (Device device : encounter.devices) {
@@ -655,19 +655,18 @@ public class CSVExporter {
   /**
    * Write a single Encounter line to encounters.csv.
    *
-   * @param rand      Source of randomness to use when generating ids etc
    * @param personID  The ID of the person that had this encounter
    * @param encounter The encounter itself
    * @return The encounter ID, to be referenced as a "foreign key" if necessary
    * @throws IOException if any IO error occurs
    */
-  private String encounter(RandomNumberGenerator rand, String personID,
+  private String encounter(String personID,
           Encounter encounter) throws IOException {
     // Id,START,STOP,PATIENT,ORGANIZATION,PROVIDER,PAYER,ENCOUNTERCLASS,CODE,DESCRIPTION,
     // BASE_ENCOUNTER_COST,TOTAL_CLAIM_COST,PAYER_COVERAGE,REASONCODE,REASONDESCRIPTION
     StringBuilder s = new StringBuilder();
 
-    String encounterID = rand.randUUID().toString();
+    String encounterID = encounter.uuid.toString();
     // ID
     s.append(encounterID).append(',');
     // START
@@ -1038,18 +1037,17 @@ public class CSVExporter {
   /**
    * Write a single CarePlan to careplans.csv.
    *
-   * @param rand        Source of randomness to use when generating ids etc
    * @param personID    ID of the person prescribed the careplan.
    * @param encounterID ID of the encounter where the careplan was prescribed
    * @param careplan    The careplan itself
    * @throws IOException if any IO error occurs
    */
-  private String careplan(RandomNumberGenerator rand, String personID, String encounterID,
+  private String careplan(String personID, String encounterID,
       CarePlan careplan) throws IOException {
     // Id,START,STOP,PATIENT,ENCOUNTER,CODE,DESCRIPTION,REASONCODE,REASONDESCRIPTION
     StringBuilder s = new StringBuilder();
 
-    String careplanID = rand.randUUID().toString();
+    String careplanID = careplan.uuid.toString();
     s.append(careplanID).append(',');
     s.append(dateFromTimestamp(careplan.start)).append(',');
     if (careplan.stop != 0L) {
@@ -1081,19 +1079,18 @@ public class CSVExporter {
   /**
    * Write a single ImagingStudy to imaging_studies.csv.
    *
-   * @param rand         Source of randomness to use when generating ids etc
    * @param personID     ID of the person the ImagingStudy was taken of.
    * @param encounterID  ID of the encounter where the ImagingStudy was performed
    * @param imagingStudy The ImagingStudy itself
    * @throws IOException if any IO error occurs
    */
-  private String imagingStudy(RandomNumberGenerator rand, String personID, String encounterID,
+  private String imagingStudy(String personID, String encounterID,
       ImagingStudy imagingStudy) throws IOException {
     // Id,DATE,PATIENT,ENCOUNTER,SERIES_UID,BODYSITE_CODE,BODYSITE_DESCRIPTION,
     // MODALITY_CODE,MODALITY_DESCRIPTION,INSTANCE_UID,SOP_CODE,SOP_DESCRIPTION,PROCEDURE_CODE
     StringBuilder s = new StringBuilder();
 
-    String studyID = rand.randUUID().toString();
+    String studyID = imagingStudy.uuid.toString();
 
     for (ImagingStudy.Series series: imagingStudy.series) {
       String seriesDicomUid = series.dicomUid;
@@ -1412,7 +1409,7 @@ public class CSVExporter {
 
     StringBuilder s = new StringBuilder();
     // Claim Id. Should be a number.
-    String claimId = rand.randUUID().toString();
+    String claimId = claim.uuid.toString();
     s.append(claimId).append(',');
     // PATIENTID
     s.append(claim.person.attributes.get(Person.ID)).append(',');
@@ -1811,6 +1808,7 @@ public class CSVExporter {
      */
     public ClaimTransaction(Encounter encounter, String encounterId, Claim claim, String claimId,
         long chargeId, Claim.ClaimEntry claimEntry, RandomNumberGenerator rand) {
+      // TODO: fix this one
       this.id = rand.randUUID().toString();
       this.encounterId = encounterId;
       this.claimId = claimId;

--- a/src/main/java/org/mitre/synthea/export/FhirR4PatientHome.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4PatientHome.java
@@ -5,7 +5,6 @@ import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.codesystems.LocationPhysicalType;
-import org.mitre.synthea.world.agents.Person;
 
 /**
  * Singleton class to manage the instance of the "Patient's Home" Location resource.
@@ -32,9 +31,10 @@ public class FhirR4PatientHome {
               .setDisplay(LocationPhysicalType.HO.getDisplay())
           ));
       patientHome.setDescription("Patient's Home");
-      // Not really generating a random UUID. Given that this is not tied to a particular provider
-      // or person, this just makes up a person with a hardcoded random seed.
-      patientHome.setId(new Person(1).randUUID().toString());
+      // Given that this is not tied to a particular provider or person,
+      // this is a fixed value based on an arbitrary choice:
+      // new Patient(1).randUUID().toString() --> bb1ad573-19b8-9cd8-68fb-0e6f684df992
+      patientHome.setId("bb1ad573-19b8-9cd8-68fb-0e6f684df992");
       Identifier identifier = patientHome.addIdentifier();
       identifier.setSystem(FhirR4.SYNTHEA_IDENTIFIER);
       identifier.setValue(patientHome.getId());

--- a/src/main/resources/templates/ccda/allergies.ftl
+++ b/src/main/resources/templates/ccda/allergies.ftl
@@ -14,7 +14,7 @@
         <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
         <templateId root="2.16.840.1.113883.10.20.22.4.30" extension="2015-08-01"/>
         <!--Allergy act template -->
-        <id root="${UUID?api.toString()}"/>
+        <id root="${entry.uuid}"/>
         <code nullFlavor="NA"/>
         <statusCode code="active"/>
         <effectiveTime>

--- a/src/main/resources/templates/ccda/conditions.ftl
+++ b/src/main/resources/templates/ccda/conditions.ftl
@@ -14,7 +14,7 @@
         <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
         <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
         <!-- Problem act template -->
-        <id root="${UUID?api.toString()}"/>
+        <id root="${entry.uuid}"/>
         <code nullFlavor="NA"/>
         <#if entry.stop != 0>
         <statusCode code="completed"/>

--- a/src/main/resources/templates/ccda/encounters.ftl
+++ b/src/main/resources/templates/ccda/encounters.ftl
@@ -13,7 +13,7 @@
       <encounter classCode="ENC" moodCode="EVN">
 		    <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
         <!-- Encounter activity template -->
-        <id root="${UUID?api.toString()}"/>
+        <id root="${entry.uuid}"/>
         <@codes.code_section codes=entry.codes section="encounters" counter=entry?counter />
         <text>
           <reference value="#encounters-desc-${entry?counter}"/>

--- a/src/main/resources/templates/ccda/functional_status.ftl
+++ b/src/main/resources/templates/ccda/functional_status.ftl
@@ -13,7 +13,7 @@
         <entry>
          <observation classCode="OBS" moodCode="EVN">
              <templateId root="2.16.840.1.113883.10.20.22.4.69"/>
-             <id root="${UUID?api.toString()}"/>
+             <id root="${entry.uuid}"/>
              <@codes.code_section codes=entry.codes section="functional-status" counter=entry?counter />
              <text>
                <reference value="#functional-status-desc-${entry?counter}"/>

--- a/src/main/resources/templates/ccda/immunizations.ftl
+++ b/src/main/resources/templates/ccda/immunizations.ftl
@@ -13,7 +13,7 @@
       <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="false">
         <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
         <!-- Medication activity template -->
-        <id root="${UUID?api.toString()}"/>
+        <id root="${entry.uuid}"/>
         <code code='IMMUNIZ' codeSystem='2.16.840.1.113883.5.4' codeSystemName='ActCode'/>
         <text>
           <reference value="#immunizations-desc-${entry?counter}"/>

--- a/src/main/resources/templates/ccda/medical_equipment.ftl
+++ b/src/main/resources/templates/ccda/medical_equipment.ftl
@@ -13,7 +13,7 @@
       <supply classCode="SPLY" moodCode="EVN">
         <templateId root="2.16.840.1.113883.10.20.22.4.50"/>
         <!-- Supply activity template -->
-        <id root="${UUID?api.toString()}"/>
+        <id root="${entry.uuid}"/>
         <statusCode code="completed"/>
         <effectiveTime value="${entry.start?number_to_date?string["yyyyMMddHHmmss"]}"/>
         <participant typeCode="DEV">

--- a/src/main/resources/templates/ccda/medications.ftl
+++ b/src/main/resources/templates/ccda/medications.ftl
@@ -13,7 +13,7 @@
       <substanceAdministration classCode="SBADM" moodCode="EVN">
         <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
         <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09"/>
-        <id root="${UUID?api.toString()}"/>
+        <id root="${entry.uuid}"/>
         <statusCode code="completed"/>
         <effectiveTime xsi:type="IVL_TS">
           <low value="${entry.start?number_to_date?string["yyyyMMddHHmmss"]}"/>

--- a/src/main/resources/templates/ccda/procedures.ftl
+++ b/src/main/resources/templates/ccda/procedures.ftl
@@ -13,7 +13,7 @@
       <procedure classCode="PROC" moodCode="EVN">
         <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
         <!-- Procedure activity template -->
-        <id root="${UUID?api.toString()}"/>
+        <id root="${entry.uuid}"/>
         <@codes.code_section codes=entry.codes section="procedures" counter=entry?counter />
         <text>
           <reference value="#procedures-desc-#{entry?counter}"/>

--- a/src/main/resources/templates/ccda/results.ftl
+++ b/src/main/resources/templates/ccda/results.ftl
@@ -16,7 +16,7 @@
         <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
         <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
         <!--Result organizer template -->
-        <id root="${UUID?api.toString()}"/>
+        <id root="${entry.uuid}"/>
         <code code="${entry.codes[0].code}" codeSystem="<@lookup.oid_for_code_system system=entry.codes[0].system/>" codeSystemName="LOINC" displayName="${entry.codes[0].display}"/>
         <statusCode code="completed"/>
         <effectiveTime>
@@ -28,7 +28,7 @@
           <observation classCode="OBS" moodCode="EVN">
             <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2015-08-01"/>
             <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
-            <id root="${UUID?api.toString()}"/>
+            <id root="${obs.uuid}"/>
             <@codes.code_section codes=obs.codes section="reports" counter=entry?counter />
             <text>
               <reference value="#reports-desc-${entry?counter}"/>

--- a/src/main/resources/templates/ccda/social_history.ftl
+++ b/src/main/resources/templates/ccda/social_history.ftl
@@ -15,7 +15,7 @@
       <observation classCode="OBS" moodCode="EVN">
         <templateId root="2.16.840.1.113883.10.20.22.4.38" extension="2015-08-01"/>
         <!-- Social history observation template -->
-        <id root="${UUID?api.toString()}"/>
+        <id root="${entry.uuid}"/>
         <@codes.code_section codes=entry.codes section="social_history" counter=entry?counter />
         <statusCode code="completed"/>
         <effectiveTime value="${entry.start?number_to_date?string["yyyyMMddHHmmss"]}"/>
@@ -31,7 +31,7 @@
         <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
         <templateId root="2.16.840.1.113883.10.20.22.4.78" extension="2014-06-09"/>
         <!-- Smoking Status Meaningful Use template -->
-        <id root="${UUID?api.toString()}"/>
+        <id root="${ehr_smoking_history.uuid}"/>
         <code code="72166-2" codeSystem="2.16.840.1.113883.6.1" displayName="Tobacco smoking status NHIS" />
         <statusCode code="completed"/>
         <effectiveTime value="${ehr_smoking_history.start?number_to_date?string["yyyyMMddHHmmss"]}"/>

--- a/src/main/resources/templates/ccda/vital_signs.ftl
+++ b/src/main/resources/templates/ccda/vital_signs.ftl
@@ -27,7 +27,7 @@
             <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
             <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09"/>
             <!-- Result observation template -->
-            <id root="${UUID?api.toString()}"/>
+            <id root="${entry.uuid}"/>
             <@codes.code_section codes=entry.codes section="observations" counter=entry?counter />
             <text>
               <reference value="#observations-desc-${entry?counter}"/>
@@ -52,7 +52,7 @@
             <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
             <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09"/>
             <!-- Result observation template -->
-            <id root="${UUID?api.toString()}"/>
+            <id root="${obs.uuid}"/>
             <@codes.code_section codes=obs.codes section="observations" counter=entry?counter />
             <text>
               <reference value="#observations-desc-${entry?counter}"/>
@@ -81,7 +81,7 @@
             <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
             <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09"/>
             <!-- Result observation template -->
-            <id root="${UUID?api.toString()}"/>
+            <id root="${entry.uuid}"/>
             <@codes.code_section codes=entry.codes section="observations" counter=entry?counter />
             <text>
               <reference value="#observations-desc-${entry?counter}"/>


### PR DESCRIPTION
This PR completes the "reproducibility fixes" from #1237 - that PR updated the FHIR R4 exporter, this PR updates all other exporters that use UUIDs. Now instead of using Person.randUUID, the exporters use the uuid from the relevant entry where possible. In only a few instances this doesn't work out super cleanly, and there are spots where the UUIDs may differ in some cases.

Here are the (intentional) exceptions:
 - CSV Exporter, claim_transactions.csv
   - The CSV exporter uses a monotonically increasing value for "ChargeID" which is shared across all patients. If Synthea is run with only a single thread and all the same settings, 2 runs will be exactly identical. If the run uses multithreading, then the order of exports will be different, and different entries in this file will receive different IDs and ChargeIDs
 - CCDA Exporter
   - Any instance where a Synthea HealthRecord.Entry maps cleanly to a single CCDA template will be fine, but instances where one Entry maps to multiple templates still use the randUUID() method. For example see `conditions.ftl` - the Entry UUID is assigned to the "problem act template" (line 17) but there is another UUID down in the nested "Problem observation template" below (line 33) which is left as randUUID(). (The randUUID will still evaluate to the same thing given the exact exact same settings, but is not guaranteed in all cases)

Still in progress: I'm also adding a wiki page with notes on how to recreate a population and what the expectations and limitations are. WIP here: https://github.com/synthetichealth/synthea/wiki/Recreating-a-Dataset