### PR TITLE
Update CI action versions

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -6,14 +6,15 @@ jobs:
     name: Java 17
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: 'zulu'
 
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -50,14 +51,15 @@ jobs:
     name: Java 11
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'zulu'
 
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -75,7 +75,7 @@ jobs:
         run: ./gradlew check
   
       - name: Code coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
 
       - name: Slack Notification
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,14 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'zulu'
 
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
Update the versions of the actions used in our CI to address some of the deprecation warnings. 

For example see https://github.com/synthetichealth/synthea/actions/runs/4117160673  
If you dig into the log https://github.com/synthetichealth/synthea/actions/runs/4117160673/jobs/7108119437  you can see that the deprecation warnings come from the steps "Set up JDK" and "Gradle cache".

The only difference beyond just version numbers is we now need to specify a java distribution to use:
https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md  
`'zulu'` was the implicit default previously so I stuck with that here.

