### PR TITLE
Additional reproducibility fixes, plus a "single person seed" feature

### DIFF
--- a/src/main/java/App.java
+++ b/src/main/java/App.java
@@ -23,6 +23,7 @@ public class App {
   public static void usage() {
     System.out.println("Usage: run_synthea [options] [state [city]]");
     System.out.println("Options: [-s seed] [-cs clinicianSeed] [-p populationSize]");
+    System.out.println("         [-ps singlePersonSeed]");
     System.out.println("         [-r referenceDate as YYYYMMDD]");
     System.out.println("         [-e endDate as YYYYMMDD]");
     System.out.println("         [-g gender] [-a minAge-maxAge]");
@@ -74,6 +75,9 @@ public class App {
           } else if (currArg.equalsIgnoreCase("-cs")) {
             String value = argsQ.poll();
             options.clinicianSeed = Long.parseLong(value);
+          } else if (currArg.equalsIgnoreCase("-ps")) {
+            String value = argsQ.poll();
+            options.singlePersonSeed = Long.valueOf(value);
           } else if (currArg.equalsIgnoreCase("-r")) {
             String value = argsQ.poll();
             // note that Y = "week year" and y = "year" per the formatting guidelines

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -114,6 +114,7 @@ public class Generator {
     /** By default use the current time as random seed. */
     public long seed = referenceTime;
     public long clinicianSeed = referenceTime;
+    public Long singlePersonSeed;
     /** Population as exclusively live persons or including deceased.
      * True for live, false includes deceased */
     public boolean overflow = true;
@@ -373,13 +374,16 @@ public class Generator {
           threadPool.submit(() -> updateRecordExportPerson(p, index));
         }
       }
-    } else {
+    } else if (this.options.singlePersonSeed == null) {
       // Generate patients up to the specified population size.
       for (int i = 0; i < this.options.population; i++) {
         final int index = i;
         final long seed = this.populationRandom.randLong();
         threadPool.submit(() -> generatePerson(index, seed));
       }
+    } else {
+      // we have a single fixed seed to generate, don't bother with threadpool
+      generatePerson(0, this.options.singlePersonSeed);
     }
 
     try {

--- a/src/main/java/org/mitre/synthea/world/agents/Person.java
+++ b/src/main/java/org/mitre/synthea/world/agents/Person.java
@@ -7,7 +7,7 @@ import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,9 +41,9 @@ import org.mitre.synthea.world.geography.quadtree.QuadTreeElement;
 
 public class Person implements Serializable, RandomNumberGenerator, QuadTreeElement {
   private static final long serialVersionUID = 4322116644425686379L;
-  private static final ZoneId timeZone = ZoneId.systemDefault();
 
   public static final String BIRTHDATE = "birthdate";
+  public static final String BIRTHDATE_AS_LOCALDATE = "birthdate_as_localdate";
   public static final String DEATHDATE = "deathdate";
   public static final String FIRST_NAME = "first_name";
   public static final String MIDDLE_NAME = "middle_name";
@@ -250,9 +250,16 @@ public class Person implements Serializable, RandomNumberGenerator, QuadTreeElem
     Period age = Period.ZERO;
 
     if (attributes.containsKey(BIRTHDATE)) {
-      LocalDate now = Instant.ofEpochMilli(time).atZone(timeZone).toLocalDate();
-      LocalDate birthdate = Instant.ofEpochMilli((long) attributes.get(BIRTHDATE))
-          .atZone(timeZone).toLocalDate();
+      LocalDate now = Instant.ofEpochMilli(time).atZone(ZoneOffset.UTC).toLocalDate();
+
+      // we call age() a lot, so caching the birthdate as a LocalDate saves some translation
+      LocalDate birthdate = (LocalDate) attributes.get(BIRTHDATE_AS_LOCALDATE);
+      if (birthdate == null) {
+        birthdate = Instant.ofEpochMilli((long) attributes.get(BIRTHDATE))
+            .atZone(ZoneOffset.UTC).toLocalDate();
+        attributes.put(BIRTHDATE_AS_LOCALDATE, birthdate);
+      }
+
       age = Period.between(birthdate, now);
     }
     return age;

--- a/src/test/java/org/mitre/synthea/engine/LogicTest.java
+++ b/src/test/java/org/mitre/synthea/engine/LogicTest.java
@@ -108,6 +108,7 @@ public class LogicTest {
     LocalDateTime bday = now.minus(age, ChronoUnit.YEARS);
     long birthdate = bday.toInstant(ZoneOffset.UTC).toEpochMilli();
     person.attributes.put(Person.BIRTHDATE, birthdate);
+    person.attributes.remove(Person.BIRTHDATE_AS_LOCALDATE);
   }
 
   @Test

--- a/src/test/java/org/mitre/synthea/modules/covid/C19ImmunizationModuleTest.java
+++ b/src/test/java/org/mitre/synthea/modules/covid/C19ImmunizationModuleTest.java
@@ -47,6 +47,7 @@ public class C19ImmunizationModuleTest {
     assertTrue(C19ImmunizationModule.eligibleForShot(person, decemberFifteenth));
     long eleven = TestHelper.timestamp(2009, 8, 1, 0, 0, 0);
     person.attributes.put(Person.BIRTHDATE, eleven);
+    person.attributes.remove(Person.BIRTHDATE_AS_LOCALDATE);
     assertFalse(C19ImmunizationModule.eligibleForShot(person, decemberFifteenth));
   }
 
@@ -100,6 +101,7 @@ public class C19ImmunizationModuleTest {
         person.attributes.get(C19ImmunizationModule.C19_VACCINE_STATUS));
     long newBirthday = TestHelper.timestamp(1978, 8, 1, 0, 0, 0);
     person.attributes.put(Person.BIRTHDATE, newBirthday);
+    person.attributes.remove(Person.BIRTHDATE_AS_LOCALDATE);
     mod.process(person, januaryOne);
     C19ImmunizationModule.VaccinationStatus status =
         (C19ImmunizationModule.VaccinationStatus)

--- a/src/test/java/org/mitre/synthea/world/agents/PersonTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/PersonTest.java
@@ -537,6 +537,20 @@ public class PersonTest {
     }
   }
 
+  @Test
+  public void testGetSymptoms() {
+    Person person = new Person(0L);
+    person.setSymptom("LifecycleModule", "life", "confusion", 0, 20, false);
+    person.setSymptom("LifecycleModule", "life", "headache", 0, 67, false);
+    person.setSymptom("LifecycleModule", "life", "irritability", 0, 8, false);
+    person.setSymptom("LifecycleModule", "life", "back pain", 0, 55, false);
+
+    // expect a sorted list of symptom names, for symptoms of severity >= 20
+    List<String> symptoms = person.getSymptoms();
+    assertEquals(3, symptoms.size());
+    assertEquals(List.of("headache", "back pain", "confusion"), symptoms);
+  }
+
   @Test()
   public void testPersonRandomStability() {
     Person personA = new Person(0L);

--- a/src/test/java/org/mitre/synthea/world/agents/PersonTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/PersonTest.java
@@ -162,11 +162,13 @@ public class PersonTest {
 
   private void testAgeYears(long birthdate, long now, long expectedAge) {
     person.attributes.put(Person.BIRTHDATE, birthdate);
+    person.attributes.remove(Person.BIRTHDATE_AS_LOCALDATE);
     assertEquals(expectedAge, person.ageInYears(now));
   }
 
   private void testAgeMonths(long birthdate, long now, long expectedAge) {
     person.attributes.put(Person.BIRTHDATE, birthdate);
+    person.attributes.remove(Person.BIRTHDATE_AS_LOCALDATE);
     assertEquals(expectedAge, person.ageInMonths(now));
   }
 


### PR DESCRIPTION
Fixes two additional instances where running with the same settings may produce different results, and adds a new feature to assist in debugging.

1. Fixes the issue seen here: https://github.com/synthetichealth/synthea/issues/1236#issuecomment-1442152946 where the records were identical up to a point, then diverged. The issue appears to be with age calculation, specifically if you're unlucky a person's age in months can be different for a given timestep based on the time zone. The change here makes it so that all age calculations are done in UTC. (This does introduce the possibility of age-based events happening up to 12 hours before they would be expected to, or one full timestep later, but in context I don't think that's a big deal)
While there I also cached the birthdate as a LocalDate object, because in normal usage it will never change. (We do have some tests where we change the birthdate on a Person object unfortunately)

2. Changes Person.getSymptoms() from returning a Set to returning a sorted List. This is extremely minor as it's only ever used in the ClinicalNoteExporter, but the Set version can result in a different order of symptoms between runs.

3. Adds a new -ps for a single person seed, to assist in debugging. Now when you have a patient record you want to replicate, you don't have to re-run the entire population it was part of. Note this will silently override the -p setting. I can add a warning message or exception if people think that's useful.