### PR TITLE
Bump github action version on Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           mv build/docs/javadoc/* output/build/javadoc
       
       - name: Delete Previous master-branch-latest Tag
-        uses: dev-drprasad/delete-tag-and-release@v0.1.2
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
         with:
           delete_release: true
           tag_name: master-branch-latest


### PR DESCRIPTION
Bumps the delete-tag-and-release action up to 0.2.1. Apparently the repo owner deleted all previous releases (intentionally) when pushing v0.2.1.