### PR TITLE
 BFD Exporter Updates

### DIFF
--- a/src/main/java/org/mitre/synthea/export/rif/DMEExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/DMEExporter.java
@@ -134,10 +134,10 @@ public class DMEExporter extends RIFExporter {
         }
       }
       fieldValues.put(BB2RIFStructure.DME.CARR_CLM_CASH_DDCTBL_APLD_AMT,
-          String.format("%.2f", subTotals.deductiblePaidByPatient));
+          String.format("%.2f", subTotals.getDeductiblePaid()));
       fieldValues.put(BB2RIFStructure.DME.NCH_CARR_CLM_SBMTD_CHRG_AMT,
-          String.format("%.2f", subTotals.cost));
-      BigDecimal paidAmount = subTotals.coinsurancePaidByPayer.add(subTotals.paidByPayer);
+          String.format("%.2f", subTotals.getTotalClaimCost()));
+      BigDecimal paidAmount = subTotals.getCoveredCost();
       fieldValues.put(BB2RIFStructure.DME.CARR_CLM_PRMRY_PYR_PD_AMT,
           String.format("%.2f", paidAmount));
       fieldValues.put(BB2RIFStructure.DME.NCH_CARR_CLM_ALOWD_AMT,
@@ -186,14 +186,14 @@ public class DMEExporter extends RIFExporter {
           fieldValues.put(BB2RIFStructure.DME.LINE_COINSRNC_AMT,
                   String.format("%.2f", lineItem.getCoinsurancePaid()));
           // LINE_BENE_PMT_AMT and NCH_CLM_BENE_PMT_AMT are always 0, set in field value spreadsheet
-          BigDecimal providerAmount = lineItem.coinsurancePaidByPayer.add(lineItem.paidByPayer);
+          BigDecimal providerAmount = lineItem.getCoveredCost();
           fieldValues.put(BB2RIFStructure.DME.LINE_PRVDR_PMT_AMT,
               String.format("%.2f", providerAmount));
           fieldValues.put(BB2RIFStructure.DME.LINE_NCH_PMT_AMT,
               String.format("%.2f", providerAmount));
           fieldValues.put(BB2RIFStructure.DME.LINE_SBMTD_CHRG_AMT,
-              String.format("%.2f", lineItem.cost));
-          BigDecimal allowedAmount = lineItem.cost.subtract(lineItem.adjustment);
+              String.format("%.2f", lineItem.getTotalClaimCost()));
+          BigDecimal allowedAmount = lineItem.getTotalClaimCost().subtract(lineItem.adjustment);
           fieldValues.put(BB2RIFStructure.DME.LINE_ALOWD_CHRG_AMT,
               String.format("%.2f", allowedAmount));
           fieldValues.put(BB2RIFStructure.DME.LINE_PRMRY_ALOWD_CHRG_AMT,

--- a/src/main/java/org/mitre/synthea/export/rif/HospiceExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/HospiceExporter.java
@@ -150,9 +150,9 @@ public class HospiceExporter extends RIFExporter {
                     .divide(BigDecimal.valueOf(Integer.max(1, count)), RoundingMode.HALF_EVEN)
                     .setScale(2, RoundingMode.HALF_EVEN)));
     fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_PMT_AMT_AMT,
-            String.format("%.2f", lineItem.coinsurancePaidByPayer.add(lineItem.paidByPayer)));
+            String.format("%.2f", lineItem.getCoveredCost()));
     fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_PRVDR_PMT_AMT,
-            String.format("%.2f", lineItem.coinsurancePaidByPayer.add(lineItem.paidByPayer)));
+            String.format("%.2f", lineItem.getCoveredCost()));
     fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_TOT_CHRG_AMT,
             String.format("%.2f", lineItem.cost));
     fieldValues.put(BB2RIFStructure.HOSPICE.REV_CNTR_NCVRD_CHRG_AMT,
@@ -200,7 +200,7 @@ public class HospiceExporter extends RIFExporter {
     fieldValues.put(BB2RIFStructure.HOSPICE.RNDRNG_PHYSN_NPI, encounter.clinician.npi);
     fieldValues.put(BB2RIFStructure.HOSPICE.ORG_NPI_NUM, encounter.provider.npi);
     fieldValues.put(BB2RIFStructure.HOSPICE.CLM_PMT_AMT,
-            String.format("%.2f", cost.getTotalClaimCost()));
+            String.format("%.2f", cost.getCoveredCost()));
     if (encounter.claim.coveredByMedicare()) {
       fieldValues.put(BB2RIFStructure.HOSPICE.NCH_PRMRY_PYR_CLM_PD_AMT, "0");
     } else {

--- a/src/main/java/org/mitre/synthea/export/rif/InpatientExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/InpatientExporter.java
@@ -272,7 +272,7 @@ public class InpatientExporter extends RIFExporter {
   private void setClaimCosts(HashMap<BB2RIFStructure.INPATIENT, String> fieldValues,
           Claim.ClaimEntry claim) {
     fieldValues.put(BB2RIFStructure.INPATIENT.CLM_PMT_AMT,
-            String.format("%.2f", claim.getTotalClaimCost()));
+            String.format("%.2f", claim.getCoveredCost()));
     fieldValues.put(BB2RIFStructure.INPATIENT.CLM_TOT_CHRG_AMT,
             String.format("%.2f", claim.getTotalClaimCost()));
     fieldValues.put(BB2RIFStructure.INPATIENT.NCH_BENE_IP_DDCTBL_AMT,

--- a/src/main/java/org/mitre/synthea/export/rif/InpatientExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/InpatientExporter.java
@@ -43,7 +43,7 @@ public class InpatientExporter extends RIFExporter {
       if (encounter.stop < startTime || encounter.stop < CLAIM_CUTOFF) {
         continue;
       }
-      if (encounter.claim.getTotalClaimCost().equals(Claim.ZERO_CENTS)) {
+      if (encounter.claim.getTotalClaimCost().compareTo(Claim.ZERO_CENTS) == 0) {
         continue;
       }
       if (!hasPartABCoverage(person, encounter.stop)) {
@@ -329,7 +329,7 @@ public class InpatientExporter extends RIFExporter {
     billableItems.add(encounter.claim.mainEntry);
     billableItems.addAll(encounter.claim.items);
     billableItems.removeIf((claimEntry) -> {
-      if (claimEntry.cost.equals(Claim.ZERO_CENTS)) {
+      if (claimEntry.cost.compareTo(Claim.ZERO_CENTS) == 0) {
         return true; // zero cost entries are dropped
       } else if (claimEntry.entry instanceof HealthRecord.Procedure) {
         for (HealthRecord.Code code : claimEntry.entry.codes) {

--- a/src/main/java/org/mitre/synthea/export/rif/OutpatientExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/OutpatientExporter.java
@@ -238,16 +238,12 @@ public class OutpatientExporter extends RIFExporter {
 
   private void setLineItemCosts(HashMap<BB2RIFStructure.OUTPATIENT, String> fieldValues,
           Claim.ClaimEntry claim) {
-    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_TOT_CHRG_AMT,
-            String.format("%.2f", claim.getCoveredCost()));
     fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_NCVRD_CHRG_AMT,
             String.format("%.2f", claim.getPatientCost()));
     fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_CASH_DDCTBL_AMT,
             String.format("%.2f", claim.getDeductiblePaid()));
     fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_COINSRNC_WGE_ADJSTD_C,
             String.format("%.2f", claim.getCoinsurancePaid()));
-    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_PMT_AMT_AMT,
-            String.format("%.2f", claim.getTotalClaimCost()));
     fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_PRVDR_PMT_AMT,
             String.format("%.2f", claim.getTotalClaimCost()));
     fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_PTNT_RSPNSBLTY_PMT,

--- a/src/main/java/org/mitre/synthea/export/rif/OutpatientExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/OutpatientExporter.java
@@ -227,7 +227,7 @@ public class OutpatientExporter extends RIFExporter {
   private void setClaimCosts(HashMap<BB2RIFStructure.OUTPATIENT, String> fieldValues,
           Claim.ClaimEntry claim) {
     fieldValues.put(BB2RIFStructure.OUTPATIENT.CLM_PMT_AMT, String.format("%.2f",
-            claim.getTotalClaimCost()));
+            claim.getCoveredCost()));
     fieldValues.put(BB2RIFStructure.OUTPATIENT.CLM_TOT_CHRG_AMT,
             String.format("%.2f", claim.getTotalClaimCost()));
     fieldValues.put(BB2RIFStructure.OUTPATIENT.CLM_OP_PRVDR_PMT_AMT,

--- a/src/main/java/org/mitre/synthea/export/rif/OutpatientExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/OutpatientExporter.java
@@ -39,11 +39,21 @@ public class OutpatientExporter extends RIFExporter {
       if (encounter.stop < startTime || encounter.stop < CLAIM_CUTOFF) {
         continue;
       }
+      if (encounter.claim.getTotalClaimCost().compareTo(Claim.ZERO_CENTS) == 0) {
+        continue;
+      }
       if (!hasPartABCoverage(person, encounter.stop)) {
         continue;
       }
       if (!RIFExporter.getClaimTypes(encounter).contains(ClaimType.OUTPATIENT)) {
         continue;
+      }
+
+      // Get subset of billable items
+      List<Claim.ClaimEntry> billableItems = getBillableProcedureAndMedAdminItems(encounter);
+      Claim.ClaimEntry billableTotal = encounter.claim.new ClaimEntry(null);
+      for (Claim.ClaimEntry lineItem: billableItems) {
+        billableTotal.addCosts(lineItem);
       }
 
       long claimId = RIFExporter.nextClaimId.getAndDecrement();
@@ -70,13 +80,12 @@ public class OutpatientExporter extends RIFExporter {
       fieldValues.put(BB2RIFStructure.OUTPATIENT.RNDRNG_PHYSN_NPI, encounter.clinician.npi);
       fieldValues.put(BB2RIFStructure.OUTPATIENT.ORG_NPI_NUM, encounter.provider.npi);
       fieldValues.put(BB2RIFStructure.OUTPATIENT.OP_PHYSN_NPI, encounter.clinician.npi);
-      fieldValues.put(BB2RIFStructure.OUTPATIENT.CLM_PMT_AMT, String.format("%.2f",
-              encounter.claim.getTotalClaimCost()));
+      setClaimCosts(fieldValues, billableTotal);
       if (encounter.claim.coveredByMedicare()) {
         fieldValues.put(BB2RIFStructure.OUTPATIENT.NCH_PRMRY_PYR_CLM_PD_AMT, "0");
       } else {
         fieldValues.put(BB2RIFStructure.OUTPATIENT.NCH_PRMRY_PYR_CLM_PD_AMT,
-                String.format("%.2f", encounter.claim.getTotalCoveredCost()));
+                String.format("%.2f", billableTotal.getCoveredCost()));
       }
       fieldValues.put(BB2RIFStructure.OUTPATIENT.PRVDR_STATE_CD,
               exporter.locationMapper.getStateCode(encounter.provider.state));
@@ -91,30 +100,6 @@ public class OutpatientExporter extends RIFExporter {
         field = "20"; // the patient died before the encounter ended
       }
       fieldValues.put(BB2RIFStructure.OUTPATIENT.PTNT_DSCHRG_STUS_CD, field);
-      fieldValues.put(BB2RIFStructure.OUTPATIENT.CLM_TOT_CHRG_AMT,
-              String.format("%.2f", encounter.claim.getTotalClaimCost()));
-      fieldValues.put(BB2RIFStructure.OUTPATIENT.CLM_OP_PRVDR_PMT_AMT,
-              String.format("%.2f", encounter.claim.getTotalClaimCost()));
-      fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_TOT_CHRG_AMT,
-              String.format("%.2f", encounter.claim.getTotalCoveredCost()));
-      fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_NCVRD_CHRG_AMT,
-              String.format("%.2f", encounter.claim.getTotalPatientCost()));
-      fieldValues.put(BB2RIFStructure.OUTPATIENT.NCH_BENE_PTB_DDCTBL_AMT,
-              String.format("%.2f", encounter.claim.getTotalDeductiblePaid()));
-      fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_CASH_DDCTBL_AMT,
-              String.format("%.2f", encounter.claim.getTotalDeductiblePaid()));
-      fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_COINSRNC_WGE_ADJSTD_C,
-              String.format("%.2f", encounter.claim.getTotalCoinsurancePaid()));
-      fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_PMT_AMT_AMT,
-              String.format("%.2f", encounter.claim.getTotalClaimCost()));
-      fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_PRVDR_PMT_AMT,
-              String.format("%.2f", encounter.claim.getTotalClaimCost()));
-      fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_PTNT_RSPNSBLTY_PMT,
-              String.format("%.2f",
-                      encounter.claim.getTotalDeductiblePaid()
-                              .add(encounter.claim.getTotalCoinsurancePaid())));
-      fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_RDCD_COINSRNC_AMT,
-              String.format("%.2f", encounter.claim.getTotalCoinsurancePaid()));
 
       String icdReasonCode = null;
       if (encounter.reason != null) {
@@ -192,15 +177,10 @@ public class OutpatientExporter extends RIFExporter {
 
       synchronized (exporter.rifWriters.getOrCreateWriter(BB2RIFStructure.OUTPATIENT.class)) {
         int claimLine = 1;
-        for (Claim.ClaimEntry lineItem : encounter.claim.items) {
+        for (Claim.ClaimEntry lineItem : billableItems) {
           String hcpcsCode = null;
           if (lineItem.entry instanceof HealthRecord.Procedure) {
-            for (HealthRecord.Code code : lineItem.entry.codes) {
-              if (exporter.hcpcsCodeMapper.canMap(code)) {
-                hcpcsCode = exporter.hcpcsCodeMapper.map(code, person, true);
-                break; // take the first mappable code for each procedure
-              }
-            }
+            hcpcsCode = getFirstMappedHCPCSCode(lineItem.entry.codes, person);
             fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR, revCenter);
             fieldValues.remove(BB2RIFStructure.OUTPATIENT.REV_CNTR_IDE_NDC_UPC_NUM);
             fieldValues.remove(BB2RIFStructure.OUTPATIENT.REV_CNTR_NDC_QTY);
@@ -217,23 +197,12 @@ public class OutpatientExporter extends RIFExporter {
               fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_NDC_QTY_QLFR_CD, "UN"); // Unit
             }
           }
-          if (hcpcsCode == null) {
-            continue;
-          }
 
           fieldValues.put(BB2RIFStructure.OUTPATIENT.CLM_LINE_NUM, Integer.toString(claimLine++));
           fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_DT,
                   RIFExporter.bb2DateFromTimestamp(lineItem.entry.start));
           fieldValues.put(BB2RIFStructure.OUTPATIENT.HCPCS_CD, hcpcsCode);
-          fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_RATE_AMT,
-              String.format("%.2f", (lineItem.cost)));
-          fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_PMT_AMT_AMT,
-              String.format("%.2f", lineItem.coinsurancePaidByPayer.add(lineItem.paidByPayer)));
-          fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_TOT_CHRG_AMT,
-              String.format("%.2f", lineItem.cost));
-          fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_NCVRD_CHRG_AMT,
-              String.format("%.2f", lineItem.copayPaidByPatient
-              .add(lineItem.deductiblePaidByPatient).add(lineItem.patientOutOfPocket)));
+          setLineItemCosts(fieldValues, lineItem);
           exporter.rifWriters.writeValues(BB2RIFStructure.OUTPATIENT.class, fieldValues);
         }
 
@@ -245,11 +214,53 @@ public class OutpatientExporter extends RIFExporter {
                   RIFExporter.bb2DateFromTimestamp(encounter.start));
           // 99241: "Office consultation for a new or established patient"
           fieldValues.put(BB2RIFStructure.OUTPATIENT.HCPCS_CD, "99241");
+          setClaimCosts(fieldValues, encounter.claim.totals);
+          setLineItemCosts(fieldValues, encounter.claim.totals);
           exporter.rifWriters.writeValues(BB2RIFStructure.OUTPATIENT.class, fieldValues);
         }
       }
       claimCount++;
     }
     return claimCount;
+  }
+
+  private void setClaimCosts(HashMap<BB2RIFStructure.OUTPATIENT, String> fieldValues,
+          Claim.ClaimEntry claim) {
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.CLM_PMT_AMT, String.format("%.2f",
+            claim.getTotalClaimCost()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.CLM_TOT_CHRG_AMT,
+            String.format("%.2f", claim.getTotalClaimCost()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.CLM_OP_PRVDR_PMT_AMT,
+            String.format("%.2f", claim.getTotalClaimCost()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.NCH_BENE_PTB_DDCTBL_AMT,
+            String.format("%.2f", claim.getDeductiblePaid()));
+  }
+
+  private void setLineItemCosts(HashMap<BB2RIFStructure.OUTPATIENT, String> fieldValues,
+          Claim.ClaimEntry claim) {
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_TOT_CHRG_AMT,
+            String.format("%.2f", claim.getCoveredCost()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_NCVRD_CHRG_AMT,
+            String.format("%.2f", claim.getPatientCost()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_CASH_DDCTBL_AMT,
+            String.format("%.2f", claim.getDeductiblePaid()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_COINSRNC_WGE_ADJSTD_C,
+            String.format("%.2f", claim.getCoinsurancePaid()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_PMT_AMT_AMT,
+            String.format("%.2f", claim.getTotalClaimCost()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_PRVDR_PMT_AMT,
+            String.format("%.2f", claim.getTotalClaimCost()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_PTNT_RSPNSBLTY_PMT,
+            String.format("%.2f", claim.getDeductiblePaid().add(claim.getCoinsurancePaid())));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_RDCD_COINSRNC_AMT,
+            String.format("%.2f", claim.getCoinsurancePaid()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_RATE_AMT,
+        String.format("%.2f", claim.getTotalClaimCost()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_PMT_AMT_AMT,
+        String.format("%.2f", claim.getCoveredCost()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_TOT_CHRG_AMT,
+        String.format("%.2f", claim.getTotalClaimCost()));
+    fieldValues.put(BB2RIFStructure.OUTPATIENT.REV_CNTR_NCVRD_CHRG_AMT,
+        String.format("%.2f", claim.getPatientCost()));
   }
 }

--- a/src/test/java/org/mitre/synthea/export/rif/BB2RIFExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/rif/BB2RIFExporterTest.java
@@ -102,7 +102,7 @@ public class BB2RIFExporterTest {
     URI uri = BB2RIFExporterTest.class.getResource("/module").toURI();
     File file = new File(uri);
     Module.addModules(file);
-    int numberOfPeople = 10;
+    int numberOfPeople = 20;
     Exporter.ExporterRuntimeOptions exportOpts = new Exporter.ExporterRuntimeOptions();
     Generator.GeneratorOptions generatorOpts = new Generator.GeneratorOptions();
     generatorOpts.population = numberOfPeople;


### PR DESCRIPTION
1. Update BFD inpatient exporter to ensure line item totals match claim totals
2. Update BFD outpatient exporter to ensure line item totals match claim totals
3. Pull common code for inpatient and outpatient exporter up in RIFExporter base class
4. Add tests for BFD HHA exporter to ensure line item totals match claim totals
5. Update BFD SNF exporter to ensure line item totals match claim totals
6. Update BFD Hospice exporter to ensure line item totals match claim totals