### PR TITLE
Fix CI test failures due to US Core 5 artifacts

### DIFF
--- a/src/test/java/org/mitre/synthea/ParallelTestingService.java
+++ b/src/test/java/org/mitre/synthea/ParallelTestingService.java
@@ -12,20 +12,20 @@ import java.util.concurrent.TimeUnit;
 import org.mitre.synthea.world.agents.Person;
 
 public class ParallelTestingService {
- /**
-  * Runs the provided PersonTester in parallel. The PersonTester will be supplied with 10 people.
-  * Tests are run in a fixed thread pool with some of the tests having to wait until the first few
-  * tests complete. Tests can return a List of validation errors (in String form).
-  * @param pt An implementation of PersonTester
-  * @return A list of errors
-  * @throws Exception when bad things happen during the test
-  */
+  /**
+   * Runs the provided PersonTester in parallel. The PersonTester will be supplied with 10 people.
+   * Tests are run in a fixed thread pool with some of the tests having to wait until the first few
+   * tests complete. Tests can return a List of validation errors (in String form).
+   * @param pt An implementation of PersonTester
+   * @return A list of errors
+   * @throws Exception when bad things happen during the test
+   */
   public static List<String> runInParallel(PersonTester pt) throws Exception {
     return runInParallel(10, pt);
   }
 
   /**
-   * Runs the provided PersonTester in parallel. The PersonTester will be supplied with up to 10 people.
+   * Runs the provided PersonTester in parallel. The PersonTester will be passed up to 10 people.
    * Tests are run in a fixed thread pool with some of the tests having to wait until the first few
    * tests complete. Tests can return a List of validation errors (in String form).
    * @param pt An implementation of PersonTester
@@ -34,7 +34,8 @@ public class ParallelTestingService {
    */
   public static List<String> runInParallel(int numberOfPeople, PersonTester pt) throws Exception {
     if (numberOfPeople > 10) {
-      throw new IllegalArgumentException("At most 10 people are supported in the ParallelTestingService");
+      throw new IllegalArgumentException(
+          "At most 10 people are supported in the ParallelTestingService");
     }
     ExecutorService service = Executors.newFixedThreadPool(6);
     List<String> validationErrors = new ArrayList<>();

--- a/src/test/java/org/mitre/synthea/ParallelTestingService.java
+++ b/src/test/java/org/mitre/synthea/ParallelTestingService.java
@@ -1,6 +1,8 @@
 package org.mitre.synthea;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -10,20 +12,37 @@ import java.util.concurrent.TimeUnit;
 import org.mitre.synthea.world.agents.Person;
 
 public class ParallelTestingService {
+ /**
+  * Runs the provided PersonTester in parallel. The PersonTester will be supplied with 10 people.
+  * Tests are run in a fixed thread pool with some of the tests having to wait until the first few
+  * tests complete. Tests can return a List of validation errors (in String form).
+  * @param pt An implementation of PersonTester
+  * @return A list of errors
+  * @throws Exception when bad things happen during the test
+  */
+  public static List<String> runInParallel(PersonTester pt) throws Exception {
+    return runInParallel(10, pt);
+  }
+
   /**
-   * Runs the provided PersonTester in parallel. The PersonTester will be supplied with 10 people.
+   * Runs the provided PersonTester in parallel. The PersonTester will be supplied with up to 10 people.
    * Tests are run in a fixed thread pool with some of the tests having to wait until the first few
    * tests complete. Tests can return a List of validation errors (in String form).
    * @param pt An implementation of PersonTester
    * @return A list of errors
    * @throws Exception when bad things happen during the test
    */
-  public static List<String> runInParallel(PersonTester pt) throws Exception {
+  public static List<String> runInParallel(int numberOfPeople, PersonTester pt) throws Exception {
+    if (numberOfPeople > 10) {
+      throw new IllegalArgumentException("At most 10 people are supported in the ParallelTestingService");
+    }
     ExecutorService service = Executors.newFixedThreadPool(6);
     List<String> validationErrors = new ArrayList<>();
-    int numberOfPeople = 10;
-    List<Future<Exception>> potentialCrashes = new ArrayList<>(10);
+    List<Future<Exception>> potentialCrashes = new ArrayList<>(numberOfPeople);
     Person[] people = TestHelper.getGeneratedPeople();
+    // shuffle the people just for a little more variety when re-used
+    Collections.shuffle(Arrays.asList(people));
+
     for (int i = 0; i < numberOfPeople; i++) {
       Person person = people[i];
       final int counter = i;

--- a/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
@@ -107,11 +107,11 @@ public class FHIRR4ExporterTest {
   @Test
   public void testFHIRR4Export() throws Exception {
     TestHelper.loadTestProperties();
-	Generator.DEFAULT_STATE = Config.get("test_state.default", "Massachusetts");
-	Config.set("exporter.baseDirectory", tempFolder.newFolder().toString());
+    Generator.DEFAULT_STATE = Config.get("test_state.default", "Massachusetts");
+    Config.set("exporter.baseDirectory", tempFolder.newFolder().toString());
 
-	// setting these static fields randomly per patient creates nondeterministic effects
-	// since the exporters run in parallel below.
+    // setting these static fields randomly per patient creates nondeterministic effects
+    // since the exporters run in parallel below.
     // instead, set them once and run a few patients for each of the relevant combinations
     TestHelper.exportOff();
     FhirR4.reloadIncludeExclude();
@@ -125,19 +125,24 @@ public class FHIRR4ExporterTest {
     // pass 1 - us core off
     // use the uscore 4 validator anyway
     baseTestFHIRR4Export(uscore4Validator);
-    
+
     FhirR4.USE_US_CORE_IG = true;
     FhirR4.useUSCore4();
     // pass 2 - us core 4 enabled
     baseTestFHIRR4Export(uscore4Validator);
-    
+
     ValidationResources uscore5Validator = ValidationResources.forR4(false, true);
     FhirR4.US_CORE_VERSION = "5";
     FhirR4.useUSCore5();
     // pass 3 - us core 5 enabled
     baseTestFHIRR4Export(uscore5Validator);
   }
-  
+
+  /**
+   * Common test steps for testing FHIR R4 exporter. Assumes that various settings
+   * have been previously set, and the given validator is in alignment with those settings.
+   * @param validator ValidationResources configured for specific FHIR settings
+   */
   public void baseTestFHIRR4Export(ValidationResources validator) throws Exception {
     FhirContext ctx = FhirR4.getContext();
     IParser parser = ctx.newJsonParser().setPrettyPrint(true);
@@ -175,10 +180,6 @@ public class FHIRR4ExporterTest {
                * Ignore warnings.
                */
               valid = true;
-            } else if (emessage.getMessage().equals("None of the codings provided are in the value set 'US Core DocumentReference Type' (http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type), and a coding from this value set is required) (codes = http://loinc.org#34117-2, http://loinc.org#51847-2)")) {
-            	// ignore this specific error message
-            	// TODO: do something better than just ignoring this
-            	valid = true;
             }
             if (!valid) {
               System.out.println(parser.encodeResourceToString(entry.getResource()));

--- a/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRSTU3ExporterTest.java
@@ -111,7 +111,7 @@ public class FHIRSTU3ExporterTest {
     validator.setValidateAgainstStandardSchema(true);
     validator.setValidateAgainstStandardSchematron(true);
 
-    ValidationResources validationResources = new ValidationResources();
+    ValidationResources validationResources = ValidationResources.forSTU3();
 
     List<String> errors = ParallelTestingService.runInParallel((person) -> {
       List<String> validationErrors = new ArrayList<String>();

--- a/src/test/java/org/mitre/synthea/export/ValidationResources.java
+++ b/src/test/java/org/mitre/synthea/export/ValidationResources.java
@@ -26,9 +26,20 @@ public class ValidationResources {
   /**
    * Create FHIR context, validator, and validation chain.
    */
-  public ValidationResources() {
-    initializeSTU3();
-    initializeR4();
+  private ValidationResources() {
+    // private - use the factory
+  }
+  
+  public static ValidationResources forSTU3() {
+    ValidationResources vr = new ValidationResources();
+    vr.initializeSTU3();
+    return vr;
+  }
+  
+  public static ValidationResources forR4(boolean useUSCore4, boolean useUSCore5) {
+    ValidationResources vr = new ValidationResources();
+    vr.initializeR4(useUSCore4, useUSCore5);
+    return vr;
   }
 
   private void initializeSTU3() {
@@ -47,19 +58,19 @@ public class ValidationResources {
     validatorSTU3 = ctx.newValidator().registerValidatorModule(instanceValidator);
   }
 
-  private void initializeR4() {
+  private void initializeR4(boolean useUSCore4, boolean useUSCore5) {
     FhirContext ctx = FhirR4.getContext();
     FhirInstanceValidator instanceValidator =
         new FhirInstanceValidator(ctx);
     ValidationSupportChain chain = new ValidationSupportChain(
-            new ValidationSupportR4(ctx),
+            new ValidationSupportR4(ctx, useUSCore4, useUSCore5),
             new DefaultProfileValidationSupport(ctx),
             new CommonCodeSystemsTerminologyService(ctx),
             new InMemoryTerminologyServerValidationSupport(ctx)
     );
     instanceValidator.setValidationSupport(chain);
     instanceValidator.setAnyExtensionsAllowed(true);
-    instanceValidator.setErrorForUnknownProfiles(false);
+    instanceValidator.setErrorForUnknownProfiles(true);
     validatorR4 = ctx.newValidator().registerValidatorModule(instanceValidator);
   }
 

--- a/src/test/java/org/mitre/synthea/export/ValidationResources.java
+++ b/src/test/java/org/mitre/synthea/export/ValidationResources.java
@@ -23,19 +23,28 @@ public class ValidationResources {
   private FhirValidator validatorR4;
   static final Logger logger = LoggerFactory.getLogger(ValidationResources.class);
 
-  /**
-   * Create FHIR context, validator, and validation chain.
-   */
   private ValidationResources() {
     // private - use the factory
   }
-  
+
+  /**
+   * Create FHIR context, validator, and validation chain for FHIR STU3.
+   */
   public static ValidationResources forSTU3() {
     ValidationResources vr = new ValidationResources();
     vr.initializeSTU3();
     return vr;
   }
-  
+
+  /**
+   * Create FHIR context, validator, and validation chain for FHIR R4.
+   * US Core 4 and 5 support is optional. Note that if both are loaded,
+   * the validator may not be able to choose the correct artifact when
+   * validating a given resource.
+   *
+   * @param useUSCore4 Whether or not the US Core v4 artifacts should be loaded
+   * @param useUSCore5 Whether or not the US Core v5 artifacts should be loaded
+   */
   public static ValidationResources forR4(boolean useUSCore4, boolean useUSCore5) {
     ValidationResources vr = new ValidationResources();
     vr.initializeR4(useUSCore4, useUSCore5);

--- a/src/test/java/org/mitre/synthea/export/ValidationSupportR4.java
+++ b/src/test/java/org/mitre/synthea/export/ValidationSupportR4.java
@@ -40,6 +40,8 @@ public class ValidationSupportR4 extends PrePopulatedValidationSupport {
   /**
    * Defines the custom validation support for various implementation guides.
    * @param ctx the FHIR context
+   * @param useUSCore4 Whether or not to load US Core 4 artifacts
+   * @param useUSCore5 Whether or not to load US Core 5 artifacts
    */
   public ValidationSupportR4(FhirContext ctx, boolean useUSCore4, boolean useUSCore5) {
     super(ctx);
@@ -54,11 +56,12 @@ public class ValidationSupportR4 extends PrePopulatedValidationSupport {
   /**
    * Loads the structure definitions from the given directory.
    * @param rootDir the directory to load structure definitions from
-   * @return a list of structure definitions
+   * @param useUSCore4 Whether or not to load US Core 4 artifacts
+   * @param useUSCore5 Whether or not to load US Core 5 artifacts
    * @throws Throwable when there is an error reading the structure definitions.
    */
-  private void loadFromDirectory(String rootDir, boolean useUSCore4, boolean useUSCore5) throws Throwable {
-
+  private void loadFromDirectory(String rootDir, boolean useUSCore4, boolean useUSCore5)
+      throws Throwable {
     IParser jsonParser = FhirR4.getContext().newJsonParser();
     jsonParser.setParserErrorHandler(new StrictErrorHandler());
 
@@ -67,13 +70,13 @@ public class ValidationSupportR4 extends PrePopulatedValidationSupport {
     Files.walk(path, Integer.MAX_VALUE).filter(Files::isReadable).filter(Files::isRegularFile)
         .filter(p -> p.toString().endsWith(".json")).forEach(f -> {
           try {
-        	  if (!useUSCore4 && f.toString().contains("uscore4")) {
-        		  return;
-        	  }
-        	  if (!useUSCore5 && f.toString().contains("uscore5")) {
-        		  return;
-        	  }
-        	  
+            if (!useUSCore4 && f.toString().contains("uscore4")) {
+              return;
+            }
+            if (!useUSCore5 && f.toString().contains("uscore5")) {
+              return;
+            }
+
             IBaseResource resource = jsonParser.parseResource(new FileReader(f.toFile()));
             handleResource(resource);
           } catch (FileNotFoundException e) {

--- a/src/test/java/org/mitre/synthea/export/ValidationSupportR4.java
+++ b/src/test/java/org/mitre/synthea/export/ValidationSupportR4.java
@@ -41,11 +41,11 @@ public class ValidationSupportR4 extends PrePopulatedValidationSupport {
    * Defines the custom validation support for various implementation guides.
    * @param ctx the FHIR context
    */
-  public ValidationSupportR4(FhirContext ctx) {
+  public ValidationSupportR4(FhirContext ctx, boolean useUSCore4, boolean useUSCore5) {
     super(ctx);
 
     try {
-      loadFromDirectory(PROFILE_DIR);
+      loadFromDirectory(PROFILE_DIR, useUSCore4, useUSCore5);
     } catch (Throwable t) {
       throw new RuntimeException(t);
     }
@@ -57,7 +57,7 @@ public class ValidationSupportR4 extends PrePopulatedValidationSupport {
    * @return a list of structure definitions
    * @throws Throwable when there is an error reading the structure definitions.
    */
-  private void loadFromDirectory(String rootDir) throws Throwable {
+  private void loadFromDirectory(String rootDir, boolean useUSCore4, boolean useUSCore5) throws Throwable {
 
     IParser jsonParser = FhirR4.getContext().newJsonParser();
     jsonParser.setParserErrorHandler(new StrictErrorHandler());
@@ -67,6 +67,13 @@ public class ValidationSupportR4 extends PrePopulatedValidationSupport {
     Files.walk(path, Integer.MAX_VALUE).filter(Files::isReadable).filter(Files::isRegularFile)
         .filter(p -> p.toString().endsWith(".json")).forEach(f -> {
           try {
+        	  if (!useUSCore4 && f.toString().contains("uscore4")) {
+        		  return;
+        	  }
+        	  if (!useUSCore5 && f.toString().contains("uscore5")) {
+        		  return;
+        	  }
+        	  
             IBaseResource resource = jsonParser.parseResource(new FileReader(f.toFile()));
             handleResource(resource);
           } catch (FileNotFoundException e) {

--- a/src/test/resources/structureDefinitions/r4/2.16.840.1.113762.1.4.1.json
+++ b/src/test/resources/structureDefinitions/r4/2.16.840.1.113762.1.4.1.json
@@ -1,0 +1,51 @@
+{
+  "resourceType": "ValueSet",
+  "id": "2.16.840.1.113762.1.4.1",
+  "meta": {
+    "versionId": "5",
+    "lastUpdated": "2015-03-31T01:00:01.000-04:00",
+    "profile": [ "http://hl7.org/fhir/StructureDefinition/shareablevalueset", "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/publishable-valueset-cqfm" ]
+  },
+  "extension": [ {
+    "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+    "valueString": "MD Partners Author"
+  }, {
+    "url": "http://hl7.org/fhir/StructureDefinition/valueset-keyWord",
+    "valueString": "CCDAr21"
+  }, {
+    "url": "http://hl7.org/fhir/StructureDefinition/resource-lastReviewDate",
+    "valueDate": "2022-12-15"
+  }, {
+    "url": "http://hl7.org/fhir/StructureDefinition/valueset-effectiveDate",
+    "valueDate": "2015-03-31"
+  } ],
+  "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1",
+  "version": "20150331",
+  "name": "ONC Administrative Sex",
+  "title": "changed from HL7 v2.5 code system to HL7 V3 code system to align with HL7 V3 artifact requirements. Non-gender identity concepts, such as Unknown are also removed because V3 artifacts are to use the Null Attribute for those concepts.",
+  "status": "active",
+  "experimental": false,
+  "date": "2015-03-31T01:00:01-04:00",
+  "publisher": "ONC",
+  "description": "changed from HL7 v2.5 code system to HL7 V3 code system to align with HL7 V3 artifact requirements. Non-gender identity concepts, such as Unknown are also removed because V3 artifacts are to use the Null Attribute for those concepts.",
+  "jurisdiction": [ {
+    "extension": [ {
+      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+      "valueString": "UNKNOWN"
+    } ]
+  } ],
+  "purpose": "(Clinical Focus: Gender identity restricted to only Male and Female used in administrative situations requiring a restriction to these two categories.),(Data Element Scope: Gender),(Inclusion Criteria: Male and Female only.),(Exclusion Criteria: Any gender identity that is not male or female.)",
+  "compose": {
+    "include": [ {
+      "system": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
+      "version": "2022-11",
+      "concept": [ {
+        "code": "F",
+        "display": "Female"
+      }, {
+        "code": "M",
+        "display": "Male"
+      } ]
+    } ]
+  }
+}

--- a/src/test/resources/structureDefinitions/r4/2.16.840.1.113762.1.4.1021.103.json
+++ b/src/test/resources/structureDefinitions/r4/2.16.840.1.113762.1.4.1021.103.json
@@ -1,0 +1,49 @@
+{
+  "resourceType": "ValueSet",
+  "id": "2.16.840.1.113762.1.4.1021.103",
+  "meta": {
+    "versionId": "5",
+    "lastUpdated": "2021-11-13T01:05:12.000-05:00",
+    "profile": [ "http://hl7.org/fhir/StructureDefinition/shareablevalueset", "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/publishable-valueset-cqfm" ]
+  },
+  "extension": [ {
+    "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+    "valueString": "MD Partners Author"
+  }, {
+    "url": "http://hl7.org/fhir/StructureDefinition/resource-lastReviewDate",
+    "valueDate": "2022-12-15"
+  }, {
+    "url": "http://hl7.org/fhir/StructureDefinition/valueset-effectiveDate",
+    "valueDate": "2021-11-13"
+  } ],
+  "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.103",
+  "version": "20211113",
+  "name": "Other or unknown or refused to answer",
+  "status": "active",
+  "experimental": false,
+  "date": "2021-11-13T01:05:12-05:00",
+  "publisher": "MD Partners Steward",
+  "jurisdiction": [ {
+    "extension": [ {
+      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+      "valueString": "UNKNOWN"
+    } ]
+  } ],
+  "purpose": "(Clinical Focus: Concepts that represent general ideas of a choice other that those provided, or the value is unknown by the data enterer, or the informant refused to answer),(Data Element Scope: ),(Inclusion Criteria: ),(Exclusion Criteria: )",
+  "compose": {
+    "include": [ {
+      "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+      "version": "2022-11",
+      "concept": [ {
+        "code": "ASKU",
+        "display": "asked but unknown"
+      }, {
+        "code": "OTH",
+        "display": "other"
+      }, {
+        "code": "UNK",
+        "display": "unknown"
+      } ]
+    } ]
+  }
+}

--- a/src/test/resources/structureDefinitions/r4/2.16.840.1.114222.4.11.836.json
+++ b/src/test/resources/structureDefinitions/r4/2.16.840.1.114222.4.11.836.json
@@ -1,0 +1,55 @@
+{
+  "resourceType": "ValueSet",
+  "id": "2.16.840.1.114222.4.11.836",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2012-10-25T12:28:31.000-04:00",
+    "profile": [ "http://hl7.org/fhir/StructureDefinition/shareablevalueset", "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/publishable-valueset-cqfm" ]
+  },
+  "extension": [ {
+    "url": "http://hl7.org/fhir/StructureDefinition/resource-lastReviewDate",
+    "valueDate": "2022-12-15"
+  }, {
+    "url": "http://hl7.org/fhir/StructureDefinition/valueset-effectiveDate",
+    "valueDate": "2012-10-25"
+  } ],
+  "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836",
+  "version": "20121025",
+  "name": "Race",
+  "status": "active",
+  "experimental": false,
+  "date": "2012-10-25T12:28:31-04:00",
+  "publisher": "CDC NCHS",
+  "jurisdiction": [ {
+    "extension": [ {
+      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+      "valueString": "UNKNOWN"
+    } ]
+  } ],
+  "purpose": "(Clinical Focus: ),(Data Element Scope: ),(Inclusion Criteria: ),(Exclusion Criteria: )",
+  "compose": {
+    "include": [ {
+      "system": "urn:oid:2.16.840.1.113883.6.238",
+      "version": "1.2",
+      "concept": [ {
+        "code": "1002-5",
+        "display": "American Indian or Alaska Native"
+      }, {
+        "code": "2028-9",
+        "display": "Asian"
+      }, {
+        "code": "2054-5",
+        "display": "Black or African American"
+      }, {
+        "code": "2076-8",
+        "display": "Native Hawaiian or Other Pacific Islander"
+      }, {
+        "code": "2106-3",
+        "display": "White"
+      }, {
+        "code": "2131-1",
+        "display": "Other Race"
+      } ]
+    } ]
+  }
+}

--- a/src/test/resources/structureDefinitions/r4/2.16.840.1.114222.4.11.837.json
+++ b/src/test/resources/structureDefinitions/r4/2.16.840.1.114222.4.11.837.json
@@ -1,0 +1,46 @@
+{
+  "resourceType": "ValueSet",
+  "id": "2.16.840.1.114222.4.11.837",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2012-10-25T12:28:31.000-04:00",
+    "profile": [ "http://hl7.org/fhir/StructureDefinition/shareablevalueset", "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/publishable-valueset-cqfm" ]
+  },
+  "extension": [ {
+    "url": "http://hl7.org/fhir/StructureDefinition/valueset-keyWord",
+    "valueString": "C-CDA,CCDAr1_1,CCDAr21"
+  }, {
+    "url": "http://hl7.org/fhir/StructureDefinition/resource-lastReviewDate",
+    "valueDate": "2022-12-15"
+  }, {
+    "url": "http://hl7.org/fhir/StructureDefinition/valueset-effectiveDate",
+    "valueDate": "2012-10-25"
+  } ],
+  "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837",
+  "version": "20121025",
+  "name": "Ethnicity",
+  "status": "active",
+  "experimental": false,
+  "date": "2012-10-25T12:28:31-04:00",
+  "publisher": "CDC NCHS",
+  "jurisdiction": [ {
+    "extension": [ {
+      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+      "valueString": "UNKNOWN"
+    } ]
+  } ],
+  "purpose": "(Clinical Focus: ),(Data Element Scope: ),(Inclusion Criteria: ),(Exclusion Criteria: )",
+  "compose": {
+    "include": [ {
+      "system": "urn:oid:2.16.840.1.113883.6.238",
+      "version": "1.2",
+      "concept": [ {
+        "code": "2135-2",
+        "display": "Hispanic or Latino"
+      }, {
+        "code": "2186-5",
+        "display": "Not Hispanic or Latino"
+      } ]
+    } ]
+  }
+}

--- a/src/test/resources/structureDefinitions/r4/uscore5/ValueSet-us-core-documentreference-type.json
+++ b/src/test/resources/structureDefinitions/r4/uscore5/ValueSet-us-core-documentreference-type.json
@@ -1,1 +1,92 @@
-{"resourceType":"ValueSet","id":"us-core-documentreference-type","text":{"status":"extensions","div":"<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include these codes as defined in <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-NullFlavor.html\"><code>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-NullFlavor.html#v3-NullFlavor-UNK\">UNK</a></td><td>unknown</td><td>**Description:**A proper value is applicable, but not known.<br/><br/>**Usage Notes**: This means the actual value is not known. If the only thing that is unknown is how to properly express the value in the necessary constraints (value set, datatype, etc.), then the OTH or UNC flavor should be used. No properties should be included for a datatype with this property unless:<br/><br/>1.  Those properties themselves directly translate to a semantic of &quot;unknown&quot;. (E.g. a local code sent as a translation that conveys 'unknown')<br/>2.  Those properties further qualify the nature of what is unknown. (E.g. specifying a use code of &quot;H&quot; and a URL prefix of &quot;tel:&quot; to convey that it is the home phone number that is unknown.)</td></tr></table></li><li>Include codes from <a href=\"http://loinc.org\"><code>http://loinc.org</code></a> where SCALE_TYP  =  DOC</li></ul></div>"},"url":"http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type","version":"5.0.1","name":"USCoreDocumentReferenceType","title":"US Core DocumentReference Type","status":"active","date":"2019-05-21","publisher":"HL7 International - Cross-Group Projects","contact":[{"name":"HL7 International - Cross-Group Projects","telecom":[{"system":"url","value":"http://www.hl7.org/Special/committees/cgp"},{"system":"email","value":"cgp@lists.HL7.org"}]}],"description":"The US Core DocumentReference Type Value Set includes all LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'","jurisdiction":[{"coding":[{"system":"urn:iso:std:iso:3166","code":"US"}]}],"copyright":"This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc","compose":{"include":[{"system":"http://terminology.hl7.org/CodeSystem/v3-NullFlavor","concept":[{"code":"UNK","display":"unknown"}]},{"system":"http://loinc.org","filter":[{"property":"SCALE_TYP","op":"=","value":"DOC"}]}]}}
+{
+	"resourceType": "ValueSet",
+	"id": "us-core-documentreference-type",
+	"text": {
+		"status": "extensions",
+		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include these codes as defined in <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-NullFlavor.html\"><code>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-NullFlavor.html#v3-NullFlavor-UNK\">UNK</a></td><td>unknown</td><td>**Description:**A proper value is applicable, but not known.<br/><br/>**Usage Notes**: This means the actual value is not known. If the only thing that is unknown is how to properly express the value in the necessary constraints (value set, datatype, etc.), then the OTH or UNC flavor should be used. No properties should be included for a datatype with this property unless:<br/><br/>1.  Those properties themselves directly translate to a semantic of &quot;unknown&quot;. (E.g. a local code sent as a translation that conveys 'unknown')<br/>2.  Those properties further qualify the nature of what is unknown. (E.g. specifying a use code of &quot;H&quot; and a URL prefix of &quot;tel:&quot; to convey that it is the home phone number that is unknown.)</td></tr></table></li><li>Include codes from <a href=\"http://loinc.org\"><code>http://loinc.org</code></a> where SCALE_TYP  =  DOC</li></ul></div>"
+	},
+	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type",
+	"version": "5.0.1",
+	"name": "USCoreDocumentReferenceType",
+	"title": "US Core DocumentReference Type",
+	"status": "active",
+	"date": "2019-05-21",
+	"publisher": "HL7 International - Cross-Group Projects",
+	"contact": [
+		{
+			"name": "HL7 International - Cross-Group Projects",
+			"telecom": [
+				{
+					"system": "url",
+					"value": "http://www.hl7.org/Special/committees/cgp"
+				},
+				{
+					"system": "email",
+					"value": "cgp@lists.HL7.org"
+				}
+			]
+		}
+	],
+	"description": "The US Core DocumentReference Type Value Set includes all LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
+	"jurisdiction": [
+		{
+			"coding": [
+				{
+					"system": "urn:iso:std:iso:3166",
+					"code": "US"
+				}
+			]
+		}
+	],
+	"copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "expansion": {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/valueset-toocostly",
+          "valueBoolean": true
+        }
+      ],
+      "identifier": "urn:uuid:a46afb2b-b701-4b33-9840-e59c837904f3",
+      "timestamp": "2023-04-27T19:12:31+00:00",
+      "total": 1001,
+      "parameter": [
+        {
+          "name": "excludeNested",
+          "valueBoolean": false
+        },
+        {
+          "name": "version",
+          "valueUri": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor|2.0.0"
+        },
+        {
+          "name": "limitedExpansion",
+          "valueBoolean": true
+        },
+        {
+          "name": "excludeNested",
+          "valueBoolean": true
+        },
+        {
+          "name": "version",
+          "valueString": "http://loinc.org|2.69"
+        }
+      ],
+      "contains": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+          "code": "UNK",
+          "display": "unknown"
+        },
+        {
+          "system": "http://loinc.org",
+          "code": "34117-2",
+          "display": "History and physical note"
+        },
+        {
+          "system": "http://loinc.org",
+          "code": "51847-2",
+          "display": "Evaluation+Plan note"
+        }
+      ]
+  }
+}


### PR DESCRIPTION
This PR fixes the failing CI tests, which I believe are because certain US Core 5 ValueSets don't contain relevant codes directly, they reference other valuesets. (Why the tests used to work and suddenly stopped one day a few weeks ago... I don't have an answer for that)

This does a few things:
 - Brings in the referenced value sets for "ONC Administrative Sex", "Race", "Ethnicity", and "Other or unknown or refused to answer". The HAPI validator is smart enough to be able to find these when trying to validate whether codes belong to, for example, the US Core birthsex valueset which references the ONC one.
 - Replaces the official US Core DocumentReference Type compose (which points to LOINC with type DOC) with the two specific LOINC codes we actually use. This was apparently what we did for R4 already: see https://github.com/synthetichealth/synthea/commit/78765353f732030532940aba8cbbe8289511f005#diff-0bdfbfbdef306b8401497948f30c06a573b80ab7ec944e0d6633dea92e9ec91c
 - Adds methods to ValidationResources so that we can either get a STU3 or R4 version. Since the objects here aren't static, there's no reason to load the STU3 artifacts for the R4 test, or vice versa.
 - Adds parameters to the ValidationSupportR4 to select whether US Core 4 or 5 (or both or neither) should be loaded. I can change this into an enum if people would prefer
 - Prevents toggling static fields back & forth between values in the FHIRR4ExporterTest as that seemed to be creating weird combinations in testing. Now there are 3 sub-tests with specific combinations of parameters.
 - Adds support to the ParallelTestingService to request fewer than 10 people. (so that the above test remains consistent on time, instead of running 3x as long. I think this is one of the longest tests already)

FYI, there is another unrelated uscore 5 bug (1283) which I will address in this PR if I can fix it before this is merged.