### PR TITLE
Claims CSV contains invalid uuids

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -1424,14 +1424,14 @@ public class CSVExporter {
     // PRIMARYPATIENTINSURANCEID
     if (encounter.claim.getPayer() == null
         || encounter.claim.getPayer().isNoInsurance()) {
-      s.append("0,"); // 0 == No Insurance
+      s.append(","); // Empty for no insurance
     } else {
       s.append(claim.getPayer().getResourceID()).append(',');
     }
     // SECONDARYPATIENTINSURANCEID (0 default if none)
     if (encounter.claim.getSecondaryPayer() == null
         || encounter.claim.getSecondaryPayer().isNoInsurance()) {
-      s.append("0,");
+      s.append(",");
     } else {
       s.append(claim.getSecondaryPayer().getResourceID()).append(',');
     }


### PR DESCRIPTION
Hi,
claims, exported as CSV, contains both, according to the wiki, a Primary Patient Insurance ID and a Secondary Patient Insurance ID of type UUID. However, the code produces 0, if no Payer exists. 0 is not a valid UUID and hence we are unable to import the exported CSV files into a PostgreSQL database.
In case of no Payer exists, I suggest to generate nothing (NULL in SQL speak) instead of 0.