### PR TITLE
Adjust patient residence codes.

### DIFF
--- a/src/main/java/org/mitre/synthea/export/rif/PDEExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/PDEExporter.java
@@ -228,7 +228,7 @@ public class PDEExporter extends RIFExporter {
     } else if (claimTypes.contains(ClaimType.CARRIER)
         || claimTypes.contains(ClaimType.OUTPATIENT)) {
       if (roll <= 0.87) {
-        residenceCode = "01"; // 03=long-term
+        residenceCode = "01"; // 01=home
       } else if (roll <= 0.95) {
         residenceCode = "00"; // 00=not specified
       } else if (roll <= 0.99) {

--- a/src/main/java/org/mitre/synthea/export/rif/PDEExporter.java
+++ b/src/main/java/org/mitre/synthea/export/rif/PDEExporter.java
@@ -219,7 +219,7 @@ public class PDEExporter extends RIFExporter {
       residenceCode = "11"; // 11=hospice
     } else if (claimTypes.contains(ClaimType.INPATIENT)) {
       if (roll <= 0.95) {
-        residenceCode = "01"; // 01=home
+        residenceCode = "03"; // 03=nursing
       } else if (roll <= 0.99) {
         residenceCode = "04"; // 04=assisted living
       } else {


### PR DESCRIPTION
First pass at improving the prescription drug event patient residence codes.

The decision of which residence code is selected is based on the encounter class, and sometimes patient homelessness status.

Prior to this change, something like 99.99% of the codes were `01 - home` and an exceptionally small number were `14 - homeless`.

The following table shows the results after the change, and was based on 10K synthetic patients using `--generate.providers.selection_behavior=medicare` and `-a 65-80` 

PTNT_RSDNC_CD | Display | SYNTHETIC % | REAL % | DELTA
-- | -- | -- | -- | --
01 | home | 0.873368 | 0.802164 | +0.071204
00 | not specified | 0.085420 | 0.073489 | +0.011931
04 | assisted living | 0.040491 | 0.039337 | +0.001154
13 | inpatient rehab | 0.000577 | 0.000001 | +0.000576
11 | hospice | 0.000096 | 0.000073 | +0.000024
03 | nursing | 0.000031 | 0.084936 | -0.084905
14 | homeless | 0.000017 | 0.000001 | +0.000017

The results are pretty good, except for `03 - nursing`.

