### PR TITLE
Configuration option to disable pretty printing for XML and JSON

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -266,7 +266,8 @@ public class FhirDstu2 {
    */
   public static String convertToFHIRJson(Person person, long stopTime) {
     Bundle bundle = convertToFHIR(person, stopTime);
-    String bundleJson = FHIR_CTX.newJsonParser().setPrettyPrint(true)
+    Boolean pretty = Config.getAsBoolean("exporter.pretty_print", true);
+    String bundleJson = FHIR_CTX.newJsonParser().setPrettyPrint(pretty)
         .encodeResourceToString(bundle);
     return bundleJson;
   }

--- a/src/main/java/org/mitre/synthea/export/FhirGroupExporterR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirGroupExporterR4.java
@@ -84,7 +84,8 @@ public abstract class FhirGroupExporterR4 {
         String filename = group.getResourceType().toString() + ".ndjson";
         outFilePath = f.toPath().resolve(filename);
       } else {
-        IParser parser = FhirR4.getContext().newJsonParser().setPrettyPrint(true);
+        Boolean pretty = Config.getAsBoolean("exporter.pretty_print", true);
+        IParser parser = FhirR4.getContext().newJsonParser().setPrettyPrint(pretty);
         groupJson = parser.encodeResourceToString(group);
         outFilePath = f.toPath().resolve("groupInformation" + stop + ".json");
       }

--- a/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterDstu2.java
@@ -71,7 +71,8 @@ public abstract class FhirPractitionerExporterDstu2 {
           Exporter.appendToFile(outFilePath, entryJson);
         }
       } else {
-        parser = parser.setPrettyPrint(true);
+        Boolean pretty = Config.getAsBoolean("exporter.pretty_print", true);
+        parser = parser.setPrettyPrint(pretty);
         Path outFilePath =
             outputFolder.toPath().resolve("practitionerInformation" + stop + ".json");
         String bundleJson = parser.encodeResourceToString(bundle);

--- a/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterR4.java
@@ -84,7 +84,8 @@ public abstract class FhirPractitionerExporterR4 {
           }
         }
       } else {
-        parser = parser.setPrettyPrint(true);
+        Boolean pretty = Config.getAsBoolean("exporter.pretty_print", true);
+        parser = parser.setPrettyPrint(pretty);
         Path outFilePath =
             outputFolder.toPath().resolve("practitionerInformation" + stop + ".json");
         String bundleJson = parser.encodeResourceToString(bundle);

--- a/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirPractitionerExporterStu3.java
@@ -70,7 +70,8 @@ public abstract class FhirPractitionerExporterStu3 {
           Exporter.appendToFile(outFilePath, entryJson);
         }
       } else {
-        parser = parser.setPrettyPrint(true);
+        Boolean pretty = Config.getAsBoolean("exporter.pretty_print", true);
+        parser = parser.setPrettyPrint(pretty);
         Path outFilePath =
             outputFolder.toPath().resolve("practitionerInformation" + stop + ".json");
         String bundleJson = parser.encodeResourceToString(bundle);

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -525,7 +525,8 @@ public class FhirR4 {
    */
   public static String convertToFHIRJson(Person person, long stopTime) {
     Bundle bundle = convertToFHIR(person, stopTime);
-    String bundleJson = FHIR_CTX.newJsonParser().setPrettyPrint(true)
+    Boolean pretty = Config.getAsBoolean("exporter.pretty_print", true);
+    String bundleJson = FHIR_CTX.newJsonParser().setPrettyPrint(pretty)
         .encodeResourceToString(bundle);
 
     return bundleJson;

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -316,7 +316,8 @@ public class FhirStu3 {
    */
   public static String convertToFHIRJson(Person person, long stopTime) {
     Bundle bundle = convertToFHIR(person, stopTime);
-    String bundleJson = FHIR_CTX.newJsonParser().setPrettyPrint(true)
+    Boolean pretty = Config.getAsBoolean("exporter.pretty_print", true);
+    String bundleJson = FHIR_CTX.newJsonParser().setPrettyPrint(pretty)
         .encodeResourceToString(bundle);
     return bundleJson;
   }

--- a/src/main/java/org/mitre/synthea/export/HospitalExporterDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporterDstu2.java
@@ -55,7 +55,8 @@ public abstract class HospitalExporterDstu2 {
           Exporter.appendToFile(outFilePath, entryJson);
         }
       } else {
-        parser = parser.setPrettyPrint(true);
+        Boolean pretty = Config.getAsBoolean("exporter.pretty_print", true);
+        parser = parser.setPrettyPrint(pretty);
         Path outFilePath = outputFolder.toPath().resolve("hospitalInformation" + stop + ".json");
         String bundleJson = parser.encodeResourceToString(bundle);
         Exporter.overwriteFile(outFilePath, bundleJson);

--- a/src/main/java/org/mitre/synthea/export/HospitalExporterR4.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporterR4.java
@@ -64,7 +64,8 @@ public abstract class HospitalExporterR4 {
           }
         }
       } else {
-        parser = parser.setPrettyPrint(true);
+        Boolean pretty = Config.getAsBoolean("exporter.pretty_print", true);
+        parser = parser.setPrettyPrint(pretty);
         Path outFilePath = outputFolder.toPath().resolve("hospitalInformation" + stop + ".json");
         String bundleJson = parser.encodeResourceToString(bundle);
         Exporter.overwriteFile(outFilePath, bundleJson);

--- a/src/main/java/org/mitre/synthea/export/HospitalExporterStu3.java
+++ b/src/main/java/org/mitre/synthea/export/HospitalExporterStu3.java
@@ -55,7 +55,8 @@ public abstract class HospitalExporterStu3 {
           Exporter.appendToFile(outFilePath, entryJson);
         }
       } else {
-        parser = parser.setPrettyPrint(true);
+        Boolean pretty = Config.getAsBoolean("exporter.pretty_print", true);
+        parser = parser.setPrettyPrint(pretty);
         Path outFilePath = outputFolder.toPath().resolve("hospitalInformation" + stop + ".json");
         String bundleJson = parser.encodeResourceToString(bundle);
         Exporter.overwriteFile(outFilePath, bundleJson);

--- a/src/main/java/org/mitre/synthea/export/JSONExporter.java
+++ b/src/main/java/org/mitre/synthea/export/JSONExporter.java
@@ -18,9 +18,6 @@ import java.util.Random;
 
 import org.mitre.synthea.engine.State;
 import org.mitre.synthea.helpers.Config;
-import org.mitre.synthea.identity.Entity;
-import org.mitre.synthea.identity.LocalDateDeserializer;
-import org.mitre.synthea.identity.Period;
 import org.mitre.synthea.world.agents.Payer;
 import org.mitre.synthea.world.agents.Person;
 
@@ -37,8 +34,7 @@ public class JSONExporter {
    * @return a lot of JSON in a String
    */
   public static String export(Person person) {
-    Gson gson = new GsonBuilder()
-            .setPrettyPrinting()
+    GsonBuilder builder = new GsonBuilder()
         .excludeFieldsWithModifiers(Modifier.STATIC, Modifier.TRANSIENT, Modifier.VOLATILE)
         .addSerializationExclusionStrategy(new SyntheaExclusionStrategy())
         .registerTypeHierarchyAdapter(State.class, new StateSerializer())
@@ -46,8 +42,11 @@ public class JSONExporter {
             new PersonSerializer(!Config.getAsBoolean("exporter.json.include_module_history")))
         .registerTypeHierarchyAdapter(Payer.class, new ShortPayerSerializer())
         .registerTypeHierarchyAdapter(Random.class, new RandomSerializer())
-        .registerTypeHierarchyAdapter(LocalDate.class, new LocalDateSerializer())
-        .create();
+        .registerTypeHierarchyAdapter(LocalDate.class, new LocalDateSerializer());
+    if (Config.getAsBoolean("exporter.pretty_print", true)) {
+      builder.setPrettyPrinting();
+    }
+    Gson gson = builder.create();
     return gson.toJson(person);
   }
 

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -3,6 +3,8 @@
 exporter.baseDirectory = ./output/
 exporter.use_uuid_filenames = false
 exporter.subfolders_by_id_substring = false
+# exporters that use XML or JSON can enable or disable 'pretty printing'
+exporter.pretty_print = true
 # number of years of history to keep in exported records, anything older than this may be filtered out
 # set years_of_history = 0 to skip filtering altogether and keep the entire history
 exporter.years_of_history = 10
@@ -18,6 +20,7 @@ exporter.fhir.use_shr_extensions = false
 exporter.fhir.use_us_core_ig = true
 exporter.fhir.us_core_version = 5.0.1
 exporter.fhir.transaction_bundle = true
+# using bulk_data=true will ignore exporter.pretty_print
 exporter.fhir.bulk_data = false
 # included_ and excluded_resources list out the resource types to include/exclude in the csv exporters.
 # only one of these may be set at a time, if both are set then both will be ignored.


### PR DESCRIPTION
The following exporters will now use the `exporter.pretty_print` configuration setting:

- FHIR (all versions)
  - Pretty printing settings are ignored when using `exporter.fhir.bulk_data` 
- CCDA
- JSON

The savings in C-CDA file size is low, only around 2% smaller.
The savings in FHIR file size can be quite large, approximately 33% smaller in most cases.
