### PR TITLE
Fix SDOH address category.

### DIFF
--- a/src/main/resources/modules/encounter/sdoh_hrsn.json
+++ b/src/main/resources/modules/encounter/sdoh_hrsn.json
@@ -145,7 +145,7 @@
           "attribute": "prapare_a8"
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {


### PR DESCRIPTION
Fixes the PRAPARE SDOH module so that the "Address" observation has a category of `survey` instead of `laboratory`.