### PR TITLE
Bump gradle wrapper version to 8.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ These instructions are intended for those wishing to examine the Synthea source 
 ### Installation
 
 **System Requirements:**
-Synthea<sup>TM</sup> requires Java JDK 11 or newer, and is tested to work with up to Java 19.
+Synthea<sup>TM</sup> requires Java JDK 11 or newer. We strongly recommend using a Long-Term Support (LTS) release of Java, 11 or 17, as issues may occur with more recent non-LTS versions.
 
 To clone the Synthea<sup>TM</sup> repo, then build and run the test suite:
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ These instructions are intended for those wishing to examine the Synthea source 
 ### Installation
 
 **System Requirements:**
-Synthea<sup>TM</sup> requires Java 11 or newer.
+Synthea<sup>TM</sup> requires Java JDK 11 or newer, and is tested to work with up to Java 19.
 
 To clone the Synthea<sup>TM</sup> repo, then build and run the test suite:
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -325,12 +325,12 @@ run {
 }
 
 task sourceJar(type: Jar) {
-    classifier "sources"
+    archiveClassifier = "sources"
     from sourceSets.main.allJava
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier "javadoc"
+    archiveClassifier = "javadoc"
     from javadoc.destinationDir
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bump the gradle wrapper version to 8.2.1 (latest as of July 10, 2023 - https://gradle.org/releases/)

This will enable support up through JDK 20 yet. (Note JDK 21 LTS is also right around the corner.) (An earlier version of this said JDK 20 was not yet supported, that was a mistake I'm not sure why I thought that)
Gradle/JDK compatibility is described here: https://docs.gradle.org/current/userguide/compatibility.html
Also see the JDK support matrix at https://endoflife.date/java

The changes to build.gradle are required to get past some errors, I guess they changed the gradle DSL:
```
* What went wrong:
A problem occurred evaluating root project 'synthea'.
> Could not find method classifier() for arguments [sources] on task ':sourceJar' of type org.gradle.api.tasks.bundling.Jar.
```

I tested this with Docker, across JDKs 11, 16, 17, 18, 19, and 20. For posterity:

Dockerfile:
```dockerfile
ARG JAVAVERSION=20
FROM alpine:3.18.2 as downloader
# used only for zip/unzip

# --insecure is for mitre only
# -L means follow redirects
RUN apk add --no-cache --allow-untrusted --repository http://dl-cdn.alpinelinux.org/alpine/v3.15/main zip unzip curl && curl --insecure -L -O https://github.com/synthetichealth/synthea/archive/refs/heads/bump_gradle.zip && unzip bump_gradle.zip

FROM eclipse-temurin:${JAVAVERSION}-jdk

# RUN curl -ksSL https://gitlab.mitre.org/mitre-scripts/mitre-pki/raw/master/os_scripts/install_certs.sh | MODE=ubuntu sh

COPY --from=downloader /synthea-bump_gradle/ /synthea-bump_gradle/

WORKDIR "/synthea-bump_gradle"

RUN ./gradlew compileJava

CMD java -version && ./gradlew test concepts uberJar javadoc graphviz run --console=plain
```

Script to build and run it for the various java versions:
```sh
#!/bin/bash

# build images separately from running them
# see https://hub.docker.com/_/eclipse-temurin/tags -- there are no images for 12 thru 15
for VERSION in 20 19 18 17 16 11
do
  docker build --build-arg "JAVAVERSION=$VERSION" --tag syntheagradle:$VERSION - < Dockerfile.1
done

# echo Done Building.

for VERSION in 20 19 18 17 16 11
do
  docker run -it syntheagradle:$VERSION | tee gradledockertest_${VERSION}.txt
done
```