### PR TITLE
Proof of Concept: Custom exporter support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,8 @@ dependencies {
   // JfreeChart for drawing physiology charts
   implementation 'org.jfree:jfreechart:1.5.0'
 
+  implementation fileTree(dir: 'lib/custom', include: '*.jar')
+
   // Use JUnit test framework
   testImplementation 'junit:junit:4.12'
   testImplementation fileTree(dir: 'lib/mdhtruntime/mdht', include: '*.jar')
@@ -273,7 +275,7 @@ artifacts {
 }
 
 def mavenGroup = 'org.mitre.synthea'
-def mavenVersion = '3.0.0-SNAPSHOT'
+def mavenVersion = '3.0.1'
 
 publishing {
     publications {

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -204,6 +204,7 @@ public class Generator implements RandomNumberGenerator {
     if (Config.getAsBoolean("exporter.cdw.export")) {
       CDWExporter.getInstance().setKeyStart((stateIndex * 1_000_000) + 1);
     }
+    Exporter.loadCustomExporters();
 
     this.random = new Random(options.seed);
     this.timestep = Long.parseLong(Config.get("generate.timestep"));

--- a/src/main/java/org/mitre/synthea/export/PatientExporter.java
+++ b/src/main/java/org/mitre/synthea/export/PatientExporter.java
@@ -1,0 +1,19 @@
+package org.mitre.synthea.export;
+
+import org.mitre.synthea.export.Exporter.ExporterRuntimeOptions;
+import org.mitre.synthea.world.agents.Person;
+
+/**
+ * 
+ *
+ */
+public interface PatientExporter {
+
+  /**
+   * 
+   * @param person   Patient to export
+   * @param stopTime Time at which the simulation stopped
+   * @param options Runtime exporter options
+   */
+  void export(Person person, long stopTime, ExporterRuntimeOptions options);
+}

--- a/src/main/java/org/mitre/synthea/export/PostCompletionExporter.java
+++ b/src/main/java/org/mitre/synthea/export/PostCompletionExporter.java
@@ -1,0 +1,17 @@
+package org.mitre.synthea.export;
+
+import org.mitre.synthea.engine.Generator;
+import org.mitre.synthea.export.Exporter.ExporterRuntimeOptions;
+
+/**
+ * 
+ *
+ */
+public interface PostCompletionExporter {
+  /**
+   * 
+   * @param generator
+   * @param options
+   */
+  void export(Generator generator, ExporterRuntimeOptions options);
+}

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -59,6 +59,9 @@ exporter.symptoms.csv.append_mode = false
 exporter.symptoms.csv.folder_per_run = false
 exporter.symptoms.text.export = false
 
+# enable searching for custom exporter implementations
+exporter.enable_custom_exporters = true
+
 # the number of patients to generate, by default
 # this can be overridden by passing a different value to the Generator constructor
 generate.default_population = 1


### PR DESCRIPTION
This is a proof of concept for supporting drop-in custom exporters. Not sure we care to pursue this so I'm making this a PR which we can close and delete the branch. (Then revisit if it's ever relevant)

This approach takes advantage of the [Java ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) to load in JARs containing classes that implement a certain interface. I've defined two interfaces here, PatientExporter and PostCompletionExporter. (The existing exporters weren't modified here but they could easily extend these interfaces as well)

A template for building a custom exporter is here: https://github.com/dehall/custom-exporter-template

And an example Postgres loader which loads Patient basic info and Conditions into simple tables: https://github.com/dehall/example-exporter-postgres

(Documentation is limited, apologies)

Note this was never tested with the uberJar