### PR TITLE
Custom Exporters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -343,7 +343,7 @@ artifacts {
 }
 
 def mavenGroup = 'org.mitre.synthea'
-def mavenVersion = '3.2.1-SNAPSHOT'
+def mavenVersion = '3.2.2-SNAPSHOT'
 
 publishing {
     publications {

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,8 @@ dependencies {
   // JfreeChart for drawing physiology charts
   implementation 'org.jfree:jfreechart:1.5.3'
 
+  implementation fileTree(dir: 'lib/custom', include: '*.jar')
+
   // Use JUnit test framework
   testImplementation('junit:junit') {
     version {

--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -219,6 +219,7 @@ public class Generator {
     if (Config.getAsBoolean("exporter.cdw.export")) {
       CDWExporter.getInstance().setKeyStart((stateIndex * 1_000_000) + 1);
     }
+    Exporter.loadCustomExporters();
 
     this.populationRandom = new DefaultRandomNumberGenerator(options.seed);
     this.clinicianRandom = new DefaultRandomNumberGenerator(options.clinicianSeed);

--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -57,6 +58,28 @@ public abstract class Exporter {
 
   private static final int FILE_BUFFER_SIZE = 4 * 1024 * 1024;
 
+  private static List<PatientExporter> patientExporters;
+  private static List<PostCompletionExporter> postCompletionExporters;
+  
+  public static void loadCustomExporters() {
+    if (Config.getAsBoolean("exporter.enable_custom_exporters", false)) {
+      patientExporters = new LinkedList<>();
+      postCompletionExporters = new LinkedList<>();
+      
+      ServiceLoader<PatientExporter> loader = ServiceLoader.load(PatientExporter.class);
+      for (PatientExporter instance : loader) {
+        System.out.println(instance.getClass().getCanonicalName());
+        patientExporters.add(instance);
+      }
+
+      ServiceLoader<PostCompletionExporter> loader2 = ServiceLoader.load(PostCompletionExporter.class);
+      for (PostCompletionExporter instance : loader2) {
+        System.out.println(instance.getClass().getCanonicalName());
+        postCompletionExporters.add(instance);
+      }
+    }
+  }
+  
   /**
    * Runtime configuration of the record exporter.
    */
@@ -318,6 +341,13 @@ public abstract class Exporter {
       String consolidatedNotes = ClinicalNoteExporter.export(person);
       writeNewFile(outFilePath, consolidatedNotes);
     }
+    
+    if (patientExporters != null && !patientExporters.isEmpty()) {
+      for (PatientExporter patientExporter : patientExporters) {
+        patientExporter.export(person, stopTime, options);
+      }
+    }
+    
     if (options.isQueueEnabled()) {
       try {
         switch (options.queuedFhirVersion()) {
@@ -506,6 +536,12 @@ public abstract class Exporter {
         MetadataExporter.exportMetadata(generator);
       } catch (IOException e) {
         e.printStackTrace();
+      }
+    }
+    
+    if (postCompletionExporters != null && !postCompletionExporters.isEmpty()) {
+      for (PostCompletionExporter postCompletionExporter : postCompletionExporters) {
+        postCompletionExporter.export(generator, options);
       }
     }
 

--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -60,26 +60,32 @@ public abstract class Exporter {
 
   private static List<PatientExporter> patientExporters;
   private static List<PostCompletionExporter> postCompletionExporters;
-  
+
+  /**
+   * If the config setting "exporter.enable_custom_exporters" is enabled,
+   * load classes implementing the {@link PatientExporter} or {@link PostCompletionExporter}
+   * interfaces from the classpath, via the ServiceLoader.
+   */
   public static void loadCustomExporters() {
     if (Config.getAsBoolean("exporter.enable_custom_exporters", false)) {
-      patientExporters = new LinkedList<>();
-      postCompletionExporters = new LinkedList<>();
-      
+      patientExporters = new ArrayList<>();
+      postCompletionExporters = new ArrayList<>();
+
       ServiceLoader<PatientExporter> loader = ServiceLoader.load(PatientExporter.class);
       for (PatientExporter instance : loader) {
         System.out.println(instance.getClass().getCanonicalName());
         patientExporters.add(instance);
       }
 
-      ServiceLoader<PostCompletionExporter> loader2 = ServiceLoader.load(PostCompletionExporter.class);
+      ServiceLoader<PostCompletionExporter> loader2 =
+          ServiceLoader.load(PostCompletionExporter.class);
       for (PostCompletionExporter instance : loader2) {
         System.out.println(instance.getClass().getCanonicalName());
         postCompletionExporters.add(instance);
       }
     }
   }
-  
+
   /**
    * Runtime configuration of the record exporter.
    */
@@ -341,13 +347,13 @@ public abstract class Exporter {
       String consolidatedNotes = ClinicalNoteExporter.export(person);
       writeNewFile(outFilePath, consolidatedNotes);
     }
-    
+
     if (patientExporters != null && !patientExporters.isEmpty()) {
       for (PatientExporter patientExporter : patientExporters) {
         patientExporter.export(person, stopTime, options);
       }
     }
-    
+
     if (options.isQueueEnabled()) {
       try {
         switch (options.queuedFhirVersion()) {
@@ -538,7 +544,7 @@ public abstract class Exporter {
         e.printStackTrace();
       }
     }
-    
+
     if (postCompletionExporters != null && !postCompletionExporters.isEmpty()) {
       for (PostCompletionExporter postCompletionExporter : postCompletionExporters) {
         postCompletionExporter.export(generator, options);

--- a/src/main/java/org/mitre/synthea/export/PatientExporter.java
+++ b/src/main/java/org/mitre/synthea/export/PatientExporter.java
@@ -1,0 +1,19 @@
+package org.mitre.synthea.export;
+
+import org.mitre.synthea.export.Exporter.ExporterRuntimeOptions;
+import org.mitre.synthea.world.agents.Person;
+
+/**
+ * 
+ *
+ */
+public interface PatientExporter {
+
+  /**
+   * 
+   * @param person   Patient to export
+   * @param stopTime Time at which the simulation stopped
+   * @param options Runtime exporter options
+   */
+  void export(Person person, long stopTime, ExporterRuntimeOptions options);
+}

--- a/src/main/java/org/mitre/synthea/export/PatientExporter.java
+++ b/src/main/java/org/mitre/synthea/export/PatientExporter.java
@@ -4,13 +4,12 @@ import org.mitre.synthea.export.Exporter.ExporterRuntimeOptions;
 import org.mitre.synthea.world.agents.Person;
 
 /**
- * 
- *
+ * This interface defines an exporter that will be run for every patient
+ * in a simulation.
  */
 public interface PatientExporter {
-
   /**
-   * 
+   * Export the given Person object.
    * @param person   Patient to export
    * @param stopTime Time at which the simulation stopped
    * @param options Runtime exporter options

--- a/src/main/java/org/mitre/synthea/export/PostCompletionExporter.java
+++ b/src/main/java/org/mitre/synthea/export/PostCompletionExporter.java
@@ -1,0 +1,17 @@
+package org.mitre.synthea.export;
+
+import org.mitre.synthea.engine.Generator;
+import org.mitre.synthea.export.Exporter.ExporterRuntimeOptions;
+
+/**
+ * 
+ *
+ */
+public interface PostCompletionExporter {
+  /**
+   * 
+   * @param generator
+   * @param options
+   */
+  void export(Generator generator, ExporterRuntimeOptions options);
+}

--- a/src/main/java/org/mitre/synthea/export/PostCompletionExporter.java
+++ b/src/main/java/org/mitre/synthea/export/PostCompletionExporter.java
@@ -4,14 +4,16 @@ import org.mitre.synthea.engine.Generator;
 import org.mitre.synthea.export.Exporter.ExporterRuntimeOptions;
 
 /**
- * 
- *
+ * This interface defines an exporter that will be invoked
+ * after the entire population has been generated.
+ * Example uses for this type of exporter include metadata,
+ * Payer- or Provider-based data, or working in combination with a separate
+ * PatientExporter where a final step is only performed once every patient
+ * has been handled.
  */
 public interface PostCompletionExporter {
   /**
-   * 
-   * @param generator
-   * @param options
+   * Export data based on the given Generator and options.
    */
   void export(Generator generator, ExporterRuntimeOptions options);
 }

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -93,6 +93,9 @@ exporter.symptoms.csv.append_mode = false
 exporter.symptoms.csv.folder_per_run = false
 exporter.symptoms.text.export = false
 
+# enable searching for custom exporter implementations
+exporter.enable_custom_exporters = true
+
 # the number of patients to generate, by default
 # this can be overridden by passing a different value to the Generator constructor
 generate.default_population = 1


### PR DESCRIPTION
This is a proof of concept for supporting drop-in custom exporters.

This approach takes advantage of the [Java ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) to load in JARs containing classes that implement a certain interface. I've defined two interfaces here, PatientExporter and PostCompletionExporter. (The existing exporters weren't modified here but they could easily extend these interfaces as well)

A template for building a custom exporter is here: https://github.com/dehall/custom-exporter-template

And an example Postgres loader which loads Patient basic info and Conditions into simple tables: https://github.com/dehall/example-exporter-postgres

(Documentation is limited on those new repos, apologies)

Note this has not yet been tested with the uberJar, but I believe it should be possible to get it working. I suspect instead of `java -jar synthea-with-dependencies.jar` though you will have to run something along the lines of `java -cp synthea-with-dependencies.jar:new-exporter.jar App`