### PR TITLE
Fix issue where vital signs were sometimes being set to `NaN`

### DIFF
--- a/src/main/java/org/mitre/synthea/world/concepts/GrowthChartEntry.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/GrowthChartEntry.java
@@ -6,6 +6,16 @@ import java.io.Serializable;
  * Represents the LMS parameters on the CDC growth chart for a particular sex and age in months.
  */
 public class GrowthChartEntry implements Serializable {
+
+  /**
+   * The highest percentile to use when attempting to calculate a value. Tests with the BMI growth
+   * charts for females at 240 months show that values greater than 0.99739 cause a term in the
+   * equation to go negative causing the code to return NaN. Values slightly less than that can
+   * return unrealistic values. This provides a limit to the maximum percentile that will be looked
+   * up.
+   */
+  public static double MAX_PERCENTILE = 0.995;
+
   private double lboxCox;
   private double median;
   private double scov;
@@ -51,11 +61,16 @@ public class GrowthChartEntry implements Serializable {
    * @return The value for the given percentile
    */
   public double lookUp(double percentile) {
-    double z = GrowthChart.calculateZScore(percentile);
+    double percentileToUse = percentile;
+    if (percentile > 0.995) {
+      percentileToUse = 0.995;
+    }
+    double z = GrowthChart.calculateZScore(percentileToUse);
     if (this.lboxCox == 0) {
       return this.median * Math.exp((this.scov * z));
     } else {
-      return this.median * Math.pow((1 + (this.lboxCox * this.scov * z)), (1.0 / this.lboxCox));
+      double expressionTerm = this.lboxCox * this.scov * z;
+      return this.median * Math.pow((1 + expressionTerm), (1.0 / this.lboxCox));
     }
   }
 }

--- a/src/main/java/org/mitre/synthea/world/concepts/GrowthChartEntry.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/GrowthChartEntry.java
@@ -62,8 +62,8 @@ public class GrowthChartEntry implements Serializable {
    */
   public double lookUp(double percentile) {
     double percentileToUse = percentile;
-    if (percentile > 0.995) {
-      percentileToUse = 0.995;
+    if (percentile > MAX_PERCENTILE) {
+      percentileToUse = MAX_PERCENTILE;
     }
     double z = GrowthChart.calculateZScore(percentileToUse);
     if (this.lboxCox == 0) {

--- a/src/test/java/org/mitre/synthea/modules/GrowthChartTest.java
+++ b/src/test/java/org/mitre/synthea/modules/GrowthChartTest.java
@@ -58,7 +58,8 @@ public class GrowthChartTest {
   @Test
   public void testGrowthChartLookupMax() throws Exception {
     double height = LifecycleModule.lookupGrowthChart("height", "M", 20, 1.0);
-    assertEquals(94.95447906, height, 0.01);
+    // Max value is now capped to the 99.5th percentile.
+    assertEquals(93.1240785326071, height, 0.01);
   }
 
   @Test

--- a/src/test/java/org/mitre/synthea/world/concepts/GrowthChartTest.java
+++ b/src/test/java/org/mitre/synthea/world/concepts/GrowthChartTest.java
@@ -1,0 +1,20 @@
+package org.mitre.synthea.world.concepts;
+
+import java.util.Map;
+
+import junit.framework.TestCase;
+
+public class GrowthChartTest extends TestCase {
+
+  /**
+   * Test the look up of BMI values at the high end of the range.
+   */
+  public void testLookUp() {
+    Map<GrowthChart.ChartType, GrowthChart> growthChart =
+            GrowthChart.loadCharts();
+    double bmi = growthChart.get(GrowthChart.ChartType.BMI).lookUp(240, "F", 0.997394309960757);
+    assertFalse(Double.isNaN(bmi));
+    bmi = growthChart.get(GrowthChart.ChartType.BMI).lookUp(240, "F", 0.5);
+    assertEquals(21.71699934, bmi, 0.01);
+  }
+}


### PR DESCRIPTION
Synthea's simulation of height and weight under the age of 20 depends on growth charts published by CDC. The growth charts are [provided with a method](https://www.cdc.gov/growthcharts/percentile_data_files.htm) for transforming values into percentiles and vice-versa. It appears that for higher percentiles, this method can break down. 

The case that was used for testing this issue is transforming the ~99.74th percentile BMI for females at 240 months into an actual BMI value. 

This code change addresses the issue by converting any request above the 99.5th percentile to just the 99.5th percentile.

This addresses #1372. 