### PR TITLE
Fix export filter keeping old entries when there is an active entry of the same type

### DIFF
--- a/src/test/java/org/mitre/synthea/export/ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/ExporterTest.java
@@ -262,7 +262,7 @@ public class ExporterTest {
   public void testExportFilterShouldNotKeepOldStuffWhenActiveOfSameType() {
     // create old encounters with the same repeated condition, ended
     long oneWeek = Utilities.convertTime("weeks", 1);
-    for (int i = 0 ; i < 3 ; i++) {
+    for (int i = 0; i < 3; i++) {
       record.encounterStart(time - years(10 - i), EncounterType.EMERGENCY);
       record.conditionStart(time - years(10 - i), "viral_sinusitis");
       record.conditionEnd(time - years(10 - i) + oneWeek, "viral_sinusitis");
@@ -271,7 +271,7 @@ public class ExporterTest {
     // create a recent encounter with the same condition, still active
     record.encounterStart(time - oneWeek, EncounterType.EMERGENCY);
     record.conditionStart(time - oneWeek, "viral_sinusitis");
-    
+
     Person filtered = Exporter.filterForExport(patient, yearsToKeep, endTime);
 
     assertEquals(1, filtered.record.encounters.size());


### PR DESCRIPTION
Fixes #1383 

This PR addresses an issue where the export filter isn't filtering out old entries when there is a separate active entry of the same "type", ie, code. This is especially likely to happen with "Medication Review Due" from the Med Rec module, but it could also happen for any potentially-recurring entry such as Viral Sinusitis or chronic medications.

The issue is that the logic is using `record.conditionActive` which only checks whether the given code is in the "active" set, it doesn't look at the specific entry at all. The change here is to only look at dates, and the date logic can be pretty simple: "if the entry is open (stop = 0) or the stop is after the cutoff, keep the entry"