### PR TITLE
Fix issues with NPEs related to the employment module

### DIFF
--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -389,7 +389,7 @@ public class Location implements Serializable {
    */
   public void setSocialDeterminants(Person person) {
     String county = (String) person.attributes.get(Person.COUNTY);
-    if (county == null) {
+    if (county == null || !socialDeterminantsOfHealth.containsKey(county)) {
       county = "AVERAGE";
     }
     Map<String, Double> sdoh = socialDeterminantsOfHealth.get(county);

--- a/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
+++ b/src/test/java/org/mitre/synthea/world/geography/LocationTest.java
@@ -18,6 +18,7 @@ import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.concepts.Employment;
 
 public class LocationTest {
   private static String locationDoesNotExist = "The Lost City of Atlantis";
@@ -238,5 +239,23 @@ public class LocationTest {
     location.setSocialDeterminants(person);
     int attributeCountAfter = person.attributes.keySet().size();
     Assert.assertTrue(attributeCountAfter > attributeCountBefore);
+    Assert.assertNotNull(person.attributes.get(Person.EMPLOYMENT_MODEL));
+
+    Person middlesexPerson = new Person(0L);
+    person.attributes.put(Person.COUNTY, "Middlesex County");
+    attributeCountBefore = middlesexPerson.attributes.keySet().size();
+    location.setSocialDeterminants(middlesexPerson);
+    attributeCountAfter = middlesexPerson.attributes.keySet().size();
+    Assert.assertTrue(attributeCountAfter > attributeCountBefore);
+    Assert.assertNotNull(middlesexPerson.attributes.get(Person.EMPLOYMENT_MODEL));
+
+    Person nowherePerson = new Person(0L);
+    person.attributes.put(Person.COUNTY, "Nowhere County");
+    attributeCountBefore = nowherePerson.attributes.keySet().size();
+    location.setSocialDeterminants(nowherePerson);
+    attributeCountAfter = nowherePerson.attributes.keySet().size();
+    Assert.assertTrue(attributeCountAfter > attributeCountBefore);
+    Assert.assertNotNull(nowherePerson.attributes.get(Person.EMPLOYMENT_MODEL));
+
   }
 }


### PR DESCRIPTION
The simulation expects every person to have an employment model set in their attributes. If a person was generated an a county where the `sdoh.csv` file did not have a row, the employment model would not get set. This change uses the state average information when the desired county can not be found.

This PR addresses Pattern 2 as described in #1380.