### PR TITLE
Fix for NPE seen when sometimes trying to clone the next state

### DIFF
--- a/src/main/resources/modules/heart/avrr/avrr_referral.json
+++ b/src/main/resources/modules/heart/avrr/avrr_referral.json
@@ -1,5 +1,5 @@
 {
-  "name": "referral",
+  "name": "AVRr referral",
   "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "AVRr Referral"

--- a/src/main/resources/modules/heart/avrr/sequence.json
+++ b/src/main/resources/modules/heart/avrr/sequence.json
@@ -351,7 +351,7 @@
     },
     "Referral and Preoperative Testing": {
       "type": "CallSubmodule",
-      "submodule": "heart/avrr/referral",
+      "submodule": "heart/avrr/avrr_referral",
       "conditional_transition": [
         {
           "transition": "Terminal",

--- a/src/main/resources/modules/heart/cabg/cabg_referral.json
+++ b/src/main/resources/modules/heart/cabg/cabg_referral.json
@@ -1,5 +1,5 @@
 {
-  "name": "referral",
+  "name": "CABG referral",
   "specialty": "CARDIOVASCULAR DISEASE (CARDIOLOGY)",
   "remarks": [
     "This submodule of Cardiac Surgery models Referral Pathways.",

--- a/src/main/resources/modules/heart/cabg_sequence.json
+++ b/src/main/resources/modules/heart/cabg_sequence.json
@@ -163,7 +163,7 @@
     },
     "Referral and Preoperative Testing": {
       "type": "CallSubmodule",
-      "submodule": "heart/cabg/referral",
+      "submodule": "heart/cabg/cabg_referral",
       "conditional_transition": [
         {
           "transition": "End Last Encounter",


### PR DESCRIPTION
This PR addresses Pattern 1 as reported in #1380. It makes sure that this issue should not happen, but there is still a likely underlying issue in Synthea. Whether it is worth addressing is up for debate.

The NPE in the bug report happens when the person in the simulation is going through the AVRr Referral submodule in the Myocardial Infarction module. When looking at the debugger for the case in question, `Module` is on the state `Priority_4_Next_Encounter_2` and trying to transition to the state `Valve Surgery`. However, `Module` is in the context of the **CABG** Referral submodule. When it tries to find the `Valve Surgery` state, it isn't there.

This is likely due to both the CABG and AVRr submodules being called `referral`. This PR renames them so that they both have unique names. There is likely a better fix that would ensure that these two submodules don't conflict, but I was unable to pinpoint where that fix would go and this is an obvious solution that is easily implemented.