### PR TITLE
Autogenerate 1k sample patient data files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           ./gradlew uberJar javadoc graphviz
           mkdir -p output/build/javadoc
           mv build/docs/javadoc/* output/build/javadoc
+          ./generate_samples.sh
       
       - name: Delete Previous master-branch-latest Tag
         uses: dev-drprasad/delete-tag-and-release@v0.2.1
@@ -84,6 +85,17 @@ jobs:
           user_email: 'jwalonoski@mitre.org'
           commit_message: rebuild graphs, javadoc and binary distribution at
           # note the commit SHA is appended automatically
+
+      - name: Push samples to sample repo
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.PUSH_SAMPLE_DATA_SSH_KEY }}
+        with:
+          source-directory: 'samples'
+          destination-github-username: 'dehall'
+          destination-repository-name: 'synthea-sample-data'
+          target-directory: 'downloads/latest'
+          target-branch: main
 
       - name: Slack Notification on Failure
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
           SSH_DEPLOY_KEY: ${{ secrets.PUSH_SAMPLE_DATA_SSH_KEY }}
         with:
           source-directory: 'samples'
-          destination-github-username: 'dehall'
+          destination-github-username: 'synthetichealth'
           destination-repository-name: 'synthea-sample-data'
           target-directory: 'downloads/latest'
           target-branch: main

--- a/generate_samples.sh
+++ b/generate_samples.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This script generates 1000 sample patients in the most common output formats
+# and zips them up by type in the ./samples/ subdirectory
+
+./run_synthea -p 1000 \
+  --exporter.ccda.export=true \
+  --exporter.fhir.export=true \
+  --exporter.fhir_stu3.export=true \
+  --exporter.fhir_dstu2.export=true \
+  --exporter.csv.export=true \
+
+mkdir samples
+
+for type in ccda fhir fhir_stu3 fhir_dstu2 csv
+do
+  zip -jr samples/synthea_sample_data_${type}_latest.zip output/${type}/
+done


### PR DESCRIPTION
This PR adds a new script and workflow action step to generate the 1k sample data files and push them to our sample data repository: https://github.com/synthetichealth/synthea-sample-data

Some notes:
 - The action `github-action-push-to-another-repository` will clear out whatever directory in the target repo that it is pointed at, so I created a new empty subdirectory for these autogenerated files
 - I followed the SSH key setup instructions at https://cpina.github.io/push-to-another-repository-docs/setup-using-ssh-deploy-keys.html#setup-ssh-deploy-keys so our synthea-sample-data has a deploy key and the private key is in a secret here on synthea
 - I tested this over on my own fork (though admittedly I didn't align everything exactly): https://github.com/dehall/synthea-sample-data <-- https://github.com/dehall/synthea/blob/master/.github/workflows/deploy.yml