### PR TITLE
Delete uncompressed sample data in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,10 +27,12 @@ jobs:
             
       - name: Create Artifacts
         run: |
+          ./generate_samples.sh
+          # delete uncompressed output, sample zips are in ./samples/
+          rm -rf output/
           ./gradlew uberJar javadoc graphviz
           mkdir -p output/build/javadoc
           mv build/docs/javadoc/* output/build/javadoc
-          ./generate_samples.sh
       
       - name: Delete Previous master-branch-latest Tag
         uses: dev-drprasad/delete-tag-and-release@v0.2.1


### PR DESCRIPTION
The deploy workflow with "autogenerate sample data" failed because the job runner ran out of disk space. This change deletes the uncompressed records (1k each of FHIR R4, STU3, DSTU2, CCDA, and CSV, so it's a lot) to save space.

Note, I made the change in the workflow instead of the generate_samples script because I don't want someone to run that script and accidentally delete data they want, and I put that step first so we could `rm ./output` without having to specify all the different subfolders and without affecting the javadoc folder.