### PR TITLE
Module cleanup

### DIFF
--- a/src/main/resources/modules/appendicitis.json
+++ b/src/main/resources/modules/appendicitis.json
@@ -309,8 +309,7 @@
         "Avg operative time is ~55 minutes",
         "https://www.ncbi.nlm.nih.gov/pubmed/17658102"
       ],
-      "direct_transition": "Appendicitis_Symptom1_Ends",
-      "name": "Appendectomy"
+      "direct_transition": "End_Appendicitis"
     },
     "Appendicitis_Symptom1_Ends": {
       "type": "Symptom",
@@ -407,8 +406,28 @@
     },
     "Transfer_To_Inpatient": {
       "type": "EncounterEnd",
-      "direct_transition": "Appendectomy_Encounter",
-      "name": "Transfer_To_Inpatient"
+      "direct_transition": "Appendectomy_Encounter"
+    },
+    "End_Appendicitis": {
+      "type": "ConditionEnd",
+      "condition_onset": "Appendicitis",
+      "conditional_transition": [
+        {
+          "transition": "End_Rupture",
+          "condition": {
+            "condition_type": "PriorState",
+            "name": "Rupture"
+          }
+        },
+        {
+          "transition": "Appendicitis_Symptom1_Ends"
+        }
+      ]
+    },
+    "End_Rupture": {
+      "type": "ConditionEnd",
+      "direct_transition": "Appendicitis_Symptom1_Ends",
+      "condition_onset": "Rupture"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/covid19/end_outcomes.json
+++ b/src/main/resources/modules/covid19/end_outcomes.json
@@ -20,7 +20,7 @@
           "display": "Pneumonia (disorder)"
         }
       ],
-      "direct_transition": "End Mild Respiratory Distress"
+      "direct_transition": "End Hypoxemia"
     },
     "End ARDS": {
       "type": "ConditionEnd",
@@ -150,6 +150,17 @@
         }
       ],
       "direct_transition": "End Heart Failure"
+    },
+    "End Hypoxemia": {
+      "type": "ConditionEnd",
+      "direct_transition": "End Mild Respiratory Distress",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 389087006,
+          "display": "Hypoxemia (disorder)"
+        }
+      ]
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/home_health_treatment.json
+++ b/src/main/resources/modules/home_health_treatment.json
@@ -18,8 +18,7 @@
         }
       ],
       "direct_transition": "Referral_Home_Health_Care",
-      "encounter_class": "urgentcare",
-      "reason": "Transition_To_Home"
+      "encounter_class": "urgentcare"
     },
     "Referral_Home_Health_Care": {
       "type": "Procedure",
@@ -64,8 +63,7 @@
         }
       ],
       "direct_transition": "Initial_Patient_Assessment",
-      "encounter_class": "home",
-      "reason": "Transition_To_Home"
+      "encounter_class": "home"
     },
     "Initial_Patient_Assessment": {
       "type": "Procedure",
@@ -125,8 +123,7 @@
         }
       ],
       "direct_transition": "Begin_Visit",
-      "encounter_class": "home",
-      "reason": "Transition_To_Home"
+      "encounter_class": "home"
     },
     "Begin_Visit": {
       "type": "Counter",
@@ -225,7 +222,7 @@
           "display": "Patient discharge (procedure)"
         }
       ],
-      "direct_transition": "End_Transition_To_Home"
+      "direct_transition": "Last Visit"
     },
     "Nursing_Care": {
       "type": "Procedure",
@@ -352,30 +349,13 @@
           }
         ]
       },
-      "direct_transition": "Transition_To_Home"
+      "direct_transition": "Face_to_Face_Encounter"
     },
     "Reset Home Health": {
       "type": "SetAttribute",
       "attribute": "home_health",
       "direct_transition": "Wait Until Home Health",
       "value": false
-    },
-    "Transition_To_Home": {
-      "type": "ConditionOnset",
-      "target_encounter": "Face_to_Face_Encounter",
-      "codes": [
-        {
-          "system": "SNOMED-CT",
-          "code": 1871000124103,
-          "display": "Transition from acute care to home-health care (finding)"
-        }
-      ],
-      "direct_transition": "Face_to_Face_Encounter"
-    },
-    "End_Transition_To_Home": {
-      "type": "ConditionEnd",
-      "direct_transition": "Last Visit",
-      "condition_onset": "Transition_To_Home"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/home_health_treatment.json
+++ b/src/main/resources/modules/home_health_treatment.json
@@ -352,13 +352,40 @@
           }
         ]
       },
-      "direct_transition": "Face_to_Face_Encounter"
+      "conditional_transition": [
+        {
+          "transition": "Default_Home_Health_Reason",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "home_health_reason",
+            "operator": "is nil"
+          }
+        },
+        {
+          "transition": "Face_to_Face_Encounter"
+        }
+      ]
     },
     "Reset Home Health": {
       "type": "SetAttribute",
       "attribute": "home_health",
-      "direct_transition": "Wait Until Home Health",
+      "direct_transition": "Reset Home Health Reason",
       "value": false
+    },
+    "Default_Home_Health_Reason": {
+      "type": "SetAttribute",
+      "attribute": "home_health_reason",
+      "direct_transition": "Face_to_Face_Encounter",
+      "value_code": {
+        "system": "SNOMED-CT",
+        "code": "1871000124103",
+        "display": "Transition from acute care to home-health care (finding)"
+      }
+    },
+    "Reset Home Health Reason": {
+      "type": "SetAttribute",
+      "attribute": "home_health_reason",
+      "direct_transition": "Wait Until Home Health"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/home_health_treatment.json
+++ b/src/main/resources/modules/home_health_treatment.json
@@ -18,7 +18,8 @@
         }
       ],
       "direct_transition": "Referral_Home_Health_Care",
-      "encounter_class": "urgentcare"
+      "encounter_class": "urgentcare",
+      "reason": "home_health_reason"
     },
     "Referral_Home_Health_Care": {
       "type": "Procedure",
@@ -63,7 +64,8 @@
         }
       ],
       "direct_transition": "Initial_Patient_Assessment",
-      "encounter_class": "home"
+      "encounter_class": "home",
+      "reason": "home_health_reason"
     },
     "Initial_Patient_Assessment": {
       "type": "Procedure",
@@ -123,7 +125,8 @@
         }
       ],
       "direct_transition": "Begin_Visit",
-      "encounter_class": "home"
+      "encounter_class": "home",
+      "reason": "home_health_reason"
     },
     "Begin_Visit": {
       "type": "Counter",

--- a/src/main/resources/modules/home_hospice_snf.json
+++ b/src/main/resources/modules/home_hospice_snf.json
@@ -431,7 +431,7 @@
       "type": "SetAttribute",
       "attribute": "home_health",
       "value": true,
-      "direct_transition": "Wait for Next Decade"
+      "direct_transition": "Set Home Health Reason"
     },
     "Wait for Next Decade": {
       "type": "Simple",
@@ -776,6 +776,16 @@
       "attribute": "hospice_reason",
       "value_attribute": "colorectal_cancer",
       "direct_transition": "Initiate Hospice"
+    },
+    "Set Home Health Reason": {
+      "type": "SetAttribute",
+      "attribute": "home_health_reason",
+      "direct_transition": "Wait for Next Decade",
+      "value_code": {
+        "system": "SNOMED-CT",
+        "code": "1871000124103",
+        "display": "Transition from acute care to home-health care (finding)"
+      }
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/home_hospice_snf.json
+++ b/src/main/resources/modules/home_hospice_snf.json
@@ -431,7 +431,7 @@
       "type": "SetAttribute",
       "attribute": "home_health",
       "value": true,
-      "direct_transition": "Set Home Health Reason"
+      "direct_transition": "Wait for Next Decade"
     },
     "Wait for Next Decade": {
       "type": "Simple",
@@ -776,16 +776,6 @@
       "attribute": "hospice_reason",
       "value_attribute": "colorectal_cancer",
       "direct_transition": "Initiate Hospice"
-    },
-    "Set Home Health Reason": {
-      "type": "SetAttribute",
-      "attribute": "home_health_reason",
-      "direct_transition": "Wait for Next Decade",
-      "value_code": {
-        "system": "SNOMED-CT",
-        "code": "1871000124103",
-        "display": "Transition from acute care to home-health care (finding)"
-      }
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/metabolic_syndrome_care.json
+++ b/src/main/resources/modules/metabolic_syndrome_care.json
@@ -288,7 +288,18 @@
       "remarks": [
         "setting prediabetes as severity 0 makes some things easier"
       ],
-      "direct_transition": "Diagnose_Prediabetes"
+      "conditional_transition": [
+        {
+          "transition": "Check_CarePlan",
+          "condition": {
+            "condition_type": "PriorState",
+            "name": "Diagnose_Diabetes"
+          }
+        },
+        {
+          "transition": "Diagnose_Prediabetes"
+        }
+      ]
     },
     "Diagnose_Prediabetes": {
       "type": "ConditionOnset",

--- a/src/main/resources/modules/opioid_addiction.json
+++ b/src/main/resources/modules/opioid_addiction.json
@@ -645,7 +645,7 @@
       "distributed_transition": [
         {
           "distribution": 0.98747,
-          "transition": "End_Directed_Use_Overdose_Encounter"
+          "transition": "End_Directed_Use_Overdose"
         },
         {
           "distribution": 0.01253,
@@ -683,7 +683,7 @@
       "distributed_transition": [
         {
           "distribution": 0.98747,
-          "transition": "End_Misuse_Overdose_Encounter"
+          "transition": "End_Misuse_Overdose"
         },
         {
           "distribution": 0.01253,
@@ -738,19 +738,7 @@
         }
       },
       "unit": "hours",
-      "conditional_transition": [
-        {
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "opioid_addiction_careplan",
-            "operator": "is nil"
-          },
-          "transition": "Opioid_Addiction_CarePlan"
-        },
-        {
-          "transition": "End_Addiction_Overdose_Encounter"
-        }
-      ]
+      "direct_transition": "End_Addiction_Overdose"
     },
     "Opioid_Addiction_CarePlan": {
       "type": "CarePlanStart",
@@ -928,6 +916,33 @@
       ],
       "direct_transition": "Recovery_Management",
       "assign_to_attribute": "opioid_drug_addiction"
+    },
+    "End_Addiction_Overdose": {
+      "type": "ConditionEnd",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "opioid_addiction_careplan",
+            "operator": "is nil"
+          },
+          "transition": "Opioid_Addiction_CarePlan"
+        },
+        {
+          "transition": "End_Addiction_Overdose_Encounter"
+        }
+      ],
+      "condition_onset": "Addiction_Overdose"
+    },
+    "End_Misuse_Overdose": {
+      "type": "ConditionEnd",
+      "direct_transition": "End_Misuse_Overdose_Encounter",
+      "condition_onset": "Misuse_Overdose"
+    },
+    "End_Directed_Use_Overdose": {
+      "type": "ConditionEnd",
+      "direct_transition": "End_Directed_Use_Overdose_Encounter",
+      "condition_onset": "Directed_Use_Overdose"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/pregnancy.json
+++ b/src/main/resources/modules/pregnancy.json
@@ -1919,11 +1919,11 @@
     "Miscarriage_Fatal_Pregnancy_Complication_Ends": {
       "type": "ConditionEnd",
       "referenced_by_attribute": "fatal_pregnancy_complication",
-      "direct_transition": "End_Miscarriage_Followup_Encounter"
+      "direct_transition": "History_of_Miscarriage"
     },
     "End_Miscarriage_Followup_Encounter": {
       "type": "EncounterEnd",
-      "direct_transition": "Miscarriage_Ends"
+      "direct_transition": "End_Miscarriage_Condition"
     },
     "Wait_For_Induced_Abortion": {
       "type": "Delay",
@@ -2129,24 +2129,6 @@
         }
       ]
     },
-    "Miscarriage_Ends": {
-      "type": "ConditionEnd",
-      "condition_onset": "Become_Pregnant",
-      "conditional_transition": [
-        {
-          "transition": "Anemia_End_2",
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "anemia_pregnancy",
-            "operator": "==",
-            "value": 1
-          }
-        },
-        {
-          "transition": "Unset_Pregnant_Attribute"
-        }
-      ]
-    },
     "Abortion_Ends": {
       "type": "ConditionEnd",
       "condition_onset": "Become_Pregnant",
@@ -2326,6 +2308,40 @@
       ],
       "assign_to_attribute": "fatal_pregnancy_complication",
       "direct_transition": "End_Initial_Visit_Towards_Ectopic_Pregnancy"
+    },
+    "Miscarriage_Ends_Pregnancy": {
+      "type": "ConditionEnd",
+      "condition_onset": "Become_Pregnant",
+      "conditional_transition": [
+        {
+          "transition": "Anemia_End_2",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "anemia_pregnancy",
+            "operator": "==",
+            "value": 1
+          }
+        },
+        {
+          "transition": "Unset_Pregnant_Attribute"
+        }
+      ]
+    },
+    "End_Miscarriage_Condition": {
+      "type": "ConditionEnd",
+      "direct_transition": "Miscarriage_Ends_Pregnancy",
+      "referenced_by_attribute": "miscarriage"
+    },
+    "History_of_Miscarriage": {
+      "type": "ConditionOnset",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": 161744009,
+          "display": "Past pregnancy history of miscarriage (situation)"
+        }
+      ],
+      "direct_transition": "End_Miscarriage_Followup_Encounter"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/snf/skilled_nursing_facility.json
+++ b/src/main/resources/modules/snf/skilled_nursing_facility.json
@@ -6,7 +6,7 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "SNF_Admission"
+      "direct_transition": "Transition_To_SNF_Reason"
     },
     "SNF_Admission": {
       "type": "Encounter",
@@ -41,7 +41,8 @@
         {
           "transition": "History_Physical_Exam"
         }
-      ]
+      ],
+      "reason": "snf_reason"
     },
     "Determine_LOS": {
       "type": "SetAttribute",
@@ -317,6 +318,16 @@
       "attribute": "snf_days",
       "value": 100,
       "direct_transition": "History_Physical_Exam"
+    },
+    "Transition_To_SNF_Reason": {
+      "type": "SetAttribute",
+      "attribute": "snf_reason",
+      "direct_transition": "SNF_Admission",
+      "value_code": {
+        "system": "SNOMED-CT",
+        "code": "25675004",
+        "display": "Patient transfer to skilled nursing facility (procedure)"
+      }
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/snf/skilled_nursing_facility.json
+++ b/src/main/resources/modules/snf/skilled_nursing_facility.json
@@ -6,7 +6,7 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "Transition_To_SNF_Reason"
+      "direct_transition": "SNF_Admission"
     },
     "SNF_Admission": {
       "type": "Encounter",
@@ -41,8 +41,7 @@
         {
           "transition": "History_Physical_Exam"
         }
-      ],
-      "reason": "Transition_To_SNF_Reason"
+      ]
     },
     "Determine_LOS": {
       "type": "SetAttribute",
@@ -296,7 +295,7 @@
     },
     "End Encounter": {
       "type": "EncounterEnd",
-      "direct_transition": "End_Transition_To_SNF_Reason"
+      "direct_transition": "Terminal"
     },
     "Facility_Wheelchair": {
       "type": "Device",
@@ -318,23 +317,6 @@
       "attribute": "snf_days",
       "value": 100,
       "direct_transition": "History_Physical_Exam"
-    },
-    "Transition_To_SNF_Reason": {
-      "type": "ConditionOnset",
-      "target_encounter": "SNF_Admission",
-      "codes": [
-        {
-          "system": "SNOMED-CT",
-          "code": 25675004,
-          "display": "Patient transfer to skilled nursing facility (procedure)"
-        }
-      ],
-      "direct_transition": "SNF_Admission"
-    },
-    "End_Transition_To_SNF_Reason": {
-      "type": "ConditionEnd",
-      "direct_transition": "Terminal",
-      "condition_onset": "Transition_To_SNF_Reason"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/snf/skilled_nursing_facility.json
+++ b/src/main/resources/modules/snf/skilled_nursing_facility.json
@@ -6,7 +6,19 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "Transition_To_SNF_Reason"
+      "conditional_transition": [
+        {
+          "transition": "Transition_To_SNF_Reason",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "snf_reason",
+            "operator": "is nil"
+          }
+        },
+        {
+          "transition": "SNF_Admission"
+        }
+      ]
     },
     "SNF_Admission": {
       "type": "Encounter",

--- a/src/main/resources/modules/snf/skilled_nursing_facility.json
+++ b/src/main/resources/modules/snf/skilled_nursing_facility.json
@@ -308,7 +308,7 @@
     },
     "End Encounter": {
       "type": "EncounterEnd",
-      "direct_transition": "Terminal"
+      "direct_transition": "Clear SNF Reason"
     },
     "Facility_Wheelchair": {
       "type": "Device",
@@ -340,6 +340,11 @@
         "code": "25675004",
         "display": "Patient transfer to skilled nursing facility (procedure)"
       }
+    },
+    "Clear SNF Reason": {
+      "type": "SetAttribute",
+      "attribute": "snf_reason",
+      "direct_transition": "Terminal"
     }
   },
   "gmf_version": 1

--- a/src/main/resources/modules/total_joint_replacement.json
+++ b/src/main/resources/modules/total_joint_replacement.json
@@ -335,8 +335,27 @@
     "Home Health Visits": {
       "type": "SetAttribute",
       "attribute": "home_health",
-      "direct_transition": "Delay_For_Recovery",
-      "value": true
+      "value": true,
+      "conditional_transition": [
+        {
+          "transition": "Home Health Reason Knee",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "joint_replacement",
+            "operator": "==",
+            "value": "knee"
+          }
+        },
+        {
+          "transition": "Home Health Reason Hip",
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "joint_replacement",
+            "operator": "==",
+            "value": "hip"
+          }
+        }
+      ]
     },
     "DME End": {
       "type": "DeviceEnd",
@@ -368,6 +387,26 @@
         "system": "SNOMED-CT",
         "code": 110466009,
         "display": "Pre-surgery evaluation (procedure)"
+      }
+    },
+    "Home Health Reason Knee": {
+      "type": "SetAttribute",
+      "attribute": "home_health_reason",
+      "direct_transition": "Delay_For_Recovery",
+      "value_code": {
+        "system": "SNOMED-CT",
+        "code": "609588000",
+        "display": "Total knee replacement"
+      }
+    },
+    "Home Health Reason Hip": {
+      "type": "SetAttribute",
+      "attribute": "home_health_reason",
+      "direct_transition": "Delay_For_Recovery",
+      "value_code": {
+        "system": "SNOMED-CT",
+        "code": "52734007",
+        "display": "Total replacement of hip"
       }
     }
   },


### PR DESCRIPTION
This PR cleans up a few items that pop up pretty often in generated records and look odd:

1. There are several ConditionOnsets that do not have a corresponding ConditionEnd and are left open forever, even though they are acute conditions which are addressed in the module:
   - Appendicitis & rupture of appendix
   - Opioid addiction: Drug overdose (note there are a few other conditions in this module which don't get ended, like "Impacted molars", "Chronic pain", and migraine, which are not really treated so I'm ok leaving them open)
   - Miscarriage (added a "history of miscarriage" condition)
   - Covid19 outcomes: Hypoxemia (seems like this was just missed in the long list of conditions, I don't see anything in the old notes for why this one specifically should stay open)
2. Prediabetes can be diagnosed after diabetes, and based on medication impacts it happens often, so that's no longer possible
3. A couple modules include "patient transfer" as a condition where it really doesn't fit. There's already a Procedure for the transfer so I just removed the Condition.