### PR TITLE
Flexporter enhancements

### DIFF
--- a/src/main/java/App.java
+++ b/src/main/java/App.java
@@ -208,6 +208,8 @@ public class App {
             if (flexporterMappingFile.exists()) {
               Mapping mapping = Mapping.parseMapping(flexporterMappingFile);
               exportOptions.addFlexporterMapping(mapping);
+              // disable the graalVM warning when FlexporterJavascriptContext is instantiated
+              System.getProperties().setProperty("polyglot.engine.WarnInterpreterOnly", "false");
             } else {
               throw new FileNotFoundException(String.format(
                   "Specified flexporter mapping file (%s) does not exist", value));

--- a/src/main/resources/modules/heart/acs_discharge_meds.json
+++ b/src/main/resources/modules/heart/acs_discharge_meds.json
@@ -11,14 +11,13 @@
     },
     "Aspirin Check": {
       "type": "Simple",
-      "remarks": ["TODO: fix to Active Allergy after merging"],
       "complex_transition": [
         {
           "condition": {
             "condition_type": "Or",
             "conditions": [
               {
-                "condition_type": "Active Condition",
+                "condition_type": "Active Allergy",
                 "codes": [
                   {
                     "system": "RxNorm",
@@ -41,7 +40,7 @@
           },
           "distributions": [
             {
-              "transition": "BB Check",
+              "transition": "No_Aspirin",
               "distribution": 1
             }
           ]
@@ -53,7 +52,7 @@
               "distribution": 0.98
             },
             {
-              "transition": "BB Check",
+              "transition": "No_Aspirin",
               "distribution": 0.02
             }
           ]
@@ -315,6 +314,10 @@
     },
     "Terminal": {
       "type": "Terminal"
+    },
+    "No_Aspirin": {
+      "type": "Simple",
+      "direct_transition": "BB Check"
     }
   },
   "gmf_version": 2

--- a/src/test/resources/flexporter/qicore_withnotdone.yaml
+++ b/src/test/resources/flexporter/qicore_withnotdone.yaml
@@ -1,6 +1,6 @@
 ---
 # name is just a friendly name for this mapping
-name: QI Core Minimal
+name: QI Core With "Not Done" Instances
 
 # applicability determines whether this mapping applies to a given file.
 # for now the assumption is 1 file = 1 synthea patient bundle.
@@ -63,3 +63,43 @@ actions:
        fields:
          - location: Procedure.extension.where(url='http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded').valueDateTime
            value: $getField([Procedure.performed])
+
+ - name: QICore NotDone Instances
+   create_resource:
+     - resourceType: MedicationRequest
+       based_on: 
+         module: Myocardial Infarction
+         # note the module has to be a top-level module,
+         # but the state can be a state name from a submodule
+         state: No_Aspirin
+       fields:
+         - location: MedicationRequest.meta.profile
+           value: http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotrequested
+         - location: MedicationRequest.doNotPerform
+           value: "true"
+         - location: MedicationRequest.status
+           value: completed
+         - location: MedicationRequest.intent
+           value: order
+         - location: MedicationRequest.subject.reference
+           value: $findRef([Patient])
+         - location: MedicationRequest.authoredOn
+           value: $getField([State.entered]) 
+           # State.entered refers to the start of the based_on state
+         - location: MedicationRequest.requester.reference
+           value: $getField([Encounter.participant.individual.reference])
+         - location: MedicationRequest.reasonCode.coding
+           value:
+               system: http://snomedct.io
+               code: "183966005"
+               display: "Drug treatment not indicated (situation)"
+         - location: MedicationRequest.medicationCodeableConcept.extension
+           value:
+               url: http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneValueSet
+               valueCanonical: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.11.1211
+               # VS is "Aspirin and Other Antiplatelets"
+
+  
+
+
+


### PR DESCRIPTION
This PR adds a few enhancements identified when trying to create "Not Done" type resources for QICore. (Ex, Medication Not Requested https://build.fhir.org/ig/HL7/fhir-qi-core/StructureDefinition-qicore-medicationnotrequested.html )

- Disables the annoying warning the flexporter introduced. For a single patient it wasn't that big a deal but for larger populations it made it impossible to follow the output.
- Adds a "fullUrl" field to the Bundle entry on any created resources
- When creating resources based on a given state, adds the ability to reference the Encounter that was active at that time
- Adds a specific "No Aspirin" state to the ACS Discharge Meds submodule for the flexporter to key off of for this example. We may want to make it a "best practice" to have an actual empty simple-type state in modules when a treatment option is skipped, to make it easier to identify.
- Adds a flexporter mapping in src/test/resources with a new Not Done example. Try running it with `./run_synthea -fm src/test/resources/flexporter/qicore_withnotdone.yaml -k must_have_cardiac_surgery.json -a 55-65`