### PR TITLE
New script to update code displays

### DIFF
--- a/src/main/javascript/update_code_display.js
+++ b/src/main/javascript/update_code_display.js
@@ -1,0 +1,265 @@
+// This is a stand alone node script to iterate through the modules
+// and update all code displays that do not match an allowed value.
+// (i.e., code displays that would not pass FHIR validation)
+// The script also attempts to standardize when the same code is used in
+// multiple modules, and to minimize the number of updates.
+// Any invalid/unknown codes will be printed to console.
+//
+// Note this does require the `sync-fetch` library to be installed first.
+// 
+// Example:
+//   npm install sync-fetch
+//   node update_code_display.js /path/to/synthea/src/main/resources/modules/
+//
+// Tested on node v20.3.1
+
+const fetch = require('sync-fetch')
+const process = require('process');
+const fs = require('fs');
+const path = require('path');
+
+const moduleDirPath = process.argv[2];
+
+let moduleDir = fs.opendirSync(moduleDirPath);
+
+const codeInventory = {};
+// codeInventory[system][code] = set("display1", "display2", ...)
+
+const allCodes = [];
+
+const codeDictionary = {};
+// codeDictionary[system][code] = "display to use"
+
+// systems to skip because tx.fhir.org doesn't know about them
+const SYSTEMS_TO_SKIP = ['NUBC', 'DICOM-DCM', 'DICOM-SOP'];
+
+// codes used in Synthea as placeholders that we know aren't real
+const PLACEHOLDER_CODES = ['999999',
+  "99999-0", "99999-1", "99999-2", "99999-3", "99999-4",
+  "99999-5", "99999-6", "99999-7", "99999-8", "99999-9",
+  "99999-10", "99999-11",
+  'X9999-0', 'X9999-1', 'X9999-2'];
+
+if (fs.existsSync('./code_dictionary.json')) {
+  const rawJSON = fs.readFileSync('./code_dictionary.json');
+  const loadedDictionary = JSON.parse(rawJSON);
+  Object.assign(codeDictionary, loadedDictionary);
+  console.log("Using previously saved ./code_dictionary.json")
+} else {
+  processFiles(moduleDir, moduleDirPath, inventoryAllCodes);
+  buildDictionary();
+  fs.writeFileSync('./code_dictionary.json', JSON.stringify(codeDictionary, null, 2));
+  console.log("Saved ./code_dictionary.json")
+  // re-open to re-iterate through
+  moduleDir = fs.opendirSync(moduleDirPath);
+}
+
+processFiles(moduleDir, moduleDirPath, checkAndUpdateAllCodes);
+
+function processFiles(dirEntry, parentPath, fileFunction) {
+  let fileInFolder = dirEntry.readSync();
+  while (fileInFolder != null) {
+    if(fileInFolder.isDirectory()) {
+      const newPath = path.join(parentPath, fileInFolder.name);
+      const subDir = fs.opendirSync(newPath);
+      processFiles(subDir, newPath, fileFunction);
+    } else if (fileInFolder.isFile() && fileInFolder.name.endsWith('.json')) {
+      const moduleJSONPath = path.join(parentPath, fileInFolder.name);
+      fileFunction(moduleJSONPath);
+    }
+    fileInFolder = dirEntry.readSync();
+  }
+}
+
+function inventoryAllCodes(moduleJSONPath) {
+  console.log(moduleJSONPath);
+  const rawJSON = fs.readFileSync(moduleJSONPath);
+  let module = JSON.parse(rawJSON);
+  
+  walkObject(module, inventoryCode);
+}
+
+function checkAndUpdateAllCodes(moduleJSONPath) {
+  console.log(moduleJSONPath);
+  const rawJSON = fs.readFileSync(moduleJSONPath);
+  let module = JSON.parse(rawJSON);
+  
+  walkObject(module, checkAndUpdateCode);
+
+  const updatedModuleJSON = JSON.stringify(module, null, 2);
+  fs.writeFileSync(moduleJSONPath, updatedModuleJSON);
+}
+
+/**
+ * Recursively iterate through the given object and
+ * apply the given function to any "code" objects.
+ * A "code" object is one that has fields "system", "code", and "display".
+ */
+function walkObject(object, codeFunction) {
+  if (Array.isArray(object)) {
+    object.forEach(o => walkObject(o, codeFunction));
+  } else if (typeof object === 'object' && object !== null) {
+    if (object.system && object.code && object.display) {
+      if (SYSTEMS_TO_SKIP.includes(object.system) || PLACEHOLDER_CODES.includes(object.code.toString())) {
+        return;
+      }
+      codeFunction(object);
+    } else {
+      for (const [key, value] of Object.entries(object)) {
+        walkObject(value, codeFunction);
+      }
+    }
+  }
+  // else, it's a null or primitive, nothing to do
+}
+
+/**
+ * Add the given code to the inventory.
+ */
+function inventoryCode(codeObj) {
+  let { system, code, display } = codeObj;
+  code = code.toString();
+
+  if (!codeInventory[system]) {
+    codeInventory[system] = {};
+  }
+  if (!codeInventory[system][code]) {
+    codeInventory[system][code] = new Set();
+    allCodes.push(codeObj);
+  }
+
+  codeInventory[system][code].add(display);
+}
+
+function buildDictionary() {
+  for (const codeObj of allCodes) {
+    let { system, code, display } = codeObj;
+    code = code.toString();
+    if (!codeDictionary[system]) {
+      codeDictionary[system] = {};
+    }
+
+    const body = requestBody(codeObj);
+    const VALIDATE_CODE_HEADERS = {
+      "Content-Type": "application/fhir+json",
+      "Accept": "application/fhir+json"
+    };
+    const res = fetch(
+        'http://tx.fhir.org/r4/CodeSystem/$validate-code?',
+        { 
+          method: 'POST', 
+          body: JSON.stringify(body, null, 2), 
+          headers: VALIDATE_CODE_HEADERS 
+        }).json();
+
+    const displayParam = res.parameter.find(p => p.name === 'display');
+    const success = res.parameter.find(p => p.name === 'result').valueBoolean;
+    if (success) {
+      // the current display may or may not be the singular best,
+      // but it is one of the allowed values.
+      // the "display" param contains the official best value
+      const bestDisplay = displayParam.valueString;
+
+      if (codeInventory[system][code].has(bestDisplay)) {
+        // we use the best display somewhere already, stick to it
+        codeDictionary[system][code] = bestDisplay;
+      } else {
+        // standardize to the current display
+        codeDictionary[system][code] = display;
+      }
+    } else {
+      if (displayParam) {
+        // the code is valid but the display is not allowed
+        // update the code to use the given display and
+        // store the given display going forward
+        codeDictionary[system][code] = displayParam.valueString;
+      } else {
+        handleErrorOrExit(body, res);
+      }
+    }
+  }
+}
+
+/**
+ * Construct the request body to validate the given code.
+ */
+function requestBody(codeObj) {
+  const coding = JSON.parse(JSON.stringify(codeObj)); // simple copy
+  coding.code = coding.code.toString();
+  switch (coding.system) {
+  case 'SNOMED-CT':
+    coding.system = 'http://snomed.info/sct';
+    break;
+  case 'LOINC':
+    coding.system = 'http://loinc.org';
+    break;
+  case 'RxNorm':
+    coding.system = 'http://www.nlm.nih.gov/research/umls/rxnorm';
+    break;
+  case 'CVX':
+    coding.system = 'http://hl7.org/fhir/sid/cvx';
+    break;
+
+  default:
+    console.log(`Unexpected code system ${coding.system} may not be supported by tx.fhir.org`);
+  }
+  return {
+    "resourceType": "Parameters",
+    "parameter": [
+      {
+        "name": "coding",
+        "valueCoding": coding
+      },
+      {
+        "name": "default-to-latest-version",
+        "valueBoolean": true
+      }
+    ]
+  }
+}
+
+/**
+ * Check whether the display on the given code is appropriate,
+ * and if not, update it.
+ */
+function checkAndUpdateCode(codeObj) {
+  let { system, code, display } = codeObj;
+  code = code.toString();
+  if (!codeDictionary[system][code]) {
+    // something went wrong in validating the code earlier,
+    // the log will show what it was
+    return;
+  }
+
+  // capitalization doesn't appear to matter, so only update a code
+  // if it differs in more than just caps
+  if (codeDictionary[system][code].toLowerCase() != display.toLowerCase()) {
+    console.log(`Updating "${display}" -> "${codeDictionary[system][code]}"`)
+    codeObj.display = codeDictionary[system][code];
+  }
+}
+
+/**
+ * Handle errors from the terminology service.
+ * "Unknown code" errors are expected so just print those out to the log.
+ * Anything else, print the request and response then exit.
+ */
+function handleErrorOrExit(body, res) {
+  const messageParam = res.parameter.find(p => p.name === 'message');
+  if (messageParam) {
+    const message = messageParam.valueString;
+
+    if (message.startsWith("Unable to find code ") 
+      || message.startsWith("Unknown Code '")) {
+      console.log(message);
+      return;
+    }
+  }
+  // something else went wrong. print message and stop
+  console.log("Error occurred.")
+  console.log("Request body:")
+  console.log(JSON.stringify(body, null, 2));
+  console.log("\nResponse:")
+  console.log(JSON.stringify(res, null, 2));
+  process.exit(1);
+}

--- a/src/main/resources/modules/cerebral_palsy.json
+++ b/src/main/resources/modules/cerebral_palsy.json
@@ -555,7 +555,7 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": 7227006,
+          "code": 47227006,
           "display": "Excision of submandibular gland (procedure)"
         }
       ],
@@ -929,7 +929,7 @@
       "codes": [
         {
           "system": "RxNorm",
-          "code": 143975,
+          "code": 1437975,
           "display": "glycopyrrolate 1.5 MG Oral Tablet [Glycate]"
         }
       ],

--- a/src/main/resources/modules/congestive_heart_failure.json
+++ b/src/main/resources/modules/congestive_heart_failure.json
@@ -1178,7 +1178,7 @@
           "display": "Ibuprofen 100 MG Oral Tablet"
         },
         {
-          "system": "SNOMED-CT",
+          "system": "RxNorm",
           "code": 310965,
           "display": "Ibuprofen 200 MG Oral Tablet"
         }

--- a/src/main/resources/modules/heart/avrr/preoperative.json
+++ b/src/main/resources/modules/heart/avrr/preoperative.json
@@ -258,8 +258,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": 3336700,
-          "display": "Coronary angiography (procedure)"
+          "code": 33367005,
+          "display": "Angiography of coronary artery (procedure)"
         }
       ],
       "unit": "minutes",

--- a/src/main/resources/modules/heart/avrr/savrr_postop.json
+++ b/src/main/resources/modules/heart/avrr/savrr_postop.json
@@ -458,7 +458,7 @@
         },
         {
           "system": "SNOMED-CT",
-          "code": 22972009,
+          "code": 422972009,
           "display": "Advance diet as tolerated (regime/therapy)"
         },
         {

--- a/src/main/resources/modules/heart/tavr/alt_access.json
+++ b/src/main/resources/modules/heart/tavr/alt_access.json
@@ -128,7 +128,7 @@
       "value_code": {
         "system": "SNOMED-CT",
         "code": 260582008,
-        "display": "SNOMED Code"
+        "display": "Via carotid artery"
       }
     },
     "Other": {

--- a/src/main/resources/modules/heart/tavr/postop.json
+++ b/src/main/resources/modules/heart/tavr/postop.json
@@ -486,7 +486,7 @@
         },
         {
           "system": "SNOMED-CT",
-          "code": 22972009,
+          "code": 422972009,
           "display": "Advance diet as tolerated (regime/therapy)"
         },
         {

--- a/src/main/resources/modules/hiv/hiv_screening.json
+++ b/src/main/resources/modules/hiv/hiv_screening.json
@@ -16,7 +16,7 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": 71121004,
+          "code": 171121004,
           "display": "Human immunodeficiency virus screening (procedure)"
         }
       ],

--- a/src/main/resources/modules/spina_bifida.json
+++ b/src/main/resources/modules/spina_bifida.json
@@ -219,7 +219,7 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": 36321500,
+          "code": 363215001,
           "display": "Musculoskeletal system physical examination (procedure)"
         }
       ],

--- a/src/main/resources/modules/uti/gu_pregnancy_check.json
+++ b/src/main/resources/modules/uti/gu_pregnancy_check.json
@@ -122,9 +122,9 @@
       "direct_transition": "Terminal",
       "name": "Negative Result",
       "value_code": {
-        "system": "LOINC",
+        "system": "SNOMED-CT",
         "code": 260385009,
-        "display": "Negative"
+        "display": "Negative (qualifier value)"
       }
     },
     "Positive Result": {
@@ -141,9 +141,9 @@
       ],
       "name": "Positive Result",
       "value_code": {
-        "system": "LOINC",
+        "system": "SNOMED-CT",
         "code": 10828004,
-        "display": "Positive"
+        "display": "Positive (qualifier value)"
       },
       "direct_transition": "Terminal"
     }


### PR DESCRIPTION
This PR introduces a new script to automatically update code displays when they do not match the preferred value for the code system. Originally I intended this process to be part of the Concepts java class, but writing changes back to the JSON file would have involved too much refactoring so instead I created a new JavaScript ... script.

To try to minimize the number of display changes, and standardize code displays across modules, this script takes a 2-pass approach:
1. Iterate over all the modules and keep an inventory of the codes/displays
2. Fetch the preferred display for each code. Keep a dictionary of code -> display
   i. If a module already uses the preferred display somewhere, store that
   ii. If the current display is allowed but not necessarily the preferred, store that (to reduce changes)
   iii. Otherwise, store the preferred display
3. Iterate over all the modules again and update any displays that don't match the value in the dictionary
There's also special handling for SNOMED codes to try to avoid flip-flopping between "Code" and "Code (tag)"

The modules are updated in-place and I recommend using `git add -p src/main/resources` to iterate over them and review each change separately before committing.

The script will also print errors when a code is not valid for the given system. We use some US-specific SNOMED codes which this will complain about but it will also reveal typos which I'm fixing as well.