### PR TITLE
Better handling of lists in Flexporter

### DIFF
--- a/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
+++ b/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
@@ -458,6 +458,10 @@ public abstract class Actions {
 
         populateFhirPathMapping(fhirPathMapping, location, valueMap);
 
+      } else if (valueDef instanceof List<?>) {
+        List<Object> valueList = (List<Object>) valueDef;
+
+        populateFhirPathMapping(fhirPathMapping, location, valueList);
       } else {
         // unexpected type here - is it even possible to get anything else?
         String type = valueDef == null ? "null" : valueDef.getClass().toGenericString();
@@ -478,11 +482,37 @@ public abstract class Actions {
 
       if (value instanceof String) {
         fhirPathMapping.put(path, value);
+      } else if (value instanceof Number) {
+        fhirPathMapping.put(path, value.toString());
       } else if (value instanceof Map<?,?>) {
         populateFhirPathMapping(fhirPathMapping, path, (Map<String, Object>) value);
+      } else if (value instanceof List<?>) {
+        populateFhirPathMapping(fhirPathMapping, path, (List<Object>) value);
       } else if (value != null) {
         System.err
-            .println("Unexpected class found in populateFhirPathMapping -- " + value.getClass());
+            .println("Unexpected class found in populateFhirPathMapping[map]: " + value.getClass());
+      }
+    }
+  }
+
+  private static void populateFhirPathMapping(Map<String, Object> fhirPathMapping, String basePath,
+      List<Object> valueList) {
+    for (int i = 0; i < valueList.size(); i++) {
+      Object value = valueList.get(i);
+
+      String path = basePath + "[" + i + "]";
+
+      if (value instanceof String) {
+        fhirPathMapping.put(path, value);
+      } else if (value instanceof Number) {
+        fhirPathMapping.put(path, value.toString());
+      } else if (value instanceof Map<?,?>) {
+        populateFhirPathMapping(fhirPathMapping, path, (Map<String, Object>) value);
+      } else if (value instanceof List<?>) {
+        populateFhirPathMapping(fhirPathMapping, path, (List<Object>) value);
+      } else if (value != null) {
+        System.err
+            .println("Unexpected class found in populateFhirPathMapping[list]:" + value.getClass());
       }
     }
   }

--- a/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
+++ b/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
@@ -10,9 +10,9 @@ import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -417,7 +417,8 @@ public abstract class Actions {
       Bundle sourceBundle, Resource sourceResource, Person person,
       FlexporterJavascriptContext fjContext) {
 
-    Map<String, Object> fhirPathMapping = new HashMap<>();
+    // linked hashmap to ensure lists are kept in order. could also use something like a treemap
+    Map<String, Object> fhirPathMapping = new LinkedHashMap<>();
 
     for (Map<String, Object> field : fields) {
       String location = (String)field.get("location");

--- a/src/main/java/org/mitre/synthea/export/flexporter/CustomFHIRPathResourceGeneratorR4.java
+++ b/src/main/java/org/mitre/synthea/export/flexporter/CustomFHIRPathResourceGeneratorR4.java
@@ -519,11 +519,9 @@ public class CustomFHIRPathResourceGeneratorR4<T extends Resource> {
 
         nextTier.nodes.add(containedNodes.get(index));
       }
-
-    } else if (nextTier.nodeDefinition instanceof RuntimePrimitiveDatatypeDefinition) {
-      // TODO: is this possible or necessary?
-      // review handlePrimitiveNode()
     }
+    // else if (nextTier.nodeDefinition instanceof RuntimePrimitiveDatatypeDefinition) {
+    // from testing this seems to not be necessary
 
     // push the created nextTier to the nodeStack
     this.nodeStack.push(nextTier);

--- a/src/main/java/org/mitre/synthea/export/flexporter/CustomFHIRPathResourceGeneratorR4.java
+++ b/src/main/java/org/mitre/synthea/export/flexporter/CustomFHIRPathResourceGeneratorR4.java
@@ -20,6 +20,7 @@ import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.hl7.fhir.r4.hapi.ctx.HapiWorkerContext;
 import org.hl7.fhir.r4.model.ExpressionNode;
 import org.hl7.fhir.r4.model.ExpressionNode.Kind;
+import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.utils.FHIRPathEngine;
 import org.mitre.synthea.export.FhirR4;
@@ -383,6 +384,10 @@ public class CustomFHIRPathResourceGeneratorR4<T extends Resource> {
       case Where:
         this.handleWhereFunctionNode(fhirPath);
         break;
+      case Item:
+        // eg, array indexing
+        this.handleIndexFunctionNode(fhirPath);
+        break;
       // case Aggregate:
       // case Alias:
       // case AliasAs:
@@ -421,7 +426,6 @@ public class CustomFHIRPathResourceGeneratorR4<T extends Resource> {
       // case Intersect:
       // case Is:
       // case IsDistinct:
-      // case Item:
       // case Last:
       // case Length:
       // case Lower:
@@ -459,6 +463,70 @@ public class CustomFHIRPathResourceGeneratorR4<T extends Resource> {
       default:
         // TODO: unimplemented, what to do?
     }
+  }
+
+  private void handleIndexFunctionNode(ExpressionNode fhirPath) {
+    // treat this tier as the same as the parent,
+    // eg, the tier for Resource.field[0] is just the parent at Resource.field
+    // since that's where the child definitions are
+
+    GenerationTier parentTier = this.nodeStack.peek();
+    GenerationTier parentsParentTier = this.nodeStack.get(this.nodeStack.size() - 2);
+    GenerationTier nextTier = new GenerationTier();
+    // get the name of the FHIRPath for the next tier
+    nextTier.fhirPathName = parentTier.fhirPathName;
+    // get the child definition from the parent nodePefinition
+    nextTier.childDefinition = parentTier.childDefinition;
+    // create a nodeDefinition for the next tier
+    nextTier.nodeDefinition = parentTier.nodeDefinition;
+
+    int index = ((IntegerType)fhirPath.getParameters().get(0).getConstant()).getValue();
+
+    if (nextTier.nodeDefinition instanceof RuntimeCompositeDatatypeDefinition) {
+      RuntimeCompositeDatatypeDefinition compositeTarget =
+          (RuntimeCompositeDatatypeDefinition) nextTier.nodeDefinition;
+
+      // this could get wonky if, ex, someone sets only item 6 in an otherwise empty list,
+      // but we'll allow it
+
+      for (IBase nodeElement : parentsParentTier.nodes) {
+        List<IBase> containedNodes = nextTier.childDefinition.getAccessor().getValues(nodeElement);
+
+        while (containedNodes.size() <= index) {
+          ICompositeType compositeNode = compositeTarget
+              .newInstance(parentTier.childDefinition.getInstanceConstructorArguments());
+          parentTier.childDefinition.getMutator().addValue(nodeElement, compositeNode);
+          parentTier.nodes.add(compositeNode);
+          containedNodes = nextTier.childDefinition.getAccessor().getValues(nodeElement);
+        }
+
+        nextTier.nodes.add(containedNodes.get(index));
+      }
+    } else if (nextTier.nodeDefinition instanceof RuntimeResourceBlockDefinition) {
+      RuntimeResourceBlockDefinition compositeTarget =
+          (RuntimeResourceBlockDefinition) nextTier.nodeDefinition;
+
+      for (IBase nodeElement : parentsParentTier.nodes) {
+        List<IBase> containedNodes = nextTier.childDefinition.getAccessor().getValues(nodeElement);
+
+        while (containedNodes.size() <= index) {
+          IBase compositeNode = compositeTarget
+              .newInstance(nextTier.childDefinition.getInstanceConstructorArguments());
+          parentTier.childDefinition.getMutator().addValue(nodeElement, compositeNode);
+          parentTier.nodes.add(compositeNode);
+          containedNodes = nextTier.childDefinition.getAccessor().getValues(nodeElement);
+        }
+
+        nextTier.nodes.add(containedNodes.get(index));
+      }
+
+    } else if (nextTier.nodeDefinition instanceof RuntimePrimitiveDatatypeDefinition) {
+      // TODO: is this possible or necessary?
+      // review handlePrimitiveNode()
+    }
+
+    // push the created nextTier to the nodeStack
+    this.nodeStack.push(nextTier);
   }
 
   /**

--- a/src/test/java/org/mitre/synthea/export/flexporter/ActionsTest.java
+++ b/src/test/java/org/mitre/synthea/export/flexporter/ActionsTest.java
@@ -27,11 +27,13 @@ import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
+import org.hl7.fhir.r4.model.Claim;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Enumeration;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.HumanName;
 import org.hl7.fhir.r4.model.Immunization;
@@ -40,6 +42,9 @@ import org.hl7.fhir.r4.model.MedicationRequest;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Period;
+import org.hl7.fhir.r4.model.PositiveIntType;
+import org.hl7.fhir.r4.model.PractitionerRole;
+import org.hl7.fhir.r4.model.PractitionerRole.DaysOfWeek;
 import org.hl7.fhir.r4.model.Procedure;
 import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Resource;
@@ -350,6 +355,40 @@ public class ActionsTest {
     }
     assertTrue(seen229);
     assertTrue(seen355);
+  }
+
+  @Test
+  public void testSetValues_listOfPrimitives() {
+    Map<String, Object> action = getActionByName("testSetValues_listOfPrimitives");
+
+    PractitionerRole pr = new PractitionerRole();
+    Claim c = new Claim();
+    Bundle b = new Bundle();
+    b.addEntry().setResource(pr);
+    b.addEntry().setResource(c);
+
+    Actions.applyAction(b, action, null, null);
+
+    assertEquals(1, pr.getAvailableTime().size());
+
+    List<Enumeration<DaysOfWeek>> daysOfWeek = pr.getAvailableTimeFirstRep().getDaysOfWeek();
+    assertEquals(3, daysOfWeek.size());
+
+    assertEquals(DaysOfWeek.WED, daysOfWeek.get(0).getValue());
+    assertEquals(DaysOfWeek.THU, daysOfWeek.get(1).getValue());
+    assertEquals(DaysOfWeek.FRI, daysOfWeek.get(2).getValue());
+
+    assertEquals(1, c.getItem().size());
+    Claim.ItemComponent item = c.getItemFirstRep();
+
+    List<PositiveIntType> diagnosisSequence = item.getDiagnosisSequence();
+    assertEquals(6, diagnosisSequence.size());
+    assertEquals(1, diagnosisSequence.get(0).getValue().intValue());
+    assertEquals(1, diagnosisSequence.get(1).getValue().intValue());
+    assertEquals(2, diagnosisSequence.get(2).getValue().intValue());
+    assertEquals(3, diagnosisSequence.get(3).getValue().intValue());
+    assertEquals(5, diagnosisSequence.get(4).getValue().intValue());
+    assertEquals(8, diagnosisSequence.get(5).getValue().intValue());
   }
 
   @Test

--- a/src/test/java/org/mitre/synthea/export/flexporter/CustomFHIRPathResourceGeneratorR4Test.java
+++ b/src/test/java/org/mitre/synthea/export/flexporter/CustomFHIRPathResourceGeneratorR4Test.java
@@ -15,7 +15,6 @@ import org.hl7.fhir.r4.model.HumanName;
 import org.hl7.fhir.r4.model.HumanName.NameUse;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.StringType;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mitre.synthea.export.FhirR4;
 
@@ -70,19 +69,12 @@ public class CustomFHIRPathResourceGeneratorR4Test {
     assertEquals("Bob", given.get(1).getValueAsString());
   }
 
-
-  @Ignore
   @Test
   public void testArray2() {
     Map<String, Object> fhirPathMapping = new HashMap<>();
 
     fhirPathMapping.put("Patient.name[0].given", "Billy");
     fhirPathMapping.put("Patient.name[1].given", "Bob");
-
-    // TODO: for some reason Patient.name.given[0] and given[1] work as expected (2 name strings in
-    // the 'given' array)
-    // but Patient.name[0].given and .name[1].given do not (same result, expected was 2 HumanName
-    // objects in the name array)
 
     Patient patient = createPatient(fhirPathMapping);
 

--- a/src/test/resources/flexporter/test_mapping.yaml
+++ b/src/test/resources/flexporter/test_mapping.yaml
@@ -90,6 +90,88 @@ actions:
                display: "Legally married (finding)"
 
 
+ - name: testSetValues_where
+   set_values:
+     - applicability: Encounter 
+       fields: 
+         - location: Encounter.serviceType.coding.where(code='229')
+           value: 
+             system: http://terminology.hl7.org/CodeSystem/service-type
+         - location: Encounter.serviceType.coding.where(code='355')
+           value: 
+             system: http://terminology.hl7.org/CodeSystem/service-type
+
+
+ - name: testSetValues_indexed
+   set_values:
+     - applicability: Encounter 
+       fields: 
+         - location: Encounter.serviceType.coding[0]
+           value: 
+             system: http://terminology.hl7.org/CodeSystem/service-type
+             code: "229"
+         - location: Encounter.serviceType.coding[1]
+           value: 
+             system: http://terminology.hl7.org/CodeSystem/service-type
+             code: "355"
+
+
+ - name: testSetValues_list
+   set_values:
+     - applicability: Encounter 
+       fields: 
+         - location: Encounter.serviceType.coding
+           value:
+             - system: http://terminology.hl7.org/CodeSystem/service-type
+               code: "229"
+             - system: http://terminology.hl7.org/CodeSystem/service-type
+               code: "355"
+
+               
+ - name: testSetValues_deeplyNested
+   set_values:
+     - applicability: Observation 
+       fields: 
+         - location: Observation.code.coding
+           value: 
+             system: http://loinc.org
+             code: "85354-9"
+             display: "Blood pressure panel with all children optional"
+         - location: Observation.code.text
+           value: "Blood pressure systolic & diastolic"
+         - location: Observation.component[0].code.coding[0]
+           value: 
+             system: http://loinc.org
+             code: "8480-6"
+             display: "Systolic blood pressure"
+         - location: Observation.component[0].code.coding[1]
+           value: 
+             system: "http://snomed.info/sct"
+             code: "271649006"
+             display: "Systolic blood pressure"
+         - location: Observation.component[0].code.coding[2]
+           value: 
+             system: "http://acme.org/devices/clinical-codes"
+             code: "bp-s"
+             display: "Systolic Blood pressure"
+         - location: Observation.component[0].valueQuantity
+           value:
+             value: 107
+             unit: "mmHg"
+             system: "http://unitsofmeasure.org"
+             code: "mm[Hg]"
+         - location: Observation.component[1].code.coding
+           value: 
+             system: http://loinc.org
+             code: "8462-4"
+             display: "Diastolic blood pressure"
+         - location: Observation.component[1].valueQuantity
+           value: 
+             value: 60
+             unit: "mmHg"
+             system: "http://unitsofmeasure.org"
+             code: "mm[Hg]"
+
 
  - name: testCreateResources_createSingle
    create_resource: 

--- a/src/test/resources/flexporter/test_mapping.yaml
+++ b/src/test/resources/flexporter/test_mapping.yaml
@@ -127,7 +127,28 @@ actions:
              - system: http://terminology.hl7.org/CodeSystem/service-type
                code: "355"
 
-               
+
+ - name: testSetValues_listOfPrimitives
+   set_values:
+     - applicability: PractitionerRole
+       fields:
+         - location: PractitionerRole.availableTime.daysOfWeek
+           value:
+             - "wed"
+             - "thu"
+             - "fri"
+     - applicability: Claim
+       fields:
+         - location:  Claim.item.diagnosisSequence
+           value:
+             - 1
+             - 1
+             - 2
+             - 3
+             - 5
+             - 8
+
+
  - name: testSetValues_deeplyNested
    set_values:
      - applicability: Observation 


### PR DESCRIPTION
This PR adds better handling of lists in the flexporter. Currently as seen in #1421, adding multiple items to a list requires awkward "where" syntax which won't be apparent to users. This PR enables a couple options that should be more intuitive.

These 3 actions should now produce equivalent results (though the ordering of the items in the first instance is not guaranteed)

```yaml
 - name: testSetValues_where
   set_values:
     - applicability: Encounter 
       fields: 
         - location: Encounter.serviceType.coding.where(code='229')
           value: 
             system: http://terminology.hl7.org/CodeSystem/service-type
         - location: Encounter.serviceType.coding.where(code='355')
           value: 
             system: http://terminology.hl7.org/CodeSystem/service-type


 - name: testSetValues_indexed
   set_values:
     - applicability: Encounter 
       fields: 
         - location: Encounter.serviceType.coding[0]
           value: 
             system: http://terminology.hl7.org/CodeSystem/service-type
             code: "229"
         - location: Encounter.serviceType.coding[1]
           value: 
             system: http://terminology.hl7.org/CodeSystem/service-type
             code: "355"


 - name: testSetValues_list
   set_values:
     - applicability: Encounter 
       fields: 
         - location: Encounter.serviceType.coding
           value:
             - system: http://terminology.hl7.org/CodeSystem/service-type
               code: "229"
             - system: http://terminology.hl7.org/CodeSystem/service-type
               code: "355"
```