### PR TITLE
Add support for code system versions

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -1809,6 +1809,7 @@ public class FhirDstu2 {
     } else {
       coding.setSystem(from.system);
     }
+    coding.setVersion(from.version); // may be null
 
     to.addCoding(coding);
 

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -3440,6 +3440,7 @@ public class FhirR4 {
     } else {
       coding.setSystem(from.system);
     }
+    coding.setVersion(from.version); // may be null
 
     to.addCoding(coding);
 

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -2662,6 +2662,7 @@ public class FhirStu3 {
     } else {
       coding.setSystem(from.system);
     }
+    coding.setVersion(from.version); // may be null
 
     to.addCoding(coding);
 

--- a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java
@@ -85,6 +85,8 @@ public class HealthRecord implements Serializable {
     public String code;
     /** The human-readable description of the code. */
     public String display;
+    /** An identifier for the version of the code system that this code is part of. */
+    public String version;
     /**
      * A ValueSet URI that defines a set of possible codes, one of which should be selected at
      * random.
@@ -116,9 +118,13 @@ public class HealthRecord implements Serializable {
       this.display = definition.get("display").getAsString();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public String toString() {
-      return String
-          .format("system=%s, code=%s, display=%s, valueSet=%s", system, code, display, valueSet);
+      return String.format(
+          "system=%s, code=%s, display=%s, version=%s, valueSet=%s",
+          system, code, display, version, valueSet);
     }
 
     /**

--- a/src/main/resources/modules/encounter/depression_screening.json
+++ b/src/main/resources/modules/encounter/depression_screening.json
@@ -108,7 +108,8 @@
         {
           "system": "SNOMED-CT",
           "code": 454711000124102,
-          "display": "Depression screening using Patient Health Questionnaire Two-Item score (procedure)"
+          "display": "Depression screening using Patient Health Questionnaire Two-Item score (procedure)",
+          "version": "http://snomed.info/sct/731000124108"
         }
       ],
       "distribution": {

--- a/src/main/resources/modules/encounter/sdoh_hrsn.json
+++ b/src/main/resources/modules/encounter/sdoh_hrsn.json
@@ -1229,7 +1229,7 @@
           "system": "SNOMED-CT",
           "code": 5251000175109,
           "display": "Received certificate of high school equivalency (finding)",
-          "value_set": ""
+          "version": "http://snomed.info/sct/731000124108"
         }
       ],
       "direct_transition": "Q11",

--- a/src/main/resources/modules/heart/avrr/outcomes.json
+++ b/src/main/resources/modules/heart/avrr/outcomes.json
@@ -756,8 +756,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": 457551000124104,
-          "display": "Acute cerebrovascular accident (disorder)"
+          "code": "230690007",
+          "display": "Cerebrovascular accident (disorder)"
         }
       ],
       "direct_transition": "End Stroke"

--- a/src/main/resources/modules/heart/avrr/sequence.json
+++ b/src/main/resources/modules/heart/avrr/sequence.json
@@ -51,7 +51,8 @@
         {
           "system": "SNOMED-CT",
           "code": 452331000124102,
-          "display": "Review of imaging finding (procedure)"
+          "display": "Review of imaging finding (procedure)",
+          "version": "http://snomed.info/sct/731000124108"
         }
       ],
       "distribution": {

--- a/src/main/resources/modules/heart/cabg/outcomes.json
+++ b/src/main/resources/modules/heart/cabg/outcomes.json
@@ -839,8 +839,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": 457551000124104,
-          "display": "Acute cerebrovascular accident (disorder)"
+          "code": "230690007",
+          "display": "Cerebrovascular accident (disorder)"
         }
       ],
       "target_encounter": "CABG_Postop",

--- a/src/main/resources/modules/heart/tavr/outcomes.json
+++ b/src/main/resources/modules/heart/tavr/outcomes.json
@@ -756,8 +756,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": 457551000124104,
-          "display": "Acute cerebrovascular accident (disorder)"
+          "code": "230690007",
+          "display": "Cerebrovascular accident (disorder)"
         }
       ],
       "direct_transition": "End Stroke"

--- a/src/main/resources/modules/injuries.json
+++ b/src/main/resources/modules/injuries.json
@@ -430,11 +430,6 @@
       "activities": [
         {
           "system": "SNOMED-CT",
-          "code": "231181000000100",
-          "display": "Delivery of rehabilitation for spinal cord injury"
-        },
-        {
-          "system": "SNOMED-CT",
           "code": "77476009",
           "display": "Application of back brace"
         }

--- a/src/main/resources/modules/self_harm.json
+++ b/src/main/resources/modules/self_harm.json
@@ -480,7 +480,7 @@
       "activities": [
         {
           "system": "SNOMED-CT",
-          "code": "784051000000106",
+          "code": "768835002",
           "display": "Depression care management"
         },
         {

--- a/src/main/resources/modules/snf/skilled_nursing_facility.json
+++ b/src/main/resources/modules/snf/skilled_nursing_facility.json
@@ -27,7 +27,8 @@
         {
           "system": "SNOMED-CT",
           "code": "449411000124106",
-          "display": "Admission to skilled nursing facility (procedure)"
+          "display": "Admission to skilled nursing facility (procedure)",
+          "version": "http://snomed.info/sct/731000124108"
         }
       ],
       "conditional_transition": [
@@ -298,7 +299,8 @@
         {
           "system": "SNOMED-CT",
           "code": "449381000124108",
-          "display": "Discharge from skilled nursing facility (procedure)"
+          "display": "Discharge from skilled nursing facility (procedure)",
+          "version": "http://snomed.info/sct/731000124108"
         }
       ],
       "direct_transition": "Return_Wheelchair"

--- a/src/main/resources/modules/veteran_self_harm.json
+++ b/src/main/resources/modules/veteran_self_harm.json
@@ -153,7 +153,7 @@
       "activities": [
         {
           "system": "SNOMED-CT",
-          "code": "784051000000106",
+          "code": "768835002",
           "display": "Depression care management"
         },
         {


### PR DESCRIPTION
Addresses #1430

For the most part, the SNOMED codes we use come from the International edition, but there are a few that are US-specific. This causes errors when validating generated resources that use these code, because if the resource doesn't specify the version, the validator/tx server will assume the international edition.

This PR adds a `version` field to our HealthRecord.code model which allows the version to be specified, and updates the codes that currently cause errors. The new version field is optional since it's only really relevant to half a dozen codes. See corresponding PR on the module builder: https://github.com/synthetichealth/module-builder/pull/330

Codes that were changed:
5251000175109 -- the one from the linked issue, added US version flag
784051000000106 -- Depression care management, replaced with an international code that already had the same display
449411000124106 -- Admission to SNF, added US version
449381000124108 -- Discharge from SNF, added US version
457551000124104 -- Acute cerebrovascular accident (disorder), this code is inactive so I replaced it with international Cerebrovascular accident
452331000124102 -- Review of imaging finding, added US version
454711000124102 -- Depression screening PHQ2, added US version
231181000000100 -- delivery of spinal cord injury rehab is UK specific, I just deleted the activity. Not sure it adds anything over the code on the CarePlan

For reference, list of SNOMED edition URIs: https://confluence.ihtsdotools.org/display/DOCEXTPG/4.4.2+Edition+URI+Examples