### PR TITLE
Module Metrics

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -32,7 +32,6 @@ import org.mitre.synthea.export.Exporter;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.DefaultRandomNumberGenerator;
 import org.mitre.synthea.helpers.RandomNumberGenerator;
-import org.mitre.synthea.helpers.TransitionMetrics;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.identity.Entity;
 import org.mitre.synthea.identity.EntityManager;
@@ -77,7 +76,6 @@ public class Generator {
   private boolean onlyVeterans;
   private Module keepPatientsModule;
   private Long maxAttemptsToKeepPatient;
-  public TransitionMetrics metrics;
   public static String DEFAULT_STATE = "Massachusetts";
   private Exporter.ExporterRuntimeOptions exporterRuntimeOptions;
   public static EntityManager entityManager;
@@ -261,10 +259,6 @@ public class Generator {
     stats.put("alive", new AtomicInteger(0));
     stats.put("dead", new AtomicInteger(0));
 
-    if (Config.getAsBoolean("generate.track_detailed_transition_metrics", false)) {
-      this.metrics = new TransitionMetrics();
-    }
-
     // initialize hospitals
     Provider.loadProviders(location, this.clinicianRandom);
     // Initialize Payers
@@ -416,10 +410,6 @@ public class Generator {
             stats.get("alive").get(), stats.get("dead").get());
     System.out.printf("RNG=%d\n", this.populationRandom.getCount());
     System.out.printf("Clinician RNG=%d\n", this.clinicianRandom.getCount());
-
-    if (this.metrics != null) {
-      metrics.printStats(totalGeneratedPopulation.get(), Module.getModules(getModulePredicate()));
-    }
   }
 
   /**
@@ -931,10 +921,6 @@ public class Generator {
 
     if (internalStore != null) {
       internalStore.add(person);
-    }
-
-    if (this.metrics != null) {
-      metrics.recordStats(person, finishTime, Module.getModules(modulePredicate));
     }
 
     if (!this.logLevel.equals("none")) {

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -260,10 +260,10 @@ public class Module implements Cloneable, Serializable {
    * @param predicate A predicate to filter a module based on path.
    * @return A list of ModuleSuppliers.
    */
-  public static List<ModuleSupplier> getModuleSuppliers(Predicate<String> predicate) {
+  public static List<ModuleSupplier> getModuleSuppliers(Predicate<ModuleSupplier> predicate) {
     List<ModuleSupplier> list = new ArrayList<ModuleSupplier>();
     modules.forEach((k, v) -> {
-      if (predicate.test(v.path)) {
+      if (predicate.test(v)) {
         list.add(v);
       }
     });

--- a/src/main/java/org/mitre/synthea/engine/Module.java
+++ b/src/main/java/org/mitre/synthea/engine/Module.java
@@ -409,7 +409,7 @@ public class Module implements Cloneable, Serializable {
       person.attributes.put(historyKey, person.history);
       /* TODO - determining whether or not this the first time a person has
          entered a submodule is currently not easily computed, so we use `true` below. */
-      TransitionMetrics.getMetric(historyKey, initial.name).enter(true);
+      TransitionMetrics.enter(historyKey, initial.name, true);
     }
     person.history = (List<State>) person.attributes.get(historyKey);
     State current = person.history.get(0);
@@ -424,10 +424,10 @@ public class Module implements Cloneable, Serializable {
       Long duration = (exited - entered);
       nextStateName = current.transition(person, time);
       boolean firstTime = !person.hadPriorState(nextStateName);
-      TransitionMetrics.getMetric(historyKey, current.name).exit(nextStateName, duration);
+      TransitionMetrics.exit(historyKey, current.name, nextStateName, duration);
       current = states.get(nextStateName).clone(); // clone the state so we don't dirty the original
       person.history.add(0, current);
-      TransitionMetrics.getMetric(historyKey, nextStateName).enter(firstTime);
+      TransitionMetrics.enter(historyKey, nextStateName, firstTime);
       if (exited != null && exited < time) {
         // stop if the patient died in the meantime...
         if (terminateOnDeath && !person.alive(exited)) {

--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -31,6 +31,7 @@ import org.mitre.synthea.export.flexporter.FlexporterJavascriptContext;
 import org.mitre.synthea.export.flexporter.Mapping;
 import org.mitre.synthea.export.rif.BB2RIFExporter;
 import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.helpers.TransitionMetrics;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.identity.Entity;
 import org.mitre.synthea.identity.Seed;
@@ -580,6 +581,10 @@ public abstract class Exporter {
       } catch (IOException e) {
         e.printStackTrace();
       }
+    }
+
+    if (Config.getAsBoolean("generate.track_detailed_transition_metrics", false)) {
+      TransitionMetrics.exportMetrics();
     }
 
     if (postCompletionExporters != null && !postCompletionExporters.isEmpty()) {

--- a/src/main/java/org/mitre/synthea/helpers/TransitionMetrics.java
+++ b/src/main/java/org/mitre/synthea/helpers/TransitionMetrics.java
@@ -3,20 +3,21 @@ package org.mitre.synthea.helpers;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import com.google.common.collect.Tables;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.mitre.synthea.engine.Module;
-import org.mitre.synthea.engine.State;
-import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.engine.Module.ModuleSupplier;
+import org.mitre.synthea.export.Exporter;
 
 /**
  * Class to track state and transition metrics from the modules.
@@ -26,61 +27,14 @@ import org.mitre.synthea.world.agents.Person;
  * - What states they transitioned to
  * - How long they were in that state (ex, Guard, Delay)
  */
-public class TransitionMetrics {
+public abstract class TransitionMetrics {
   /**
    * Internal table of (Module,State) -> Metric.
    * Note that a table may not be the most appropriate data structure,
    * but it's a lot cleaner than a Map of Module -> Map of State -> Metric.
    */
-  private Table<String, String, Metric> metrics =
+  private static final Table<String, String, Metric> metrics =
       Tables.synchronizedTable(HashBasedTable.create());
-
-  /**
-   * Record all appropriate state transition information from the given person.
-   *
-   * @param person
-   *          Person that went through the modules
-   * @param simulationEnd
-   *          Date the simulation ended
-   * @param modules
-   *          The collection of modules to record stats for
-   */
-  @SuppressWarnings("unchecked")
-  public void recordStats(Person person, long simulationEnd, Collection<Module> modules) {
-    for (Module m : modules) {
-      if (!m.getClass().equals(Module.class)) {
-        // java module, not GMF. no states to show
-        continue;
-      }
-
-      List<State> history = (List<State>) person.attributes.get(m.name);
-      if (history == null) {
-        continue;
-      }
-
-      // count basic "counter" stats for this state
-      history.forEach(s -> countStateStats(s, getMetric(m.name, s.name), simulationEnd));
-
-      // count this person only once for each distinct state they hit
-      history.stream().map(s -> s.name).distinct()
-          .forEach(sName -> getMetric(m.name, sName).population.incrementAndGet());
-
-      getMetric(m.name, history.get(0).name).current.incrementAndGet();
-
-      // loop over the states backward (0 = current, n = initial)
-      // and track from->to stats in pair
-      if (history.size() >= 2) {
-        for (int fromIndex = history.size() - 1; fromIndex > 0; fromIndex--) {
-          int toIndex = fromIndex - 1;
-
-          State from = history.get(fromIndex);
-          State to = history.get(toIndex);
-
-          getMetric(m.name, from.name).incrementDestination(to.name);
-        }
-      }
-    }
-  }
 
   /**
    * Get the Metric object for the given State in the given Module.
@@ -89,7 +43,7 @@ public class TransitionMetrics {
    * @param stateName Name of the state
    * @return Metric object
    */
-  public Metric getMetric(String moduleName, String stateName) {
+  public static Metric getMetric(String moduleName, String stateName) {
     Metric metric = metrics.get(moduleName, stateName);
 
     if (metric == null) {
@@ -105,138 +59,56 @@ public class TransitionMetrics {
     return metric;
   }
 
-  private void countStateStats(State state, Metric stateStats, long endDate) {
-    if (state == null || state.entered == null) {
-      return;
-    }
-    stateStats.entered.incrementAndGet();
-    long exitTime = (state.exited == null) ? endDate : state.exited;
-    // if they were in the last state when they died or time expired
-    long startTime = state.entered;
-    // note: the ruby module has a hack for
-    // "when the lifecycle module kills people before the initial state"
-    // but i dont think that will break anything here if it happens
-
-    stateStats.duration.addAndGet(exitTime - startTime);
+  /**
+   * Clears the metrics. Intended for unit tests.
+   */
+  static void clear() {
+    metrics.clear();
   }
 
   /**
-   * Print the statistics that have been gathered.
-   *
-   * @param totalPopulation
-   *          The total population that was simulated.
-   * @param modules
-   *          The collection of modules to display stats for
+   * Exports the metrics as JSON in the exporter base directory.
    */
-  public void printStats(int totalPopulation, Collection<Module> modules) {
-    for (Module m : modules) {
-      if (!m.getClass().equals(Module.class)) {
-        // java module, not GMF. no states to show
+  public static void exportMetrics() {
+    GsonBuilder builder = new GsonBuilder();
+    if (Config.getAsBoolean("exporter.pretty_print", true)) {
+      builder.setPrettyPrinting();
+    }
+    Gson gson = builder.create();
+
+    System.out.println("Saving metrics for " + metrics.rowKeySet().size() + " modules.");
+
+    String baseDir = Config.get("exporter.baseDirectory", "./output/");
+    String statsDir = "statistics";
+    Path output = Paths.get(baseDir, statsDir);
+    output.toFile().mkdirs();
+
+    List<ModuleSupplier> suppliers = Module.getModuleSuppliers();
+    for (ModuleSupplier supplier : suppliers) {
+      if (supplier.core) {
+        // Java module
         continue;
       }
-      System.out.println(m.name.toUpperCase());
+      // System.out.println("Saving statistics: " + supplier.path);
 
-      Map<String, Metric> moduleMetrics = metrics.row(m.name);
-      List<String> keys = new ArrayList<String>(moduleMetrics.keySet());
-      Collections.sort(keys);
+      Map<String, Metric> moduleMetrics = metrics.row(supplier.get().name);
+      String json = gson.toJson(moduleMetrics);
 
-      for (String stateName : keys) {
-        Metric stats = getMetric(m.name, stateName);
-        int entered = stats.entered.get();
-        int population = stats.population.get();
-        long duration = stats.duration.get();
-        int current = stats.current.get();
+      String filename = supplier.path + ".json";
+      Path p = output;
 
-        System.out.println(stateName + ":");
-        System.out.println(" Total times entered: " + stats.entered);
-        System.out.println(" Population that ever hit this state: " + stats.population + " ("
-            + decimal(population, totalPopulation) + "%)");
-        System.out.println(" Average # of hits per total population: "
-            + decimal(entered, totalPopulation));
-        System.out.println(" Average # of hits per person that ever hit state: "
-            + decimal(entered, population));
-        System.out.println(" Population currently in state: " + stats.current + " ("
-            + decimal(current, totalPopulation) + "%)");
-        State state = m.getState(stateName);
-        if (state instanceof State.Guard || state instanceof State.Delay) {
-          System.out.println(" Total duration: " + durationOf(duration));
-          System.out.println(" Average duration per time entered: "
-              + durationOf(duration / entered));
-          System.out.println(" Average duration per person that ever entered state: "
-              + durationOf(duration / population));
-        } else if (state instanceof State.Encounter && ((State.Encounter) state).isWellness()) {
-          System.out.println(" (duration metrics for wellness encounter omitted)");
+      if (supplier.path.contains(File.separator)) {
+        int index = supplier.path.lastIndexOf(File.separator);
+        String subfolders = supplier.path.substring(0, index);
+        filename = supplier.path.substring(index + 1) + ".json";
+        for (String sub : subfolders.split(File.separator)) {
+          p = p.resolve(sub);
         }
-
-        if (!stats.destinations.isEmpty()) {
-          System.out.println(" Transitioned to:");
-          long total = stats.destinations.values().stream().mapToLong(ai -> ai.longValue()).sum();
-          stats.destinations.forEach((toState, count) ->
-                System.out.println(" --> " + toState + " : " + count + " = "
-                                    + decimal(count.get(), total) + "%"));
-        }
-        System.out.println();
+        p.toFile().mkdirs();
       }
 
-      List<String> unreached = new ArrayList<>(m.getStateNames());
-      Collections.sort(unreached);
-      // moduleMetrics only includes states actually hit
-      unreached.removeAll(moduleMetrics.keySet());
-      unreached.forEach(state -> System.out.println(state + ": \n Never reached \n\n"));
-
-      System.out.println();
-      System.out.println();
+      Exporter.overwriteFile(p.resolve(filename), json);
     }
-  }
-
-  /**
-   * Helper function to convert a # of milliseconds into a human-readable string. Results are not
-   * necessarily precise, and are intended for general understanding only. The resulting format is
-   * not specified and may change at any time.
-   * Ex. duration(14*30*24*60*60*1000) may indicate a result of "14 months", "1 year and 2 months",
-   * "1.17 years", etc.
-   *
-   * @param time time duration in ms
-   * @return Human readable description of the time
-   */
-  public static String durationOf(long time) {
-    // this returns something like 15 days 15 hours 24 minutes 26 seconds
-    String result = DurationFormatUtils.formatDurationWords(time, true, true);
-
-    // if it starts with a large number of days, we can do a little better
-    String[] parts = result.split(" ");
-
-    if (parts.length > 1 && parts[1].equals("days")) {
-      long days = Long.parseLong(parts[0]);
-
-      if (days > 365) {
-        long years = days / 365;
-        long months = (days % 365) / 30;
-        return years + " years " + months + " months";
-      } else if (days > 30) {
-        long months = days / 30;
-        days = days % 30;
-        return months + " months " + days + " days";
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Helper function to convert a numerator and denominator into a string with a single number and
-   * exactly 2 decimal places.
-   *
-   * @param num
-   *          Numerator
-   * @param denom
-   *          Denominator
-   * @return num/denom rounded to 2 decimal places
-   */
-  private static String decimal(double num, double denom) {
-    // note that this is especially helpful because ints can be passed in without explicit casting
-    // and if you want to get a double from integer division you have to cast the input items
-    return String.format("%.2f", (100.0 * num / denom));
   }
 
   /**
@@ -275,7 +147,7 @@ public class TransitionMetrics {
      *
      * @param destination Target state that was transitioned to
      */
-    void incrementDestination(String destination) {
+    public void exit(String destination, long duration) {
 
       AtomicInteger count = destinations.get(destination);
       if (count == null) {
@@ -288,6 +160,20 @@ public class TransitionMetrics {
         }
       }
       count.incrementAndGet();
+      this.current.decrementAndGet();
+      this.duration.addAndGet(duration);
+    }
+
+    /**
+     * Helper function to increment the counts when a state is entered.
+     * @param firstTime Whether or not this state was previously entered.
+     */
+    public void enter(boolean firstTime) {
+      this.entered.incrementAndGet();
+      this.current.incrementAndGet();
+      if (firstTime) {
+        this.population.incrementAndGet();
+      }
     }
   }
 }

--- a/src/main/java/org/mitre/synthea/helpers/TransitionMetrics.java
+++ b/src/main/java/org/mitre/synthea/helpers/TransitionMetrics.java
@@ -111,12 +111,8 @@ public abstract class TransitionMetrics {
     Path output = Paths.get(baseDir, statsDir);
     output.toFile().mkdirs();
 
-    List<ModuleSupplier> suppliers = Module.getModuleSuppliers();
+    List<ModuleSupplier> suppliers = Module.getModuleSuppliers(p -> !p.core);
     for (ModuleSupplier supplier : suppliers) {
-      if (supplier.core) {
-        // Java module
-        continue;
-      }
       // System.out.println("Saving statistics: " + supplier.path);
 
       Map<String, Metric> moduleMetrics = metrics.row(supplier.get().name);

--- a/src/test/java/AppTest.java
+++ b/src/test/java/AppTest.java
@@ -13,7 +13,6 @@ import org.junit.runners.MethodSorters;
 import org.mitre.synthea.TestHelper;
 import org.mitre.synthea.engine.Generator;
 import org.mitre.synthea.helpers.Config;
-import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.PayerManager;
 import org.mitre.synthea.world.geography.Location;
 

--- a/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
+++ b/src/test/java/org/mitre/synthea/engine/GeneratorTest.java
@@ -1,7 +1,6 @@
 package org.mitre.synthea.engine;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -67,17 +66,6 @@ public class GeneratorTest {
     numberOfPeople = 3;
     Config.set("generate.default_population", Integer.toString(numberOfPeople));
     generator = new Generator();
-    generator.run();
-    assertEquals(numberOfPeople, generator.stats.get("alive").longValue());
-  }
-
-  @Test
-  public void testGenerateWithMetrics() throws Exception {
-    int numberOfPeople = 1;
-    Config.set("generate.track_detailed_transition_metrics", "true");
-    Generator generator = new Generator(numberOfPeople, 0L, 1L);
-    Config.set("generate.track_detailed_transition_metrics", "false");
-    assertNotNull(generator.metrics);
     generator.run();
     assertEquals(numberOfPeople, generator.stats.get("alive").longValue());
   }

--- a/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
@@ -1,10 +1,7 @@
 package org.mitre.synthea.helpers;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -33,6 +30,8 @@ public class TransitionMetricsTest {
 
   @Test
   public void testExampleModule() throws Exception {
+    TransitionMetrics.clear();
+
     Provider mockProvider = TestHelper.buildMockProvider();
     Person person = new Person(0L);
     person.attributes.put(Person.RACE, "black");
@@ -53,14 +52,7 @@ public class TransitionMetricsTest {
 
     time = run(person, example, time);
 
-    TransitionMetrics metrics = new TransitionMetrics();
-
-    Collection<Module> modules = Collections.singleton(example);
-
-    metrics.recordStats(person, time, modules);
-    metrics.printStats(1, modules); // print it to ensure no exceptions. don't parse the output
-
-    Metric m = metrics.getMetric(example.name, "Initial");
+    Metric m = TransitionMetrics.getMetric(example.name, "Initial");
     assertEquals(1, m.entered.get()); // 1 person entered the state
     assertEquals(0, m.current.get()); // none currently in this state
 
@@ -68,14 +60,14 @@ public class TransitionMetricsTest {
     assertEquals(null, dests.get("Age_Guard")); // the 1 person did not go here
     assertEquals(1, dests.get("Terminal").get()); // they went here
 
-    m = metrics.getMetric(example.name, "Pre_Examplitis");
+    m = TransitionMetrics.getMetric(example.name, "Pre_Examplitis");
     assertEquals(0, m.entered.get()); // nobody hit this
 
-    m = metrics.getMetric(example.name, "Terminal");
+    m = TransitionMetrics.getMetric(example.name, "Terminal");
     assertEquals(1, m.entered.get()); // 1 person hit this
     assertEquals(1, m.current.get()); // and is still there
 
-    metrics = new TransitionMetrics();
+    TransitionMetrics.clear();
 
     for (long seed : new long[] {31255L, 12L, 12345L}) {
       // seeds chosen by experimentation, to ensure we hit "Pre_Examplitis" at least once
@@ -88,12 +80,9 @@ public class TransitionMetricsTest {
       person.coverage.setPlanToNoInsurance(time);
 
       time = run(person, example, time);
-      metrics.recordStats(person, time, modules);
     }
 
-    metrics.printStats(3, modules); // print it to ensure no exceptions
-
-    m = metrics.getMetric(example.name, "Initial");
+    m = TransitionMetrics.getMetric(example.name, "Initial");
     assertEquals(3, m.entered.get()); // 3 people entered the state
     assertEquals(0, m.current.get()); // none currently in this state
 
@@ -101,10 +90,10 @@ public class TransitionMetricsTest {
     assertEquals(null, dests.get("Terminal")); // the 3 people did not go here
     assertEquals(3, dests.get("Age_Guard").get()); // they went here
 
-    m = metrics.getMetric(example.name, "Pre_Examplitis");
+    m = TransitionMetrics.getMetric(example.name, "Pre_Examplitis");
     assertEquals(1, m.entered.get());
 
-    m = metrics.getMetric(example.name, "Terminal");
+    m = TransitionMetrics.getMetric(example.name, "Terminal");
     assertEquals(3, m.entered.get());
     assertEquals(3, m.current.get());
   }
@@ -134,36 +123,5 @@ public class TransitionMetricsTest {
       person.coverage.setPlanToNoInsurance(time);
     }
     return time;
-  }
-
-  @Test public void testDurationStrings() {
-    String result;
-
-    result = TransitionMetrics.durationOf(Utilities.convertTime("years", 2));
-    assertTrue(result.contains("2 years"));
-
-    result = TransitionMetrics.durationOf(Utilities.convertTime("months", 25));
-    assertTrue(result.contains("2 years"));
-
-    result = TransitionMetrics.durationOf(Utilities.convertTime("days", 765));
-    assertTrue(result.contains("2 years"));
-
-    result = TransitionMetrics.durationOf(Utilities.convertTime("months", 2));
-    assertTrue(result.contains("2 months"));
-
-    result = TransitionMetrics.durationOf(Utilities.convertTime("days", 66));
-    assertTrue(result.contains("2 months"));
-
-    result = TransitionMetrics.durationOf(Utilities.convertTime("weeks", 2));
-    assertTrue(result.contains("2 weeks") || result.contains("14 days"));
-
-    result = TransitionMetrics.durationOf(Utilities.convertTime("days", 2));
-    assertTrue(result.contains("2 days"));
-
-    result = TransitionMetrics.durationOf(Utilities.convertTime("hours", 24));
-    assertTrue(result.contains("1 day"));
-
-    result = TransitionMetrics.durationOf(Utilities.convertTime("hours", 2));
-    assertTrue(result.contains("2 hours"));
   }
 }

--- a/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
+++ b/src/test/java/org/mitre/synthea/helpers/TransitionMetricsTest.java
@@ -30,6 +30,7 @@ public class TransitionMetricsTest {
 
   @Test
   public void testExampleModule() throws Exception {
+    TransitionMetrics.enabled = true;
     TransitionMetrics.clear();
 
     Provider mockProvider = TestHelper.buildMockProvider();
@@ -96,6 +97,7 @@ public class TransitionMetricsTest {
     m = TransitionMetrics.getMetric(example.name, "Terminal");
     assertEquals(3, m.entered.get());
     assertEquals(3, m.current.get());
+    TransitionMetrics.enabled = false;
   }
 
   private long run(Person person, Module singleModule, long start) {


### PR DESCRIPTION
This branch revamps the module, state, and transition metrics.

Previously, use of the `generate.track_detailed_transition_metrics` property outputted metrics to system out. Using this feature roughly quadrupled the runtime.

This change outputs the metrics as JSON (`./output/metrics/**`), one file per module. Using this feature will roughly double the runtime.

Sample output looks something like this for each state, where the name of the state (e.g., `Chance_of_Stroke` matches a state name in the corresponding GMF module):

```json
  "Chance_of_Stroke": {
    "entered": 58987,
    "duration": 152635104000000,
    "population": 101,
    "current": 100,
    "destinations": {
      "Stroke": 1,
      "Chance_of_Stroke": 58886
    }
  }
```

Field | Description
-----|-----
`entered` | Count, how many times this state was entered.
`duration` | Sum of time (milliseconds) spent in this state.
`population` | Count, how many unique individuals entered this state (this count is not reliable for submodules).
`current` | Count, how many individuals are currently in this state at simulation end.
`destinations` | Map of states and counts that processing transitioned to.