### PR TITLE
Quick Fix for US Core Pulse Ox error

### DIFF
--- a/src/main/resources/modules/sepsis.json
+++ b/src/main/resources/modules/sepsis.json
@@ -291,13 +291,13 @@
       "codes": [
         {
           "system": "LOINC",
-          "code": "2713-6",
-          "display": "Oxygen saturation Calculated from oxygen partial pressure in Blood"
+          "code": "2708-6",
+          "display": "Oxygen saturation in Arterial blood"
         },
         {
           "system": "LOINC",
-          "code": "2708-6",
-          "display": "Oxygen saturation in Arterial blood"
+          "code": "59408-5",
+          "display": "Oxygen saturation in Arterial blood by Pulse oximetry"
         }
       ],
       "direct_transition": "Lactate_Level1",


### PR DESCRIPTION
Fix for the US Core Pulse Ox error:
> Validation of exported FHIR bundle failed: Observation.code.coding:PulseOx: minimum required = 1, but only found 0 (from http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry)

That profile requires both these two codes

Tested out locally with the below change to ensure all patients went through the sepsis module:

```diff
--- a/src/main/resources/modules/sepsis.json
+++ b/src/main/resources/modules/sepsis.json
@@ -16,7 +16,7 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "Age_Guard"
+      "direct_transition": "Sepsis"
     },
```