### PR TITLE
Module syntax

### DIFF
--- a/src/main/resources/modules/allergies/food_allergy_incidence.json
+++ b/src/main/resources/modules/allergies/food_allergy_incidence.json
@@ -524,7 +524,7 @@
           "display": "Wheat (substance)"
         }
       ],
-      "reaction": [
+      "reactions": [
         {
           "reaction": {"system":  "SNOMED-CT", "code": "267036007", "display":  "Dyspnea (finding)"},
           "possible_severities": [
@@ -543,7 +543,7 @@
           "reaction": {"system":  "SNOMED-CT", "code": "271807003", "display":  "Eruption of skin (disorder)"},
           "possible_severities": [
             {"level":  "moderate", "value": 0.9},
-            {"level":  "none", "value":  0.09999999999999998}
+            {"level":  "none", "value":  0.1}
           ]
         },
         {

--- a/src/main/resources/modules/appendicitis.json
+++ b/src/main/resources/modules/appendicitis.json
@@ -229,7 +229,6 @@
     },
     "Appendicitis_Encounter": {
       "type": "Encounter",
-      "wellness": false,
       "encounter_class": "emergency",
       "reason": "Appendicitis",
       "remarks": [

--- a/src/main/resources/modules/appendicitis.json
+++ b/src/main/resources/modules/appendicitis.json
@@ -21,8 +21,7 @@
         {
           "transition": "Terminal"
         }
-      ],
-      "name": "Initial"
+      ]
     },
     "Male": {
       "type": "Simple",
@@ -38,8 +37,7 @@
       ],
       "remarks": [
         "Men have an approx lifetime risk of appendicitis of 8.6%. Ref: http://www.ncbi.nlm.nih.gov/pubmed/2239906"
-      ],
-      "name": "Male"
+      ]
     },
     "Female": {
       "type": "Simple",
@@ -55,8 +53,7 @@
       ],
       "remarks": [
         "Women have an approx lifetime risk of appendicitis of 6.7%. Ref: http://www.ncbi.nlm.nih.gov/pubmed/2239906"
-      ],
-      "name": "Female"
+      ]
     },
     "Pre_appendicitis": {
       "type": "Simple",
@@ -80,8 +77,7 @@
       ],
       "remarks": [
         "Age distribution of appendicitis from https://www.ncbi.nlm.nih.gov/books/NBK169006/ , Table 1"
-      ],
-      "name": "Pre_appendicitis"
+      ]
     },
     "Ages_1_17": {
       "type": "Delay",
@@ -90,8 +86,7 @@
         "high": 17,
         "unit": "years"
       },
-      "direct_transition": "Appendicitis_Symptom1",
-      "name": "Ages_1_17"
+      "direct_transition": "Appendicitis_Symptom1"
     },
     "Ages_18_44": {
       "type": "Delay",
@@ -100,8 +95,7 @@
         "high": 44,
         "unit": "years"
       },
-      "direct_transition": "Appendicitis_Symptom1",
-      "name": "Ages_18_44"
+      "direct_transition": "Appendicitis_Symptom1"
     },
     "Ages_45_64": {
       "type": "Delay",
@@ -110,8 +104,7 @@
         "high": 64,
         "unit": "years"
       },
-      "direct_transition": "Appendicitis_Symptom1",
-      "name": "Ages_45_64"
+      "direct_transition": "Appendicitis_Symptom1"
     },
     "Ages_65_Plus": {
       "type": "Delay",
@@ -120,8 +113,7 @@
         "high": 99,
         "unit": "years"
       },
-      "direct_transition": "Appendicitis_Symptom1",
-      "name": "Ages_65_Plus"
+      "direct_transition": "Appendicitis_Symptom1"
     },
     "Appendicitis_Symptom1": {
       "type": "Symptom",
@@ -130,8 +122,7 @@
         "low": 50,
         "high": 150
       },
-      "direct_transition": "Appendicitis_Symptom2",
-      "name": "Appendicitis_Symptom1"
+      "direct_transition": "Appendicitis_Symptom2"
     },
     "Appendicitis_Symptom2": {
       "type": "Symptom",
@@ -140,8 +131,7 @@
         "low": 50,
         "high": 100
       },
-      "direct_transition": "Appendicitis_Symptom3",
-      "name": "Appendicitis_Symptom2"
+      "direct_transition": "Appendicitis_Symptom3"
     },
     "Appendicitis_Symptom3": {
       "type": "Symptom",
@@ -150,8 +140,7 @@
         "low": 50,
         "high": 100
       },
-      "direct_transition": "Appendicitis_Symptom4",
-      "name": "Appendicitis_Symptom3"
+      "direct_transition": "Appendicitis_Symptom4"
     },
     "Appendicitis_Symptom4": {
       "type": "Symptom",
@@ -160,8 +149,7 @@
         "low": 0,
         "high": 50
       },
-      "direct_transition": "Appendicitis_Symptom5",
-      "name": "Appendicitis_Symptom4"
+      "direct_transition": "Appendicitis_Symptom5"
     },
     "Appendicitis_Symptom5": {
       "type": "Symptom",
@@ -170,8 +158,7 @@
         "low": 0,
         "high": 50
       },
-      "direct_transition": "Appendicitis_Symptom6",
-      "name": "Appendicitis_Symptom5"
+      "direct_transition": "Appendicitis_Symptom6"
     },
     "Appendicitis_Symptom6": {
       "type": "Symptom",
@@ -180,8 +167,7 @@
         "low": 0,
         "high": 50
       },
-      "direct_transition": "Appendicitis_Symptom7",
-      "name": "Appendicitis_Symptom6"
+      "direct_transition": "Appendicitis_Symptom7"
     },
     "Appendicitis_Symptom7": {
       "type": "Symptom",
@@ -190,8 +176,7 @@
         "low": 0,
         "high": 50
       },
-      "direct_transition": "Symptom_Period",
-      "name": "Appendicitis_Symptom7"
+      "direct_transition": "Symptom_Period"
     },
     "Symptom_Period": {
       "type": "Delay",
@@ -200,8 +185,7 @@
         "high": 3,
         "unit": "days"
       },
-      "direct_transition": "Appendicitis",
-      "name": "Symptom_Period"
+      "direct_transition": "Appendicitis"
     },
     "Appendicitis": {
       "type": "ConditionOnset",
@@ -229,8 +213,7 @@
         "(ref: http://emedicine.medscape.com/article/773895-overview#a7 )",
         "From table 1 here: https://www.ncbi.nlm.nih.gov/books/NBK169006/ it's about 30%",
         "For simplicity here I just round to 30% for all age groups."
-      ],
-      "name": "Appendicitis"
+      ]
     },
     "Rupture": {
       "type": "ConditionOnset",
@@ -242,8 +225,7 @@
           "display": "Rupture of appendix"
         }
       ],
-      "direct_transition": "Appendicitis_Encounter",
-      "name": "Rupture"
+      "direct_transition": "Appendicitis_Encounter"
     },
     "Appendicitis_Encounter": {
       "type": "Encounter",
@@ -260,8 +242,7 @@
           "display": "Emergency room admission (procedure)"
         }
       ],
-      "direct_transition": "History_of_Appendectomy",
-      "name": "Appendicitis_Encounter"
+      "direct_transition": "History_of_Appendectomy"
     },
     "History_of_Appendectomy": {
       "type": "ConditionOnset",
@@ -273,8 +254,7 @@
           "display": "History of appendectomy"
         }
       ],
-      "direct_transition": "Transfer_To_Inpatient",
-      "name": "History_of_Appendectomy"
+      "direct_transition": "Transfer_To_Inpatient"
     },
     "Appendectomy_Encounter": {
       "type": "Encounter",
@@ -287,8 +267,7 @@
           "display": "Encounter for problem (procedure)"
         }
       ],
-      "direct_transition": "Appendectomy",
-      "name": "Appendectomy_Encounter"
+      "direct_transition": "Appendectomy"
     },
     "Appendectomy": {
       "type": "Procedure",
@@ -317,8 +296,7 @@
       "exact": {
         "quantity": 0
       },
-      "direct_transition": "Appendicitis_Symptom2_Ends",
-      "name": "Appendicitis_Symptom1_Ends"
+      "direct_transition": "Appendicitis_Symptom2_Ends"
     },
     "Appendicitis_Symptom2_Ends": {
       "type": "Symptom",
@@ -326,8 +304,7 @@
       "exact": {
         "quantity": 0
       },
-      "direct_transition": "Appendicitis_Symptom3_Ends",
-      "name": "Appendicitis_Symptom2_Ends"
+      "direct_transition": "Appendicitis_Symptom3_Ends"
     },
     "Appendicitis_Symptom3_Ends": {
       "type": "Symptom",
@@ -335,8 +312,7 @@
       "exact": {
         "quantity": 0
       },
-      "direct_transition": "Appendicitis_Symptom4_Ends",
-      "name": "Appendicitis_Symptom3_Ends"
+      "direct_transition": "Appendicitis_Symptom4_Ends"
     },
     "Appendicitis_Symptom4_Ends": {
       "type": "Symptom",
@@ -344,8 +320,7 @@
       "exact": {
         "quantity": 0
       },
-      "direct_transition": "Appendicitis_Symptom5_Ends",
-      "name": "Appendicitis_Symptom4_Ends"
+      "direct_transition": "Appendicitis_Symptom5_Ends"
     },
     "Appendicitis_Symptom5_Ends": {
       "type": "Symptom",
@@ -353,8 +328,7 @@
       "exact": {
         "quantity": 0
       },
-      "direct_transition": "Appendicitis_Symptom6_Ends",
-      "name": "Appendicitis_Symptom5_Ends"
+      "direct_transition": "Appendicitis_Symptom6_Ends"
     },
     "Appendicitis_Symptom6_Ends": {
       "type": "Symptom",
@@ -362,8 +336,7 @@
       "exact": {
         "quantity": 0
       },
-      "direct_transition": "Appendicitis_Symptom7_Ends",
-      "name": "Appendicitis_Symptom6_Ends"
+      "direct_transition": "Appendicitis_Symptom7_Ends"
     },
     "Appendicitis_Symptom7_Ends": {
       "type": "Symptom",
@@ -371,8 +344,7 @@
       "exact": {
         "quantity": 0
       },
-      "direct_transition": "Recovery",
-      "name": "Appendicitis_Symptom7_Ends"
+      "direct_transition": "Recovery"
     },
     "Recovery": {
       "type": "Delay",
@@ -387,8 +359,7 @@
         "Forty-two patients were dismissed on the day of surgery and 77 were admitted for 1 to 5 days postoperatively.",
         "https://www.ncbi.nlm.nih.gov/pubmed/22369831"
       ],
-      "direct_transition": "End_Appendectomy_Encounter",
-      "name": "Recovery"
+      "direct_transition": "End_Appendectomy_Encounter"
     },
     "End_Appendectomy_Encounter": {
       "type": "EncounterEnd",
@@ -397,12 +368,10 @@
         "code": "01",
         "display": "Discharged to home care or self care (routine discharge)"
       },
-      "direct_transition": "Terminal",
-      "name": "End_Appendectomy_Encounter"
+      "direct_transition": "Terminal"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "Transfer_To_Inpatient": {
       "type": "EncounterEnd",

--- a/src/main/resources/modules/asthma.json
+++ b/src/main/resources/modules/asthma.json
@@ -505,7 +505,7 @@
     },
     "Next_Wellness_Encounter": {
       "type": "Encounter",
-      "wellness": "true",
+      "wellness": true,
       "direct_transition": "Maintenance_Medication_End",
       "reason": "asthma_condition"
     },

--- a/src/main/resources/modules/atrial_fibrillation.json
+++ b/src/main/resources/modules/atrial_fibrillation.json
@@ -56,8 +56,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 1981,
-            "value": 0
+            "year": 1981
           }
         },
         {
@@ -65,8 +64,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 1954,
-            "value": 0
+            "year": 1954
           }
         },
         {

--- a/src/main/resources/modules/breast_cancer/chemotherapy_breast.json
+++ b/src/main/resources/modules/breast_cancer/chemotherapy_breast.json
@@ -278,7 +278,7 @@
         {
           "condition": {
             "condition_type": "PriorState",
-            "name": ""
+            "name": "5-fluorouracil"
           },
           "distributions": [
             {

--- a/src/main/resources/modules/breast_cancer/surgery_therapy_breast.json
+++ b/src/main/resources/modules/breast_cancer/surgery_therapy_breast.json
@@ -512,7 +512,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "chemo"
         },
         {
@@ -690,7 +689,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "chemo"
         },
         {

--- a/src/main/resources/modules/breast_cancer/tnm_diagnosis.json
+++ b/src/main/resources/modules/breast_cancer/tnm_diagnosis.json
@@ -38,7 +38,6 @@
             "operator": "==",
             "value": "local"
           },
-          "distributions": [],
           "transition": "No Regional Lymph Node Metastasis"
         },
         {

--- a/src/main/resources/modules/chronic_kidney_disease.json
+++ b/src/main/resources/modules/chronic_kidney_disease.json
@@ -1,6 +1,8 @@
 {
   "name": "Chronic Kidney Disease",
-  "remarks": [],
+  "remarks": [
+
+  ],
   "states": {
     "Initial": {
       "type": "Initial",
@@ -184,7 +186,6 @@
             "operator": "==",
             "value": 5
           },
-          "distributions": [],
           "transition": "Expected_Lifespan_for_ESRD"
         }
       ]

--- a/src/main/resources/modules/congestive_heart_failure.json
+++ b/src/main/resources/modules/congestive_heart_failure.json
@@ -157,11 +157,9 @@
               "unit": "years"
             }
           },
-          "distributions": [],
           "transition": "Potential CHF Flare"
         },
         {
-          "distributions": [],
           "transition": "Followup CHF Encounter"
         }
       ]
@@ -277,7 +275,6 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "ICU Admission"
         },
         {
@@ -369,8 +366,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": "<",
-            "year": 2005,
-            "value": 0
+            "year": 2005
           },
           "distributions": [
             {

--- a/src/main/resources/modules/copd.json
+++ b/src/main/resources/modules/copd.json
@@ -1041,7 +1041,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "Oxygen Systems"
         },
         {

--- a/src/main/resources/modules/covid19.json
+++ b/src/main/resources/modules/covid19.json
@@ -26,17 +26,17 @@
       "lookup_table_transition": [
           {
             "transition": "Wait Until Exposure",
-            "default_probability": "1",
+            "default_probability": 1,
             "lookup_table_name": "covid19_prob.csv"
           },
           {
             "transition": "Check Vaccine Status",
-            "default_probability": "0",
+            "default_probability": 0,
             "lookup_table_name": "covid19_prob.csv"
           },
           {
             "transition": "Terminal",
-            "default_probability": "0",
+            "default_probability": 0,
             "lookup_table_name": "covid19_prob.csv"
           }
       ],

--- a/src/main/resources/modules/covid19.json
+++ b/src/main/resources/modules/covid19.json
@@ -10,12 +10,10 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "Wait Until Exposure",
-      "name": "Initial"
+      "direct_transition": "Wait Until Exposure"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "Wait Until Exposure": {
       "type": "Delay",
@@ -24,33 +22,30 @@
         "unit": "days"
       },
       "lookup_table_transition": [
-          {
-            "transition": "Wait Until Exposure",
-            "default_probability": 1,
-            "lookup_table_name": "covid19_prob.csv"
-          },
-          {
-            "transition": "Check Vaccine Status",
-            "default_probability": 0,
-            "lookup_table_name": "covid19_prob.csv"
-          },
-          {
-            "transition": "Terminal",
-            "default_probability": 0,
-            "lookup_table_name": "covid19_prob.csv"
-          }
-      ],
-      "name": "Wait Until Exposure"
+        {
+          "transition": "Wait Until Exposure",
+          "default_probability": 1,
+          "lookup_table_name": "covid19_prob.csv"
+        },
+        {
+          "transition": "Check Vaccine Status",
+          "default_probability": 0,
+          "lookup_table_name": "covid19_prob.csv"
+        },
+        {
+          "transition": "Terminal",
+          "default_probability": 0,
+          "lookup_table_name": "covid19_prob.csv"
+        }
+      ]
     },
     "Call Infection Submodule": {
       "submodule": "covid19/infection",
       "type": "CallSubmodule",
-      "direct_transition": "Terminal",
-      "name": "Call Infection Submodule"
+      "direct_transition": "Terminal"
     },
     "Check Vaccine Status": {
       "type": "Simple",
-      "name": "Check Vaccine Status",
       "complex_transition": [
         {
           "condition": {

--- a/src/main/resources/modules/covid19/admission.json
+++ b/src/main/resources/modules/covid19/admission.json
@@ -1046,39 +1046,6 @@
         "high": 45,
         "unit": "minutes"
       },
-      "conditional_transition": [
-        {
-          "transition": "Intubation Supplies",
-          "condition": {
-            "condition_type": "Or",
-            "conditions": [
-              {
-                "condition_type": "Active Condition",
-                "codes": [
-                  {
-                    "system": "SNOMED-CT",
-                    "code": 65710008,
-                    "display": "Acute respiratory failure (disorder)"
-                  }
-                ]
-              },
-              {
-                "condition_type": "Active Condition",
-                "codes": [
-                  {
-                    "system": "SNOMED-CT",
-                    "code": 76571007,
-                    "display": "Septic shock (disorder)"
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "transition": "ICU Day Begin"
-        }
-      ],
       "direct_transition": "ICU Day Begin"
     },
     "Check for Bacterial Infection": {

--- a/src/main/resources/modules/covid19/infection.json
+++ b/src/main/resources/modules/covid19/infection.json
@@ -80,7 +80,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Self Isolation At Home"
         }
       ]
@@ -310,11 +309,9 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "Wait for Admission"
         },
         {
-          "distributions": [],
           "transition": "Self Isolation Delay"
         }
       ],

--- a/src/main/resources/modules/covid19/outcomes.json
+++ b/src/main/resources/modules/covid19/outcomes.json
@@ -64,7 +64,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Terminal"
         }
       ],

--- a/src/main/resources/modules/cystic_fibrosis.json
+++ b/src/main/resources/modules/cystic_fibrosis.json
@@ -106,7 +106,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "chronic_cough"
         }
       ]
@@ -1405,7 +1404,7 @@
           "transition": "Tracheostomy",
           "condition": {
             "condition_type": "PriorState",
-            "name": "pulmonary_infective_exacerbation",
+            "name": "pulmonary_exacerbation",
             "within": {
               "quantity": 1,
               "unit": "days"

--- a/src/main/resources/modules/cystic_fibrosis.json
+++ b/src/main/resources/modules/cystic_fibrosis.json
@@ -429,7 +429,7 @@
     "Meconium_Ileus_Resolved": {
       "type": "ConditionEnd",
       "direct_transition": "Sweat_Test",
-      "condition_onset": "Meconium_Ileus"
+      "condition_onset": "Meconium Ileus"
     },
     "CF_CarePlan": {
       "type": "CarePlanStart",

--- a/src/main/resources/modules/encounter/sdoh_hrsn.json
+++ b/src/main/resources/modules/encounter/sdoh_hrsn.json
@@ -6,12 +6,10 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "Assessment",
-      "name": "Initial"
+      "direct_transition": "Assessment"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "Assessment": {
       "type": "Procedure",
@@ -31,8 +29,7 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "Q1",
-      "name": "Assessment"
+      "direct_transition": "Q1"
     },
     "PRAPARE": {
       "type": "MultiObservation",
@@ -300,8 +297,7 @@
           ],
           "attribute": "prapare_a21"
         }
-      ],
-      "name": "PRAPARE"
+      ]
     },
     "Q1": {
       "type": "Simple",
@@ -311,7 +307,6 @@
             "condition_type": "Race",
             "race": "Hispanic"
           },
-          "distributions": [],
           "transition": "A1_Yes"
         },
         {
@@ -326,8 +321,7 @@
             }
           ]
         }
-      ],
-      "name": "Q1"
+      ]
     },
     "A1_Yes": {
       "type": "SetAttribute",
@@ -337,8 +331,7 @@
         "system": "LOINC",
         "code": "LA33-6",
         "display": "Yes"
-      },
-      "name": "A1_Yes"
+      }
     },
     "A1_No": {
       "type": "SetAttribute",
@@ -348,8 +341,7 @@
         "code": "LA32-8",
         "display": "No"
       },
-      "direct_transition": "Q2",
-      "name": "A1_No"
+      "direct_transition": "Q2"
     },
     "A1_NotAnswer": {
       "type": "SetAttribute",
@@ -359,8 +351,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q2",
-      "name": "A1_NotAnswer"
+      "direct_transition": "Q2"
     },
     "Q2": {
       "type": "Simple",
@@ -373,8 +364,7 @@
           "transition": "Q2A",
           "distribution": 0.995
         }
-      ],
-      "name": "Q2"
+      ]
     },
     "Q3": {
       "type": "Simple",
@@ -391,8 +381,7 @@
         {
           "transition": "Q3N"
         }
-      ],
-      "name": "Q3"
+      ]
     },
     "A2_Asian": {
       "type": "SetAttribute",
@@ -402,8 +391,7 @@
         "code": "LA6156-9",
         "display": "Asian"
       },
-      "direct_transition": "Q3",
-      "name": "A2_Asian"
+      "direct_transition": "Q3"
     },
     "A2_Hawaiian": {
       "type": "SetAttribute",
@@ -413,8 +401,7 @@
         "code": "LA14045-1",
         "display": "Native Hawaiian"
       },
-      "direct_transition": "Q3",
-      "name": "A2_Hawaiian"
+      "direct_transition": "Q3"
     },
     "A2_PacificIslander": {
       "type": "SetAttribute",
@@ -424,8 +411,7 @@
         "code": "LA30187-1",
         "display": "Pacific Islander"
       },
-      "direct_transition": "Q3",
-      "name": "A2_PacificIslander"
+      "direct_transition": "Q3"
     },
     "A2_Black": {
       "type": "SetAttribute",
@@ -435,8 +421,7 @@
         "code": "LA14042-8",
         "display": "Black/African American"
       },
-      "direct_transition": "Q3",
-      "name": "A2_Black"
+      "direct_transition": "Q3"
     },
     "A2_White": {
       "type": "SetAttribute",
@@ -446,8 +431,7 @@
         "code": "LA4457-3",
         "display": "White"
       },
-      "direct_transition": "Q3",
-      "name": "A2_White"
+      "direct_transition": "Q3"
     },
     "A2_NativeAmerican": {
       "type": "SetAttribute",
@@ -457,8 +441,7 @@
         "code": "LA4-4",
         "display": "American Indian/Alaskan Native"
       },
-      "direct_transition": "Q3",
-      "name": "A2_NativeAmerican"
+      "direct_transition": "Q3"
     },
     "A2_Other": {
       "type": "SetAttribute",
@@ -468,8 +451,7 @@
         "code": "LA46-8",
         "display": "Other"
       },
-      "direct_transition": "Q3",
-      "name": "A2_Other"
+      "direct_transition": "Q3"
     },
     "A2_NotAnswer": {
       "type": "SetAttribute",
@@ -479,8 +461,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q3",
-      "name": "A2_NotAnswer"
+      "direct_transition": "Q3"
     },
     "Q2A": {
       "type": "Simple",
@@ -541,8 +522,7 @@
         {
           "transition": "A2_Other"
         }
-      ],
-      "name": "Q2A"
+      ]
     },
     "Q4": {
       "type": "Simple",
@@ -558,8 +538,7 @@
         {
           "transition": "Q4N"
         }
-      ],
-      "name": "Q4"
+      ]
     },
     "A3_Yes": {
       "type": "SetAttribute",
@@ -578,8 +557,7 @@
           "transition": "Q4",
           "distribution": 0.9982599999999999
         }
-      ],
-      "name": "A3_Yes"
+      ]
     },
     "A3_No": {
       "type": "SetAttribute",
@@ -589,8 +567,7 @@
         "code": "LA32-8",
         "display": "No"
       },
-      "direct_transition": "End Migrant",
-      "name": "A3_No"
+      "direct_transition": "End Migrant"
     },
     "A3_NotAnswer": {
       "type": "SetAttribute",
@@ -600,8 +577,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q4",
-      "name": "A3_NotAnswer"
+      "direct_transition": "Q4"
     },
     "Q3N": {
       "type": "Simple",
@@ -614,8 +590,7 @@
           "transition": "A3_NotAnswer",
           "distribution": 0.005
         }
-      ],
-      "name": "Q3N"
+      ]
     },
     "Q3Y": {
       "type": "Simple",
@@ -765,8 +740,7 @@
             }
           ]
         }
-      ],
-      "name": "Q3Y"
+      ]
     },
     "Social Migrant": {
       "type": "ConditionOnset",
@@ -778,14 +752,12 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q4",
-      "name": "Social Migrant"
+      "direct_transition": "Q4"
     },
     "End Migrant": {
       "type": "ConditionEnd",
       "direct_transition": "Q4",
-      "condition_onset": "Social Migrant",
-      "name": "End Migrant"
+      "condition_onset": "Social Migrant"
     },
     "Q5": {
       "type": "Simple",
@@ -810,8 +782,7 @@
         {
           "transition": "A5_Other"
         }
-      ],
-      "name": "Q5"
+      ]
     },
     "A4_Yes": {
       "type": "SetAttribute",
@@ -821,8 +792,7 @@
         "code": "LA33-6",
         "display": "Yes"
       },
-      "direct_transition": "Veteran",
-      "name": "A4_Yes"
+      "direct_transition": "Veteran"
     },
     "A4_No": {
       "type": "SetAttribute",
@@ -832,8 +802,7 @@
         "code": "LA32-8",
         "display": "No"
       },
-      "direct_transition": "Q5",
-      "name": "A4_No"
+      "direct_transition": "Q5"
     },
     "A4_NotAnswer": {
       "type": "SetAttribute",
@@ -843,8 +812,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q5",
-      "name": "A4_NotAnswer"
+      "direct_transition": "Q5"
     },
     "Q4N": {
       "type": "Simple",
@@ -857,8 +825,7 @@
           "transition": "A4_No",
           "distribution": 0.995
         }
-      ],
-      "name": "Q4N"
+      ]
     },
     "Veteran": {
       "type": "ConditionOnset",
@@ -870,8 +837,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q5",
-      "name": "Veteran"
+      "direct_transition": "Q5"
     },
     "Q6": {
       "type": "Simple",
@@ -887,8 +853,7 @@
         {
           "transition": "Q7"
         }
-      ],
-      "name": "Q6"
+      ]
     },
     "A5_English": {
       "type": "SetAttribute",
@@ -898,8 +863,7 @@
         "system": "LOINC",
         "code": "LA43-5",
         "display": "English"
-      },
-      "name": "A5_English"
+      }
     },
     "A5_Other": {
       "type": "SetAttribute",
@@ -909,8 +873,7 @@
         "code": "LA30188-9",
         "display": "Language other than English"
       },
-      "direct_transition": "Q6",
-      "name": "A5_Other"
+      "direct_transition": "Q6"
     },
     "A5_NotAnswer": {
       "type": "SetAttribute",
@@ -920,8 +883,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q6",
-      "name": "A5_NotAnswer"
+      "direct_transition": "Q6"
     },
     "Q7": {
       "type": "Simple",
@@ -933,7 +895,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "A7_Homeless"
         },
         {
@@ -948,8 +909,7 @@
             }
           ]
         }
-      ],
-      "name": "Q7"
+      ]
     },
     "Household_Size": {
       "type": "SetAttribute",
@@ -962,8 +922,7 @@
           "high": 8,
           "low": 1
         }
-      },
-      "name": "Household_Size"
+      }
     },
     "Q8": {
       "type": "Simple",
@@ -975,7 +934,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "A8_Yes"
         },
         {
@@ -990,8 +948,7 @@
             }
           ]
         }
-      ],
-      "name": "Q8"
+      ]
     },
     "A7_Homeless": {
       "type": "SetAttribute",
@@ -1001,8 +958,7 @@
         "system": "LOINC",
         "code": "LA30190-5",
         "display": "I do not have housing (staying with others, in a hotel, in a shelter, living outside on the street, on a beach, in a car, or in a park)"
-      },
-      "name": "A7_Homeless"
+      }
     },
     "A7_NotHomeless": {
       "type": "SetAttribute",
@@ -1012,8 +968,7 @@
         "code": "LA30189-7",
         "display": "I have housing"
       },
-      "direct_transition": "Not Homeless",
-      "name": "A7_NotHomeless"
+      "direct_transition": "Not Homeless"
     },
     "A7_NotAnswer": {
       "type": "SetAttribute",
@@ -1023,8 +978,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q8",
-      "name": "A7_NotAnswer"
+      "direct_transition": "Q8"
     },
     "Homeless": {
       "type": "ConditionOnset",
@@ -1036,8 +990,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q8",
-      "name": "Homeless"
+      "direct_transition": "Q8"
     },
     "Not Homeless": {
       "type": "ConditionEnd",
@@ -1049,8 +1002,7 @@
           "display": "Homeless (finding)",
           "value_set": ""
         }
-      ],
-      "name": "Not Homeless"
+      ]
     },
     "A8_Yes": {
       "type": "SetAttribute",
@@ -1060,8 +1012,7 @@
         "code": "LA33-6",
         "display": "Yes"
       },
-      "direct_transition": "Housing Issue",
-      "name": "A8_Yes"
+      "direct_transition": "Housing Issue"
     },
     "A8_No": {
       "type": "SetAttribute",
@@ -1071,8 +1022,7 @@
         "code": "LA32-8",
         "display": "No"
       },
-      "direct_transition": "End Housing Issue",
-      "name": "A8_No"
+      "direct_transition": "End Housing Issue"
     },
     "A8_NotAnswer": {
       "type": "SetAttribute",
@@ -1082,8 +1032,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q10",
-      "name": "A8_NotAnswer"
+      "direct_transition": "Q10"
     },
     "Housing Issue": {
       "type": "ConditionOnset",
@@ -1095,14 +1044,12 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q10",
-      "name": "Housing Issue"
+      "direct_transition": "Q10"
     },
     "End Housing Issue": {
       "type": "ConditionEnd",
       "direct_transition": "Q10",
-      "condition_onset": "Housing Issue",
-      "name": "End Housing Issue"
+      "condition_onset": "Housing Issue"
     },
     "Q10": {
       "type": "Simple",
@@ -1115,8 +1062,7 @@
           "transition": "A10_NotAnswer",
           "distribution": 0.005
         }
-      ],
-      "name": "Q10"
+      ]
     },
     "Q11": {
       "type": "Simple",
@@ -1133,8 +1079,7 @@
         {
           "transition": "Q11B"
         }
-      ],
-      "name": "Q11"
+      ]
     },
     "A10_NotAnswer": {
       "type": "SetAttribute",
@@ -1144,8 +1089,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q11",
-      "name": "A10_NotAnswer"
+      "direct_transition": "Q11"
     },
     "A10C": {
       "type": "SetAttribute",
@@ -1155,8 +1099,7 @@
         "code": "LA30193-9",
         "display": "More than high school"
       },
-      "direct_transition": "Education_Onset_2",
-      "name": "A10C"
+      "direct_transition": "Education_Onset_2"
     },
     "A10B": {
       "type": "SetAttribute",
@@ -1166,8 +1109,7 @@
         "code": "LA30192-1",
         "display": "High school diploma or GED"
       },
-      "direct_transition": "Education_Onset",
-      "name": "A10B"
+      "direct_transition": "Education_Onset"
     },
     "A10A": {
       "type": "SetAttribute",
@@ -1177,8 +1119,7 @@
         "system": "LOINC",
         "code": "LA30191-3",
         "display": "Less than high school degree"
-      },
-      "name": "A10A"
+      }
     },
     "Q10A": {
       "type": "Simple",
@@ -1204,8 +1145,7 @@
         {
           "transition": "A10C"
         }
-      ],
-      "name": "Q10A"
+      ]
     },
     "Education Onset": {
       "type": "ConditionOnset",
@@ -1218,8 +1158,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q11",
-      "name": "Education Onset"
+      "direct_transition": "Q11"
     },
     "Education_Onset": {
       "type": "ConditionOnset",
@@ -1232,8 +1171,7 @@
           "version": "http://snomed.info/sct/731000124108"
         }
       ],
-      "direct_transition": "Q11",
-      "name": "Education_Onset"
+      "direct_transition": "Q11"
     },
     "Education_Onset_2": {
       "type": "ConditionOnset",
@@ -1246,8 +1184,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q11",
-      "name": "Education_Onset_2"
+      "direct_transition": "Q11"
     },
     "Q12": {
       "type": "Simple",
@@ -1299,8 +1236,7 @@
         {
           "transition": "A12_NotAnswer"
         }
-      ],
-      "name": "Q12"
+      ]
     },
     "A11A": {
       "type": "SetAttribute",
@@ -1310,8 +1246,7 @@
         "code": "LA17956-6",
         "display": "Unemployed"
       },
-      "direct_transition": "Unemployed",
-      "name": "A11A"
+      "direct_transition": "Unemployed"
     },
     "Q11B": {
       "type": "Simple",
@@ -1324,8 +1259,7 @@
           "transition": "A11_NotAnswer",
           "distribution": 0.005
         }
-      ],
-      "name": "Q11B"
+      ]
     },
     "Unemployed": {
       "type": "ConditionOnset",
@@ -1338,8 +1272,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q12",
-      "name": "Unemployed"
+      "direct_transition": "Q12"
     },
     "A11_NotAnswer": {
       "type": "SetAttribute",
@@ -1349,8 +1282,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q12",
-      "name": "A11_NotAnswer"
+      "direct_transition": "Q12"
     },
     "A11B": {
       "type": "SetAttribute",
@@ -1360,8 +1292,7 @@
         "code": "LA30136-8",
         "display": "Full-time work"
       },
-      "direct_transition": "Employed Full Time",
-      "name": "A11B"
+      "direct_transition": "Employed Full Time"
     },
     "A11C": {
       "type": "SetAttribute",
@@ -1371,8 +1302,7 @@
         "code": "LA30138-4",
         "display": "Part-time or temporary work"
       },
-      "direct_transition": "Employed Part Time",
-      "name": "A11C"
+      "direct_transition": "Employed Part Time"
     },
     "A11D": {
       "type": "SetAttribute",
@@ -1382,8 +1312,7 @@
         "code": "LA30137-6",
         "display": "Otherwise unemployed but not seeking work (ex: student, retired, disabled, unpaid primary care giver)"
       },
-      "direct_transition": "Employed Not",
-      "name": "A11D"
+      "direct_transition": "Employed Not"
     },
     "Employed Full Time": {
       "type": "ConditionOnset",
@@ -1396,8 +1325,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q12",
-      "name": "Employed Full Time"
+      "direct_transition": "Q12"
     },
     "Employed Part Time": {
       "type": "ConditionOnset",
@@ -1410,8 +1338,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q12",
-      "name": "Employed Part Time"
+      "direct_transition": "Q12"
     },
     "Employed Not": {
       "type": "ConditionOnset",
@@ -1424,8 +1351,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q12",
-      "name": "Employed Not"
+      "direct_transition": "Q12"
     },
     "A12_NotAnswer": {
       "type": "SetAttribute",
@@ -1435,8 +1361,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q14",
-      "name": "A12_NotAnswer"
+      "direct_transition": "Q14"
     },
     "A12_None": {
       "type": "SetAttribute",
@@ -1446,8 +1371,7 @@
         "code": "LA30194-7",
         "display": "None/uninsured"
       },
-      "direct_transition": "Q14",
-      "name": "A12_None"
+      "direct_transition": "Q14"
     },
     "A12_Medicaid": {
       "type": "SetAttribute",
@@ -1457,8 +1381,7 @@
         "code": "LA17849-3",
         "display": "Medicaid"
       },
-      "direct_transition": "Q14",
-      "name": "A12_Medicaid"
+      "direct_transition": "Q14"
     },
     "A12_Medicare": {
       "type": "SetAttribute",
@@ -1468,8 +1391,7 @@
         "code": "LA15652-3",
         "display": "Medicare"
       },
-      "direct_transition": "Q14",
-      "name": "A12_Medicare"
+      "direct_transition": "Q14"
     },
     "A12_Private": {
       "type": "SetAttribute",
@@ -1479,8 +1401,7 @@
         "code": "LA6350-8",
         "display": "Private insurance"
       },
-      "direct_transition": "Q14",
-      "name": "A12_Private"
+      "direct_transition": "Q14"
     },
     "Q14": {
       "type": "Simple",
@@ -1506,8 +1427,7 @@
         {
           "transition": "Q14A"
         }
-      ],
-      "name": "Q14"
+      ]
     },
     "Q15": {
       "type": "Simple",
@@ -1529,7 +1449,6 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "A15_No"
         },
         {
@@ -1544,8 +1463,7 @@
             }
           ]
         }
-      ],
-      "name": "Q15"
+      ]
     },
     "A14_NotAnswer": {
       "type": "SetAttribute",
@@ -1555,8 +1473,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q15",
-      "name": "A14_NotAnswer"
+      "direct_transition": "Q15"
     },
     "Q14A": {
       "type": "Simple",
@@ -1569,8 +1486,7 @@
           "transition": "Q14B",
           "distribution": 0.99
         }
-      ],
-      "name": "Q14A"
+      ]
     },
     "Q14B": {
       "type": "Simple",
@@ -1587,8 +1503,7 @@
         {
           "transition": "Q14C"
         }
-      ],
-      "name": "Q14B"
+      ]
     },
     "A14_Food": {
       "type": "SetAttribute",
@@ -1598,8 +1513,7 @@
         "code": "LA30125-1",
         "display": "Food"
       },
-      "direct_transition": "Q15",
-      "name": "A14_Food"
+      "direct_transition": "Q15"
     },
     "A14_Clothing": {
       "type": "SetAttribute",
@@ -1609,8 +1523,7 @@
         "code": "LA30126-9",
         "display": "Clothing"
       },
-      "direct_transition": "Q15",
-      "name": "A14_Clothing"
+      "direct_transition": "Q15"
     },
     "A14_Utilities": {
       "type": "SetAttribute",
@@ -1620,8 +1533,7 @@
         "code": "LA30124-4",
         "display": "Utilities"
       },
-      "direct_transition": "Q15",
-      "name": "A14_Utilities"
+      "direct_transition": "Q15"
     },
     "A14_Childcare": {
       "type": "SetAttribute",
@@ -1631,8 +1543,7 @@
         "code": "LA30127-7",
         "display": "Child care"
       },
-      "direct_transition": "Q15",
-      "name": "A14_Childcare"
+      "direct_transition": "Q15"
     },
     "A14_Medicine": {
       "type": "SetAttribute",
@@ -1642,8 +1553,7 @@
         "code": "LA30128-5",
         "display": "Medicine or Any Health Care (Medical, Dental, Mental Health, Vision)"
       },
-      "direct_transition": "Q15",
-      "name": "A14_Medicine"
+      "direct_transition": "Q15"
     },
     "A14_Phone": {
       "type": "SetAttribute",
@@ -1653,8 +1563,7 @@
         "code": "LA30129-3",
         "display": "Phone"
       },
-      "direct_transition": "Q15",
-      "name": "A14_Phone"
+      "direct_transition": "Q15"
     },
     "A14_Other": {
       "type": "SetAttribute",
@@ -1664,8 +1573,7 @@
         "code": "LA46-8",
         "display": "Other"
       },
-      "direct_transition": "Q15",
-      "name": "A14_Other"
+      "direct_transition": "Q15"
     },
     "Q14C": {
       "type": "Simple",
@@ -1709,8 +1617,7 @@
         {
           "transition": "Q14_FiveOrHigher"
         }
-      ],
-      "name": "Q14C"
+      ]
     },
     "Q14_Half": {
       "type": "Simple",
@@ -1723,13 +1630,11 @@
           "transition": "Q14_Half_Food?",
           "distribution": 0.7729999999999999
         }
-      ],
-      "name": "Q14_Half"
+      ]
     },
     "Q14_LessThanOne": {
       "type": "Simple",
-      "direct_transition": "Q14_LessThanOne_Meds?",
-      "name": "Q14_LessThanOne"
+      "direct_transition": "Q14_LessThanOne_Meds?"
     },
     "Q14_LessThanTwo": {
       "type": "Simple",
@@ -1742,8 +1647,7 @@
           "transition": "Q14_LessThanTwo_Food?",
           "distribution": 0.804
         }
-      ],
-      "name": "Q14_LessThanTwo"
+      ]
     },
     "Q14_LessThanFive": {
       "type": "Simple",
@@ -1756,8 +1660,7 @@
           "transition": "Q14_LessThanFive_Food?",
           "distribution": 0.89
         }
-      ],
-      "name": "Q14_LessThanFive"
+      ]
     },
     "Q14_FiveOrHigher": {
       "type": "Simple",
@@ -1770,8 +1673,7 @@
           "transition": "Q14_FiveOrHigher_Food?",
           "distribution": 0.957
         }
-      ],
-      "name": "Q14_FiveOrHigher"
+      ]
     },
     "Q14_Durables": {
       "type": "Simple",
@@ -1792,8 +1694,7 @@
           "transition": "A14_Clothing",
           "distribution": 0.25
         }
-      ],
-      "name": "Q14_Durables"
+      ]
     },
     "Q14_LessThanOne_Meds?": {
       "type": "Simple",
@@ -1806,8 +1707,7 @@
           "transition": "Q14_LessThanOne_Food?",
           "distribution": 0.773
         }
-      ],
-      "name": "Q14_LessThanOne_Meds?"
+      ]
     },
     "Q14_LessThanOne_Food?": {
       "type": "Simple",
@@ -1820,8 +1720,7 @@
           "transition": "Q14_LessThanOne_Utils?",
           "distribution": 0.729
         }
-      ],
-      "name": "Q14_LessThanOne_Food?"
+      ]
     },
     "Q14_LessThanOne_Utils?": {
       "type": "Simple",
@@ -1834,8 +1733,7 @@
           "transition": "Q14_LessThanOne_Durables?",
           "distribution": 0.675
         }
-      ],
-      "name": "Q14_LessThanOne_Utils?"
+      ]
     },
     "Q14_LessThanOne_Durables?": {
       "type": "Simple",
@@ -1848,8 +1746,7 @@
           "transition": "A14_NotAnswer",
           "distribution": 0.675
         }
-      ],
-      "name": "Q14_LessThanOne_Durables?"
+      ]
     },
     "Q14_LessThanTwo_Food?": {
       "type": "Simple",
@@ -1862,8 +1759,7 @@
           "transition": "Q14_LessThanTwo_Utils?",
           "distribution": 0.815
         }
-      ],
-      "name": "Q14_LessThanTwo_Food?"
+      ]
     },
     "Q14_LessThanTwo_Utils?": {
       "type": "Simple",
@@ -1876,8 +1772,7 @@
           "transition": "Q14_LessThanTwo_Durables?",
           "distribution": 0.777
         }
-      ],
-      "name": "Q14_LessThanTwo_Utils?"
+      ]
     },
     "Q14_LessThanTwo_Durables?": {
       "type": "Simple",
@@ -1890,8 +1785,7 @@
           "transition": "A14_NotAnswer",
           "distribution": 0.784
         }
-      ],
-      "name": "Q14_LessThanTwo_Durables?"
+      ]
     },
     "Q14_Half_Food?": {
       "type": "Simple",
@@ -1904,8 +1798,7 @@
           "transition": "Q14_Half_Utils?",
           "distribution": 0.734
         }
-      ],
-      "name": "Q14_Half_Food?"
+      ]
     },
     "Q14_Half_Utils?": {
       "type": "Simple",
@@ -1918,8 +1811,7 @@
           "transition": "Q14_Half_Durables?",
           "distribution": 0.672
         }
-      ],
-      "name": "Q14_Half_Utils?"
+      ]
     },
     "Q14_Half_Durables?": {
       "type": "Simple",
@@ -1932,8 +1824,7 @@
           "transition": "A14_NotAnswer",
           "distribution": 0.689
         }
-      ],
-      "name": "Q14_Half_Durables?"
+      ]
     },
     "Q14_LessThanFive_Food?": {
       "type": "Simple",
@@ -1946,8 +1837,7 @@
           "transition": "Q14_LessThanFive_Utils?",
           "distribution": 0.916
         }
-      ],
-      "name": "Q14_LessThanFive_Food?"
+      ]
     },
     "Q14_LessThanFive_Utils?": {
       "type": "Simple",
@@ -1960,8 +1850,7 @@
           "transition": "Q14_LessThanFive_Durables?",
           "distribution": 0.876
         }
-      ],
-      "name": "Q14_LessThanFive_Utils?"
+      ]
     },
     "Q14_LessThanFive_Durables?": {
       "type": "Simple",
@@ -1974,8 +1863,7 @@
           "transition": "A14_NotAnswer",
           "distribution": 0.912
         }
-      ],
-      "name": "Q14_LessThanFive_Durables?"
+      ]
     },
     "Q14_FiveOrHigher_Food?": {
       "type": "Simple",
@@ -1988,8 +1876,7 @@
           "transition": "Q14_FiveOrHigher_Utils?",
           "distribution": 0.973
         }
-      ],
-      "name": "Q14_FiveOrHigher_Food?"
+      ]
     },
     "Q14_FiveOrHigher_Utils?": {
       "type": "Simple",
@@ -2002,8 +1889,7 @@
           "transition": "Q14_FiveOrHigher_Durables?",
           "distribution": 0.96
         }
-      ],
-      "name": "Q14_FiveOrHigher_Utils?"
+      ]
     },
     "Q14_FiveOrHigher_Durables?": {
       "type": "Simple",
@@ -2016,8 +1902,7 @@
           "transition": "A14_NotAnswer",
           "distribution": 0.963
         }
-      ],
-      "name": "Q14_FiveOrHigher_Durables?"
+      ]
     },
     "Q16": {
       "type": "Simple",
@@ -2034,8 +1919,7 @@
         {
           "transition": "Q16O"
         }
-      ],
-      "name": "Q16"
+      ]
     },
     "A15_YesA": {
       "type": "SetAttribute",
@@ -2045,8 +1929,7 @@
         "code": "LA30133-5",
         "display": "Yes, it has kept me from medical appointments or from getting my medications"
       },
-      "direct_transition": "No Transport Access",
-      "name": "A15_YesA"
+      "direct_transition": "No Transport Access"
     },
     "A15_YesB": {
       "type": "SetAttribute",
@@ -2056,8 +1939,7 @@
         "code": "LA30134-3",
         "display": "Yes, it has kept me from non-medical meetings, appointments, work, or from getting things that I need"
       },
-      "direct_transition": "Transport Problem",
-      "name": "A15_YesB"
+      "direct_transition": "Transport Problem"
     },
     "A15_No": {
       "type": "SetAttribute",
@@ -2067,8 +1949,7 @@
         "code": "LA32-8",
         "display": "No"
       },
-      "direct_transition": "Q16",
-      "name": "A15_No"
+      "direct_transition": "Q16"
     },
     "Transport Problem": {
       "type": "ConditionOnset",
@@ -2080,8 +1961,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q16",
-      "name": "Transport Problem"
+      "direct_transition": "Q16"
     },
     "No Transport Access": {
       "type": "ConditionOnset",
@@ -2093,8 +1973,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q16",
-      "name": "No Transport Access"
+      "direct_transition": "Q16"
     },
     "Q17": {
       "type": "Simple",
@@ -2123,8 +2002,7 @@
           "transition": "A17_NotAnswer",
           "distribution": 0.008
         }
-      ],
-      "name": "Q17"
+      ]
     },
     "Q16M": {
       "type": "Simple",
@@ -2149,8 +2027,7 @@
           "transition": "A16_NotAnswer",
           "distribution": 0.005
         }
-      ],
-      "name": "Q16M"
+      ]
     },
     "Q16O": {
       "type": "Simple",
@@ -2175,8 +2052,7 @@
           "transition": "A16_NotAnswer",
           "distribution": 0.005
         }
-      ],
-      "name": "Q16O"
+      ]
     },
     "A16_LessThanOne": {
       "type": "SetAttribute",
@@ -2186,8 +2062,7 @@
         "code": "LA27722-0",
         "display": "Less than once a week"
       },
-      "direct_transition": "Isolation",
-      "name": "A16_LessThanOne"
+      "direct_transition": "Isolation"
     },
     "A16_OneOrTwo": {
       "type": "SetAttribute",
@@ -2197,8 +2072,7 @@
         "code": "LA30130-1",
         "display": "1 or 2 times a week"
       },
-      "direct_transition": "Limited Contact",
-      "name": "A16_OneOrTwo"
+      "direct_transition": "Limited Contact"
     },
     "A16_ThreeToFive": {
       "type": "SetAttribute",
@@ -2208,7 +2082,6 @@
         "code": "LA30131-9",
         "display": "3 to 5 times a week"
       },
-      "name": "A16_ThreeToFive",
       "conditional_transition": [
         {
           "transition": "End Isolation",
@@ -2251,7 +2124,6 @@
         "code": "LA30132-7",
         "display": "5 or more times a week"
       },
-      "name": "A16_FiveOrMore",
       "conditional_transition": [
         {
           "transition": "End Isolation",
@@ -2294,8 +2166,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q17",
-      "name": "A16_NotAnswer"
+      "direct_transition": "Q17"
     },
     "Isolation": {
       "type": "ConditionOnset",
@@ -2308,8 +2179,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q17",
-      "name": "Isolation"
+      "direct_transition": "Q17"
     },
     "Limited Contact": {
       "type": "ConditionOnset",
@@ -2322,14 +2192,12 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q17",
-      "name": "Limited Contact"
+      "direct_transition": "Q17"
     },
     "End Isolation": {
       "type": "ConditionEnd",
       "direct_transition": "Q17",
-      "referenced_by_attribute": "social_isolation",
-      "name": "End Isolation"
+      "referenced_by_attribute": "social_isolation"
     },
     "Q18": {
       "type": "Simple",
@@ -2340,7 +2208,6 @@
             "attribute": "criminal_record",
             "operator": "is not nil"
           },
-          "distributions": [],
           "transition": "A18_Yes"
         },
         {
@@ -2359,8 +2226,7 @@
             }
           ]
         }
-      ],
-      "name": "Q18"
+      ]
     },
     "A17_NotAnswer": {
       "type": "SetAttribute",
@@ -2370,8 +2236,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q18",
-      "name": "A17_NotAnswer"
+      "direct_transition": "Q18"
     },
     "A17_NotAtAll": {
       "type": "SetAttribute",
@@ -2381,8 +2246,7 @@
         "code": "LA6568-5",
         "display": "Not at all"
       },
-      "direct_transition": "End Stress",
-      "name": "A17_NotAtAll"
+      "direct_transition": "End Stress"
     },
     "A17_LittleBit": {
       "type": "SetAttribute",
@@ -2392,8 +2256,7 @@
         "code": "LA13863-8",
         "display": "A little bit"
       },
-      "direct_transition": "Stress",
-      "name": "A17_LittleBit"
+      "direct_transition": "Stress"
     },
     "A17_Somewhat": {
       "type": "SetAttribute",
@@ -2403,8 +2266,7 @@
         "code": "LA13909-9",
         "display": "Somewhat"
       },
-      "direct_transition": "Stress",
-      "name": "A17_Somewhat"
+      "direct_transition": "Stress"
     },
     "A17_QuiteBit": {
       "type": "SetAttribute",
@@ -2414,8 +2276,7 @@
         "code": "LA13902-4",
         "display": "Quite a bit"
       },
-      "direct_transition": "Stress",
-      "name": "A17_QuiteBit"
+      "direct_transition": "Stress"
     },
     "A17_VeryMuch": {
       "type": "SetAttribute",
@@ -2425,8 +2286,7 @@
         "code": "LA13914-9",
         "display": "Very much"
       },
-      "direct_transition": "Stress",
-      "name": "A17_VeryMuch"
+      "direct_transition": "Stress"
     },
     "Stress": {
       "type": "ConditionOnset",
@@ -2438,14 +2298,12 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q18",
-      "name": "Stress"
+      "direct_transition": "Q18"
     },
     "End Stress": {
       "type": "ConditionEnd",
       "direct_transition": "Q18",
-      "condition_onset": "Stress",
-      "name": "End Stress"
+      "condition_onset": "Stress"
     },
     "Q19": {
       "type": "Simple",
@@ -2456,7 +2314,6 @@
             "attribute": "refugee",
             "operator": "is not nil"
           },
-          "distributions": [],
           "transition": "A19_Yes"
         },
         {
@@ -2497,8 +2354,7 @@
             }
           ]
         }
-      ],
-      "name": "Q19"
+      ]
     },
     "A18_NotAnswer": {
       "type": "SetAttribute",
@@ -2508,8 +2364,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q19",
-      "name": "A18_NotAnswer"
+      "direct_transition": "Q19"
     },
     "A18_No": {
       "type": "SetAttribute",
@@ -2519,8 +2374,7 @@
         "code": "LA32-8",
         "display": "No"
       },
-      "direct_transition": "Q19",
-      "name": "A18_No"
+      "direct_transition": "Q19"
     },
     "A18_Yes": {
       "type": "SetAttribute",
@@ -2530,8 +2384,7 @@
         "code": "LA33-6",
         "display": "Yes"
       },
-      "direct_transition": "Smooth Criminal",
-      "name": "A18_Yes"
+      "direct_transition": "Smooth Criminal"
     },
     "Smooth Criminal": {
       "type": "ConditionOnset",
@@ -2544,8 +2397,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q19",
-      "name": "Smooth Criminal"
+      "direct_transition": "Q19"
     },
     "Q20": {
       "type": "Simple",
@@ -2566,8 +2418,7 @@
           "transition": "A20_Yes",
           "distribution": 0.9365
         }
-      ],
-      "name": "Q20"
+      ]
     },
     "A19_NotAnswer": {
       "type": "SetAttribute",
@@ -2577,8 +2428,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q20",
-      "name": "A19_NotAnswer"
+      "direct_transition": "Q20"
     },
     "A19_No": {
       "type": "SetAttribute",
@@ -2588,8 +2438,7 @@
         "code": "LA32-8",
         "display": "No"
       },
-      "direct_transition": "Q20",
-      "name": "A19_No"
+      "direct_transition": "Q20"
     },
     "A19_Yes": {
       "type": "SetAttribute",
@@ -2599,8 +2448,7 @@
         "code": "LA33-6",
         "display": "Yes"
       },
-      "direct_transition": "Refugee",
-      "name": "A19_Yes"
+      "direct_transition": "Refugee"
     },
     "Refugee": {
       "type": "ConditionOnset",
@@ -2613,8 +2461,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q20",
-      "name": "Refugee"
+      "direct_transition": "Q20"
     },
     "Q21": {
       "type": "Simple",
@@ -2647,8 +2494,7 @@
             }
           ]
         }
-      ],
-      "name": "Q21"
+      ]
     },
     "A20_NotAnswer": {
       "type": "SetAttribute",
@@ -2658,8 +2504,7 @@
         "code": "LA30122-8",
         "display": "I choose not to answer this question"
       },
-      "direct_transition": "Q21",
-      "name": "A20_NotAnswer"
+      "direct_transition": "Q21"
     },
     "A20_No": {
       "type": "SetAttribute",
@@ -2669,8 +2514,7 @@
         "code": "LA32-8",
         "display": "No"
       },
-      "direct_transition": "Violence",
-      "name": "A20_No"
+      "direct_transition": "Violence"
     },
     "A20_Yes": {
       "type": "SetAttribute",
@@ -2680,8 +2524,7 @@
         "code": "LA33-6",
         "display": "Yes"
       },
-      "direct_transition": "End Violence",
-      "name": "A20_Yes"
+      "direct_transition": "End Violence"
     },
     "A20_Unsure": {
       "type": "SetAttribute",
@@ -2691,8 +2534,7 @@
         "code": "LA14072-5",
         "display": "Unsure"
       },
-      "direct_transition": "Q21",
-      "name": "A20_Unsure"
+      "direct_transition": "Q21"
     },
     "Violence": {
       "type": "ConditionOnset",
@@ -2704,19 +2546,16 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Q21",
-      "name": "Violence"
+      "direct_transition": "Q21"
     },
     "End Violence": {
       "type": "ConditionEnd",
       "direct_transition": "Q21",
-      "condition_onset": "Violence",
-      "name": "End Violence"
+      "condition_onset": "Violence"
     },
     "End Q": {
       "type": "Simple",
-      "direct_transition": "PRAPARE",
-      "name": "End Q"
+      "direct_transition": "PRAPARE"
     },
     "A21_Yes": {
       "type": "SetAttribute",
@@ -2726,8 +2565,7 @@
         "code": "LA33-6",
         "display": "Yes"
       },
-      "direct_transition": "Partner Violence",
-      "name": "A21_Yes"
+      "direct_transition": "Partner Violence"
     },
     "A21_No": {
       "type": "SetAttribute",
@@ -2737,8 +2575,7 @@
         "code": "LA32-8",
         "display": "No"
       },
-      "direct_transition": "End Partner Violence",
-      "name": "A21_No"
+      "direct_transition": "End Partner Violence"
     },
     "Partner Violence": {
       "type": "ConditionOnset",
@@ -2750,18 +2587,15 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "End Q",
-      "name": "Partner Violence"
+      "direct_transition": "End Q"
     },
     "End Partner Violence": {
       "type": "ConditionEnd",
       "direct_transition": "End Q",
-      "condition_onset": "Partner Violence",
-      "name": "End Partner Violence"
+      "condition_onset": "Partner Violence"
     },
     "Check Temp Work Change": {
       "type": "Simple",
-      "name": "Check Temp Work Change",
       "conditional_transition": [
         {
           "transition": "Q12",
@@ -2792,12 +2626,10 @@
     "Start Change To Temp Employment": {
       "type": "ConditionEnd",
       "direct_transition": "A11C",
-      "name": "Start Change To Temp Employment",
       "referenced_by_attribute": "employment_condition"
     },
     "Some Employment": {
       "type": "Simple",
-      "name": "Some Employment",
       "distributed_transition": [
         {
           "transition": "Check Temp Work Change",
@@ -2815,7 +2647,6 @@
     },
     "Check Full Time Work Change": {
       "type": "Simple",
-      "name": "Check Full Time Work Change",
       "conditional_transition": [
         {
           "transition": "Q12",
@@ -2845,13 +2676,11 @@
     },
     "Start Change to Full Time": {
       "type": "ConditionEnd",
-      "name": "Start Change to Full Time",
       "referenced_by_attribute": "employment_condition",
       "direct_transition": "A11B"
     },
     "Check Otherwise Work Change": {
       "type": "Simple",
-      "name": "Check Otherwise Work Change",
       "conditional_transition": [
         {
           "transition": "Q12",
@@ -2882,12 +2711,10 @@
     "Start Change to Not in Labor Force": {
       "type": "ConditionEnd",
       "direct_transition": "A11D",
-      "name": "Start Change to Not in Labor Force",
       "referenced_by_attribute": "employment_condition"
     },
     "Check Unemployment Change": {
       "type": "Simple",
-      "name": "Check Unemployment Change",
       "conditional_transition": [
         {
           "transition": "Q12",
@@ -2918,7 +2745,6 @@
     "Start Change to Unemployed": {
       "type": "ConditionEnd",
       "direct_transition": "A11A",
-      "name": "Start Change to Unemployed",
       "referenced_by_attribute": "employment_condition"
     }
   },

--- a/src/main/resources/modules/epilepsy.json
+++ b/src/main/resources/modules/epilepsy.json
@@ -158,14 +158,10 @@
         }
       ],
       "direct_transition": "Seizure_Encounter",
-      "remarks": [
-        ""
-      ],
       "assign_to_attribute": "seizure"
     },
     "Seizure_Encounter": {
       "type": "Encounter",
-      "wellness": false,
       "encounter_class": "emergency",
       "reason": "seizure",
       "remarks": [
@@ -410,18 +406,10 @@
     },
     "Medicine_Encounter": {
       "type": "Encounter",
-      "encounter_class": "outpatient",
       "wellness": true,
       "reason": "seizure",
       "remarks": [
         "Patients start with medication prescription or follow-up."
-      ],
-      "codes": [
-        {
-          "system": "SNOMED-CT",
-          "code": "390906007",
-          "display": "Follow-Up Encounter"
-        }
       ],
       "distributed_transition": [
         {

--- a/src/main/resources/modules/heart/acs_arrival_medications.json
+++ b/src/main/resources/modules/heart/acs_arrival_medications.json
@@ -70,11 +70,10 @@
     },
     "Aspirin_Rates": {
       "type": "Simple",
-      "remarks": ["TODO: fix to Active Allergy after merging"],
       "complex_transition": [
         {
           "condition": {
-            "condition_type": "Active Condition",
+            "condition_type": "Active Allergy",
             "codes": [
               {
                 "system": "RxNorm",

--- a/src/main/resources/modules/heart/avrr/antithrombotic.json
+++ b/src/main/resources/modules/heart/avrr/antithrombotic.json
@@ -96,7 +96,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Terminal"
         }
       ]

--- a/src/main/resources/modules/heart/avrr/sequence.json
+++ b/src/main/resources/modules/heart/avrr/sequence.json
@@ -125,7 +125,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "AVReplace"
         }
       ]
@@ -236,7 +235,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Set TAVR"
         }
       ]

--- a/src/main/resources/modules/heart/cabg/cabg_referral.json
+++ b/src/main/resources/modules/heart/cabg/cabg_referral.json
@@ -101,7 +101,6 @@
             "operator": ">",
             "value": 0
           },
-          "distributions": [],
           "transition": "End_Referral_Consultation"
         },
         {
@@ -417,7 +416,6 @@
             "operator": ">",
             "value": 0
           },
-          "distributions": [],
           "transition": "Referral to Surgery"
         },
         {

--- a/src/main/resources/modules/heart/cabg/postop.json
+++ b/src/main/resources/modules/heart/cabg/postop.json
@@ -176,18 +176,6 @@
           "display": "Admission to ward (procedure)"
         }
       ],
-      "conditional_transition": [
-        {
-          "transition": "cabg_icu_los set in outcomes",
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "cabg_prolonged_los",
-            "operator": "==",
-            "value": true
-          }
-        },
-        {}
-      ],
       "direct_transition": "Education",
       "reason": "cabg_history"
     },

--- a/src/main/resources/modules/heart/cabg/postop_blood.json
+++ b/src/main/resources/modules/heart/cabg/postop_blood.json
@@ -15,7 +15,6 @@
             "attribute": "anemia",
             "operator": "is not nil"
           },
-          "distributions": [],
           "transition": "RBC"
         },
         {

--- a/src/main/resources/modules/heart/chf_meds_hfref_nyha2.json
+++ b/src/main/resources/modules/heart/chf_meds_hfref_nyha2.json
@@ -424,7 +424,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Terminal"
         }
       ]

--- a/src/main/resources/modules/heart/stemi_pathway.json
+++ b/src/main/resources/modules/heart/stemi_pathway.json
@@ -86,20 +86,6 @@
     "CABG_Operation": {
       "type": "CallSubmodule",
       "submodule": "heart/cabg_sequence",
-      "conditional_transition": [
-        {
-          "transition": "Deceased",
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "cabg_mortality",
-            "operator": "==",
-            "value": true
-          }
-        },
-        {
-          "transition": "Postop ICU and Ward"
-        }
-      ],
       "direct_transition": "Set_ACS_CABG_Referral"
     },
     "Cardiology Consultation": {

--- a/src/main/resources/modules/hiv/art_sequence.json
+++ b/src/main/resources/modules/hiv/art_sequence.json
@@ -59,8 +59,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 2015,
-            "value": 0
+            "year": 2015
           }
         },
         {
@@ -68,8 +67,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 2006,
-            "value": 0
+            "year": 2006
           }
         },
         {
@@ -77,8 +75,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 2003,
-            "value": 0
+            "year": 2003
           }
         },
         {
@@ -86,8 +83,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 1997,
-            "value": 0
+            "year": 1997
           }
         },
         {
@@ -95,8 +91,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 1995,
-            "value": 0
+            "year": 1995
           }
         },
         {
@@ -104,8 +99,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 1987,
-            "value": 0
+            "year": 1987
           }
         },
         {
@@ -150,7 +144,6 @@
             "attribute": "art_year",
             "operator": "is nil"
           },
-          "distributions": [],
           "transition": "Stop All 2015"
         },
         {
@@ -160,7 +153,6 @@
             "operator": ">=",
             "value": 2015
           },
-          "distributions": [],
           "transition": "Terminal"
         },
         {

--- a/src/main/resources/modules/hiv/art_sequence_1987_1994.json
+++ b/src/main/resources/modules/hiv/art_sequence_1987_1994.json
@@ -101,7 +101,6 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "value": 0,
             "date": {
               "year": 1991,
               "month": 10,
@@ -170,7 +169,6 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "value": 0,
             "date": {
               "year": 1994,
               "month": 6,
@@ -181,14 +179,12 @@
               "millisecond": 0
             }
           },
-          "distributions": [],
           "transition": "d4T"
         },
         {
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "value": 0,
             "date": {
               "year": 1992,
               "month": 6,
@@ -211,7 +207,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "ddI"
         }
       ]

--- a/src/main/resources/modules/hiv/art_sequence_1995_1996.json
+++ b/src/main/resources/modules/hiv/art_sequence_1995_1996.json
@@ -172,7 +172,6 @@
               "millisecond": 0
             }
           },
-          "distributions": [],
           "transition": "3TC"
         },
         {
@@ -186,7 +185,6 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "ddI"
         },
         {

--- a/src/main/resources/modules/hiv/art_sequence_1997_2002.json
+++ b/src/main/resources/modules/hiv/art_sequence_1997_2002.json
@@ -11,8 +11,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": "==",
-            "year": 2002,
-            "value": 0
+            "year": 2002
           },
           "distributions": [
             {
@@ -53,12 +52,10 @@
                   "minute": 0,
                   "second": 0,
                   "millisecond": 0
-                },
-                "value": 0
+                }
               }
             ]
           },
-          "distributions": [],
           "transition": "3TC+ZDV"
         },
         {
@@ -141,8 +138,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": "<",
-            "year": 2000,
-            "value": 0
+            "year": 2000
           },
           "distributions": [
             {
@@ -230,8 +226,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": "<",
-            "year": 2000,
-            "value": 0
+            "year": 2000
           },
           "distributions": [
             {
@@ -245,7 +240,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "3TC"
         }
       ]
@@ -339,8 +333,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 2001,
-            "value": 0
+            "year": 2001
           }
         },
         {
@@ -348,8 +341,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": "==",
-            "year": 2000,
-            "value": 0
+            "year": 2000
           }
         },
         {
@@ -365,8 +357,7 @@
               "minute": 0,
               "second": 0,
               "millisecond": 0
-            },
-            "value": 0
+            }
           }
         },
         {
@@ -374,7 +365,6 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "value": 0,
             "date": {
               "year": 1997,
               "month": 9,
@@ -425,8 +415,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 2001,
-            "value": 0
+            "year": 2001
           }
         },
         {

--- a/src/main/resources/modules/hiv/art_sequence_2003_2005.json
+++ b/src/main/resources/modules/hiv/art_sequence_2003_2005.json
@@ -182,7 +182,6 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "EFV"
         },
         {
@@ -300,8 +299,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 2004,
-            "value": 0
+            "year": 2004
           },
           "distributions": [
             {
@@ -315,7 +313,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "3TC"
         }
       ]
@@ -335,8 +332,7 @@
               "minute": 0,
               "second": 0,
               "millisecond": 0
-            },
-            "value": 0
+            }
           },
           "distributions": [
             {

--- a/src/main/resources/modules/hiv/art_sequence_2006_2014.json
+++ b/src/main/resources/modules/hiv/art_sequence_2006_2014.json
@@ -148,8 +148,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 2014,
-            "value": 0
+            "year": 2014
           },
           "distributions": [
             {
@@ -178,8 +177,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 2009,
-            "value": 0
+            "year": 2009
           },
           "distributions": [
             {
@@ -204,7 +202,6 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "value": 0,
             "date": {
               "year": 2008,
               "month": 11,
@@ -326,8 +323,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 2014,
-            "value": 0
+            "year": 2014
           }
         },
         {
@@ -343,8 +339,7 @@
               "minute": 0,
               "second": 0,
               "millisecond": 0
-            },
-            "value": 0
+            }
           }
         },
         {

--- a/src/main/resources/modules/hiv/art_sequence_2015.json
+++ b/src/main/resources/modules/hiv/art_sequence_2015.json
@@ -94,8 +94,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 2021,
-            "value": 0
+            "year": 2021
           },
           "distributions": [
             {
@@ -108,8 +107,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 2017,
-            "value": 0
+            "year": 2017
           },
           "distributions": [
             {
@@ -216,8 +214,7 @@
                   "minute": 0,
                   "second": 0,
                   "millisecond": 0
-                },
-                "value": 0
+                }
               },
               {
                 "condition_type": "And",
@@ -273,8 +270,7 @@
               "minute": 0,
               "second": 0,
               "millisecond": 0
-            },
-            "value": 0
+            }
           },
           "distributions": [
             {
@@ -302,14 +298,12 @@
               {
                 "condition_type": "Date",
                 "operator": "<=",
-                "year": 2018,
-                "value": 0
+                "year": 2018
               },
               {
                 "condition_type": "Date",
                 "operator": ">=",
-                "year": 2016,
-                "value": 0
+                "year": 2016
               }
             ]
           },

--- a/src/main/resources/modules/hiv/hiv_baseline.json
+++ b/src/main/resources/modules/hiv/hiv_baseline.json
@@ -654,7 +654,6 @@
             "attribute": "ckd",
             "operator": "is not nil"
           },
-          "distributions": [],
           "transition": "Metabolic Panel"
         },
         {
@@ -1217,7 +1216,6 @@
             "attribute": "anemia",
             "operator": "is not nil"
           },
-          "distributions": [],
           "transition": "Has Anemia"
         },
         {
@@ -1265,7 +1263,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "No Anemia"
         }
       ]
@@ -2028,8 +2025,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 1996,
-            "value": 0
+            "year": 1996
           }
         },
         {

--- a/src/main/resources/modules/hiv/hiv_oi_prophylaxis.json
+++ b/src/main/resources/modules/hiv/hiv_oi_prophylaxis.json
@@ -77,7 +77,6 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "Atovaquone"
         },
         {

--- a/src/main/resources/modules/hiv/hiv_viral_load.json
+++ b/src/main/resources/modules/hiv/hiv_viral_load.json
@@ -363,7 +363,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "Suppression"
         },
         {

--- a/src/main/resources/modules/hiv_care.json
+++ b/src/main/resources/modules/hiv_care.json
@@ -133,7 +133,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "End Treatment Encounter"
         },
         {
@@ -143,7 +142,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "Medication_Submodule"
         },
         {
@@ -272,7 +270,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Long Encounter Delay"
         }
       ]
@@ -330,8 +327,7 @@
               {
                 "condition_type": "Date",
                 "operator": ">=",
-                "year": 2016,
-                "value": 0
+                "year": 2016
               },
               {
                 "condition_type": "Attribute",
@@ -353,7 +349,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Medium Encounter Delay"
         }
       ],
@@ -437,8 +432,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 1996,
-            "value": 0
+            "year": 1996
           }
         },
         {
@@ -503,8 +497,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 1996,
-            "value": 0
+            "year": 1996
           }
         },
         {
@@ -553,7 +546,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "ART Sequence"
         },
         {
@@ -832,8 +824,7 @@
               {
                 "condition_type": "Date",
                 "operator": ">=",
-                "year": 2017,
-                "value": 0
+                "year": 2017
               }
             ]
           }
@@ -957,8 +948,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": "<",
-            "year": 2010,
-            "value": 0
+            "year": 2010
           }
         },
         {

--- a/src/main/resources/modules/hiv_diagnosis.json
+++ b/src/main/resources/modules/hiv_diagnosis.json
@@ -263,8 +263,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 1979,
-            "value": 0
+            "year": 1979
           }
         },
         {
@@ -277,8 +276,7 @@
       "allow": {
         "condition_type": "Date",
         "operator": ">=",
-        "year": 1979,
-        "value": 0
+        "year": 1979
       },
       "direct_transition": "Diagnosis Check"
     }

--- a/src/main/resources/modules/home_health_treatment.json
+++ b/src/main/resources/modules/home_health_treatment.json
@@ -300,38 +300,10 @@
     },
     "Finish Day": {
       "type": "EncounterEnd",
-      "conditional_transition": [
-        {
-          "transition": "Delay",
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "home_health_days",
-            "operator": ">",
-            "value": 0
-          }
-        },
-        {
-          "transition": "Patient_Discharge"
-        }
-      ],
       "direct_transition": "Delay"
     },
     "Last Visit": {
       "type": "EncounterEnd",
-      "conditional_transition": [
-        {
-          "transition": "Delay",
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "home_health_days",
-            "operator": ">",
-            "value": 0
-          }
-        },
-        {
-          "transition": "Patient_Discharge"
-        }
-      ],
       "direct_transition": "Reset Home Health"
     },
     "Wait Until Home Health": {

--- a/src/main/resources/modules/home_hospice_snf.json
+++ b/src/main/resources/modules/home_hospice_snf.json
@@ -85,9 +85,9 @@
                 "condition_type": "Active Condition",
                 "codes": [
                   {
-                    "system": "LOINC",
-                    "code": "55277-8",
-                    "display": "HIV Positive Status"
+                    "system": "SNOMED-CT",
+                    "code": "86406008",
+                    "display": "Human immunodeficiency virus infection (disorder)"
                   }
                 ]
               },

--- a/src/main/resources/modules/homelessness.json
+++ b/src/main/resources/modules/homelessness.json
@@ -232,34 +232,22 @@
     },
     "Question_2": {
       "type": "Simple",
-      "remarks": [
-        "simple random statistics here until we have a real HIV model",
-        "National Alliance to End Homelessness estimates that 3.4% of homeless people are HIV+",
-        "compared to 0.4% in the general population. (2006 data)",
-        "http://www.nationalhomeless.org/factsheets/hiv.html"
-      ],
-      "complex_transition": [
+      "conditional_transition": [
         {
-          "condition": {
-            "condition_type": "PriorState",
-            "name": "Question_2_Positive"
-          },
           "transition": "Question_2_Positive",
-          "remarks": [
-            "If they previously said they are HIV+ then stick with it"
-          ]
+          "condition": {
+            "condition_type": "Active Condition",
+            "codes": [
+              {
+                "system": "SNOMED-CT",
+                "code": 86406008,
+                "display": "Human immunodeficiency virus infection (disorder)"
+              }
+            ]
+          }
         },
         {
-          "distributions": [
-            {
-              "distribution": 0.966,
-              "transition": "Question_2_Negative"
-            },
-            {
-              "distribution": 0.034,
-              "transition": "Question_2_Positive"
-            }
-          ]
+          "transition": "Question_2_Negative"
         }
       ]
     },

--- a/src/main/resources/modules/homelessness.json
+++ b/src/main/resources/modules/homelessness.json
@@ -429,7 +429,6 @@
     },
     "Homeless_Condition": {
       "type": "ConditionOnset",
-      "target_encounter": "",
       "codes": [
         {
           "system": "SNOMED-CT",

--- a/src/main/resources/modules/hospice_treatment.json
+++ b/src/main/resources/modules/hospice_treatment.json
@@ -200,20 +200,6 @@
     },
     "Discharged Dead": {
       "type": "EncounterEnd",
-      "conditional_transition": [
-        {
-          "transition": "Delay",
-          "condition": {
-            "condition_type": "Attribute",
-            "attribute": "home_health_days",
-            "operator": ">",
-            "value": 0
-          }
-        },
-        {
-          "transition": "Patient_Discharge"
-        }
-      ],
       "direct_transition": "Terminal",
       "discharge_disposition": {
         "system": "NUBC",

--- a/src/main/resources/modules/hypertension.json
+++ b/src/main/resources/modules/hypertension.json
@@ -235,7 +235,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "Delay 2_Month"
         },
         {
@@ -314,7 +313,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "Delay_2_Month_2"
         },
         {
@@ -324,7 +322,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "Delay_2_Month_2"
         },
         {
@@ -346,7 +343,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Delay_2_Month_2"
         }
       ]
@@ -551,7 +547,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "Hypertension_Followup_Encounter"
         },
         {
@@ -776,7 +771,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "Hypertension_Followup_Encounter_2"
         },
         {
@@ -786,7 +780,6 @@
             "operator": "==",
             "value": true
           },
-          "distributions": [],
           "transition": "Hypertension_Followup_Encounter_2"
         },
         {

--- a/src/main/resources/modules/mTBI.json
+++ b/src/main/resources/modules/mTBI.json
@@ -61,15 +61,7 @@
     },
     "Wellness Encounter": {
       "type": "Encounter",
-      "encounter_class": "ambulatory",
       "reason": "mTBI",
-      "codes": [
-        {
-          "system": "SNOMED-CT",
-          "code": 185345009,
-          "display": "Encounter for symptom (procedure)"
-        }
-      ],
       "direct_transition": "end encounter",
       "wellness": true
     },

--- a/src/main/resources/modules/medications/ace_arb.json
+++ b/src/main/resources/modules/medications/ace_arb.json
@@ -1,2049 +1,1965 @@
 {
-    "name": "Ace Arb",
-    "remarks": [
-        "======================================================================",
-        "  SUBMODULE ACE ARB",
-        "======================================================================",
-        "",
-        "This submodule prescribes a medication based on population data.",
-        "",
-        "IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
-        "All medications prescribed in this module are assigned to the attribute",
-        "'ace_arb'.",
-        "",
-        "Reference links:",
-        "    RxClass: https://mor.nlm.nih.gov/RxClass/",
-        "    RxNorm: https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
-        "    RxNav: https://mor.nlm.nih.gov/RxNav/",
-        "    MEPS: https://meps.ahrq.gov/mepsweb/data_stats/MEPS_topics.jsp?topicid=46Z-1",
-        "    FDA: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory",
-        "",
-        "Made with (</>) by the CodeRx Medication Diversification Tool (MDT)",
-        "",
-        "MDT settings for this submodule:",
-        "{",
-        "    \"module\": {",
-        "        \"name\": null,",
-        "        \"assign_to_attribute\": null,",
-        "        \"reason\": null,",
-        "        \"as_needed\": false,",
-        "        \"chronic\": false,",
-        "        \"refills\": 0",
-        "    },",
-        "    \"rxclass\": {",
-        "        \"include\": [",
-        "            {",
-        "                \"class_id\": \"C09A\",",
-        "                \"relationship\": \"ATC\"",
-        "            },",
-        "            {",
-        "                \"class_id\": \"C09C\",",
-        "                \"relationship\": \"ATC\"",
-        "            }",
-        "        ],",
-        "        \"exclude\": null",
-        "    },",
-        "    \"rxcui\": {",
-        "        \"include\": null,",
-        "        \"exclude\": null",
-        "    },",
-        "    \"ingredient_tty_filter\": null,",
-        "    \"dose_form_filter\": null,",
-        "    \"meps\": {",
-        "        \"age_ranges\": null,",
-        "        \"demographic_distribution_flags\": {",
-        "            \"age\": true,",
-        "            \"gender\": true,",
-        "            \"state\": true",
-        "        }",
-        "    },",
-        "    \"state_prefix\": \"Prescribe_\",",
-        "    \"ingredient_distribution_suffix\": \"_ingredient_distribution\",",
-        "    \"product_distribution_suffix\": \"_product_distribution\",",
-        "    \"default_age_ranges\": [",
-        "        \"0-3\",",
-        "        \"4-7\",",
-        "        \"8-11\",",
-        "        \"12-17\",",
-        "        \"18-25\",",
-        "        \"26-35\",",
-        "        \"36-45\",",
-        "        \"46-65\",",
-        "        \"65-103\"",
-        "    ]",
-        "}"
-    ],
-    "gmf_version": 2,
-    "states": {
-        "Initial": {
-            "type": "Initial",
-            "conditional_transition": [
-                {
-                    "condition": {
-                        "condition_type": "Attribute",
-                        "attribute": "ace_arb",
-                        "operator": "is nil"
-                    },
-                    "transition": "Prescribe_Ingredient"
-                },
-                {
-                    "transition": "Terminal"
-                }
-            ]
-        },
-        "Terminal": {
-            "type": "Terminal"
-        },
-        "Prescribe_Ingredient": {
-            "name": "Prescribe_Ingredient",
-            "remarks": [
-                "======================================================================",
-                " MEDICATION INGREDIENT TABLE TRANSITION                               ",
-                "======================================================================",
-                "Ingredients in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 1.7% ] Amlodipine_Benazepril",
-                "2. [ 2.6% ] Benazepril",
-                "3. [ 0.5% ] Benazepril_Hydrochlorothiazide",
-                "4. [ 2.3% ] Enalapril",
-                "5. [ 7.0% ] Hydrochlorothiazide_Lisinopril",
-                "6. [ 6.4% ] Hydrochlorothiazide_Losartan",
-                "7. [ 1.6% ] Hydrochlorothiazide_Valsartan",
-                "8. [ 2.0% ] Irbesartan",
-                "9. [ 43.3% ] Lisinopril",
-                "10. [ 24.5% ] Losartan",
-                "11. [ 0.6% ] Quinapril",
-                "12. [ 2.0% ] Ramipril",
-                "13. [ 0.6% ] Sacubitril_Valsartan",
-                "14. [ 0.7% ] Telmisartan",
-                "15. [ 4.1% ] Valsartan"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Amlodipine_Benazepril",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Benazepril",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Benazepril_Hydrochlorothiazide",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Enalapril",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_Lisinopril",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_Losartan",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_Valsartan",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Irbesartan",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Lisinopril",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Losartan",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Quinapril",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Ramipril",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Sacubitril_Valsartan",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Telmisartan",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Valsartan",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ingredient_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Amlodipine_Benazepril": {
-            "name": "Prescribe_Amlodipine_Benazepril",
-            "remarks": [
-                "======================================================================",
-                " AMLODIPINE_BENAZEPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 23.1% ] Amlodipine_10_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule",
-                "2. [ 19.3% ] Amlodipine_10_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule",
-                "3. [ 6.0% ] Amlodipine_2_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule",
-                "4. [ 18.3% ] Amlodipine_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule",
-                "5. [ 28.8% ] Amlodipine_5_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule",
-                "6. [ 4.4% ] Amlodipine_5_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Amlodipine_10_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Amlodipine_10_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Amlodipine_2_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Benazepril": {
-            "name": "Prescribe_Benazepril",
-            "remarks": [
-                "======================================================================",
-                " BENAZEPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 18.8% ] Benazepril_Hydrochloride_10_Mg_Oral_Tablet",
-                "2. [ 42.0% ] Benazepril_Hydrochloride_20_Mg_Oral_Tablet",
-                "3. [ 29.4% ] Benazepril_Hydrochloride_40_Mg_Oral_Tablet",
-                "4. [ 9.7% ] Benazepril_Hydrochloride_5_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Benazepril_Hydrochloride_10_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_benazepril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Benazepril_Hydrochloride_20_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_benazepril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Benazepril_Hydrochloride_40_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_benazepril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Benazepril_Hydrochloride_5_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_benazepril_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Benazepril_Hydrochlorothiazide": {
-            "name": "Prescribe_Benazepril_Hydrochlorothiazide",
-            "remarks": [
-                "======================================================================",
-                " BENAZEPRIL_HYDROCHLOROTHIAZIDE MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 23.0% ] Benazepril_Hydrochloride_10_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet",
-                "2. [ 34.5% ] Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet",
-                "3. [ 42.6% ] Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_25_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Benazepril_Hydrochloride_10_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_benazepril_hydrochlorothiazide_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_benazepril_hydrochlorothiazide_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_25_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_benazepril_hydrochlorothiazide_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Enalapril": {
-            "name": "Prescribe_Enalapril",
-            "remarks": [
-                "======================================================================",
-                " ENALAPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 37.4% ] Enalapril_Maleate_10_Mg_Oral_Tablet",
-                "2. [ 0.3% ] Enalapril_Maleate_1_Mg_Ml_Oral_Solution_Epaned",
-                "3. [ 37.4% ] Enalapril_Maleate_20_Mg_Oral_Tablet",
-                "4. [ 12.3% ] Enalapril_Maleate_2_5_Mg_Oral_Tablet",
-                "5. [ 12.7% ] Enalapril_Maleate_5_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Enalapril_Maleate_10_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Enalapril_Maleate_20_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Enalapril_Maleate_5_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Enalapril_Maleate_2_5_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Enalapril_Maleate_1_Mg_Ml_Oral_Solution_Epaned",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Hydrochlorothiazide_Lisinopril": {
-            "name": "Prescribe_Hydrochlorothiazide_Lisinopril",
-            "remarks": [
-                "======================================================================",
-                " HYDROCHLOROTHIAZIDE_LISINOPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 31.2% ] Hydrochlorothiazide_12_5_Mg_Lisinopril_10_Mg_Oral_Tablet",
-                "2. [ 35.9% ] Hydrochlorothiazide_12_5_Mg_Lisinopril_20_Mg_Oral_Tablet",
-                "3. [ 32.9% ] Hydrochlorothiazide_25_Mg_Lisinopril_20_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Lisinopril_10_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_lisinopril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Lisinopril_20_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_lisinopril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Lisinopril_20_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_lisinopril_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Hydrochlorothiazide_Losartan": {
-            "name": "Prescribe_Hydrochlorothiazide_Losartan",
-            "remarks": [
-                "======================================================================",
-                " HYDROCHLOROTHIAZIDE_LOSARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 16.5% ] Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet",
-                "2. [ 0.2% ] Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar",
-                "3. [ 32.7% ] Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet",
-                "4. [ 0.3% ] Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet_Hyzaar",
-                "5. [ 49.5% ] Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet",
-                "6. [ 0.8% ] Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet_Hyzaar",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Hydrochlorothiazide_Valsartan": {
-            "name": "Prescribe_Hydrochlorothiazide_Valsartan",
-            "remarks": [
-                "======================================================================",
-                " HYDROCHLOROTHIAZIDE_VALSARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 29.1% ] Hydrochlorothiazide_12_5_Mg_Valsartan_160_Mg_Oral_Tablet",
-                "2. [ 4.5% ] Hydrochlorothiazide_12_5_Mg_Valsartan_320_Mg_Oral_Tablet",
-                "3. [ 15.5% ] Hydrochlorothiazide_12_5_Mg_Valsartan_80_Mg_Oral_Tablet",
-                "4. [ 23.7% ] Hydrochlorothiazide_25_Mg_Valsartan_160_Mg_Oral_Tablet",
-                "5. [ 27.2% ] Hydrochlorothiazide_25_Mg_Valsartan_320_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_160_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_80_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Valsartan_160_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Valsartan_320_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_320_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Irbesartan": {
-            "name": "Prescribe_Irbesartan",
-            "remarks": [
-                "======================================================================",
-                " IRBESARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 42.4% ] Irbesartan_150_Mg_Oral_Tablet",
-                "2. [ 45.4% ] Irbesartan_300_Mg_Oral_Tablet",
-                "3. [ 12.1% ] Irbesartan_75_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Irbesartan_150_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_irbesartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Irbesartan_300_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_irbesartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Irbesartan_75_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_irbesartan_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Lisinopril": {
-            "name": "Prescribe_Lisinopril",
-            "remarks": [
-                "======================================================================",
-                " LISINOPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 30.3% ] Lisinopril_10_Mg_Oral_Tablet",
-                "2. [ 0.1% ] Lisinopril_1_Mg_Ml_Oral_Solution_Qbrelis",
-                "3. [ 27.3% ] Lisinopril_20_Mg_Oral_Tablet",
-                "4. [ 7.1% ] Lisinopril_2_5_Mg_Oral_Tablet",
-                "5. [ 1.5% ] Lisinopril_30_Mg_Oral_Tablet",
-                "6. [ 18.3% ] Lisinopril_40_Mg_Oral_Tablet",
-                "7. [ 15.3% ] Lisinopril_5_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Lisinopril_10_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Lisinopril_20_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Lisinopril_30_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Lisinopril_2_5_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Lisinopril_40_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Lisinopril_5_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Lisinopril_1_Mg_Ml_Oral_Solution_Qbrelis",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Losartan": {
-            "name": "Prescribe_Losartan",
-            "remarks": [
-                "======================================================================",
-                " LOSARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 41.1% ] Losartan_Potassium_100_Mg_Oral_Tablet",
-                "2. [ 20.8% ] Losartan_Potassium_25_Mg_Oral_Tablet",
-                "3. [ 0.0% ] Losartan_Potassium_25_Mg_Oral_Tablet_Cozaar",
-                "4. [ 38.0% ] Losartan_Potassium_50_Mg_Oral_Tablet",
-                "5. [ 0.1% ] Losartan_Potassium_50_Mg_Oral_Tablet_Cozaar"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Losartan_Potassium_100_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Losartan_Potassium_25_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Losartan_Potassium_50_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Losartan_Potassium_50_Mg_Oral_Tablet_Cozaar",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Losartan_Potassium_25_Mg_Oral_Tablet_Cozaar",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Quinapril": {
-            "name": "Prescribe_Quinapril",
-            "remarks": [
-                "======================================================================",
-                " QUINAPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 14.1% ] Quinapril_10_Mg_Oral_Tablet",
-                "2. [ 18.6% ] Quinapril_20_Mg_Oral_Tablet",
-                "3. [ 63.3% ] Quinapril_40_Mg_Oral_Tablet",
-                "4. [ 4.0% ] Quinapril_5_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Quinapril_10_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_quinapril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Quinapril_40_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_quinapril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Quinapril_20_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_quinapril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Quinapril_5_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_quinapril_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Ramipril": {
-            "name": "Prescribe_Ramipril",
-            "remarks": [
-                "======================================================================",
-                " RAMIPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 47.7% ] Ramipril_10_Mg_Oral_Capsule",
-                "2. [ 3.8% ] Ramipril_1_25_Mg_Oral_Capsule",
-                "3. [ 19.3% ] Ramipril_2_5_Mg_Oral_Capsule",
-                "4. [ 29.2% ] Ramipril_5_Mg_Oral_Capsule"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Ramipril_10_Mg_Oral_Capsule",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_ramipril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Ramipril_2_5_Mg_Oral_Capsule",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ramipril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Ramipril_5_Mg_Oral_Capsule",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ramipril_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Ramipril_1_25_Mg_Oral_Capsule",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_ramipril_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Sacubitril_Valsartan": {
-            "name": "Prescribe_Sacubitril_Valsartan",
-            "remarks": [
-                "======================================================================",
-                " SACUBITRIL_VALSARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 50.0% ] Sacubitril_24_Mg_Valsartan_26_Mg_Oral_Tablet_Entresto",
-                "2. [ 23.3% ] Sacubitril_49_Mg_Valsartan_51_Mg_Oral_Tablet_Entresto",
-                "3. [ 26.6% ] Sacubitril_97_Mg_Valsartan_103_Mg_Oral_Tablet_Entresto"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Sacubitril_24_Mg_Valsartan_26_Mg_Oral_Tablet_Entresto",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_sacubitril_valsartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Sacubitril_49_Mg_Valsartan_51_Mg_Oral_Tablet_Entresto",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_sacubitril_valsartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Sacubitril_97_Mg_Valsartan_103_Mg_Oral_Tablet_Entresto",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_sacubitril_valsartan_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Telmisartan": {
-            "name": "Prescribe_Telmisartan",
-            "remarks": [
-                "======================================================================",
-                " TELMISARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 3.9% ] Telmisartan_20_Mg_Oral_Tablet",
-                "2. [ 0.3% ] Telmisartan_20_Mg_Oral_Tablet_Micardis",
-                "3. [ 26.6% ] Telmisartan_40_Mg_Oral_Tablet",
-                "4. [ 53.9% ] Telmisartan_80_Mg_Oral_Tablet",
-                "5. [ 15.3% ] Telmisartan_80_Mg_Oral_Tablet_Micardis"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Telmisartan_20_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Telmisartan_20_Mg_Oral_Tablet_Micardis",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Telmisartan_40_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Telmisartan_80_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Telmisartan_80_Mg_Oral_Tablet_Micardis",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Valsartan": {
-            "name": "Prescribe_Valsartan",
-            "remarks": [
-                "======================================================================",
-                " VALSARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 34.7% ] Valsartan_160_Mg_Oral_Tablet",
-                "2. [ 27.7% ] Valsartan_320_Mg_Oral_Tablet",
-                "3. [ 1.9% ] Valsartan_320_Mg_Oral_Tablet_Diovan",
-                "4. [ 3.3% ] Valsartan_40_Mg_Oral_Tablet",
-                "5. [ 32.4% ] Valsartan_80_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Valsartan_160_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Valsartan_320_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Valsartan_80_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Valsartan_40_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Valsartan_320_Mg_Oral_Tablet_Diovan",
-                    "default_probability": 0,
-                    "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Amlodipine_10_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule": {
-            "remarks": [
-                "======================================================================",
-                " BEGIN MEDICATION ORDER STATES                                        ",
-                "======================================================================"
-            ],
-            "name": "Prescribe_Amlodipine_10_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898342",
-                    "display": "amlodipine 10 MG / benazepril hydrochloride 20 MG Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Amlodipine_10_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule": {
-            "name": "Prescribe_Amlodipine_10_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898346",
-                    "display": "amlodipine 10 MG / benazepril hydrochloride 40 MG Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Amlodipine_2_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule": {
-            "name": "Prescribe_Amlodipine_2_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898350",
-                    "display": "amlodipine 2.5 MG / benazepril hydrochloride 10 MG Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule": {
-            "name": "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898353",
-                    "display": "amlodipine 5 MG / benazepril hydrochloride 10 MG Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule": {
-            "name": "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898356",
-                    "display": "amlodipine 5 MG / benazepril hydrochloride 20 MG Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule": {
-            "name": "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898359",
-                    "display": "amlodipine 5 MG / benazepril hydrochloride 40 MG Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Benazepril_Hydrochloride_10_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet": {
-            "name": "Prescribe_Benazepril_Hydrochloride_10_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898362",
-                    "display": "benazepril hydrochloride 10 MG / hydrochlorothiazide 12.5 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Benazepril_Hydrochloride_10_Mg_Oral_Tablet": {
-            "name": "Prescribe_Benazepril_Hydrochloride_10_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898687",
-                    "display": "benazepril hydrochloride 10 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet": {
-            "name": "Prescribe_Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898367",
-                    "display": "benazepril hydrochloride 20 MG / hydrochlorothiazide 12.5 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_25_Mg_Oral_Tablet": {
-            "name": "Prescribe_Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_25_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898372",
-                    "display": "benazepril hydrochloride 20 MG / hydrochlorothiazide 25 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Benazepril_Hydrochloride_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Benazepril_Hydrochloride_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898690",
-                    "display": "benazepril hydrochloride 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Benazepril_Hydrochloride_40_Mg_Oral_Tablet": {
-            "name": "Prescribe_Benazepril_Hydrochloride_40_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898719",
-                    "display": "benazepril hydrochloride 40 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Benazepril_Hydrochloride_5_Mg_Oral_Tablet": {
-            "name": "Prescribe_Benazepril_Hydrochloride_5_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "898723",
-                    "display": "benazepril hydrochloride 5 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Enalapril_Maleate_1_Mg_Ml_Oral_Solution_Epaned": {
-            "name": "Prescribe_Enalapril_Maleate_1_Mg_Ml_Oral_Solution_Epaned",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1435630",
-                    "display": "enalapril maleate 1 MG/ML Oral Solution [Epaned]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Enalapril_Maleate_10_Mg_Oral_Tablet": {
-            "name": "Prescribe_Enalapril_Maleate_10_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "858817",
-                    "display": "enalapril maleate 10 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Enalapril_Maleate_2_5_Mg_Oral_Tablet": {
-            "name": "Prescribe_Enalapril_Maleate_2_5_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "858804",
-                    "display": "enalapril maleate 2.5 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Enalapril_Maleate_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Enalapril_Maleate_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "858810",
-                    "display": "enalapril maleate 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Enalapril_Maleate_5_Mg_Oral_Tablet": {
-            "name": "Prescribe_Enalapril_Maleate_5_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "858813",
-                    "display": "enalapril maleate 5 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_12_5_Mg_Lisinopril_10_Mg_Oral_Tablet": {
-            "name": "Prescribe_Hydrochlorothiazide_12_5_Mg_Lisinopril_10_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "197885",
-                    "display": "hydrochlorothiazide 12.5 MG / lisinopril 10 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_12_5_Mg_Lisinopril_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Hydrochlorothiazide_12_5_Mg_Lisinopril_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "197886",
-                    "display": "hydrochlorothiazide 12.5 MG / lisinopril 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet": {
-            "name": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "979464",
-                    "display": "hydrochlorothiazide 12.5 MG / losartan potassium 100 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar": {
-            "name": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "979466",
-                    "display": "hydrochlorothiazide 12.5 MG / losartan potassium 100 MG Oral Tablet [Hyzaar]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet": {
-            "name": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "979468",
-                    "display": "hydrochlorothiazide 12.5 MG / losartan potassium 50 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet_Hyzaar": {
-            "name": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet_Hyzaar",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "979470",
-                    "display": "hydrochlorothiazide 12.5 MG / losartan potassium 50 MG Oral Tablet [Hyzaar]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_160_Mg_Oral_Tablet": {
-            "name": "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_160_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "200285",
-                    "display": "hydrochlorothiazide 12.5 MG / valsartan 160 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_320_Mg_Oral_Tablet": {
-            "name": "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_320_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "636042",
-                    "display": "hydrochlorothiazide 12.5 MG / valsartan 320 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_80_Mg_Oral_Tablet": {
-            "name": "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_80_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "200284",
-                    "display": "hydrochlorothiazide 12.5 MG / valsartan 80 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_25_Mg_Lisinopril_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Hydrochlorothiazide_25_Mg_Lisinopril_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "197887",
-                    "display": "hydrochlorothiazide 25 MG / lisinopril 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet": {
-            "name": "Prescribe_Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "979471",
-                    "display": "hydrochlorothiazide 25 MG / losartan potassium 100 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar": {
-            "name": "Prescribe_Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "979473",
-                    "display": "hydrochlorothiazide 25 MG / losartan potassium 100 MG Oral Tablet [Hyzaar]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_25_Mg_Valsartan_160_Mg_Oral_Tablet": {
-            "name": "Prescribe_Hydrochlorothiazide_25_Mg_Valsartan_160_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "349353",
-                    "display": "hydrochlorothiazide 25 MG / valsartan 160 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Hydrochlorothiazide_25_Mg_Valsartan_320_Mg_Oral_Tablet": {
-            "name": "Prescribe_Hydrochlorothiazide_25_Mg_Valsartan_320_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "636045",
-                    "display": "hydrochlorothiazide 25 MG / valsartan 320 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Irbesartan_150_Mg_Oral_Tablet": {
-            "name": "Prescribe_Irbesartan_150_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "200095",
-                    "display": "irbesartan 150 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Irbesartan_300_Mg_Oral_Tablet": {
-            "name": "Prescribe_Irbesartan_300_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "200096",
-                    "display": "irbesartan 300 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Irbesartan_75_Mg_Oral_Tablet": {
-            "name": "Prescribe_Irbesartan_75_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "200094",
-                    "display": "irbesartan 75 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Lisinopril_1_Mg_Ml_Oral_Solution_Qbrelis": {
-            "name": "Prescribe_Lisinopril_1_Mg_Ml_Oral_Solution_Qbrelis",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1806890",
-                    "display": "lisinopril 1 MG/ML Oral Solution [Qbrelis]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Lisinopril_10_Mg_Oral_Tablet": {
-            "name": "Prescribe_Lisinopril_10_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "314076",
-                    "display": "lisinopril 10 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Lisinopril_2_5_Mg_Oral_Tablet": {
-            "name": "Prescribe_Lisinopril_2_5_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "311353",
-                    "display": "lisinopril 2.5 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Lisinopril_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Lisinopril_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "314077",
-                    "display": "lisinopril 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Lisinopril_30_Mg_Oral_Tablet": {
-            "name": "Prescribe_Lisinopril_30_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "205326",
-                    "display": "lisinopril 30 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Lisinopril_40_Mg_Oral_Tablet": {
-            "name": "Prescribe_Lisinopril_40_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "197884",
-                    "display": "lisinopril 40 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Lisinopril_5_Mg_Oral_Tablet": {
-            "name": "Prescribe_Lisinopril_5_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "311354",
-                    "display": "lisinopril 5 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Losartan_Potassium_100_Mg_Oral_Tablet": {
-            "name": "Prescribe_Losartan_Potassium_100_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "979480",
-                    "display": "losartan potassium 100 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Losartan_Potassium_25_Mg_Oral_Tablet": {
-            "name": "Prescribe_Losartan_Potassium_25_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "979485",
-                    "display": "losartan potassium 25 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Losartan_Potassium_25_Mg_Oral_Tablet_Cozaar": {
-            "name": "Prescribe_Losartan_Potassium_25_Mg_Oral_Tablet_Cozaar",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "979487",
-                    "display": "losartan potassium 25 MG Oral Tablet [Cozaar]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Losartan_Potassium_50_Mg_Oral_Tablet": {
-            "name": "Prescribe_Losartan_Potassium_50_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "979492",
-                    "display": "losartan potassium 50 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Losartan_Potassium_50_Mg_Oral_Tablet_Cozaar": {
-            "name": "Prescribe_Losartan_Potassium_50_Mg_Oral_Tablet_Cozaar",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "979494",
-                    "display": "losartan potassium 50 MG Oral Tablet [Cozaar]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Quinapril_10_Mg_Oral_Tablet": {
-            "name": "Prescribe_Quinapril_10_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "312748",
-                    "display": "quinapril 10 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Quinapril_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Quinapril_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "312749",
-                    "display": "quinapril 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Quinapril_40_Mg_Oral_Tablet": {
-            "name": "Prescribe_Quinapril_40_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "314203",
-                    "display": "quinapril 40 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Quinapril_5_Mg_Oral_Tablet": {
-            "name": "Prescribe_Quinapril_5_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "312750",
-                    "display": "quinapril 5 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Ramipril_1_25_Mg_Oral_Capsule": {
-            "name": "Prescribe_Ramipril_1_25_Mg_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "845488",
-                    "display": "ramipril 1.25 MG Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Ramipril_10_Mg_Oral_Capsule": {
-            "name": "Prescribe_Ramipril_10_Mg_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "261962",
-                    "display": "ramipril 10 MG Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Ramipril_2_5_Mg_Oral_Capsule": {
-            "name": "Prescribe_Ramipril_2_5_Mg_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "198188",
-                    "display": "ramipril 2.5 MG Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Ramipril_5_Mg_Oral_Capsule": {
-            "name": "Prescribe_Ramipril_5_Mg_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "198189",
-                    "display": "ramipril 5 MG Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Sacubitril_24_Mg_Valsartan_26_Mg_Oral_Tablet_Entresto": {
-            "name": "Prescribe_Sacubitril_24_Mg_Valsartan_26_Mg_Oral_Tablet_Entresto",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1656346",
-                    "display": "sacubitril 24 MG / valsartan 26 MG Oral Tablet [Entresto]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Sacubitril_49_Mg_Valsartan_51_Mg_Oral_Tablet_Entresto": {
-            "name": "Prescribe_Sacubitril_49_Mg_Valsartan_51_Mg_Oral_Tablet_Entresto",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1656351",
-                    "display": "sacubitril 49 MG / valsartan 51 MG Oral Tablet [Entresto]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Sacubitril_97_Mg_Valsartan_103_Mg_Oral_Tablet_Entresto": {
-            "name": "Prescribe_Sacubitril_97_Mg_Valsartan_103_Mg_Oral_Tablet_Entresto",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1656356",
-                    "display": "sacubitril 97 MG / valsartan 103 MG Oral Tablet [Entresto]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Telmisartan_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Telmisartan_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "282755",
-                    "display": "telmisartan 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Telmisartan_20_Mg_Oral_Tablet_Micardis": {
-            "name": "Prescribe_Telmisartan_20_Mg_Oral_Tablet_Micardis",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "284531",
-                    "display": "telmisartan 20 MG Oral Tablet [Micardis]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Telmisartan_40_Mg_Oral_Tablet": {
-            "name": "Prescribe_Telmisartan_40_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "205304",
-                    "display": "telmisartan 40 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Telmisartan_80_Mg_Oral_Tablet": {
-            "name": "Prescribe_Telmisartan_80_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "205305",
-                    "display": "telmisartan 80 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Telmisartan_80_Mg_Oral_Tablet_Micardis": {
-            "name": "Prescribe_Telmisartan_80_Mg_Oral_Tablet_Micardis",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "213432",
-                    "display": "telmisartan 80 MG Oral Tablet [Micardis]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Valsartan_160_Mg_Oral_Tablet": {
-            "name": "Prescribe_Valsartan_160_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "349201",
-                    "display": "valsartan 160 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Valsartan_320_Mg_Oral_Tablet": {
-            "name": "Prescribe_Valsartan_320_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "349200",
-                    "display": "valsartan 320 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Valsartan_320_Mg_Oral_Tablet_Diovan": {
-            "name": "Prescribe_Valsartan_320_Mg_Oral_Tablet_Diovan",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "352001",
-                    "display": "valsartan 320 MG Oral Tablet [Diovan]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Valsartan_40_Mg_Oral_Tablet": {
-            "name": "Prescribe_Valsartan_40_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "349483",
-                    "display": "valsartan 40 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Valsartan_80_Mg_Oral_Tablet": {
-            "name": "Prescribe_Valsartan_80_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "ace_arb",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "349199",
-                    "display": "valsartan 80 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
+  "name": "Ace Arb",
+  "remarks": [
+    "======================================================================",
+    "  SUBMODULE ACE ARB",
+    "======================================================================",
+    "",
+    "This submodule prescribes a medication based on population data.",
+    "",
+    "IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
+    "All medications prescribed in this module are assigned to the attribute",
+    "'ace_arb'.",
+    "",
+    "Reference links:",
+    "    RxClass: https://mor.nlm.nih.gov/RxClass/",
+    "    RxNorm: https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
+    "    RxNav: https://mor.nlm.nih.gov/RxNav/",
+    "    MEPS: https://meps.ahrq.gov/mepsweb/data_stats/MEPS_topics.jsp?topicid=46Z-1",
+    "    FDA: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory",
+    "",
+    "Made with (</>) by the CodeRx Medication Diversification Tool (MDT)",
+    "",
+    "MDT settings for this submodule:",
+    "{",
+    "    \"module\": {",
+    "        \"name\": null,",
+    "        \"assign_to_attribute\": null,",
+    "        \"reason\": null,",
+    "        \"as_needed\": false,",
+    "        \"chronic\": false,",
+    "        \"refills\": 0",
+    "    },",
+    "    \"rxclass\": {",
+    "        \"include\": [",
+    "            {",
+    "                \"class_id\": \"C09A\",",
+    "                \"relationship\": \"ATC\"",
+    "            },",
+    "            {",
+    "                \"class_id\": \"C09C\",",
+    "                \"relationship\": \"ATC\"",
+    "            }",
+    "        ],",
+    "        \"exclude\": null",
+    "    },",
+    "    \"rxcui\": {",
+    "        \"include\": null,",
+    "        \"exclude\": null",
+    "    },",
+    "    \"ingredient_tty_filter\": null,",
+    "    \"dose_form_filter\": null,",
+    "    \"meps\": {",
+    "        \"age_ranges\": null,",
+    "        \"demographic_distribution_flags\": {",
+    "            \"age\": true,",
+    "            \"gender\": true,",
+    "            \"state\": true",
+    "        }",
+    "    },",
+    "    \"state_prefix\": \"Prescribe_\",",
+    "    \"ingredient_distribution_suffix\": \"_ingredient_distribution\",",
+    "    \"product_distribution_suffix\": \"_product_distribution\",",
+    "    \"default_age_ranges\": [",
+    "        \"0-3\",",
+    "        \"4-7\",",
+    "        \"8-11\",",
+    "        \"12-17\",",
+    "        \"18-25\",",
+    "        \"26-35\",",
+    "        \"36-45\",",
+    "        \"46-65\",",
+    "        \"65-103\"",
+    "    ]",
+    "}"
+  ],
+  "gmf_version": 2,
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "ace_arb",
+            "operator": "is nil"
+          },
+          "transition": "Prescribe_Ingredient"
+        },
+        {
+          "transition": "Terminal"
         }
+      ]
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Prescribe_Ingredient": {
+      "remarks": [
+        "======================================================================",
+        " MEDICATION INGREDIENT TABLE TRANSITION                               ",
+        "======================================================================",
+        "Ingredients in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 1.7% ] Amlodipine_Benazepril",
+        "2. [ 2.6% ] Benazepril",
+        "3. [ 0.5% ] Benazepril_Hydrochlorothiazide",
+        "4. [ 2.3% ] Enalapril",
+        "5. [ 7.0% ] Hydrochlorothiazide_Lisinopril",
+        "6. [ 6.4% ] Hydrochlorothiazide_Losartan",
+        "7. [ 1.6% ] Hydrochlorothiazide_Valsartan",
+        "8. [ 2.0% ] Irbesartan",
+        "9. [ 43.3% ] Lisinopril",
+        "10. [ 24.5% ] Losartan",
+        "11. [ 0.6% ] Quinapril",
+        "12. [ 2.0% ] Ramipril",
+        "13. [ 0.6% ] Sacubitril_Valsartan",
+        "14. [ 0.7% ] Telmisartan",
+        "15. [ 4.1% ] Valsartan"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Amlodipine_Benazepril",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Benazepril",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Benazepril_Hydrochlorothiazide",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Enalapril",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_Lisinopril",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_Losartan",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_Valsartan",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Irbesartan",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Lisinopril",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Losartan",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Quinapril",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Ramipril",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Sacubitril_Valsartan",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Telmisartan",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Valsartan",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ingredient_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Amlodipine_Benazepril": {
+      "remarks": [
+        "======================================================================",
+        " AMLODIPINE_BENAZEPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 23.1% ] Amlodipine_10_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule",
+        "2. [ 19.3% ] Amlodipine_10_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule",
+        "3. [ 6.0% ] Amlodipine_2_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule",
+        "4. [ 18.3% ] Amlodipine_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule",
+        "5. [ 28.8% ] Amlodipine_5_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule",
+        "6. [ 4.4% ] Amlodipine_5_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Amlodipine_10_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Amlodipine_10_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Amlodipine_2_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Benazepril": {
+      "remarks": [
+        "======================================================================",
+        " BENAZEPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 18.8% ] Benazepril_Hydrochloride_10_Mg_Oral_Tablet",
+        "2. [ 42.0% ] Benazepril_Hydrochloride_20_Mg_Oral_Tablet",
+        "3. [ 29.4% ] Benazepril_Hydrochloride_40_Mg_Oral_Tablet",
+        "4. [ 9.7% ] Benazepril_Hydrochloride_5_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Benazepril_Hydrochloride_10_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_benazepril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Benazepril_Hydrochloride_20_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_benazepril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Benazepril_Hydrochloride_40_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_benazepril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Benazepril_Hydrochloride_5_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_benazepril_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Benazepril_Hydrochlorothiazide": {
+      "remarks": [
+        "======================================================================",
+        " BENAZEPRIL_HYDROCHLOROTHIAZIDE MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 23.0% ] Benazepril_Hydrochloride_10_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet",
+        "2. [ 34.5% ] Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet",
+        "3. [ 42.6% ] Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_25_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Benazepril_Hydrochloride_10_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_benazepril_hydrochlorothiazide_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_benazepril_hydrochlorothiazide_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_25_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_benazepril_hydrochlorothiazide_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Enalapril": {
+      "remarks": [
+        "======================================================================",
+        " ENALAPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 37.4% ] Enalapril_Maleate_10_Mg_Oral_Tablet",
+        "2. [ 0.3% ] Enalapril_Maleate_1_Mg_Ml_Oral_Solution_Epaned",
+        "3. [ 37.4% ] Enalapril_Maleate_20_Mg_Oral_Tablet",
+        "4. [ 12.3% ] Enalapril_Maleate_2_5_Mg_Oral_Tablet",
+        "5. [ 12.7% ] Enalapril_Maleate_5_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Enalapril_Maleate_10_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Enalapril_Maleate_20_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Enalapril_Maleate_5_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Enalapril_Maleate_2_5_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Enalapril_Maleate_1_Mg_Ml_Oral_Solution_Epaned",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Hydrochlorothiazide_Lisinopril": {
+      "remarks": [
+        "======================================================================",
+        " HYDROCHLOROTHIAZIDE_LISINOPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 31.2% ] Hydrochlorothiazide_12_5_Mg_Lisinopril_10_Mg_Oral_Tablet",
+        "2. [ 35.9% ] Hydrochlorothiazide_12_5_Mg_Lisinopril_20_Mg_Oral_Tablet",
+        "3. [ 32.9% ] Hydrochlorothiazide_25_Mg_Lisinopril_20_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Lisinopril_10_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_lisinopril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Lisinopril_20_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_lisinopril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Lisinopril_20_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_lisinopril_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Hydrochlorothiazide_Losartan": {
+      "remarks": [
+        "======================================================================",
+        " HYDROCHLOROTHIAZIDE_LOSARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 16.5% ] Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet",
+        "2. [ 0.2% ] Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar",
+        "3. [ 32.7% ] Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet",
+        "4. [ 0.3% ] Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet_Hyzaar",
+        "5. [ 49.5% ] Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet",
+        "6. [ 0.8% ] Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet_Hyzaar",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Hydrochlorothiazide_Valsartan": {
+      "remarks": [
+        "======================================================================",
+        " HYDROCHLOROTHIAZIDE_VALSARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 29.1% ] Hydrochlorothiazide_12_5_Mg_Valsartan_160_Mg_Oral_Tablet",
+        "2. [ 4.5% ] Hydrochlorothiazide_12_5_Mg_Valsartan_320_Mg_Oral_Tablet",
+        "3. [ 15.5% ] Hydrochlorothiazide_12_5_Mg_Valsartan_80_Mg_Oral_Tablet",
+        "4. [ 23.7% ] Hydrochlorothiazide_25_Mg_Valsartan_160_Mg_Oral_Tablet",
+        "5. [ 27.2% ] Hydrochlorothiazide_25_Mg_Valsartan_320_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_160_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_80_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Valsartan_160_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Valsartan_320_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_320_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Irbesartan": {
+      "remarks": [
+        "======================================================================",
+        " IRBESARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 42.4% ] Irbesartan_150_Mg_Oral_Tablet",
+        "2. [ 45.4% ] Irbesartan_300_Mg_Oral_Tablet",
+        "3. [ 12.1% ] Irbesartan_75_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Irbesartan_150_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_irbesartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Irbesartan_300_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_irbesartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Irbesartan_75_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_irbesartan_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Lisinopril": {
+      "remarks": [
+        "======================================================================",
+        " LISINOPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 30.3% ] Lisinopril_10_Mg_Oral_Tablet",
+        "2. [ 0.1% ] Lisinopril_1_Mg_Ml_Oral_Solution_Qbrelis",
+        "3. [ 27.3% ] Lisinopril_20_Mg_Oral_Tablet",
+        "4. [ 7.1% ] Lisinopril_2_5_Mg_Oral_Tablet",
+        "5. [ 1.5% ] Lisinopril_30_Mg_Oral_Tablet",
+        "6. [ 18.3% ] Lisinopril_40_Mg_Oral_Tablet",
+        "7. [ 15.3% ] Lisinopril_5_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Lisinopril_10_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Lisinopril_20_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Lisinopril_30_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Lisinopril_2_5_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Lisinopril_40_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Lisinopril_5_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Lisinopril_1_Mg_Ml_Oral_Solution_Qbrelis",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Losartan": {
+      "remarks": [
+        "======================================================================",
+        " LOSARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 41.1% ] Losartan_Potassium_100_Mg_Oral_Tablet",
+        "2. [ 20.8% ] Losartan_Potassium_25_Mg_Oral_Tablet",
+        "3. [ 0.0% ] Losartan_Potassium_25_Mg_Oral_Tablet_Cozaar",
+        "4. [ 38.0% ] Losartan_Potassium_50_Mg_Oral_Tablet",
+        "5. [ 0.1% ] Losartan_Potassium_50_Mg_Oral_Tablet_Cozaar"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Losartan_Potassium_100_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Losartan_Potassium_25_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Losartan_Potassium_50_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Losartan_Potassium_50_Mg_Oral_Tablet_Cozaar",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Losartan_Potassium_25_Mg_Oral_Tablet_Cozaar",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Quinapril": {
+      "remarks": [
+        "======================================================================",
+        " QUINAPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 14.1% ] Quinapril_10_Mg_Oral_Tablet",
+        "2. [ 18.6% ] Quinapril_20_Mg_Oral_Tablet",
+        "3. [ 63.3% ] Quinapril_40_Mg_Oral_Tablet",
+        "4. [ 4.0% ] Quinapril_5_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Quinapril_10_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_quinapril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Quinapril_40_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_quinapril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Quinapril_20_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_quinapril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Quinapril_5_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_quinapril_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Ramipril": {
+      "remarks": [
+        "======================================================================",
+        " RAMIPRIL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 47.7% ] Ramipril_10_Mg_Oral_Capsule",
+        "2. [ 3.8% ] Ramipril_1_25_Mg_Oral_Capsule",
+        "3. [ 19.3% ] Ramipril_2_5_Mg_Oral_Capsule",
+        "4. [ 29.2% ] Ramipril_5_Mg_Oral_Capsule"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Ramipril_10_Mg_Oral_Capsule",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_ramipril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Ramipril_2_5_Mg_Oral_Capsule",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ramipril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Ramipril_5_Mg_Oral_Capsule",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ramipril_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Ramipril_1_25_Mg_Oral_Capsule",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_ramipril_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Sacubitril_Valsartan": {
+      "remarks": [
+        "======================================================================",
+        " SACUBITRIL_VALSARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 50.0% ] Sacubitril_24_Mg_Valsartan_26_Mg_Oral_Tablet_Entresto",
+        "2. [ 23.3% ] Sacubitril_49_Mg_Valsartan_51_Mg_Oral_Tablet_Entresto",
+        "3. [ 26.6% ] Sacubitril_97_Mg_Valsartan_103_Mg_Oral_Tablet_Entresto"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Sacubitril_24_Mg_Valsartan_26_Mg_Oral_Tablet_Entresto",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_sacubitril_valsartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Sacubitril_49_Mg_Valsartan_51_Mg_Oral_Tablet_Entresto",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_sacubitril_valsartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Sacubitril_97_Mg_Valsartan_103_Mg_Oral_Tablet_Entresto",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_sacubitril_valsartan_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Telmisartan": {
+      "remarks": [
+        "======================================================================",
+        " TELMISARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 3.9% ] Telmisartan_20_Mg_Oral_Tablet",
+        "2. [ 0.3% ] Telmisartan_20_Mg_Oral_Tablet_Micardis",
+        "3. [ 26.6% ] Telmisartan_40_Mg_Oral_Tablet",
+        "4. [ 53.9% ] Telmisartan_80_Mg_Oral_Tablet",
+        "5. [ 15.3% ] Telmisartan_80_Mg_Oral_Tablet_Micardis"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Telmisartan_20_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Telmisartan_20_Mg_Oral_Tablet_Micardis",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Telmisartan_40_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Telmisartan_80_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Telmisartan_80_Mg_Oral_Tablet_Micardis",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Valsartan": {
+      "remarks": [
+        "======================================================================",
+        " VALSARTAN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 34.7% ] Valsartan_160_Mg_Oral_Tablet",
+        "2. [ 27.7% ] Valsartan_320_Mg_Oral_Tablet",
+        "3. [ 1.9% ] Valsartan_320_Mg_Oral_Tablet_Diovan",
+        "4. [ 3.3% ] Valsartan_40_Mg_Oral_Tablet",
+        "5. [ 32.4% ] Valsartan_80_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Valsartan_160_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Valsartan_320_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Valsartan_80_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Valsartan_40_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Valsartan_320_Mg_Oral_Tablet_Diovan",
+          "default_probability": 0,
+          "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Amlodipine_10_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule": {
+      "remarks": [
+        "======================================================================",
+        " BEGIN MEDICATION ORDER STATES                                        ",
+        "======================================================================"
+      ],
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898342",
+          "display": "amlodipine 10 MG / benazepril hydrochloride 20 MG Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Amlodipine_10_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898346",
+          "display": "amlodipine 10 MG / benazepril hydrochloride 40 MG Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Amlodipine_2_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898350",
+          "display": "amlodipine 2.5 MG / benazepril hydrochloride 10 MG Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898353",
+          "display": "amlodipine 5 MG / benazepril hydrochloride 10 MG Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898356",
+          "display": "amlodipine 5 MG / benazepril hydrochloride 20 MG Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898359",
+          "display": "amlodipine 5 MG / benazepril hydrochloride 40 MG Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Benazepril_Hydrochloride_10_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898362",
+          "display": "benazepril hydrochloride 10 MG / hydrochlorothiazide 12.5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Benazepril_Hydrochloride_10_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898687",
+          "display": "benazepril hydrochloride 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898367",
+          "display": "benazepril hydrochloride 20 MG / hydrochlorothiazide 12.5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_25_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898372",
+          "display": "benazepril hydrochloride 20 MG / hydrochlorothiazide 25 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Benazepril_Hydrochloride_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898690",
+          "display": "benazepril hydrochloride 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Benazepril_Hydrochloride_40_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898719",
+          "display": "benazepril hydrochloride 40 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Benazepril_Hydrochloride_5_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "898723",
+          "display": "benazepril hydrochloride 5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Enalapril_Maleate_1_Mg_Ml_Oral_Solution_Epaned": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1435630",
+          "display": "enalapril maleate 1 MG/ML Oral Solution [Epaned]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Enalapril_Maleate_10_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "858817",
+          "display": "enalapril maleate 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Enalapril_Maleate_2_5_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "858804",
+          "display": "enalapril maleate 2.5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Enalapril_Maleate_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "858810",
+          "display": "enalapril maleate 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Enalapril_Maleate_5_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "858813",
+          "display": "enalapril maleate 5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_12_5_Mg_Lisinopril_10_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "197885",
+          "display": "hydrochlorothiazide 12.5 MG / lisinopril 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_12_5_Mg_Lisinopril_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "197886",
+          "display": "hydrochlorothiazide 12.5 MG / lisinopril 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "979464",
+          "display": "hydrochlorothiazide 12.5 MG / losartan potassium 100 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "979466",
+          "display": "hydrochlorothiazide 12.5 MG / losartan potassium 100 MG Oral Tablet [Hyzaar]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "979468",
+          "display": "hydrochlorothiazide 12.5 MG / losartan potassium 50 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet_Hyzaar": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "979470",
+          "display": "hydrochlorothiazide 12.5 MG / losartan potassium 50 MG Oral Tablet [Hyzaar]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_160_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "200285",
+          "display": "hydrochlorothiazide 12.5 MG / valsartan 160 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_320_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "636042",
+          "display": "hydrochlorothiazide 12.5 MG / valsartan 320 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_80_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "200284",
+          "display": "hydrochlorothiazide 12.5 MG / valsartan 80 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_25_Mg_Lisinopril_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "197887",
+          "display": "hydrochlorothiazide 25 MG / lisinopril 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "979471",
+          "display": "hydrochlorothiazide 25 MG / losartan potassium 100 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "979473",
+          "display": "hydrochlorothiazide 25 MG / losartan potassium 100 MG Oral Tablet [Hyzaar]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_25_Mg_Valsartan_160_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "349353",
+          "display": "hydrochlorothiazide 25 MG / valsartan 160 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Hydrochlorothiazide_25_Mg_Valsartan_320_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "636045",
+          "display": "hydrochlorothiazide 25 MG / valsartan 320 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Irbesartan_150_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "200095",
+          "display": "irbesartan 150 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Irbesartan_300_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "200096",
+          "display": "irbesartan 300 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Irbesartan_75_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "200094",
+          "display": "irbesartan 75 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Lisinopril_1_Mg_Ml_Oral_Solution_Qbrelis": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1806890",
+          "display": "lisinopril 1 MG/ML Oral Solution [Qbrelis]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Lisinopril_10_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "314076",
+          "display": "lisinopril 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Lisinopril_2_5_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "311353",
+          "display": "lisinopril 2.5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Lisinopril_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "314077",
+          "display": "lisinopril 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Lisinopril_30_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "205326",
+          "display": "lisinopril 30 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Lisinopril_40_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "197884",
+          "display": "lisinopril 40 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Lisinopril_5_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "311354",
+          "display": "lisinopril 5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Losartan_Potassium_100_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "979480",
+          "display": "losartan potassium 100 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Losartan_Potassium_25_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "979485",
+          "display": "losartan potassium 25 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Losartan_Potassium_25_Mg_Oral_Tablet_Cozaar": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "979487",
+          "display": "losartan potassium 25 MG Oral Tablet [Cozaar]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Losartan_Potassium_50_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "979492",
+          "display": "losartan potassium 50 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Losartan_Potassium_50_Mg_Oral_Tablet_Cozaar": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "979494",
+          "display": "losartan potassium 50 MG Oral Tablet [Cozaar]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Quinapril_10_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "312748",
+          "display": "quinapril 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Quinapril_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "312749",
+          "display": "quinapril 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Quinapril_40_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "314203",
+          "display": "quinapril 40 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Quinapril_5_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "312750",
+          "display": "quinapril 5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Ramipril_1_25_Mg_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "845488",
+          "display": "ramipril 1.25 MG Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Ramipril_10_Mg_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "261962",
+          "display": "ramipril 10 MG Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Ramipril_2_5_Mg_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "198188",
+          "display": "ramipril 2.5 MG Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Ramipril_5_Mg_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "198189",
+          "display": "ramipril 5 MG Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Sacubitril_24_Mg_Valsartan_26_Mg_Oral_Tablet_Entresto": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1656346",
+          "display": "sacubitril 24 MG / valsartan 26 MG Oral Tablet [Entresto]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Sacubitril_49_Mg_Valsartan_51_Mg_Oral_Tablet_Entresto": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1656351",
+          "display": "sacubitril 49 MG / valsartan 51 MG Oral Tablet [Entresto]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Sacubitril_97_Mg_Valsartan_103_Mg_Oral_Tablet_Entresto": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1656356",
+          "display": "sacubitril 97 MG / valsartan 103 MG Oral Tablet [Entresto]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Telmisartan_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "282755",
+          "display": "telmisartan 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Telmisartan_20_Mg_Oral_Tablet_Micardis": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "284531",
+          "display": "telmisartan 20 MG Oral Tablet [Micardis]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Telmisartan_40_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "205304",
+          "display": "telmisartan 40 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Telmisartan_80_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "205305",
+          "display": "telmisartan 80 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Telmisartan_80_Mg_Oral_Tablet_Micardis": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "213432",
+          "display": "telmisartan 80 MG Oral Tablet [Micardis]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Valsartan_160_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "349201",
+          "display": "valsartan 160 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Valsartan_320_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "349200",
+          "display": "valsartan 320 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Valsartan_320_Mg_Oral_Tablet_Diovan": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "352001",
+          "display": "valsartan 320 MG Oral Tablet [Diovan]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Valsartan_40_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "349483",
+          "display": "valsartan 40 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Valsartan_80_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "ace_arb",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "349199",
+          "display": "valsartan 80 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
     }
+  }
 }

--- a/src/main/resources/modules/medications/ace_arb.json
+++ b/src/main/resources/modules/medications/ace_arb.json
@@ -123,77 +123,77 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Amlodipine_Benazepril",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Benazepril",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Benazepril_Hydrochlorothiazide",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Enalapril",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_Lisinopril",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_Losartan",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_Valsartan",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Irbesartan",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Lisinopril",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Losartan",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Quinapril",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Ramipril",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Sacubitril_Valsartan",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Telmisartan",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Valsartan",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ingredient_distribution.csv"
                 }
             ]
@@ -218,32 +218,32 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Amlodipine_10_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_20_Mg_Oral_Capsule",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Amlodipine_10_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Amlodipine_5_Mg_Benazepril_Hydrochloride_40_Mg_Oral_Capsule",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Amlodipine_2_5_Mg_Benazepril_Hydrochloride_10_Mg_Oral_Capsule",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_amlodipine_benazepril_product_distribution.csv"
                 }
             ]
@@ -266,22 +266,22 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Benazepril_Hydrochloride_10_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_benazepril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Benazepril_Hydrochloride_20_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_benazepril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Benazepril_Hydrochloride_40_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_benazepril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Benazepril_Hydrochloride_5_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_benazepril_product_distribution.csv"
                 }
             ]
@@ -303,17 +303,17 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Benazepril_Hydrochloride_10_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_benazepril_hydrochlorothiazide_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_12_5_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_benazepril_hydrochlorothiazide_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Benazepril_Hydrochloride_20_Mg_Hydrochlorothiazide_25_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_benazepril_hydrochlorothiazide_product_distribution.csv"
                 }
             ]
@@ -337,27 +337,27 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Enalapril_Maleate_10_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Enalapril_Maleate_20_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Enalapril_Maleate_5_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Enalapril_Maleate_2_5_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Enalapril_Maleate_1_Mg_Ml_Oral_Solution_Epaned",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_enalapril_product_distribution.csv"
                 }
             ]
@@ -379,17 +379,17 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Lisinopril_10_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_lisinopril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Lisinopril_20_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_lisinopril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Lisinopril_20_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_lisinopril_product_distribution.csv"
                 }
             ]
@@ -414,32 +414,32 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Losartan_Potassium_50_Mg_Oral_Tablet_Hyzaar",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Losartan_Potassium_100_Mg_Oral_Tablet_Hyzaar",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_losartan_product_distribution.csv"
                 }
             ]
@@ -463,27 +463,27 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_160_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_80_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Valsartan_160_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_25_Mg_Valsartan_320_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Hydrochlorothiazide_12_5_Mg_Valsartan_320_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_hydrochlorothiazide_valsartan_product_distribution.csv"
                 }
             ]
@@ -505,17 +505,17 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Irbesartan_150_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_irbesartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Irbesartan_300_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_irbesartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Irbesartan_75_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_irbesartan_product_distribution.csv"
                 }
             ]
@@ -541,37 +541,37 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Lisinopril_10_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Lisinopril_20_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Lisinopril_30_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Lisinopril_2_5_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Lisinopril_40_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Lisinopril_5_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Lisinopril_1_Mg_Ml_Oral_Solution_Qbrelis",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_lisinopril_product_distribution.csv"
                 }
             ]
@@ -595,27 +595,27 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Losartan_Potassium_100_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Losartan_Potassium_25_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Losartan_Potassium_50_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Losartan_Potassium_50_Mg_Oral_Tablet_Cozaar",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Losartan_Potassium_25_Mg_Oral_Tablet_Cozaar",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_losartan_product_distribution.csv"
                 }
             ]
@@ -638,22 +638,22 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Quinapril_10_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_quinapril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Quinapril_40_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_quinapril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Quinapril_20_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_quinapril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Quinapril_5_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_quinapril_product_distribution.csv"
                 }
             ]
@@ -676,22 +676,22 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Ramipril_10_Mg_Oral_Capsule",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_ramipril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Ramipril_2_5_Mg_Oral_Capsule",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ramipril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Ramipril_5_Mg_Oral_Capsule",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ramipril_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Ramipril_1_25_Mg_Oral_Capsule",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_ramipril_product_distribution.csv"
                 }
             ]
@@ -713,17 +713,17 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Sacubitril_24_Mg_Valsartan_26_Mg_Oral_Tablet_Entresto",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_sacubitril_valsartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Sacubitril_49_Mg_Valsartan_51_Mg_Oral_Tablet_Entresto",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_sacubitril_valsartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Sacubitril_97_Mg_Valsartan_103_Mg_Oral_Tablet_Entresto",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_sacubitril_valsartan_product_distribution.csv"
                 }
             ]
@@ -747,27 +747,27 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Telmisartan_20_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Telmisartan_20_Mg_Oral_Tablet_Micardis",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Telmisartan_40_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Telmisartan_80_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Telmisartan_80_Mg_Oral_Tablet_Micardis",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_telmisartan_product_distribution.csv"
                 }
             ]
@@ -791,27 +791,27 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Valsartan_160_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Valsartan_320_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Valsartan_80_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Valsartan_40_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Valsartan_320_Mg_Oral_Tablet_Diovan",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "ace_arb_valsartan_product_distribution.csv"
                 }
             ]

--- a/src/main/resources/modules/medications/beta_blocker.json
+++ b/src/main/resources/modules/medications/beta_blocker.json
@@ -112,42 +112,42 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Atenolol",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Bisoprolol",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Bisoprolol_Hydrochlorothiazide",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Carvedilol",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Labetalol",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Metoprolol",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Nebivolol",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Propranolol",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
                 }
             ]
@@ -169,17 +169,17 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Atenolol_100_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "beta_blocker_atenolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Atenolol_50_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_atenolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Atenolol_25_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_atenolol_product_distribution.csv"
                 }
             ]
@@ -200,12 +200,12 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Bisoprolol_Fumarate_10_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "beta_blocker_bisoprolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Bisoprolol_Fumarate_5_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_bisoprolol_product_distribution.csv"
                 }
             ]
@@ -227,17 +227,17 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Bisoprolol_Fumarate_10_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "beta_blocker_bisoprolol_hydrochlorothiazide_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Bisoprolol_Fumarate_2_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_bisoprolol_hydrochlorothiazide_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Bisoprolol_Fumarate_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_bisoprolol_hydrochlorothiazide_product_distribution.csv"
                 }
             ]
@@ -266,52 +266,52 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_24_Hr_Carvedilol_Phosphate_10_Mg_Extended_Release_Oral_Capsule",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Carvedilol_12_5_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Carvedilol_25_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Carvedilol_3_125_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Carvedilol_6_25_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Carvedilol_12_5_Mg_Oral_Tablet_Coreg",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule_Coreg",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Carvedilol_6_25_Mg_Oral_Tablet_Coreg",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Carvedilol_25_Mg_Oral_Tablet_Coreg",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
                 }
             ]
@@ -333,17 +333,17 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Labetalol_Hydrochloride_100_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "beta_blocker_labetalol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Labetalol_Hydrochloride_200_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_labetalol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Labetalol_Hydrochloride_300_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_labetalol_product_distribution.csv"
                 }
             ]
@@ -374,62 +374,62 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_24_Hr_Metoprolol_Succinate_100_Mg_Extended_Release_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Metoprolol_Tartrate_50_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Metoprolol_Tartrate_100_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Metoprolol_Tartrate_25_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_24_Hr_Metoprolol_Succinate_200_Mg_Extended_Release_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet_Toprol",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet_Toprol",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Metoprolol_Tartrate_50_Mg_Oral_Tablet_Lopressor",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Cartridge",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Injection",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
                 }
             ]
@@ -452,22 +452,22 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Nebivolol_10_Mg_Oral_Tablet_Bystolic",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "beta_blocker_nebivolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Nebivolol_20_Mg_Oral_Tablet_Bystolic",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_nebivolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Nebivolol_2_5_Mg_Oral_Tablet_Bystolic",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_nebivolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Nebivolol_5_Mg_Oral_Tablet_Bystolic",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_nebivolol_product_distribution.csv"
                 }
             ]
@@ -495,47 +495,47 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_24_Hr_Propranolol_Hydrochloride_120_Mg_Extended_Release_Oral_Capsule",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_24_Hr_Propranolol_Hydrochloride_60_Mg_Extended_Release_Oral_Capsule",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_24_Hr_Propranolol_Hydrochloride_80_Mg_Extended_Release_Oral_Capsule",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Propranolol_Hydrochloride_40_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_24_Hr_Propranolol_Hydrochloride_160_Mg_Extended_Release_Oral_Capsule",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Propranolol_Hydrochloride_10_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Propranolol_Hydrochloride_20_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Propranolol_Hydrochloride_80_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Propranolol_Hydrochloride_60_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
                 }
             ]

--- a/src/main/resources/modules/medications/beta_blocker.json
+++ b/src/main/resources/modules/medications/beta_blocker.json
@@ -1,1377 +1,1322 @@
 {
-    "name": "Beta Blocker",
-    "remarks": [
-        "======================================================================",
-        "  SUBMODULE BETA BLOCKER",
-        "======================================================================",
-        "",
-        "This submodule prescribes a medication based on population data.",
-        "",
-        "IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
-        "All medications prescribed in this module are assigned to the attribute",
-        "'beta_blocker'.",
-        "",
-        "Reference links:",
-        "    RxClass: https://mor.nlm.nih.gov/RxClass/",
-        "    RxNorm: https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
-        "    RxNav: https://mor.nlm.nih.gov/RxNav/",
-        "    MEPS: https://meps.ahrq.gov/mepsweb/data_stats/MEPS_topics.jsp?topicid=46Z-1",
-        "    FDA: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory",
-        "",
-        "Made with (</>) by the CodeRx Medication Diversification Tool (MDT)",
-        "",
-        "MDT settings for this submodule:",
-        "{",
-        "    \"module\": {",
-        "        \"name\": null,",
-        "        \"assign_to_attribute\": null,",
-        "        \"reason\": null,",
-        "        \"as_needed\": false,",
-        "        \"chronic\": false,",
-        "        \"refills\": 0",
-        "    },",
-        "    \"rxclass\": {",
-        "        \"include\": [",
-        "            {",
-        "                \"class_id\": \"N0000175556\",",
-        "                \"relationship\": \"has_EPC\"",
-        "            }",
-        "        ],",
-        "        \"exclude\": null",
-        "    },",
-        "    \"rxcui\": {",
-        "        \"include\": null,",
-        "        \"exclude\": null",
-        "    },",
-        "    \"ingredient_tty_filter\": null,",
-        "    \"dose_form_filter\": null,",
-        "    \"meps\": {",
-        "        \"age_ranges\": null,",
-        "        \"demographic_distribution_flags\": {",
-        "            \"age\": true,",
-        "            \"gender\": true,",
-        "            \"state\": true",
-        "        }",
-        "    },",
-        "    \"state_prefix\": \"Prescribe_\",",
-        "    \"ingredient_distribution_suffix\": \"_ingredient_distribution\",",
-        "    \"product_distribution_suffix\": \"_product_distribution\",",
-        "    \"default_age_ranges\": [",
-        "        \"0-3\",",
-        "        \"4-7\",",
-        "        \"8-11\",",
-        "        \"12-17\",",
-        "        \"18-25\",",
-        "        \"26-35\",",
-        "        \"36-45\",",
-        "        \"46-65\",",
-        "        \"65-103\"",
-        "    ]",
-        "}"
-    ],
-    "gmf_version": 2,
-    "states": {
-        "Initial": {
-            "type": "Initial",
-            "conditional_transition": [
-                {
-                    "condition": {
-                        "condition_type": "Attribute",
-                        "attribute": "beta_blocker",
-                        "operator": "is nil"
-                    },
-                    "transition": "Prescribe_Ingredient"
-                },
-                {
-                    "transition": "Terminal"
-                }
-            ]
+  "name": "Beta Blocker",
+  "remarks": [
+    "======================================================================",
+    "  SUBMODULE BETA BLOCKER",
+    "======================================================================",
+    "",
+    "This submodule prescribes a medication based on population data.",
+    "",
+    "IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
+    "All medications prescribed in this module are assigned to the attribute",
+    "'beta_blocker'.",
+    "",
+    "Reference links:",
+    "    RxClass: https://mor.nlm.nih.gov/RxClass/",
+    "    RxNorm: https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
+    "    RxNav: https://mor.nlm.nih.gov/RxNav/",
+    "    MEPS: https://meps.ahrq.gov/mepsweb/data_stats/MEPS_topics.jsp?topicid=46Z-1",
+    "    FDA: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory",
+    "",
+    "Made with (</>) by the CodeRx Medication Diversification Tool (MDT)",
+    "",
+    "MDT settings for this submodule:",
+    "{",
+    "    \"module\": {",
+    "        \"name\": null,",
+    "        \"assign_to_attribute\": null,",
+    "        \"reason\": null,",
+    "        \"as_needed\": false,",
+    "        \"chronic\": false,",
+    "        \"refills\": 0",
+    "    },",
+    "    \"rxclass\": {",
+    "        \"include\": [",
+    "            {",
+    "                \"class_id\": \"N0000175556\",",
+    "                \"relationship\": \"has_EPC\"",
+    "            }",
+    "        ],",
+    "        \"exclude\": null",
+    "    },",
+    "    \"rxcui\": {",
+    "        \"include\": null,",
+    "        \"exclude\": null",
+    "    },",
+    "    \"ingredient_tty_filter\": null,",
+    "    \"dose_form_filter\": null,",
+    "    \"meps\": {",
+    "        \"age_ranges\": null,",
+    "        \"demographic_distribution_flags\": {",
+    "            \"age\": true,",
+    "            \"gender\": true,",
+    "            \"state\": true",
+    "        }",
+    "    },",
+    "    \"state_prefix\": \"Prescribe_\",",
+    "    \"ingredient_distribution_suffix\": \"_ingredient_distribution\",",
+    "    \"product_distribution_suffix\": \"_product_distribution\",",
+    "    \"default_age_ranges\": [",
+    "        \"0-3\",",
+    "        \"4-7\",",
+    "        \"8-11\",",
+    "        \"12-17\",",
+    "        \"18-25\",",
+    "        \"26-35\",",
+    "        \"36-45\",",
+    "        \"46-65\",",
+    "        \"65-103\"",
+    "    ]",
+    "}"
+  ],
+  "gmf_version": 2,
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "beta_blocker",
+            "operator": "is nil"
+          },
+          "transition": "Prescribe_Ingredient"
         },
-        "Terminal": {
-            "type": "Terminal"
-        },
-        "Prescribe_Ingredient": {
-            "name": "Prescribe_Ingredient",
-            "remarks": [
-                "======================================================================",
-                " MEDICATION INGREDIENT TABLE TRANSITION                               ",
-                "======================================================================",
-                "Ingredients in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 15.3% ] Atenolol",
-                "2. [ 1.3% ] Bisoprolol",
-                "3. [ 1.1% ] Bisoprolol_Hydrochlorothiazide",
-                "4. [ 16.8% ] Carvedilol",
-                "5. [ 2.5% ] Labetalol",
-                "6. [ 53.9% ] Metoprolol",
-                "7. [ 2.2% ] Nebivolol",
-                "8. [ 6.7% ] Propranolol"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Atenolol",
-                    "default_probability": 1,
-                    "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Bisoprolol",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Bisoprolol_Hydrochlorothiazide",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Carvedilol",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Labetalol",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Metoprolol",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Nebivolol",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Propranolol",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Atenolol": {
-            "name": "Prescribe_Atenolol",
-            "remarks": [
-                "======================================================================",
-                " ATENOLOL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 9.9% ] Atenolol_100_Mg_Oral_Tablet",
-                "2. [ 46.1% ] Atenolol_25_Mg_Oral_Tablet",
-                "3. [ 44.0% ] Atenolol_50_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Atenolol_100_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "beta_blocker_atenolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Atenolol_50_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_atenolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Atenolol_25_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_atenolol_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Bisoprolol": {
-            "name": "Prescribe_Bisoprolol",
-            "remarks": [
-                "======================================================================",
-                " BISOPROLOL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 28.9% ] Bisoprolol_Fumarate_10_Mg_Oral_Tablet",
-                "2. [ 71.1% ] Bisoprolol_Fumarate_5_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Bisoprolol_Fumarate_10_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "beta_blocker_bisoprolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Bisoprolol_Fumarate_5_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_bisoprolol_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Bisoprolol_Hydrochlorothiazide": {
-            "name": "Prescribe_Bisoprolol_Hydrochlorothiazide",
-            "remarks": [
-                "======================================================================",
-                " BISOPROLOL_HYDROCHLOROTHIAZIDE MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 27.3% ] Bisoprolol_Fumarate_10_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
-                "2. [ 42.2% ] Bisoprolol_Fumarate_2_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
-                "3. [ 30.5% ] Bisoprolol_Fumarate_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Bisoprolol_Fumarate_10_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "beta_blocker_bisoprolol_hydrochlorothiazide_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Bisoprolol_Fumarate_2_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_bisoprolol_hydrochlorothiazide_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Bisoprolol_Fumarate_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_bisoprolol_hydrochlorothiazide_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Carvedilol": {
-            "name": "Prescribe_Carvedilol",
-            "remarks": [
-                "======================================================================",
-                " CARVEDILOL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 0.3% ] 24_Hr_Carvedilol_Phosphate_10_Mg_Extended_Release_Oral_Capsule",
-                "2. [ 0.0% ] 24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule",
-                "3. [ 0.3% ] 24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule_Coreg",
-                "4. [ 25.0% ] Carvedilol_12_5_Mg_Oral_Tablet",
-                "5. [ 0.2% ] Carvedilol_12_5_Mg_Oral_Tablet_Coreg",
-                "6. [ 27.4% ] Carvedilol_25_Mg_Oral_Tablet",
-                "7. [ 0.1% ] Carvedilol_25_Mg_Oral_Tablet_Coreg",
-                "8. [ 21.8% ] Carvedilol_3_125_Mg_Oral_Tablet",
-                "9. [ 24.8% ] Carvedilol_6_25_Mg_Oral_Tablet",
-                "10. [ 0.0% ] Carvedilol_6_25_Mg_Oral_Tablet_Coreg"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_24_Hr_Carvedilol_Phosphate_10_Mg_Extended_Release_Oral_Capsule",
-                    "default_probability": 1,
-                    "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Carvedilol_12_5_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Carvedilol_25_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Carvedilol_3_125_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Carvedilol_6_25_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Carvedilol_12_5_Mg_Oral_Tablet_Coreg",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule_Coreg",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Carvedilol_6_25_Mg_Oral_Tablet_Coreg",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Carvedilol_25_Mg_Oral_Tablet_Coreg",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Labetalol": {
-            "name": "Prescribe_Labetalol",
-            "remarks": [
-                "======================================================================",
-                " LABETALOL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 46.4% ] Labetalol_Hydrochloride_100_Mg_Oral_Tablet",
-                "2. [ 35.4% ] Labetalol_Hydrochloride_200_Mg_Oral_Tablet",
-                "3. [ 18.2% ] Labetalol_Hydrochloride_300_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Labetalol_Hydrochloride_100_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "beta_blocker_labetalol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Labetalol_Hydrochloride_200_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_labetalol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Labetalol_Hydrochloride_300_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_labetalol_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Metoprolol": {
-            "name": "Prescribe_Metoprolol",
-            "remarks": [
-                "======================================================================",
-                " METOPROLOL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 12.3% ] 24_Hr_Metoprolol_Succinate_100_Mg_Extended_Release_Oral_Tablet",
-                "2. [ 1.8% ] 24_Hr_Metoprolol_Succinate_200_Mg_Extended_Release_Oral_Tablet",
-                "3. [ 18.7% ] 24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet",
-                "4. [ 0.6% ] 24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet_Toprol",
-                "5. [ 19.3% ] 24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet",
-                "6. [ 0.3% ] 24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet_Toprol",
-                "7. [ 0.0% ] 5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Cartridge",
-                "8. [ 0.0% ] 5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Injection",
-                "9. [ 4.5% ] Metoprolol_Tartrate_100_Mg_Oral_Tablet",
-                "10. [ 24.1% ] Metoprolol_Tartrate_25_Mg_Oral_Tablet",
-                "11. [ 18.3% ] Metoprolol_Tartrate_50_Mg_Oral_Tablet",
-                "12. [ 0.1% ] Metoprolol_Tartrate_50_Mg_Oral_Tablet_Lopressor"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_24_Hr_Metoprolol_Succinate_100_Mg_Extended_Release_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Metoprolol_Tartrate_50_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Metoprolol_Tartrate_100_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Metoprolol_Tartrate_25_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_24_Hr_Metoprolol_Succinate_200_Mg_Extended_Release_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet_Toprol",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet_Toprol",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Metoprolol_Tartrate_50_Mg_Oral_Tablet_Lopressor",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Cartridge",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Injection",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Nebivolol": {
-            "name": "Prescribe_Nebivolol",
-            "remarks": [
-                "======================================================================",
-                " NEBIVOLOL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 40.7% ] Nebivolol_10_Mg_Oral_Tablet_Bystolic",
-                "2. [ 11.2% ] Nebivolol_20_Mg_Oral_Tablet_Bystolic",
-                "3. [ 2.2% ] Nebivolol_2_5_Mg_Oral_Tablet_Bystolic",
-                "4. [ 45.8% ] Nebivolol_5_Mg_Oral_Tablet_Bystolic"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Nebivolol_10_Mg_Oral_Tablet_Bystolic",
-                    "default_probability": 1,
-                    "lookup_table_name": "beta_blocker_nebivolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Nebivolol_20_Mg_Oral_Tablet_Bystolic",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_nebivolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Nebivolol_2_5_Mg_Oral_Tablet_Bystolic",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_nebivolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Nebivolol_5_Mg_Oral_Tablet_Bystolic",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_nebivolol_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Propranolol": {
-            "name": "Prescribe_Propranolol",
-            "remarks": [
-                "======================================================================",
-                " PROPRANOLOL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 3.2% ] 24_Hr_Propranolol_Hydrochloride_120_Mg_Extended_Release_Oral_Capsule",
-                "2. [ 4.5% ] 24_Hr_Propranolol_Hydrochloride_160_Mg_Extended_Release_Oral_Capsule",
-                "3. [ 15.0% ] 24_Hr_Propranolol_Hydrochloride_60_Mg_Extended_Release_Oral_Capsule",
-                "4. [ 6.3% ] 24_Hr_Propranolol_Hydrochloride_80_Mg_Extended_Release_Oral_Capsule",
-                "5. [ 19.6% ] Propranolol_Hydrochloride_10_Mg_Oral_Tablet",
-                "6. [ 26.2% ] Propranolol_Hydrochloride_20_Mg_Oral_Tablet",
-                "7. [ 19.7% ] Propranolol_Hydrochloride_40_Mg_Oral_Tablet",
-                "8. [ 1.6% ] Propranolol_Hydrochloride_60_Mg_Oral_Tablet",
-                "9. [ 3.9% ] Propranolol_Hydrochloride_80_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_24_Hr_Propranolol_Hydrochloride_120_Mg_Extended_Release_Oral_Capsule",
-                    "default_probability": 1,
-                    "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_24_Hr_Propranolol_Hydrochloride_60_Mg_Extended_Release_Oral_Capsule",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_24_Hr_Propranolol_Hydrochloride_80_Mg_Extended_Release_Oral_Capsule",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Propranolol_Hydrochloride_40_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_24_Hr_Propranolol_Hydrochloride_160_Mg_Extended_Release_Oral_Capsule",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Propranolol_Hydrochloride_10_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Propranolol_Hydrochloride_20_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Propranolol_Hydrochloride_80_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Propranolol_Hydrochloride_60_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_24_Hr_Carvedilol_Phosphate_10_Mg_Extended_Release_Oral_Capsule": {
-            "remarks": [
-                "======================================================================",
-                " BEGIN MEDICATION ORDER STATES                                        ",
-                "======================================================================"
-            ],
-            "name": "Prescribe_24_Hr_Carvedilol_Phosphate_10_Mg_Extended_Release_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "860510",
-                    "display": "24 HR carvedilol phosphate 10 MG Extended Release Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule": {
-            "name": "Prescribe_24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "860516",
-                    "display": "24 HR carvedilol phosphate 20 MG Extended Release Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule_Coreg": {
-            "name": "Prescribe_24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule_Coreg",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "860518",
-                    "display": "24 HR carvedilol phosphate 20 MG Extended Release Oral Capsule [Coreg]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_24_Hr_Metoprolol_Succinate_100_Mg_Extended_Release_Oral_Tablet": {
-            "name": "Prescribe_24_Hr_Metoprolol_Succinate_100_Mg_Extended_Release_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "866412",
-                    "display": "24 HR metoprolol succinate 100 MG Extended Release Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_24_Hr_Metoprolol_Succinate_200_Mg_Extended_Release_Oral_Tablet": {
-            "name": "Prescribe_24_Hr_Metoprolol_Succinate_200_Mg_Extended_Release_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "866419",
-                    "display": "24 HR metoprolol succinate 200 MG Extended Release Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet": {
-            "name": "Prescribe_24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "866427",
-                    "display": "24 HR metoprolol succinate 25 MG Extended Release Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet_Toprol": {
-            "name": "Prescribe_24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet_Toprol",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "866429",
-                    "display": "24 HR metoprolol succinate 25 MG Extended Release Oral Tablet [Toprol]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet": {
-            "name": "Prescribe_24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "866436",
-                    "display": "24 HR metoprolol succinate 50 MG Extended Release Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet_Toprol": {
-            "name": "Prescribe_24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet_Toprol",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "866438",
-                    "display": "24 HR metoprolol succinate 50 MG Extended Release Oral Tablet [Toprol]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_24_Hr_Propranolol_Hydrochloride_120_Mg_Extended_Release_Oral_Capsule": {
-            "name": "Prescribe_24_Hr_Propranolol_Hydrochloride_120_Mg_Extended_Release_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "856460",
-                    "display": "24 HR propranolol hydrochloride 120 MG Extended Release Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_24_Hr_Propranolol_Hydrochloride_160_Mg_Extended_Release_Oral_Capsule": {
-            "name": "Prescribe_24_Hr_Propranolol_Hydrochloride_160_Mg_Extended_Release_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "856481",
-                    "display": "24 HR propranolol hydrochloride 160 MG Extended Release Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_24_Hr_Propranolol_Hydrochloride_60_Mg_Extended_Release_Oral_Capsule": {
-            "name": "Prescribe_24_Hr_Propranolol_Hydrochloride_60_Mg_Extended_Release_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "856535",
-                    "display": "24 HR propranolol hydrochloride 60 MG Extended Release Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_24_Hr_Propranolol_Hydrochloride_80_Mg_Extended_Release_Oral_Capsule": {
-            "name": "Prescribe_24_Hr_Propranolol_Hydrochloride_80_Mg_Extended_Release_Oral_Capsule",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "856569",
-                    "display": "24 HR propranolol hydrochloride 80 MG Extended Release Oral Capsule"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Cartridge": {
-            "name": "Prescribe_5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Cartridge",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1744259",
-                    "display": "5 ML metoprolol tartrate 1 MG/ML Cartridge"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Injection": {
-            "name": "Prescribe_5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Injection",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "866508",
-                    "display": "5 ML metoprolol tartrate 1 MG/ML Injection"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Atenolol_100_Mg_Oral_Tablet": {
-            "name": "Prescribe_Atenolol_100_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "197379",
-                    "display": "atenolol 100 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Atenolol_25_Mg_Oral_Tablet": {
-            "name": "Prescribe_Atenolol_25_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "197380",
-                    "display": "atenolol 25 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Atenolol_50_Mg_Oral_Tablet": {
-            "name": "Prescribe_Atenolol_50_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "197381",
-                    "display": "atenolol 50 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Bisoprolol_Fumarate_10_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet": {
-            "name": "Prescribe_Bisoprolol_Fumarate_10_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "854908",
-                    "display": "bisoprolol fumarate 10 MG / hydrochlorothiazide 6.25 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Bisoprolol_Fumarate_10_Mg_Oral_Tablet": {
-            "name": "Prescribe_Bisoprolol_Fumarate_10_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "854901",
-                    "display": "bisoprolol fumarate 10 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Bisoprolol_Fumarate_2_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet": {
-            "name": "Prescribe_Bisoprolol_Fumarate_2_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "854916",
-                    "display": "bisoprolol fumarate 2.5 MG / hydrochlorothiazide 6.25 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Bisoprolol_Fumarate_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet": {
-            "name": "Prescribe_Bisoprolol_Fumarate_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "854919",
-                    "display": "bisoprolol fumarate 5 MG / hydrochlorothiazide 6.25 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Bisoprolol_Fumarate_5_Mg_Oral_Tablet": {
-            "name": "Prescribe_Bisoprolol_Fumarate_5_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "854905",
-                    "display": "bisoprolol fumarate 5 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Carvedilol_12_5_Mg_Oral_Tablet": {
-            "name": "Prescribe_Carvedilol_12_5_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "200032",
-                    "display": "carvedilol 12.5 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Carvedilol_12_5_Mg_Oral_Tablet_Coreg": {
-            "name": "Prescribe_Carvedilol_12_5_Mg_Oral_Tablet_Coreg",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "212389",
-                    "display": "carvedilol 12.5 MG Oral Tablet [Coreg]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Carvedilol_25_Mg_Oral_Tablet": {
-            "name": "Prescribe_Carvedilol_25_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "200033",
-                    "display": "carvedilol 25 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Carvedilol_25_Mg_Oral_Tablet_Coreg": {
-            "name": "Prescribe_Carvedilol_25_Mg_Oral_Tablet_Coreg",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "212390",
-                    "display": "carvedilol 25 MG Oral Tablet [Coreg]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Carvedilol_3_125_Mg_Oral_Tablet": {
-            "name": "Prescribe_Carvedilol_3_125_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "686924",
-                    "display": "carvedilol 3.125 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Carvedilol_6_25_Mg_Oral_Tablet": {
-            "name": "Prescribe_Carvedilol_6_25_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "200031",
-                    "display": "carvedilol 6.25 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Carvedilol_6_25_Mg_Oral_Tablet_Coreg": {
-            "name": "Prescribe_Carvedilol_6_25_Mg_Oral_Tablet_Coreg",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "212388",
-                    "display": "carvedilol 6.25 MG Oral Tablet [Coreg]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Labetalol_Hydrochloride_100_Mg_Oral_Tablet": {
-            "name": "Prescribe_Labetalol_Hydrochloride_100_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "896758",
-                    "display": "labetalol hydrochloride 100 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Labetalol_Hydrochloride_200_Mg_Oral_Tablet": {
-            "name": "Prescribe_Labetalol_Hydrochloride_200_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "896762",
-                    "display": "labetalol hydrochloride 200 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Labetalol_Hydrochloride_300_Mg_Oral_Tablet": {
-            "name": "Prescribe_Labetalol_Hydrochloride_300_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "896766",
-                    "display": "labetalol hydrochloride 300 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Metoprolol_Tartrate_100_Mg_Oral_Tablet": {
-            "name": "Prescribe_Metoprolol_Tartrate_100_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "866511",
-                    "display": "metoprolol tartrate 100 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Metoprolol_Tartrate_25_Mg_Oral_Tablet": {
-            "name": "Prescribe_Metoprolol_Tartrate_25_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "866924",
-                    "display": "metoprolol tartrate 25 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Metoprolol_Tartrate_50_Mg_Oral_Tablet": {
-            "name": "Prescribe_Metoprolol_Tartrate_50_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "866514",
-                    "display": "metoprolol tartrate 50 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Metoprolol_Tartrate_50_Mg_Oral_Tablet_Lopressor": {
-            "name": "Prescribe_Metoprolol_Tartrate_50_Mg_Oral_Tablet_Lopressor",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "866516",
-                    "display": "metoprolol tartrate 50 MG Oral Tablet [Lopressor]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Nebivolol_10_Mg_Oral_Tablet_Bystolic": {
-            "name": "Prescribe_Nebivolol_10_Mg_Oral_Tablet_Bystolic",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "751616",
-                    "display": "nebivolol 10 MG Oral Tablet [Bystolic]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Nebivolol_2_5_Mg_Oral_Tablet_Bystolic": {
-            "name": "Prescribe_Nebivolol_2_5_Mg_Oral_Tablet_Bystolic",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "751620",
-                    "display": "nebivolol 2.5 MG Oral Tablet [Bystolic]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Nebivolol_20_Mg_Oral_Tablet_Bystolic": {
-            "name": "Prescribe_Nebivolol_20_Mg_Oral_Tablet_Bystolic",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "827075",
-                    "display": "nebivolol 20 MG Oral Tablet [Bystolic]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Nebivolol_5_Mg_Oral_Tablet_Bystolic": {
-            "name": "Prescribe_Nebivolol_5_Mg_Oral_Tablet_Bystolic",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "751623",
-                    "display": "nebivolol 5 MG Oral Tablet [Bystolic]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Propranolol_Hydrochloride_10_Mg_Oral_Tablet": {
-            "name": "Prescribe_Propranolol_Hydrochloride_10_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "856448",
-                    "display": "propranolol hydrochloride 10 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Propranolol_Hydrochloride_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Propranolol_Hydrochloride_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "856457",
-                    "display": "propranolol hydrochloride 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Propranolol_Hydrochloride_40_Mg_Oral_Tablet": {
-            "name": "Prescribe_Propranolol_Hydrochloride_40_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "856519",
-                    "display": "propranolol hydrochloride 40 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Propranolol_Hydrochloride_60_Mg_Oral_Tablet": {
-            "name": "Prescribe_Propranolol_Hydrochloride_60_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "856556",
-                    "display": "propranolol hydrochloride 60 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Propranolol_Hydrochloride_80_Mg_Oral_Tablet": {
-            "name": "Prescribe_Propranolol_Hydrochloride_80_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "beta_blocker",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "856578",
-                    "display": "propranolol hydrochloride 80 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
+        {
+          "transition": "Terminal"
         }
+      ]
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Prescribe_Ingredient": {
+      "remarks": [
+        "======================================================================",
+        " MEDICATION INGREDIENT TABLE TRANSITION                               ",
+        "======================================================================",
+        "Ingredients in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 15.3% ] Atenolol",
+        "2. [ 1.3% ] Bisoprolol",
+        "3. [ 1.1% ] Bisoprolol_Hydrochlorothiazide",
+        "4. [ 16.8% ] Carvedilol",
+        "5. [ 2.5% ] Labetalol",
+        "6. [ 53.9% ] Metoprolol",
+        "7. [ 2.2% ] Nebivolol",
+        "8. [ 6.7% ] Propranolol"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Atenolol",
+          "default_probability": 1,
+          "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Bisoprolol",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Bisoprolol_Hydrochlorothiazide",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Carvedilol",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Labetalol",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Metoprolol",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Nebivolol",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Propranolol",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_ingredient_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Atenolol": {
+      "remarks": [
+        "======================================================================",
+        " ATENOLOL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 9.9% ] Atenolol_100_Mg_Oral_Tablet",
+        "2. [ 46.1% ] Atenolol_25_Mg_Oral_Tablet",
+        "3. [ 44.0% ] Atenolol_50_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Atenolol_100_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "beta_blocker_atenolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Atenolol_50_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_atenolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Atenolol_25_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_atenolol_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Bisoprolol": {
+      "remarks": [
+        "======================================================================",
+        " BISOPROLOL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 28.9% ] Bisoprolol_Fumarate_10_Mg_Oral_Tablet",
+        "2. [ 71.1% ] Bisoprolol_Fumarate_5_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Bisoprolol_Fumarate_10_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "beta_blocker_bisoprolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Bisoprolol_Fumarate_5_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_bisoprolol_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Bisoprolol_Hydrochlorothiazide": {
+      "remarks": [
+        "======================================================================",
+        " BISOPROLOL_HYDROCHLOROTHIAZIDE MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 27.3% ] Bisoprolol_Fumarate_10_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
+        "2. [ 42.2% ] Bisoprolol_Fumarate_2_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
+        "3. [ 30.5% ] Bisoprolol_Fumarate_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Bisoprolol_Fumarate_10_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "beta_blocker_bisoprolol_hydrochlorothiazide_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Bisoprolol_Fumarate_2_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_bisoprolol_hydrochlorothiazide_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Bisoprolol_Fumarate_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_bisoprolol_hydrochlorothiazide_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Carvedilol": {
+      "remarks": [
+        "======================================================================",
+        " CARVEDILOL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 0.3% ] 24_Hr_Carvedilol_Phosphate_10_Mg_Extended_Release_Oral_Capsule",
+        "2. [ 0.0% ] 24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule",
+        "3. [ 0.3% ] 24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule_Coreg",
+        "4. [ 25.0% ] Carvedilol_12_5_Mg_Oral_Tablet",
+        "5. [ 0.2% ] Carvedilol_12_5_Mg_Oral_Tablet_Coreg",
+        "6. [ 27.4% ] Carvedilol_25_Mg_Oral_Tablet",
+        "7. [ 0.1% ] Carvedilol_25_Mg_Oral_Tablet_Coreg",
+        "8. [ 21.8% ] Carvedilol_3_125_Mg_Oral_Tablet",
+        "9. [ 24.8% ] Carvedilol_6_25_Mg_Oral_Tablet",
+        "10. [ 0.0% ] Carvedilol_6_25_Mg_Oral_Tablet_Coreg"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_24_Hr_Carvedilol_Phosphate_10_Mg_Extended_Release_Oral_Capsule",
+          "default_probability": 1,
+          "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Carvedilol_12_5_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Carvedilol_25_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Carvedilol_3_125_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Carvedilol_6_25_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Carvedilol_12_5_Mg_Oral_Tablet_Coreg",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule_Coreg",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Carvedilol_6_25_Mg_Oral_Tablet_Coreg",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Carvedilol_25_Mg_Oral_Tablet_Coreg",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_carvedilol_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Labetalol": {
+      "remarks": [
+        "======================================================================",
+        " LABETALOL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 46.4% ] Labetalol_Hydrochloride_100_Mg_Oral_Tablet",
+        "2. [ 35.4% ] Labetalol_Hydrochloride_200_Mg_Oral_Tablet",
+        "3. [ 18.2% ] Labetalol_Hydrochloride_300_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Labetalol_Hydrochloride_100_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "beta_blocker_labetalol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Labetalol_Hydrochloride_200_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_labetalol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Labetalol_Hydrochloride_300_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_labetalol_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Metoprolol": {
+      "remarks": [
+        "======================================================================",
+        " METOPROLOL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 12.3% ] 24_Hr_Metoprolol_Succinate_100_Mg_Extended_Release_Oral_Tablet",
+        "2. [ 1.8% ] 24_Hr_Metoprolol_Succinate_200_Mg_Extended_Release_Oral_Tablet",
+        "3. [ 18.7% ] 24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet",
+        "4. [ 0.6% ] 24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet_Toprol",
+        "5. [ 19.3% ] 24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet",
+        "6. [ 0.3% ] 24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet_Toprol",
+        "7. [ 0.0% ] 5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Cartridge",
+        "8. [ 0.0% ] 5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Injection",
+        "9. [ 4.5% ] Metoprolol_Tartrate_100_Mg_Oral_Tablet",
+        "10. [ 24.1% ] Metoprolol_Tartrate_25_Mg_Oral_Tablet",
+        "11. [ 18.3% ] Metoprolol_Tartrate_50_Mg_Oral_Tablet",
+        "12. [ 0.1% ] Metoprolol_Tartrate_50_Mg_Oral_Tablet_Lopressor"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_24_Hr_Metoprolol_Succinate_100_Mg_Extended_Release_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Metoprolol_Tartrate_50_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Metoprolol_Tartrate_100_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Metoprolol_Tartrate_25_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_24_Hr_Metoprolol_Succinate_200_Mg_Extended_Release_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet_Toprol",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet_Toprol",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Metoprolol_Tartrate_50_Mg_Oral_Tablet_Lopressor",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Cartridge",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Injection",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_metoprolol_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Nebivolol": {
+      "remarks": [
+        "======================================================================",
+        " NEBIVOLOL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 40.7% ] Nebivolol_10_Mg_Oral_Tablet_Bystolic",
+        "2. [ 11.2% ] Nebivolol_20_Mg_Oral_Tablet_Bystolic",
+        "3. [ 2.2% ] Nebivolol_2_5_Mg_Oral_Tablet_Bystolic",
+        "4. [ 45.8% ] Nebivolol_5_Mg_Oral_Tablet_Bystolic"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Nebivolol_10_Mg_Oral_Tablet_Bystolic",
+          "default_probability": 1,
+          "lookup_table_name": "beta_blocker_nebivolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Nebivolol_20_Mg_Oral_Tablet_Bystolic",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_nebivolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Nebivolol_2_5_Mg_Oral_Tablet_Bystolic",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_nebivolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Nebivolol_5_Mg_Oral_Tablet_Bystolic",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_nebivolol_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Propranolol": {
+      "remarks": [
+        "======================================================================",
+        " PROPRANOLOL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 3.2% ] 24_Hr_Propranolol_Hydrochloride_120_Mg_Extended_Release_Oral_Capsule",
+        "2. [ 4.5% ] 24_Hr_Propranolol_Hydrochloride_160_Mg_Extended_Release_Oral_Capsule",
+        "3. [ 15.0% ] 24_Hr_Propranolol_Hydrochloride_60_Mg_Extended_Release_Oral_Capsule",
+        "4. [ 6.3% ] 24_Hr_Propranolol_Hydrochloride_80_Mg_Extended_Release_Oral_Capsule",
+        "5. [ 19.6% ] Propranolol_Hydrochloride_10_Mg_Oral_Tablet",
+        "6. [ 26.2% ] Propranolol_Hydrochloride_20_Mg_Oral_Tablet",
+        "7. [ 19.7% ] Propranolol_Hydrochloride_40_Mg_Oral_Tablet",
+        "8. [ 1.6% ] Propranolol_Hydrochloride_60_Mg_Oral_Tablet",
+        "9. [ 3.9% ] Propranolol_Hydrochloride_80_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_24_Hr_Propranolol_Hydrochloride_120_Mg_Extended_Release_Oral_Capsule",
+          "default_probability": 1,
+          "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_24_Hr_Propranolol_Hydrochloride_60_Mg_Extended_Release_Oral_Capsule",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_24_Hr_Propranolol_Hydrochloride_80_Mg_Extended_Release_Oral_Capsule",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Propranolol_Hydrochloride_40_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_24_Hr_Propranolol_Hydrochloride_160_Mg_Extended_Release_Oral_Capsule",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Propranolol_Hydrochloride_10_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Propranolol_Hydrochloride_20_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Propranolol_Hydrochloride_80_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Propranolol_Hydrochloride_60_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "beta_blocker_propranolol_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_24_Hr_Carvedilol_Phosphate_10_Mg_Extended_Release_Oral_Capsule": {
+      "remarks": [
+        "======================================================================",
+        " BEGIN MEDICATION ORDER STATES                                        ",
+        "======================================================================"
+      ],
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "860510",
+          "display": "24 HR carvedilol phosphate 10 MG Extended Release Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "860516",
+          "display": "24 HR carvedilol phosphate 20 MG Extended Release Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_24_Hr_Carvedilol_Phosphate_20_Mg_Extended_Release_Oral_Capsule_Coreg": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "860518",
+          "display": "24 HR carvedilol phosphate 20 MG Extended Release Oral Capsule [Coreg]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_24_Hr_Metoprolol_Succinate_100_Mg_Extended_Release_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "866412",
+          "display": "24 HR metoprolol succinate 100 MG Extended Release Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_24_Hr_Metoprolol_Succinate_200_Mg_Extended_Release_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "866419",
+          "display": "24 HR metoprolol succinate 200 MG Extended Release Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "866427",
+          "display": "24 HR metoprolol succinate 25 MG Extended Release Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_24_Hr_Metoprolol_Succinate_25_Mg_Extended_Release_Oral_Tablet_Toprol": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "866429",
+          "display": "24 HR metoprolol succinate 25 MG Extended Release Oral Tablet [Toprol]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "866436",
+          "display": "24 HR metoprolol succinate 50 MG Extended Release Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_24_Hr_Metoprolol_Succinate_50_Mg_Extended_Release_Oral_Tablet_Toprol": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "866438",
+          "display": "24 HR metoprolol succinate 50 MG Extended Release Oral Tablet [Toprol]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_24_Hr_Propranolol_Hydrochloride_120_Mg_Extended_Release_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "856460",
+          "display": "24 HR propranolol hydrochloride 120 MG Extended Release Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_24_Hr_Propranolol_Hydrochloride_160_Mg_Extended_Release_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "856481",
+          "display": "24 HR propranolol hydrochloride 160 MG Extended Release Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_24_Hr_Propranolol_Hydrochloride_60_Mg_Extended_Release_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "856535",
+          "display": "24 HR propranolol hydrochloride 60 MG Extended Release Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_24_Hr_Propranolol_Hydrochloride_80_Mg_Extended_Release_Oral_Capsule": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "856569",
+          "display": "24 HR propranolol hydrochloride 80 MG Extended Release Oral Capsule"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Cartridge": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1744259",
+          "display": "5 ML metoprolol tartrate 1 MG/ML Cartridge"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_5_Ml_Metoprolol_Tartrate_1_Mg_Ml_Injection": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "866508",
+          "display": "5 ML metoprolol tartrate 1 MG/ML Injection"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Atenolol_100_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "197379",
+          "display": "atenolol 100 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Atenolol_25_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "197380",
+          "display": "atenolol 25 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Atenolol_50_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "197381",
+          "display": "atenolol 50 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Bisoprolol_Fumarate_10_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "854908",
+          "display": "bisoprolol fumarate 10 MG / hydrochlorothiazide 6.25 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Bisoprolol_Fumarate_10_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "854901",
+          "display": "bisoprolol fumarate 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Bisoprolol_Fumarate_2_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "854916",
+          "display": "bisoprolol fumarate 2.5 MG / hydrochlorothiazide 6.25 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Bisoprolol_Fumarate_5_Mg_Hydrochlorothiazide_6_25_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "854919",
+          "display": "bisoprolol fumarate 5 MG / hydrochlorothiazide 6.25 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Bisoprolol_Fumarate_5_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "854905",
+          "display": "bisoprolol fumarate 5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Carvedilol_12_5_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "200032",
+          "display": "carvedilol 12.5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Carvedilol_12_5_Mg_Oral_Tablet_Coreg": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "212389",
+          "display": "carvedilol 12.5 MG Oral Tablet [Coreg]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Carvedilol_25_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "200033",
+          "display": "carvedilol 25 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Carvedilol_25_Mg_Oral_Tablet_Coreg": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "212390",
+          "display": "carvedilol 25 MG Oral Tablet [Coreg]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Carvedilol_3_125_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "686924",
+          "display": "carvedilol 3.125 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Carvedilol_6_25_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "200031",
+          "display": "carvedilol 6.25 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Carvedilol_6_25_Mg_Oral_Tablet_Coreg": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "212388",
+          "display": "carvedilol 6.25 MG Oral Tablet [Coreg]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Labetalol_Hydrochloride_100_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "896758",
+          "display": "labetalol hydrochloride 100 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Labetalol_Hydrochloride_200_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "896762",
+          "display": "labetalol hydrochloride 200 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Labetalol_Hydrochloride_300_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "896766",
+          "display": "labetalol hydrochloride 300 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Metoprolol_Tartrate_100_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "866511",
+          "display": "metoprolol tartrate 100 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Metoprolol_Tartrate_25_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "866924",
+          "display": "metoprolol tartrate 25 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Metoprolol_Tartrate_50_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "866514",
+          "display": "metoprolol tartrate 50 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Metoprolol_Tartrate_50_Mg_Oral_Tablet_Lopressor": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "866516",
+          "display": "metoprolol tartrate 50 MG Oral Tablet [Lopressor]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Nebivolol_10_Mg_Oral_Tablet_Bystolic": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "751616",
+          "display": "nebivolol 10 MG Oral Tablet [Bystolic]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Nebivolol_2_5_Mg_Oral_Tablet_Bystolic": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "751620",
+          "display": "nebivolol 2.5 MG Oral Tablet [Bystolic]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Nebivolol_20_Mg_Oral_Tablet_Bystolic": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "827075",
+          "display": "nebivolol 20 MG Oral Tablet [Bystolic]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Nebivolol_5_Mg_Oral_Tablet_Bystolic": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "751623",
+          "display": "nebivolol 5 MG Oral Tablet [Bystolic]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Propranolol_Hydrochloride_10_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "856448",
+          "display": "propranolol hydrochloride 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Propranolol_Hydrochloride_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "856457",
+          "display": "propranolol hydrochloride 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Propranolol_Hydrochloride_40_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "856519",
+          "display": "propranolol hydrochloride 40 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Propranolol_Hydrochloride_60_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "856556",
+          "display": "propranolol hydrochloride 60 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Propranolol_Hydrochloride_80_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "beta_blocker",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "856578",
+          "display": "propranolol hydrochloride 80 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
     }
+  }
 }

--- a/src/main/resources/modules/medications/ear_infection_antibiotic.json
+++ b/src/main/resources/modules/medications/ear_infection_antibiotic.json
@@ -36,8 +36,7 @@
         {
           "transition": "Ear_Infection_Antibiotic_Terminal"
         }
-      ],
-      "name": "Initial"
+      ]
     },
     "Prescribe_Ear_Infection_Antibiotic": {
       "type": "Simple",
@@ -160,8 +159,7 @@
             }
           ]
         }
-      ],
-      "name": "Prescribe_Ear_Infection_Antibiotic"
+      ]
     },
     "Prescribe_Penicillin": {
       "type": "MedicationOrder",
@@ -198,8 +196,7 @@
           }
         ]
       },
-      "direct_transition": "Ear_Infection_Antibiotic_Terminal",
-      "name": "Prescribe_Penicillin"
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
     },
     "Prescribe_Ampicillin": {
       "type": "MedicationOrder",
@@ -236,8 +233,7 @@
           }
         ]
       },
-      "direct_transition": "Ear_Infection_Antibiotic_Terminal",
-      "name": "Prescribe_Ampicillin"
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
     },
     "Prescribe_Doxycycline": {
       "type": "Simple",
@@ -258,8 +254,7 @@
         {
           "transition": "Adult_Doxycycline"
         }
-      ],
-      "name": "Prescribe_Doxycycline"
+      ]
     },
     "Pediatric_Doxycycline": {
       "type": "MedicationOrder",
@@ -296,8 +291,7 @@
           }
         ]
       },
-      "direct_transition": "Ear_Infection_Antibiotic_Terminal",
-      "name": "Pediatric_Doxycycline"
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
     },
     "Adult_Doxycycline": {
       "type": "MedicationOrder",
@@ -334,12 +328,10 @@
           }
         ]
       },
-      "direct_transition": "Ear_Infection_Antibiotic_Terminal",
-      "name": "Adult_Doxycycline"
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
     },
     "Prescribe_Amoxicillin": {
       "type": "Simple",
-      "name": "Prescribe_Amoxicillin",
       "conditional_transition": [
         {
           "transition": "Pediatric_Allergy_Check",
@@ -385,8 +377,7 @@
           }
         ]
       },
-      "direct_transition": "Ear_Infection_Antibiotic_Terminal",
-      "name": "Pediatric_Amoxicillin"
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
     },
     "Adult_Amoxicillin": {
       "type": "MedicationOrder",
@@ -418,8 +409,7 @@
           }
         ]
       },
-      "direct_transition": "Ear_Infection_Antibiotic_Terminal",
-      "name": "Adult_Amoxicillin"
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
     },
     "Prescribe_Cefaclor": {
       "type": "Simple",
@@ -436,8 +426,7 @@
         {
           "transition": "Adult_Cefaclor"
         }
-      ],
-      "name": "Prescribe_Cefaclor"
+      ]
     },
     "Pediatric_Cefaclor": {
       "type": "MedicationOrder",
@@ -469,8 +458,7 @@
           }
         ]
       },
-      "direct_transition": "Ear_Infection_Antibiotic_Terminal",
-      "name": "Pediatric_Cefaclor"
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
     },
     "Adult_Cefaclor": {
       "type": "MedicationOrder",
@@ -502,8 +490,7 @@
           }
         ]
       },
-      "direct_transition": "Ear_Infection_Antibiotic_Terminal",
-      "name": "Adult_Cefaclor"
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
     },
     "Prescribe_Cefuroxime": {
       "type": "MedicationOrder",
@@ -538,12 +525,10 @@
           }
         ]
       },
-      "direct_transition": "Ear_Infection_Antibiotic_Terminal",
-      "name": "Prescribe_Cefuroxime"
+      "direct_transition": "Ear_Infection_Antibiotic_Terminal"
     },
     "Ear_Infection_Antibiotic_Terminal": {
-      "type": "Terminal",
-      "name": "Ear_Infection_Antibiotic_Terminal"
+      "type": "Terminal"
     },
     "Pediatric_Allergy_Check": {
       "type": "Simple",
@@ -564,12 +549,10 @@
         {
           "transition": "Pediatric_Amoxicillin"
         }
-      ],
-      "name": "Pediatric_Allergy_Check"
+      ]
     },
     "Adult_Allergy_Check": {
       "type": "Simple",
-      "name": "Adult_Allergy_Check",
       "conditional_transition": [
         {
           "transition": "Adult_Azithromycin",
@@ -600,7 +583,6 @@
         }
       ],
       "direct_transition": "Ear_Infection_Antibiotic_Terminal",
-      "name": "Pediatric_Cefdinir",
       "assign_to_attribute": "antibiotic_prescription"
     },
     "Adult_Azithromycin": {
@@ -614,7 +596,6 @@
         }
       ],
       "direct_transition": "Ear_Infection_Antibiotic_Terminal",
-      "name": "Adult_Azithromycin",
       "assign_to_attribute": "antibiotic_prescription"
     }
   },

--- a/src/main/resources/modules/medications/emergency_inhaler.json
+++ b/src/main/resources/modules/medications/emergency_inhaler.json
@@ -1,432 +1,418 @@
 {
-    "name": "Emergency Inhaler",
-    "remarks": [
-        "======================================================================",
-        "  SUBMODULE EMERGENCY INHALER",
-        "======================================================================",
-        "",
-        "This submodule prescribes a medication based on population data.",
-        "",
-        "IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
-        "All medications prescribed in this module are assigned to the attribute",
-        "'emergency_inhaler'.",
-        "",
-        "Reference links:",
-        "    RxClass: https://mor.nlm.nih.gov/RxClass/",
-        "    RxNorm: https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
-        "    RxNav: https://mor.nlm.nih.gov/RxNav/",
-        "    MEPS: https://meps.ahrq.gov/mepsweb/data_stats/MEPS_topics.jsp?topicid=46Z-1",
-        "    FDA: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory",
-        "",
-        "Made with (</>) by the CodeRx Medication Diversification Tool (MDT)",
-        "",
-        "MDT settings for this submodule:",
-        "{",
-        "    \"module\": {",
-        "        \"name\": null,",
-        "        \"assign_to_attribute\": null,",
-        "        \"reason\": \"asthma_condition\",",
-        "        \"as_needed\": true,",
-        "        \"chronic\": true,",
-        "        \"refills\": 0",
-        "    },",
-        "    \"rxclass\": {",
-        "        \"include\": null,",
-        "        \"exclude\": null",
-        "    },",
-        "    \"rxcui\": {",
-        "        \"include\": [",
-        "            \"435\",",
-        "            \"237159\"",
-        "        ],",
-        "        \"exclude\": null",
-        "    },",
-        "    \"ingredient_tty_filter\": \"IN\",",
-        "    \"dose_form_filter\": [",
-        "        \"Metered Dose Inhaler\",",
-        "        \"Inhalation Solution\"",
-        "    ],",
-        "    \"meps\": {",
-        "        \"age_ranges\": [",
-        "            \"0-5\",",
-        "            \"6-103\"",
-        "        ],",
-        "        \"demographic_distribution_flags\": {",
-        "            \"age\": true,",
-        "            \"gender\": false,",
-        "            \"state\": false",
-        "        }",
-        "    },",
-        "    \"state_prefix\": \"Prescribe_\",",
-        "    \"ingredient_distribution_suffix\": \"_ingredient_distribution\",",
-        "    \"product_distribution_suffix\": \"_product_distribution\",",
-        "    \"default_age_ranges\": [",
-        "        \"0-3\",",
-        "        \"4-7\",",
-        "        \"8-11\",",
-        "        \"12-17\",",
-        "        \"18-25\",",
-        "        \"26-35\",",
-        "        \"36-45\",",
-        "        \"46-65\",",
-        "        \"65-103\"",
-        "    ]",
-        "}"
-    ],
-    "gmf_version": 2,
-    "states": {
-        "Initial": {
-            "type": "Initial",
-            "conditional_transition": [
-                {
-                    "condition": {
-                        "condition_type": "Attribute",
-                        "attribute": "emergency_inhaler",
-                        "operator": "is nil"
-                    },
-                    "transition": "Prescribe_Ingredient"
-                },
-                {
-                    "transition": "Terminal"
-                }
-            ]
+  "name": "Emergency Inhaler",
+  "remarks": [
+    "======================================================================",
+    "  SUBMODULE EMERGENCY INHALER",
+    "======================================================================",
+    "",
+    "This submodule prescribes a medication based on population data.",
+    "",
+    "IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
+    "All medications prescribed in this module are assigned to the attribute",
+    "'emergency_inhaler'.",
+    "",
+    "Reference links:",
+    "    RxClass: https://mor.nlm.nih.gov/RxClass/",
+    "    RxNorm: https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
+    "    RxNav: https://mor.nlm.nih.gov/RxNav/",
+    "    MEPS: https://meps.ahrq.gov/mepsweb/data_stats/MEPS_topics.jsp?topicid=46Z-1",
+    "    FDA: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory",
+    "",
+    "Made with (</>) by the CodeRx Medication Diversification Tool (MDT)",
+    "",
+    "MDT settings for this submodule:",
+    "{",
+    "    \"module\": {",
+    "        \"name\": null,",
+    "        \"assign_to_attribute\": null,",
+    "        \"reason\": \"asthma_condition\",",
+    "        \"as_needed\": true,",
+    "        \"chronic\": true,",
+    "        \"refills\": 0",
+    "    },",
+    "    \"rxclass\": {",
+    "        \"include\": null,",
+    "        \"exclude\": null",
+    "    },",
+    "    \"rxcui\": {",
+    "        \"include\": [",
+    "            \"435\",",
+    "            \"237159\"",
+    "        ],",
+    "        \"exclude\": null",
+    "    },",
+    "    \"ingredient_tty_filter\": \"IN\",",
+    "    \"dose_form_filter\": [",
+    "        \"Metered Dose Inhaler\",",
+    "        \"Inhalation Solution\"",
+    "    ],",
+    "    \"meps\": {",
+    "        \"age_ranges\": [",
+    "            \"0-5\",",
+    "            \"6-103\"",
+    "        ],",
+    "        \"demographic_distribution_flags\": {",
+    "            \"age\": true,",
+    "            \"gender\": false,",
+    "            \"state\": false",
+    "        }",
+    "    },",
+    "    \"state_prefix\": \"Prescribe_\",",
+    "    \"ingredient_distribution_suffix\": \"_ingredient_distribution\",",
+    "    \"product_distribution_suffix\": \"_product_distribution\",",
+    "    \"default_age_ranges\": [",
+    "        \"0-3\",",
+    "        \"4-7\",",
+    "        \"8-11\",",
+    "        \"12-17\",",
+    "        \"18-25\",",
+    "        \"26-35\",",
+    "        \"36-45\",",
+    "        \"46-65\",",
+    "        \"65-103\"",
+    "    ]",
+    "}"
+  ],
+  "gmf_version": 2,
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "emergency_inhaler",
+            "operator": "is nil"
+          },
+          "transition": "Prescribe_Ingredient"
         },
-        "Terminal": {
-            "type": "Terminal"
-        },
-        "Prescribe_Ingredient": {
-            "name": "Prescribe_Ingredient",
-            "remarks": [
-                "======================================================================",
-                " MEDICATION INGREDIENT TABLE TRANSITION                               ",
-                "======================================================================",
-                "Ingredients in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 98.0% ] Albuterol",
-                "2. [ 2.0% ] Levalbuterol"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Albuterol",
-                    "default_probability": 1,
-                    "lookup_table_name": "emergency_inhaler_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Levalbuterol",
-                    "default_probability": 0,
-                    "lookup_table_name": "emergency_inhaler_ingredient_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Albuterol": {
-            "name": "Prescribe_Albuterol",
-            "remarks": [
-                "======================================================================",
-                " ALBUTEROL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 0.9% ] Albuterol_0_21_Mg_Ml_Inhalation_Solution",
-                "2. [ 1.5% ] Albuterol_0_417_Mg_Ml_Inhalation_Solution",
-                "3. [ 26.1% ] Albuterol_0_83_Mg_Ml_Inhalation_Solution",
-                "4. [ 0.4% ] Albuterol_5_Mg_Ml_Inhalation_Solution",
-                "5. [ 2.1% ] Nda020503_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proventil",
-                "6. [ 34.3% ] Nda020983_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin",
-                "7. [ 0.2% ] Nda020983_60_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin",
-                "8. [ 34.6% ] Nda021457_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proair"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Albuterol_0_21_Mg_Ml_Inhalation_Solution",
-                    "default_probability": 1,
-                    "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Albuterol_0_417_Mg_Ml_Inhalation_Solution",
-                    "default_probability": 0,
-                    "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Albuterol_0_83_Mg_Ml_Inhalation_Solution",
-                    "default_probability": 0,
-                    "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Albuterol_5_Mg_Ml_Inhalation_Solution",
-                    "default_probability": 0,
-                    "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Nda020503_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proventil",
-                    "default_probability": 0,
-                    "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Nda020983_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin",
-                    "default_probability": 0,
-                    "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Nda021457_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proair",
-                    "default_probability": 0,
-                    "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Nda020983_60_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin",
-                    "default_probability": 0,
-                    "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Levalbuterol": {
-            "name": "Prescribe_Levalbuterol",
-            "remarks": [
-                "======================================================================",
-                " LEVALBUTEROL MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 32.8% ] 200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler",
-                "2. [ 20.0% ] 200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler_Xopenex",
-                "3. [ 47.2% ] Levalbuterol_0_417_Mg_Ml_Inhalation_Solution"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler",
-                    "default_probability": 1,
-                    "lookup_table_name": "emergency_inhaler_levalbuterol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler_Xopenex",
-                    "default_probability": 0,
-                    "lookup_table_name": "emergency_inhaler_levalbuterol_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Levalbuterol_0_417_Mg_Ml_Inhalation_Solution",
-                    "default_probability": 0,
-                    "lookup_table_name": "emergency_inhaler_levalbuterol_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler": {
-            "remarks": [
-                "======================================================================",
-                " BEGIN MEDICATION ORDER STATES                                        ",
-                "======================================================================"
-            ],
-            "name": "Prescribe_200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "emergency_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "745791",
-                    "display": "200 ACTUAT levalbuterol 0.045 MG/ACTUAT Metered Dose Inhaler"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": true
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler_Xopenex": {
-            "name": "Prescribe_200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler_Xopenex",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "emergency_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "746466",
-                    "display": "200 ACTUAT levalbuterol 0.045 MG/ACTUAT Metered Dose Inhaler [Xopenex]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": true
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Nda020503_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proventil": {
-            "name": "Prescribe_Nda020503_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proventil",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "emergency_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "746763",
-                    "display": "NDA020503 200 ACTUAT albuterol 0.09 MG/ACTUAT Metered Dose Inhaler [Proventil]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": true
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Nda020983_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin": {
-            "name": "Prescribe_Nda020983_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "emergency_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "859088",
-                    "display": "NDA020983 200 ACTUAT albuterol 0.09 MG/ACTUAT Metered Dose Inhaler [Ventolin]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": true
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Nda020983_60_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin": {
-            "name": "Prescribe_Nda020983_60_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "emergency_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "801095",
-                    "display": "NDA020983 60 ACTUAT albuterol 0.09 MG/ACTUAT Metered Dose Inhaler [Ventolin]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": true
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Nda021457_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proair": {
-            "name": "Prescribe_Nda021457_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proair",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "emergency_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "745752",
-                    "display": "NDA021457 200 ACTUAT albuterol 0.09 MG/ACTUAT Metered Dose Inhaler [ProAir]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": true
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Albuterol_0_21_Mg_Ml_Inhalation_Solution": {
-            "name": "Prescribe_Albuterol_0_21_Mg_Ml_Inhalation_Solution",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "emergency_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "351137",
-                    "display": "albuterol 0.21 MG/ML Inhalation Solution"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": true
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Albuterol_0_417_Mg_Ml_Inhalation_Solution": {
-            "name": "Prescribe_Albuterol_0_417_Mg_Ml_Inhalation_Solution",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "emergency_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "351136",
-                    "display": "albuterol 0.417 MG/ML Inhalation Solution"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": true
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Albuterol_0_83_Mg_Ml_Inhalation_Solution": {
-            "name": "Prescribe_Albuterol_0_83_Mg_Ml_Inhalation_Solution",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "emergency_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "630208",
-                    "display": "albuterol 0.83 MG/ML Inhalation Solution"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": true
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Albuterol_5_Mg_Ml_Inhalation_Solution": {
-            "name": "Prescribe_Albuterol_5_Mg_Ml_Inhalation_Solution",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "emergency_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "245314",
-                    "display": "albuterol 5 MG/ML Inhalation Solution"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": true
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Levalbuterol_0_417_Mg_Ml_Inhalation_Solution": {
-            "name": "Prescribe_Levalbuterol_0_417_Mg_Ml_Inhalation_Solution",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "emergency_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "242754",
-                    "display": "levalbuterol 0.417 MG/ML Inhalation Solution"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": true
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
+        {
+          "transition": "Terminal"
         }
+      ]
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Prescribe_Ingredient": {
+      "remarks": [
+        "======================================================================",
+        " MEDICATION INGREDIENT TABLE TRANSITION                               ",
+        "======================================================================",
+        "Ingredients in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 98.0% ] Albuterol",
+        "2. [ 2.0% ] Levalbuterol"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Albuterol",
+          "default_probability": 1,
+          "lookup_table_name": "emergency_inhaler_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Levalbuterol",
+          "default_probability": 0,
+          "lookup_table_name": "emergency_inhaler_ingredient_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Albuterol": {
+      "remarks": [
+        "======================================================================",
+        " ALBUTEROL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 0.9% ] Albuterol_0_21_Mg_Ml_Inhalation_Solution",
+        "2. [ 1.5% ] Albuterol_0_417_Mg_Ml_Inhalation_Solution",
+        "3. [ 26.1% ] Albuterol_0_83_Mg_Ml_Inhalation_Solution",
+        "4. [ 0.4% ] Albuterol_5_Mg_Ml_Inhalation_Solution",
+        "5. [ 2.1% ] Nda020503_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proventil",
+        "6. [ 34.3% ] Nda020983_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin",
+        "7. [ 0.2% ] Nda020983_60_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin",
+        "8. [ 34.6% ] Nda021457_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proair"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Albuterol_0_21_Mg_Ml_Inhalation_Solution",
+          "default_probability": 1,
+          "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Albuterol_0_417_Mg_Ml_Inhalation_Solution",
+          "default_probability": 0,
+          "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Albuterol_0_83_Mg_Ml_Inhalation_Solution",
+          "default_probability": 0,
+          "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Albuterol_5_Mg_Ml_Inhalation_Solution",
+          "default_probability": 0,
+          "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Nda020503_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proventil",
+          "default_probability": 0,
+          "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Nda020983_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin",
+          "default_probability": 0,
+          "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Nda021457_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proair",
+          "default_probability": 0,
+          "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Nda020983_60_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin",
+          "default_probability": 0,
+          "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Levalbuterol": {
+      "remarks": [
+        "======================================================================",
+        " LEVALBUTEROL MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 32.8% ] 200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler",
+        "2. [ 20.0% ] 200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler_Xopenex",
+        "3. [ 47.2% ] Levalbuterol_0_417_Mg_Ml_Inhalation_Solution"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler",
+          "default_probability": 1,
+          "lookup_table_name": "emergency_inhaler_levalbuterol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler_Xopenex",
+          "default_probability": 0,
+          "lookup_table_name": "emergency_inhaler_levalbuterol_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Levalbuterol_0_417_Mg_Ml_Inhalation_Solution",
+          "default_probability": 0,
+          "lookup_table_name": "emergency_inhaler_levalbuterol_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler": {
+      "remarks": [
+        "======================================================================",
+        " BEGIN MEDICATION ORDER STATES                                        ",
+        "======================================================================"
+      ],
+      "type": "MedicationOrder",
+      "assign_to_attribute": "emergency_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "745791",
+          "display": "200 ACTUAT levalbuterol 0.045 MG/ACTUAT Metered Dose Inhaler"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": true
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler_Xopenex": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "emergency_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "746466",
+          "display": "200 ACTUAT levalbuterol 0.045 MG/ACTUAT Metered Dose Inhaler [Xopenex]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": true
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Nda020503_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proventil": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "emergency_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "746763",
+          "display": "NDA020503 200 ACTUAT albuterol 0.09 MG/ACTUAT Metered Dose Inhaler [Proventil]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": true
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Nda020983_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "emergency_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "859088",
+          "display": "NDA020983 200 ACTUAT albuterol 0.09 MG/ACTUAT Metered Dose Inhaler [Ventolin]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": true
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Nda020983_60_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "emergency_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "801095",
+          "display": "NDA020983 60 ACTUAT albuterol 0.09 MG/ACTUAT Metered Dose Inhaler [Ventolin]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": true
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Nda021457_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proair": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "emergency_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "745752",
+          "display": "NDA021457 200 ACTUAT albuterol 0.09 MG/ACTUAT Metered Dose Inhaler [ProAir]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": true
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Albuterol_0_21_Mg_Ml_Inhalation_Solution": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "emergency_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "351137",
+          "display": "albuterol 0.21 MG/ML Inhalation Solution"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": true
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Albuterol_0_417_Mg_Ml_Inhalation_Solution": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "emergency_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "351136",
+          "display": "albuterol 0.417 MG/ML Inhalation Solution"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": true
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Albuterol_0_83_Mg_Ml_Inhalation_Solution": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "emergency_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "630208",
+          "display": "albuterol 0.83 MG/ML Inhalation Solution"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": true
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Albuterol_5_Mg_Ml_Inhalation_Solution": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "emergency_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "245314",
+          "display": "albuterol 5 MG/ML Inhalation Solution"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": true
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Levalbuterol_0_417_Mg_Ml_Inhalation_Solution": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "emergency_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "242754",
+          "display": "levalbuterol 0.417 MG/ML Inhalation Solution"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": true
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
     }
+  }
 }

--- a/src/main/resources/modules/medications/emergency_inhaler.json
+++ b/src/main/resources/modules/medications/emergency_inhaler.json
@@ -110,12 +110,12 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Albuterol",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "emergency_inhaler_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Levalbuterol",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "emergency_inhaler_ingredient_distribution.csv"
                 }
             ]
@@ -142,42 +142,42 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Albuterol_0_21_Mg_Ml_Inhalation_Solution",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Albuterol_0_417_Mg_Ml_Inhalation_Solution",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Albuterol_0_83_Mg_Ml_Inhalation_Solution",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Albuterol_5_Mg_Ml_Inhalation_Solution",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Nda020503_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proventil",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Nda020983_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Nda021457_200_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Proair",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Nda020983_60_Actuat_Albuterol_0_09_Mg_Actuat_Metered_Dose_Inhaler_Ventolin",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "emergency_inhaler_albuterol_product_distribution.csv"
                 }
             ]
@@ -199,17 +199,17 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "emergency_inhaler_levalbuterol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_200_Actuat_Levalbuterol_0_045_Mg_Actuat_Metered_Dose_Inhaler_Xopenex",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "emergency_inhaler_levalbuterol_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Levalbuterol_0_417_Mg_Ml_Inhalation_Solution",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "emergency_inhaler_levalbuterol_product_distribution.csv"
                 }
             ]

--- a/src/main/resources/modules/medications/hypertension_medication.json
+++ b/src/main/resources/modules/medications/hypertension_medication.json
@@ -237,7 +237,6 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "ACE_Allergy_Check_2"
         },
         {
@@ -893,7 +892,6 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "ACE_Allergy_Check"
         },
         {

--- a/src/main/resources/modules/medications/maintenance_inhaler.json
+++ b/src/main/resources/modules/medications/maintenance_inhaler.json
@@ -1,725 +1,699 @@
 {
-    "name": "Maintenance Inhaler",
-    "remarks": [
-        "======================================================================",
-        "  SUBMODULE MAINTENANCE INHALER",
-        "======================================================================",
-        "",
-        "This submodule prescribes a medication based on population data.",
-        "",
-        "IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
-        "All medications prescribed in this module are assigned to the attribute",
-        "'maintenance_inhaler'.",
-        "",
-        "Reference links:",
-        "    RxClass: https://mor.nlm.nih.gov/RxClass/",
-        "    RxNorm: https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
-        "    RxNav: https://mor.nlm.nih.gov/RxNav/",
-        "    MEPS: https://meps.ahrq.gov/mepsweb/data_stats/MEPS_topics.jsp?topicid=46Z-1",
-        "    FDA: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory",
-        "",
-        "Made with (</>) by the CodeRx Medication Diversification Tool (MDT)",
-        "",
-        "MDT settings for this submodule:",
-        "{",
-        "    \"module\": {",
-        "        \"name\": null,",
-        "        \"assign_to_attribute\": null,",
-        "        \"reason\": \"asthma_condition\",",
-        "        \"as_needed\": false,",
-        "        \"chronic\": true,",
-        "        \"refills\": 0",
-        "    },",
-        "    \"rxclass\": {",
-        "        \"include\": [",
-        "            {",
-        "                \"class_id\": \"R01AD\",",
-        "                \"relationship\": \"ATC\"",
-        "            }",
-        "        ],",
-        "        \"exclude\": null",
-        "    },",
-        "    \"rxcui\": {",
-        "        \"include\": null,",
-        "        \"exclude\": null",
-        "    },",
-        "    \"ingredient_tty_filter\": \"IN\",",
-        "    \"dose_form_filter\": [",
-        "        \"Metered Dose Inhaler\",",
-        "        \"Dry Powder Inhaler\",",
-        "        \"Inhalation Suspension\"",
-        "    ],",
-        "    \"meps\": {",
-        "        \"age_ranges\": [",
-        "            \"0-5\",",
-        "            \"6-103\"",
-        "        ],",
-        "        \"demographic_distribution_flags\": {",
-        "            \"age\": true,",
-        "            \"gender\": false,",
-        "            \"state\": false",
-        "        }",
-        "    },",
-        "    \"state_prefix\": \"Prescribe_\",",
-        "    \"ingredient_distribution_suffix\": \"_ingredient_distribution\",",
-        "    \"product_distribution_suffix\": \"_product_distribution\",",
-        "    \"default_age_ranges\": [",
-        "        \"0-3\",",
-        "        \"4-7\",",
-        "        \"8-11\",",
-        "        \"12-17\",",
-        "        \"18-25\",",
-        "        \"26-35\",",
-        "        \"36-45\",",
-        "        \"46-65\",",
-        "        \"65-103\"",
-        "    ]",
-        "}"
-    ],
-    "gmf_version": 2,
-    "states": {
-        "Initial": {
-            "type": "Initial",
-            "conditional_transition": [
-                {
-                    "condition": {
-                        "condition_type": "Attribute",
-                        "attribute": "maintenance_inhaler",
-                        "operator": "is nil"
-                    },
-                    "transition": "Prescribe_Ingredient"
-                },
-                {
-                    "transition": "Terminal"
-                }
-            ]
+  "name": "Maintenance Inhaler",
+  "remarks": [
+    "======================================================================",
+    "  SUBMODULE MAINTENANCE INHALER",
+    "======================================================================",
+    "",
+    "This submodule prescribes a medication based on population data.",
+    "",
+    "IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
+    "All medications prescribed in this module are assigned to the attribute",
+    "'maintenance_inhaler'.",
+    "",
+    "Reference links:",
+    "    RxClass: https://mor.nlm.nih.gov/RxClass/",
+    "    RxNorm: https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
+    "    RxNav: https://mor.nlm.nih.gov/RxNav/",
+    "    MEPS: https://meps.ahrq.gov/mepsweb/data_stats/MEPS_topics.jsp?topicid=46Z-1",
+    "    FDA: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory",
+    "",
+    "Made with (</>) by the CodeRx Medication Diversification Tool (MDT)",
+    "",
+    "MDT settings for this submodule:",
+    "{",
+    "    \"module\": {",
+    "        \"name\": null,",
+    "        \"assign_to_attribute\": null,",
+    "        \"reason\": \"asthma_condition\",",
+    "        \"as_needed\": false,",
+    "        \"chronic\": true,",
+    "        \"refills\": 0",
+    "    },",
+    "    \"rxclass\": {",
+    "        \"include\": [",
+    "            {",
+    "                \"class_id\": \"R01AD\",",
+    "                \"relationship\": \"ATC\"",
+    "            }",
+    "        ],",
+    "        \"exclude\": null",
+    "    },",
+    "    \"rxcui\": {",
+    "        \"include\": null,",
+    "        \"exclude\": null",
+    "    },",
+    "    \"ingredient_tty_filter\": \"IN\",",
+    "    \"dose_form_filter\": [",
+    "        \"Metered Dose Inhaler\",",
+    "        \"Dry Powder Inhaler\",",
+    "        \"Inhalation Suspension\"",
+    "    ],",
+    "    \"meps\": {",
+    "        \"age_ranges\": [",
+    "            \"0-5\",",
+    "            \"6-103\"",
+    "        ],",
+    "        \"demographic_distribution_flags\": {",
+    "            \"age\": true,",
+    "            \"gender\": false,",
+    "            \"state\": false",
+    "        }",
+    "    },",
+    "    \"state_prefix\": \"Prescribe_\",",
+    "    \"ingredient_distribution_suffix\": \"_ingredient_distribution\",",
+    "    \"product_distribution_suffix\": \"_product_distribution\",",
+    "    \"default_age_ranges\": [",
+    "        \"0-3\",",
+    "        \"4-7\",",
+    "        \"8-11\",",
+    "        \"12-17\",",
+    "        \"18-25\",",
+    "        \"26-35\",",
+    "        \"36-45\",",
+    "        \"46-65\",",
+    "        \"65-103\"",
+    "    ]",
+    "}"
+  ],
+  "gmf_version": 2,
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "maintenance_inhaler",
+            "operator": "is nil"
+          },
+          "transition": "Prescribe_Ingredient"
         },
-        "Terminal": {
-            "type": "Terminal"
-        },
-        "Prescribe_Ingredient": {
-            "name": "Prescribe_Ingredient",
-            "remarks": [
-                "======================================================================",
-                " MEDICATION INGREDIENT TABLE TRANSITION                               ",
-                "======================================================================",
-                "Ingredients in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 6.3% ] Beclomethasone",
-                "2. [ 27.8% ] Budesonide",
-                "3. [ 54.1% ] Fluticasone",
-                "4. [ 11.8% ] Mometasone"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Beclomethasone",
-                    "default_probability": 1,
-                    "lookup_table_name": "maintenance_inhaler_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Budesonide",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Fluticasone",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Mometasone",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_ingredient_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Beclomethasone": {
-            "name": "Prescribe_Beclomethasone",
-            "remarks": [
-                "======================================================================",
-                " BECLOMETHASONE MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 44.7% ] Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_04_Mg_Actuat_Metered_Dose_Inhaler_Qvar",
-                "2. [ 55.3% ] Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_08_Mg_Actuat_Metered_Dose_Inhaler_Qvar"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_04_Mg_Actuat_Metered_Dose_Inhaler_Qvar",
-                    "default_probability": 1,
-                    "lookup_table_name": "maintenance_inhaler_beclomethasone_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_08_Mg_Actuat_Metered_Dose_Inhaler_Qvar",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_beclomethasone_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Budesonide": {
-            "name": "Prescribe_Budesonide",
-            "remarks": [
-                "======================================================================",
-                " BUDESONIDE MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 19.5% ] 120_Actuat_Budesonide_0_18_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort",
-                "2. [ 8.9% ] 60_Actuat_Budesonide_0_09_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort",
-                "3. [ 9.7% ] Budesonide_0_125_Mg_Ml_Inhalation_Suspension",
-                "4. [ 10.1% ] Budesonide_0_125_Mg_Ml_Inhalation_Suspension_Pulmicort",
-                "5. [ 49.5% ] Budesonide_0_25_Mg_Ml_Inhalation_Suspension",
-                "6. [ 2.4% ] Budesonide_0_5_Mg_Ml_Inhalation_Suspension"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_120_Actuat_Budesonide_0_18_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort",
-                    "default_probability": 1,
-                    "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_60_Actuat_Budesonide_0_09_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Budesonide_0_125_Mg_Ml_Inhalation_Suspension",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Budesonide_0_125_Mg_Ml_Inhalation_Suspension_Pulmicort",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Budesonide_0_25_Mg_Ml_Inhalation_Suspension",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Budesonide_0_5_Mg_Ml_Inhalation_Suspension",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Fluticasone": {
-            "name": "Prescribe_Fluticasone",
-            "remarks": [
-                "======================================================================",
-                " FLUTICASONE MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 32.3% ] 120_Actuat_Fluticasone_Propionate_0_044_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
-                "2. [ 40.7% ] 120_Actuat_Fluticasone_Propionate_0_11_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
-                "3. [ 12.3% ] 120_Actuat_Fluticasone_Propionate_0_22_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
-                "4. [ 2.7% ] 30_Actuat_Fluticasone_Furoate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Arnuity",
-                "5. [ 2.5% ] 30_Actuat_Fluticasone_Furoate_0_2_Mg_Actuat_Dry_Powder_Inhaler_Arnuity",
-                "6. [ 3.4% ] 60_Actuat_Fluticasone_Propionate_0_05_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
-                "7. [ 5.5% ] 60_Actuat_Fluticasone_Propionate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
-                "8. [ 0.5% ] 60_Actuat_Fluticasone_Propionate_0_25_Mg_Actuat_Dry_Powder_Inhaler_Flovent"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_120_Actuat_Fluticasone_Propionate_0_044_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
-                    "default_probability": 1,
-                    "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_120_Actuat_Fluticasone_Propionate_0_11_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_120_Actuat_Fluticasone_Propionate_0_22_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_30_Actuat_Fluticasone_Furoate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Arnuity",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_30_Actuat_Fluticasone_Furoate_0_2_Mg_Actuat_Dry_Powder_Inhaler_Arnuity",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_60_Actuat_Fluticasone_Propionate_0_05_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_60_Actuat_Fluticasone_Propionate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_60_Actuat_Fluticasone_Propionate_0_25_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Mometasone": {
-            "name": "Prescribe_Mometasone",
-            "remarks": [
-                "======================================================================",
-                " MOMETASONE MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 31.8% ] 120_Actuat_Mometasone_Furoate_0_1_Mg_Actuat_Metered_Dose_Inhaler_Asmanex",
-                "2. [ 3.4% ] 120_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
-                "3. [ 27.9% ] 120_Actuat_Mometasone_Furoate_0_2_Mg_Actuat_Metered_Dose_Inhaler_Asmanex",
-                "4. [ 3.1% ] 14_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
-                "5. [ 33.8% ] 60_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_120_Actuat_Mometasone_Furoate_0_1_Mg_Actuat_Metered_Dose_Inhaler_Asmanex",
-                    "default_probability": 1,
-                    "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_120_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_120_Actuat_Mometasone_Furoate_0_2_Mg_Actuat_Metered_Dose_Inhaler_Asmanex",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_14_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_60_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
-                    "default_probability": 0,
-                    "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_120_Actuat_Budesonide_0_18_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort": {
-            "remarks": [
-                "======================================================================",
-                " BEGIN MEDICATION ORDER STATES                                        ",
-                "======================================================================"
-            ],
-            "name": "Prescribe_120_Actuat_Budesonide_0_18_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "966524",
-                    "display": "120 ACTUAT budesonide 0.18 MG/ACTUAT Dry Powder Inhaler [Pulmicort]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_120_Actuat_Fluticasone_Propionate_0_044_Mg_Actuat_Metered_Dose_Inhaler_Flovent": {
-            "name": "Prescribe_120_Actuat_Fluticasone_Propionate_0_044_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "895996",
-                    "display": "120 ACTUAT fluticasone propionate 0.044 MG/ACTUAT Metered Dose Inhaler [Flovent]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_120_Actuat_Fluticasone_Propionate_0_11_Mg_Actuat_Metered_Dose_Inhaler_Flovent": {
-            "name": "Prescribe_120_Actuat_Fluticasone_Propionate_0_11_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "896001",
-                    "display": "120 ACTUAT fluticasone propionate 0.11 MG/ACTUAT Metered Dose Inhaler [Flovent]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_120_Actuat_Fluticasone_Propionate_0_22_Mg_Actuat_Metered_Dose_Inhaler_Flovent": {
-            "name": "Prescribe_120_Actuat_Fluticasone_Propionate_0_22_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "896006",
-                    "display": "120 ACTUAT fluticasone propionate 0.22 MG/ACTUAT Metered Dose Inhaler [Flovent]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_120_Actuat_Mometasone_Furoate_0_1_Mg_Actuat_Metered_Dose_Inhaler_Asmanex": {
-            "name": "Prescribe_120_Actuat_Mometasone_Furoate_0_1_Mg_Actuat_Metered_Dose_Inhaler_Asmanex",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1536144",
-                    "display": "120 ACTUAT mometasone furoate 0.1 MG/ACTUAT Metered Dose Inhaler [Asmanex]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_120_Actuat_Mometasone_Furoate_0_2_Mg_Actuat_Metered_Dose_Inhaler_Asmanex": {
-            "name": "Prescribe_120_Actuat_Mometasone_Furoate_0_2_Mg_Actuat_Metered_Dose_Inhaler_Asmanex",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1536148",
-                    "display": "120 ACTUAT mometasone furoate 0.2 MG/ACTUAT Metered Dose Inhaler [Asmanex]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_120_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex": {
-            "name": "Prescribe_120_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "746804",
-                    "display": "120 ACTUAT mometasone furoate 0.22 MG/ACTUAT Dry Powder Inhaler [Asmanex]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_14_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex": {
-            "name": "Prescribe_14_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "746811",
-                    "display": "14 ACTUAT mometasone furoate 0.22 MG/ACTUAT Dry Powder Inhaler [Asmanex]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_30_Actuat_Fluticasone_Furoate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Arnuity": {
-            "name": "Prescribe_30_Actuat_Fluticasone_Furoate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Arnuity",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1547660",
-                    "display": "30 ACTUAT fluticasone furoate 0.1 MG/ACTUAT Dry Powder Inhaler [Arnuity]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_30_Actuat_Fluticasone_Furoate_0_2_Mg_Actuat_Dry_Powder_Inhaler_Arnuity": {
-            "name": "Prescribe_30_Actuat_Fluticasone_Furoate_0_2_Mg_Actuat_Dry_Powder_Inhaler_Arnuity",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1547672",
-                    "display": "30 ACTUAT fluticasone furoate 0.2 MG/ACTUAT Dry Powder Inhaler [Arnuity]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_60_Actuat_Budesonide_0_09_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort": {
-            "name": "Prescribe_60_Actuat_Budesonide_0_09_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "966529",
-                    "display": "60 ACTUAT budesonide 0.09 MG/ACTUAT Dry Powder Inhaler [Pulmicort]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_60_Actuat_Fluticasone_Propionate_0_05_Mg_Actuat_Dry_Powder_Inhaler_Flovent": {
-            "name": "Prescribe_60_Actuat_Fluticasone_Propionate_0_05_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "896019",
-                    "display": "60 ACTUAT fluticasone propionate 0.05 MG/ACTUAT Dry Powder Inhaler [Flovent]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_60_Actuat_Fluticasone_Propionate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Flovent": {
-            "name": "Prescribe_60_Actuat_Fluticasone_Propionate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "896023",
-                    "display": "60 ACTUAT fluticasone propionate 0.1 MG/ACTUAT Dry Powder Inhaler [Flovent]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_60_Actuat_Fluticasone_Propionate_0_25_Mg_Actuat_Dry_Powder_Inhaler_Flovent": {
-            "name": "Prescribe_60_Actuat_Fluticasone_Propionate_0_25_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "896027",
-                    "display": "60 ACTUAT fluticasone propionate 0.25 MG/ACTUAT Dry Powder Inhaler [Flovent]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_60_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex": {
-            "name": "Prescribe_60_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "746815",
-                    "display": "60 ACTUAT mometasone furoate 0.22 MG/ACTUAT Dry Powder Inhaler [Asmanex]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_04_Mg_Actuat_Metered_Dose_Inhaler_Qvar": {
-            "name": "Prescribe_Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_04_Mg_Actuat_Metered_Dose_Inhaler_Qvar",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1998774",
-                    "display": "Breath-Actuated 120 ACTUAT beclomethasone dipropionate 0.04 MG/ACTUAT Metered Dose Inhaler [Qvar]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_08_Mg_Actuat_Metered_Dose_Inhaler_Qvar": {
-            "name": "Prescribe_Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_08_Mg_Actuat_Metered_Dose_Inhaler_Qvar",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1998772",
-                    "display": "Breath-Actuated 120 ACTUAT beclomethasone dipropionate 0.08 MG/ACTUAT Metered Dose Inhaler [Qvar]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Budesonide_0_125_Mg_Ml_Inhalation_Suspension": {
-            "name": "Prescribe_Budesonide_0_125_Mg_Ml_Inhalation_Suspension",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "349094",
-                    "display": "budesonide 0.125 MG/ML Inhalation Suspension"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Budesonide_0_125_Mg_Ml_Inhalation_Suspension_Pulmicort": {
-            "name": "Prescribe_Budesonide_0_125_Mg_Ml_Inhalation_Suspension_Pulmicort",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "616830",
-                    "display": "budesonide 0.125 MG/ML Inhalation Suspension [Pulmicort]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Budesonide_0_25_Mg_Ml_Inhalation_Suspension": {
-            "name": "Prescribe_Budesonide_0_25_Mg_Ml_Inhalation_Suspension",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "351109",
-                    "display": "budesonide 0.25 MG/ML Inhalation Suspension"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
-        },
-        "Prescribe_Budesonide_0_5_Mg_Ml_Inhalation_Suspension": {
-            "name": "Prescribe_Budesonide_0_5_Mg_Ml_Inhalation_Suspension",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "maintenance_inhaler",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "252559",
-                    "display": "budesonide 0.5 MG/ML Inhalation Suspension"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": true,
-            "reason": "asthma_condition"
+        {
+          "transition": "Terminal"
         }
+      ]
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Prescribe_Ingredient": {
+      "remarks": [
+        "======================================================================",
+        " MEDICATION INGREDIENT TABLE TRANSITION                               ",
+        "======================================================================",
+        "Ingredients in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 6.3% ] Beclomethasone",
+        "2. [ 27.8% ] Budesonide",
+        "3. [ 54.1% ] Fluticasone",
+        "4. [ 11.8% ] Mometasone"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Beclomethasone",
+          "default_probability": 1,
+          "lookup_table_name": "maintenance_inhaler_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Budesonide",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Fluticasone",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Mometasone",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_ingredient_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Beclomethasone": {
+      "remarks": [
+        "======================================================================",
+        " BECLOMETHASONE MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 44.7% ] Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_04_Mg_Actuat_Metered_Dose_Inhaler_Qvar",
+        "2. [ 55.3% ] Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_08_Mg_Actuat_Metered_Dose_Inhaler_Qvar"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_04_Mg_Actuat_Metered_Dose_Inhaler_Qvar",
+          "default_probability": 1,
+          "lookup_table_name": "maintenance_inhaler_beclomethasone_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_08_Mg_Actuat_Metered_Dose_Inhaler_Qvar",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_beclomethasone_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Budesonide": {
+      "remarks": [
+        "======================================================================",
+        " BUDESONIDE MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 19.5% ] 120_Actuat_Budesonide_0_18_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort",
+        "2. [ 8.9% ] 60_Actuat_Budesonide_0_09_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort",
+        "3. [ 9.7% ] Budesonide_0_125_Mg_Ml_Inhalation_Suspension",
+        "4. [ 10.1% ] Budesonide_0_125_Mg_Ml_Inhalation_Suspension_Pulmicort",
+        "5. [ 49.5% ] Budesonide_0_25_Mg_Ml_Inhalation_Suspension",
+        "6. [ 2.4% ] Budesonide_0_5_Mg_Ml_Inhalation_Suspension"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_120_Actuat_Budesonide_0_18_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort",
+          "default_probability": 1,
+          "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_60_Actuat_Budesonide_0_09_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Budesonide_0_125_Mg_Ml_Inhalation_Suspension",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Budesonide_0_125_Mg_Ml_Inhalation_Suspension_Pulmicort",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Budesonide_0_25_Mg_Ml_Inhalation_Suspension",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Budesonide_0_5_Mg_Ml_Inhalation_Suspension",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Fluticasone": {
+      "remarks": [
+        "======================================================================",
+        " FLUTICASONE MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 32.3% ] 120_Actuat_Fluticasone_Propionate_0_044_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
+        "2. [ 40.7% ] 120_Actuat_Fluticasone_Propionate_0_11_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
+        "3. [ 12.3% ] 120_Actuat_Fluticasone_Propionate_0_22_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
+        "4. [ 2.7% ] 30_Actuat_Fluticasone_Furoate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Arnuity",
+        "5. [ 2.5% ] 30_Actuat_Fluticasone_Furoate_0_2_Mg_Actuat_Dry_Powder_Inhaler_Arnuity",
+        "6. [ 3.4% ] 60_Actuat_Fluticasone_Propionate_0_05_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
+        "7. [ 5.5% ] 60_Actuat_Fluticasone_Propionate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
+        "8. [ 0.5% ] 60_Actuat_Fluticasone_Propionate_0_25_Mg_Actuat_Dry_Powder_Inhaler_Flovent"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_120_Actuat_Fluticasone_Propionate_0_044_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
+          "default_probability": 1,
+          "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_120_Actuat_Fluticasone_Propionate_0_11_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_120_Actuat_Fluticasone_Propionate_0_22_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_30_Actuat_Fluticasone_Furoate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Arnuity",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_30_Actuat_Fluticasone_Furoate_0_2_Mg_Actuat_Dry_Powder_Inhaler_Arnuity",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_60_Actuat_Fluticasone_Propionate_0_05_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_60_Actuat_Fluticasone_Propionate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_60_Actuat_Fluticasone_Propionate_0_25_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Mometasone": {
+      "remarks": [
+        "======================================================================",
+        " MOMETASONE MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 31.8% ] 120_Actuat_Mometasone_Furoate_0_1_Mg_Actuat_Metered_Dose_Inhaler_Asmanex",
+        "2. [ 3.4% ] 120_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
+        "3. [ 27.9% ] 120_Actuat_Mometasone_Furoate_0_2_Mg_Actuat_Metered_Dose_Inhaler_Asmanex",
+        "4. [ 3.1% ] 14_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
+        "5. [ 33.8% ] 60_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_120_Actuat_Mometasone_Furoate_0_1_Mg_Actuat_Metered_Dose_Inhaler_Asmanex",
+          "default_probability": 1,
+          "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_120_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_120_Actuat_Mometasone_Furoate_0_2_Mg_Actuat_Metered_Dose_Inhaler_Asmanex",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_14_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_60_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
+          "default_probability": 0,
+          "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_120_Actuat_Budesonide_0_18_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort": {
+      "remarks": [
+        "======================================================================",
+        " BEGIN MEDICATION ORDER STATES                                        ",
+        "======================================================================"
+      ],
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "966524",
+          "display": "120 ACTUAT budesonide 0.18 MG/ACTUAT Dry Powder Inhaler [Pulmicort]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_120_Actuat_Fluticasone_Propionate_0_044_Mg_Actuat_Metered_Dose_Inhaler_Flovent": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "895996",
+          "display": "120 ACTUAT fluticasone propionate 0.044 MG/ACTUAT Metered Dose Inhaler [Flovent]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_120_Actuat_Fluticasone_Propionate_0_11_Mg_Actuat_Metered_Dose_Inhaler_Flovent": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "896001",
+          "display": "120 ACTUAT fluticasone propionate 0.11 MG/ACTUAT Metered Dose Inhaler [Flovent]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_120_Actuat_Fluticasone_Propionate_0_22_Mg_Actuat_Metered_Dose_Inhaler_Flovent": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "896006",
+          "display": "120 ACTUAT fluticasone propionate 0.22 MG/ACTUAT Metered Dose Inhaler [Flovent]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_120_Actuat_Mometasone_Furoate_0_1_Mg_Actuat_Metered_Dose_Inhaler_Asmanex": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1536144",
+          "display": "120 ACTUAT mometasone furoate 0.1 MG/ACTUAT Metered Dose Inhaler [Asmanex]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_120_Actuat_Mometasone_Furoate_0_2_Mg_Actuat_Metered_Dose_Inhaler_Asmanex": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1536148",
+          "display": "120 ACTUAT mometasone furoate 0.2 MG/ACTUAT Metered Dose Inhaler [Asmanex]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_120_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "746804",
+          "display": "120 ACTUAT mometasone furoate 0.22 MG/ACTUAT Dry Powder Inhaler [Asmanex]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_14_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "746811",
+          "display": "14 ACTUAT mometasone furoate 0.22 MG/ACTUAT Dry Powder Inhaler [Asmanex]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_30_Actuat_Fluticasone_Furoate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Arnuity": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1547660",
+          "display": "30 ACTUAT fluticasone furoate 0.1 MG/ACTUAT Dry Powder Inhaler [Arnuity]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_30_Actuat_Fluticasone_Furoate_0_2_Mg_Actuat_Dry_Powder_Inhaler_Arnuity": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1547672",
+          "display": "30 ACTUAT fluticasone furoate 0.2 MG/ACTUAT Dry Powder Inhaler [Arnuity]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_60_Actuat_Budesonide_0_09_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "966529",
+          "display": "60 ACTUAT budesonide 0.09 MG/ACTUAT Dry Powder Inhaler [Pulmicort]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_60_Actuat_Fluticasone_Propionate_0_05_Mg_Actuat_Dry_Powder_Inhaler_Flovent": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "896019",
+          "display": "60 ACTUAT fluticasone propionate 0.05 MG/ACTUAT Dry Powder Inhaler [Flovent]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_60_Actuat_Fluticasone_Propionate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Flovent": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "896023",
+          "display": "60 ACTUAT fluticasone propionate 0.1 MG/ACTUAT Dry Powder Inhaler [Flovent]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_60_Actuat_Fluticasone_Propionate_0_25_Mg_Actuat_Dry_Powder_Inhaler_Flovent": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "896027",
+          "display": "60 ACTUAT fluticasone propionate 0.25 MG/ACTUAT Dry Powder Inhaler [Flovent]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_60_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "746815",
+          "display": "60 ACTUAT mometasone furoate 0.22 MG/ACTUAT Dry Powder Inhaler [Asmanex]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_04_Mg_Actuat_Metered_Dose_Inhaler_Qvar": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1998774",
+          "display": "Breath-Actuated 120 ACTUAT beclomethasone dipropionate 0.04 MG/ACTUAT Metered Dose Inhaler [Qvar]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_08_Mg_Actuat_Metered_Dose_Inhaler_Qvar": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1998772",
+          "display": "Breath-Actuated 120 ACTUAT beclomethasone dipropionate 0.08 MG/ACTUAT Metered Dose Inhaler [Qvar]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Budesonide_0_125_Mg_Ml_Inhalation_Suspension": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "349094",
+          "display": "budesonide 0.125 MG/ML Inhalation Suspension"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Budesonide_0_125_Mg_Ml_Inhalation_Suspension_Pulmicort": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "616830",
+          "display": "budesonide 0.125 MG/ML Inhalation Suspension [Pulmicort]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Budesonide_0_25_Mg_Ml_Inhalation_Suspension": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "351109",
+          "display": "budesonide 0.25 MG/ML Inhalation Suspension"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
+    },
+    "Prescribe_Budesonide_0_5_Mg_Ml_Inhalation_Suspension": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "maintenance_inhaler",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "252559",
+          "display": "budesonide 0.5 MG/ML Inhalation Suspension"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": true,
+      "reason": "asthma_condition"
     }
+  }
 }

--- a/src/main/resources/modules/medications/maintenance_inhaler.json
+++ b/src/main/resources/modules/medications/maintenance_inhaler.json
@@ -115,22 +115,22 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Beclomethasone",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "maintenance_inhaler_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Budesonide",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Fluticasone",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Mometasone",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_ingredient_distribution.csv"
                 }
             ]
@@ -151,12 +151,12 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_04_Mg_Actuat_Metered_Dose_Inhaler_Qvar",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "maintenance_inhaler_beclomethasone_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Breath_Actuated_120_Actuat_Beclomethasone_Dipropionate_0_08_Mg_Actuat_Metered_Dose_Inhaler_Qvar",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_beclomethasone_product_distribution.csv"
                 }
             ]
@@ -181,32 +181,32 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_120_Actuat_Budesonide_0_18_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_60_Actuat_Budesonide_0_09_Mg_Actuat_Dry_Powder_Inhaler_Pulmicort",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Budesonide_0_125_Mg_Ml_Inhalation_Suspension",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Budesonide_0_125_Mg_Ml_Inhalation_Suspension_Pulmicort",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Budesonide_0_25_Mg_Ml_Inhalation_Suspension",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Budesonide_0_5_Mg_Ml_Inhalation_Suspension",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_budesonide_product_distribution.csv"
                 }
             ]
@@ -233,42 +233,42 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_120_Actuat_Fluticasone_Propionate_0_044_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_120_Actuat_Fluticasone_Propionate_0_11_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_120_Actuat_Fluticasone_Propionate_0_22_Mg_Actuat_Metered_Dose_Inhaler_Flovent",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_30_Actuat_Fluticasone_Furoate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Arnuity",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_30_Actuat_Fluticasone_Furoate_0_2_Mg_Actuat_Dry_Powder_Inhaler_Arnuity",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_60_Actuat_Fluticasone_Propionate_0_05_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_60_Actuat_Fluticasone_Propionate_0_1_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_60_Actuat_Fluticasone_Propionate_0_25_Mg_Actuat_Dry_Powder_Inhaler_Flovent",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_fluticasone_product_distribution.csv"
                 }
             ]
@@ -292,27 +292,27 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_120_Actuat_Mometasone_Furoate_0_1_Mg_Actuat_Metered_Dose_Inhaler_Asmanex",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_120_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_120_Actuat_Mometasone_Furoate_0_2_Mg_Actuat_Metered_Dose_Inhaler_Asmanex",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_14_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_60_Actuat_Mometasone_Furoate_0_22_Mg_Actuat_Dry_Powder_Inhaler_Asmanex",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "maintenance_inhaler_mometasone_product_distribution.csv"
                 }
             ]

--- a/src/main/resources/modules/medications/otc_pain_reliever.json
+++ b/src/main/resources/modules/medications/otc_pain_reliever.json
@@ -38,8 +38,7 @@
         {
           "transition": "OTC_Pain_Reliever_Terminal"
         }
-      ],
-      "name": "Initial"
+      ]
     },
     "Prescribe_OTC_Pain_Reliever": {
       "type": "Simple",
@@ -128,8 +127,7 @@
             }
           ]
         }
-      ],
-      "name": "Prescribe_OTC_Pain_Reliever"
+      ]
     },
     "Prescribe_Aspirin": {
       "type": "MedicationOrder",
@@ -149,8 +147,7 @@
       "prescription": {
         "as_needed": true
       },
-      "direct_transition": "OTC_Pain_Reliever_Terminal",
-      "name": "Prescribe_Aspirin"
+      "direct_transition": "OTC_Pain_Reliever_Terminal"
     },
     "Prescribe_Acetaminophen": {
       "type": "Simple",
@@ -167,8 +164,7 @@
         {
           "transition": "Adult_Acetaminophen"
         }
-      ],
-      "name": "Prescribe_Acetaminophen"
+      ]
     },
     "Pediatric_Acetaminophen": {
       "type": "MedicationOrder",
@@ -184,8 +180,7 @@
       "prescription": {
         "as_needed": true
       },
-      "direct_transition": "OTC_Pain_Reliever_Terminal",
-      "name": "Pediatric_Acetaminophen"
+      "direct_transition": "OTC_Pain_Reliever_Terminal"
     },
     "Adult_Acetaminophen": {
       "type": "MedicationOrder",
@@ -201,8 +196,7 @@
       "prescription": {
         "as_needed": true
       },
-      "direct_transition": "OTC_Pain_Reliever_Terminal",
-      "name": "Adult_Acetaminophen"
+      "direct_transition": "OTC_Pain_Reliever_Terminal"
     },
     "Prescribe_Ibuprofen": {
       "type": "Simple",
@@ -239,8 +233,7 @@
             "value": 0
           }
         }
-      ],
-      "name": "Prescribe_Ibuprofen"
+      ]
     },
     "Pediatric_Ibuprofen": {
       "type": "MedicationOrder",
@@ -256,8 +249,7 @@
       "prescription": {
         "as_needed": true
       },
-      "direct_transition": "OTC_Pain_Reliever_Terminal",
-      "name": "Pediatric_Ibuprofen"
+      "direct_transition": "OTC_Pain_Reliever_Terminal"
     },
     "Adult_Ibuprofen": {
       "type": "MedicationOrder",
@@ -273,8 +265,7 @@
       "prescription": {
         "as_needed": true
       },
-      "direct_transition": "OTC_Pain_Reliever_Terminal",
-      "name": "Adult_Ibuprofen"
+      "direct_transition": "OTC_Pain_Reliever_Terminal"
     },
     "Prescribe_Naproxen_Sodium": {
       "type": "Simple",
@@ -309,8 +300,7 @@
             }
           ]
         }
-      ],
-      "name": "Prescribe_Naproxen_Sodium"
+      ]
     },
     "Naproxen_Sodium": {
       "type": "MedicationOrder",
@@ -326,12 +316,10 @@
       "prescription": {
         "as_needed": true
       },
-      "direct_transition": "OTC_Pain_Reliever_Terminal",
-      "name": "Naproxen_Sodium"
+      "direct_transition": "OTC_Pain_Reliever_Terminal"
     },
     "OTC_Pain_Reliever_Terminal": {
-      "type": "Terminal",
-      "name": "OTC_Pain_Reliever_Terminal"
+      "type": "Terminal"
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/medications/statin.json
+++ b/src/main/resources/modules/medications/statin.json
@@ -1,1069 +1,1027 @@
 {
-    "name": "Statin",
-    "remarks": [
-        "======================================================================",
-        "  SUBMODULE STATIN",
-        "======================================================================",
-        "",
-        "This submodule prescribes a medication based on population data.",
-        "",
-        "IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
-        "All medications prescribed in this module are assigned to the attribute",
-        "'statin'.",
-        "",
-        "Reference links:",
-        "    RxClass: https://mor.nlm.nih.gov/RxClass/",
-        "    RxNorm: https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
-        "    RxNav: https://mor.nlm.nih.gov/RxNav/",
-        "    MEPS: https://meps.ahrq.gov/mepsweb/data_stats/MEPS_topics.jsp?topicid=46Z-1",
-        "    FDA: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory",
-        "",
-        "Made with (</>) by the CodeRx Medication Diversification Tool (MDT)",
-        "",
-        "MDT settings for this submodule:",
-        "{",
-        "    \"module\": {",
-        "        \"name\": null,",
-        "        \"assign_to_attribute\": null,",
-        "        \"reason\": null,",
-        "        \"as_needed\": false,",
-        "        \"chronic\": false,",
-        "        \"refills\": 0",
-        "    },",
-        "    \"rxclass\": {",
-        "        \"include\": [",
-        "            {",
-        "                \"class_id\": \"C10AA\",",
-        "                \"relationship\": \"ATC\"",
-        "            }",
-        "        ],",
-        "        \"exclude\": null",
-        "    },",
-        "    \"rxcui\": {",
-        "        \"include\": null,",
-        "        \"exclude\": null",
-        "    },",
-        "    \"ingredient_tty_filter\": null,",
-        "    \"dose_form_filter\": null,",
-        "    \"meps\": {",
-        "        \"age_ranges\": null,",
-        "        \"demographic_distribution_flags\": {",
-        "            \"age\": true,",
-        "            \"gender\": true,",
-        "            \"state\": true",
-        "        }",
-        "    },",
-        "    \"state_prefix\": \"Prescribe_\",",
-        "    \"ingredient_distribution_suffix\": \"_ingredient_distribution\",",
-        "    \"product_distribution_suffix\": \"_product_distribution\",",
-        "    \"default_age_ranges\": [",
-        "        \"0-3\",",
-        "        \"4-7\",",
-        "        \"8-11\",",
-        "        \"12-17\",",
-        "        \"18-25\",",
-        "        \"26-35\",",
-        "        \"36-45\",",
-        "        \"46-65\",",
-        "        \"65-103\"",
-        "    ]",
-        "}"
-    ],
-    "gmf_version": 2,
-    "states": {
-        "Initial": {
-            "type": "Initial",
-            "conditional_transition": [
-                {
-                    "condition": {
-                        "condition_type": "Attribute",
-                        "attribute": "statin",
-                        "operator": "is nil"
-                    },
-                    "transition": "Prescribe_Ingredient"
-                },
-                {
-                    "transition": "Terminal"
-                }
-            ]
+  "name": "Statin",
+  "remarks": [
+    "======================================================================",
+    "  SUBMODULE STATIN",
+    "======================================================================",
+    "",
+    "This submodule prescribes a medication based on population data.",
+    "",
+    "IT IS UP TO THE CALLING MODULE TO END THIS MEDICATION BY ATTRIBUTE.",
+    "All medications prescribed in this module are assigned to the attribute",
+    "'statin'.",
+    "",
+    "Reference links:",
+    "    RxClass: https://mor.nlm.nih.gov/RxClass/",
+    "    RxNorm: https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
+    "    RxNav: https://mor.nlm.nih.gov/RxNav/",
+    "    MEPS: https://meps.ahrq.gov/mepsweb/data_stats/MEPS_topics.jsp?topicid=46Z-1",
+    "    FDA: https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory",
+    "",
+    "Made with (</>) by the CodeRx Medication Diversification Tool (MDT)",
+    "",
+    "MDT settings for this submodule:",
+    "{",
+    "    \"module\": {",
+    "        \"name\": null,",
+    "        \"assign_to_attribute\": null,",
+    "        \"reason\": null,",
+    "        \"as_needed\": false,",
+    "        \"chronic\": false,",
+    "        \"refills\": 0",
+    "    },",
+    "    \"rxclass\": {",
+    "        \"include\": [",
+    "            {",
+    "                \"class_id\": \"C10AA\",",
+    "                \"relationship\": \"ATC\"",
+    "            }",
+    "        ],",
+    "        \"exclude\": null",
+    "    },",
+    "    \"rxcui\": {",
+    "        \"include\": null,",
+    "        \"exclude\": null",
+    "    },",
+    "    \"ingredient_tty_filter\": null,",
+    "    \"dose_form_filter\": null,",
+    "    \"meps\": {",
+    "        \"age_ranges\": null,",
+    "        \"demographic_distribution_flags\": {",
+    "            \"age\": true,",
+    "            \"gender\": true,",
+    "            \"state\": true",
+    "        }",
+    "    },",
+    "    \"state_prefix\": \"Prescribe_\",",
+    "    \"ingredient_distribution_suffix\": \"_ingredient_distribution\",",
+    "    \"product_distribution_suffix\": \"_product_distribution\",",
+    "    \"default_age_ranges\": [",
+    "        \"0-3\",",
+    "        \"4-7\",",
+    "        \"8-11\",",
+    "        \"12-17\",",
+    "        \"18-25\",",
+    "        \"26-35\",",
+    "        \"36-45\",",
+    "        \"46-65\",",
+    "        \"65-103\"",
+    "    ]",
+    "}"
+  ],
+  "gmf_version": 2,
+  "states": {
+    "Initial": {
+      "type": "Initial",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "Attribute",
+            "attribute": "statin",
+            "operator": "is nil"
+          },
+          "transition": "Prescribe_Ingredient"
         },
-        "Terminal": {
-            "type": "Terminal"
-        },
-        "Prescribe_Ingredient": {
-            "name": "Prescribe_Ingredient",
-            "remarks": [
-                "======================================================================",
-                " MEDICATION INGREDIENT TABLE TRANSITION                               ",
-                "======================================================================",
-                "Ingredients in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 49.9% ] Atorvastatin",
-                "2. [ 0.5% ] Ezetimibe_Simvastatin",
-                "3. [ 4.3% ] Lovastatin",
-                "4. [ 0.6% ] Pitavastatin",
-                "5. [ 11.6% ] Pravastatin",
-                "6. [ 11.1% ] Rosuvastatin",
-                "7. [ 22.0% ] Simvastatin"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Atorvastatin",
-                    "default_probability": 1,
-                    "lookup_table_name": "statin_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Ezetimibe_Simvastatin",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Lovastatin",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Pitavastatin",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Pravastatin",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Rosuvastatin",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_ingredient_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Simvastatin",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_ingredient_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Atorvastatin": {
-            "name": "Prescribe_Atorvastatin",
-            "remarks": [
-                "======================================================================",
-                " ATORVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 22.5% ] Atorvastatin_10_Mg_Oral_Tablet",
-                "2. [ 0.6% ] Atorvastatin_10_Mg_Oral_Tablet_Lipitor",
-                "3. [ 30.1% ] Atorvastatin_20_Mg_Oral_Tablet",
-                "4. [ 33.4% ] Atorvastatin_40_Mg_Oral_Tablet",
-                "5. [ 0.8% ] Atorvastatin_40_Mg_Oral_Tablet_Lipitor",
-                "6. [ 12.5% ] Atorvastatin_80_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Atorvastatin_10_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Atorvastatin_20_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Atorvastatin_40_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Atorvastatin_80_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Atorvastatin_40_Mg_Oral_Tablet_Lipitor",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Atorvastatin_10_Mg_Oral_Tablet_Lipitor",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Ezetimibe_Simvastatin": {
-            "name": "Prescribe_Ezetimibe_Simvastatin",
-            "remarks": [
-                "======================================================================",
-                " EZETIMIBE_SIMVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 28.5% ] Ezetimibe_10_Mg_Simvastatin_20_Mg_Oral_Tablet",
-                "2. [ 49.5% ] Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet",
-                "3. [ 10.8% ] Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet_Vytorin",
-                "4. [ 11.2% ] Ezetimibe_10_Mg_Simvastatin_80_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Ezetimibe_10_Mg_Simvastatin_20_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "statin_ezetimibe_simvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_ezetimibe_simvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Ezetimibe_10_Mg_Simvastatin_80_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_ezetimibe_simvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet_Vytorin",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_ezetimibe_simvastatin_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Lovastatin": {
-            "name": "Prescribe_Lovastatin",
-            "remarks": [
-                "======================================================================",
-                " LOVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 8.5% ] Lovastatin_10_Mg_Oral_Tablet",
-                "2. [ 46.9% ] Lovastatin_20_Mg_Oral_Tablet",
-                "3. [ 44.7% ] Lovastatin_40_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Lovastatin_10_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "statin_lovastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Lovastatin_20_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_lovastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Lovastatin_40_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_lovastatin_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Pitavastatin": {
-            "name": "Prescribe_Pitavastatin",
-            "remarks": [
-                "======================================================================",
-                " PITAVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 9.9% ] Pitavastatin_Calcium_1_Mg_Oral_Tablet_Livalo",
-                "2. [ 67.7% ] Pitavastatin_Calcium_2_Mg_Oral_Tablet_Livalo",
-                "3. [ 22.3% ] Pitavastatin_Calcium_4_Mg_Oral_Tablet_Livalo"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Pitavastatin_Calcium_1_Mg_Oral_Tablet_Livalo",
-                    "default_probability": 1,
-                    "lookup_table_name": "statin_pitavastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Pitavastatin_Calcium_2_Mg_Oral_Tablet_Livalo",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_pitavastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Pitavastatin_Calcium_4_Mg_Oral_Tablet_Livalo",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_pitavastatin_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Pravastatin": {
-            "name": "Prescribe_Pravastatin",
-            "remarks": [
-                "======================================================================",
-                " PRAVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 6.1% ] Pravastatin_Sodium_10_Mg_Oral_Tablet",
-                "2. [ 32.7% ] Pravastatin_Sodium_20_Mg_Oral_Tablet",
-                "3. [ 49.5% ] Pravastatin_Sodium_40_Mg_Oral_Tablet",
-                "4. [ 0.3% ] Pravastatin_Sodium_40_Mg_Oral_Tablet_Pravachol",
-                "5. [ 11.4% ] Pravastatin_Sodium_80_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Pravastatin_Sodium_10_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "statin_pravastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Pravastatin_Sodium_20_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_pravastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Pravastatin_Sodium_40_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_pravastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Pravastatin_Sodium_80_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_pravastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Pravastatin_Sodium_40_Mg_Oral_Tablet_Pravachol",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_pravastatin_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Rosuvastatin": {
-            "name": "Prescribe_Rosuvastatin",
-            "remarks": [
-                "======================================================================",
-                " ROSUVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 31.2% ] Rosuvastatin_Calcium_10_Mg_Oral_Tablet",
-                "2. [ 3.6% ] Rosuvastatin_Calcium_10_Mg_Oral_Tablet_Crestor",
-                "3. [ 27.2% ] Rosuvastatin_Calcium_20_Mg_Oral_Tablet",
-                "4. [ 2.2% ] Rosuvastatin_Calcium_20_Mg_Oral_Tablet_Crestor",
-                "5. [ 16.6% ] Rosuvastatin_Calcium_40_Mg_Oral_Tablet",
-                "6. [ 0.8% ] Rosuvastatin_Calcium_40_Mg_Oral_Tablet_Crestor",
-                "7. [ 18.1% ] Rosuvastatin_Calcium_5_Mg_Oral_Tablet",
-                "8. [ 0.4% ] Rosuvastatin_Calcium_5_Mg_Oral_Tablet_Crestor"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Rosuvastatin_Calcium_10_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Rosuvastatin_Calcium_10_Mg_Oral_Tablet_Crestor",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Rosuvastatin_Calcium_20_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Rosuvastatin_Calcium_20_Mg_Oral_Tablet_Crestor",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Rosuvastatin_Calcium_40_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Rosuvastatin_Calcium_5_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Rosuvastatin_Calcium_40_Mg_Oral_Tablet_Crestor",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Rosuvastatin_Calcium_5_Mg_Oral_Tablet_Crestor",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Simvastatin": {
-            "name": "Prescribe_Simvastatin",
-            "remarks": [
-                "======================================================================",
-                " SIMVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
-                "======================================================================",
-                "Products in lookup table:",
-                "#  [ % pop ] Name",
-                "-- --------- ----",
-                "1. [ 15.1% ] Simvastatin_10_Mg_Oral_Tablet",
-                "2. [ 41.7% ] Simvastatin_20_Mg_Oral_Tablet",
-                "3. [ 39.0% ] Simvastatin_40_Mg_Oral_Tablet",
-                "4. [ 0.9% ] Simvastatin_5_Mg_Oral_Tablet",
-                "5. [ 3.4% ] Simvastatin_80_Mg_Oral_Tablet"
-            ],
-            "type": "Simple",
-            "lookup_table_transition": [
-                {
-                    "transition": "Prescribe_Simvastatin_10_Mg_Oral_Tablet",
-                    "default_probability": 1,
-                    "lookup_table_name": "statin_simvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Simvastatin_40_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_simvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Simvastatin_20_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_simvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Simvastatin_80_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_simvastatin_product_distribution.csv"
-                },
-                {
-                    "transition": "Prescribe_Simvastatin_5_Mg_Oral_Tablet",
-                    "default_probability": 0,
-                    "lookup_table_name": "statin_simvastatin_product_distribution.csv"
-                }
-            ]
-        },
-        "Prescribe_Atorvastatin_10_Mg_Oral_Tablet": {
-            "remarks": [
-                "======================================================================",
-                " BEGIN MEDICATION ORDER STATES                                        ",
-                "======================================================================"
-            ],
-            "name": "Prescribe_Atorvastatin_10_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "617312",
-                    "display": "atorvastatin 10 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Atorvastatin_10_Mg_Oral_Tablet_Lipitor": {
-            "name": "Prescribe_Atorvastatin_10_Mg_Oral_Tablet_Lipitor",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "617314",
-                    "display": "atorvastatin 10 MG Oral Tablet [Lipitor]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Atorvastatin_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Atorvastatin_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "617310",
-                    "display": "atorvastatin 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Atorvastatin_40_Mg_Oral_Tablet": {
-            "name": "Prescribe_Atorvastatin_40_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "617311",
-                    "display": "atorvastatin 40 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Atorvastatin_40_Mg_Oral_Tablet_Lipitor": {
-            "name": "Prescribe_Atorvastatin_40_Mg_Oral_Tablet_Lipitor",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "617320",
-                    "display": "atorvastatin 40 MG Oral Tablet [Lipitor]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Atorvastatin_80_Mg_Oral_Tablet": {
-            "name": "Prescribe_Atorvastatin_80_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "259255",
-                    "display": "atorvastatin 80 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Ezetimibe_10_Mg_Simvastatin_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Ezetimibe_10_Mg_Simvastatin_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "476349",
-                    "display": "ezetimibe 10 MG / simvastatin 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet": {
-            "name": "Prescribe_Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "476350",
-                    "display": "ezetimibe 10 MG / simvastatin 40 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet_Vytorin": {
-            "name": "Prescribe_Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet_Vytorin",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "1245441",
-                    "display": "ezetimibe 10 MG / simvastatin 40 MG Oral Tablet [Vytorin]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Ezetimibe_10_Mg_Simvastatin_80_Mg_Oral_Tablet": {
-            "name": "Prescribe_Ezetimibe_10_Mg_Simvastatin_80_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "476351",
-                    "display": "ezetimibe 10 MG / simvastatin 80 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Lovastatin_10_Mg_Oral_Tablet": {
-            "name": "Prescribe_Lovastatin_10_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "197903",
-                    "display": "lovastatin 10 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Lovastatin_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Lovastatin_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "197904",
-                    "display": "lovastatin 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Lovastatin_40_Mg_Oral_Tablet": {
-            "name": "Prescribe_Lovastatin_40_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "197905",
-                    "display": "lovastatin 40 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Pitavastatin_Calcium_1_Mg_Oral_Tablet_Livalo": {
-            "name": "Prescribe_Pitavastatin_Calcium_1_Mg_Oral_Tablet_Livalo",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "861646",
-                    "display": "pitavastatin calcium 1 MG Oral Tablet [Livalo]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Pitavastatin_Calcium_2_Mg_Oral_Tablet_Livalo": {
-            "name": "Prescribe_Pitavastatin_Calcium_2_Mg_Oral_Tablet_Livalo",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "861650",
-                    "display": "pitavastatin calcium 2 MG Oral Tablet [Livalo]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Pitavastatin_Calcium_4_Mg_Oral_Tablet_Livalo": {
-            "name": "Prescribe_Pitavastatin_Calcium_4_Mg_Oral_Tablet_Livalo",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "861654",
-                    "display": "pitavastatin calcium 4 MG Oral Tablet [Livalo]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Pravastatin_Sodium_10_Mg_Oral_Tablet": {
-            "name": "Prescribe_Pravastatin_Sodium_10_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "904458",
-                    "display": "pravastatin sodium 10 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Pravastatin_Sodium_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Pravastatin_Sodium_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "904467",
-                    "display": "pravastatin sodium 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Pravastatin_Sodium_40_Mg_Oral_Tablet": {
-            "name": "Prescribe_Pravastatin_Sodium_40_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "904475",
-                    "display": "pravastatin sodium 40 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Pravastatin_Sodium_40_Mg_Oral_Tablet_Pravachol": {
-            "name": "Prescribe_Pravastatin_Sodium_40_Mg_Oral_Tablet_Pravachol",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "904477",
-                    "display": "pravastatin sodium 40 MG Oral Tablet [Pravachol]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Pravastatin_Sodium_80_Mg_Oral_Tablet": {
-            "name": "Prescribe_Pravastatin_Sodium_80_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "904481",
-                    "display": "pravastatin sodium 80 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Rosuvastatin_Calcium_10_Mg_Oral_Tablet": {
-            "name": "Prescribe_Rosuvastatin_Calcium_10_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "859747",
-                    "display": "rosuvastatin calcium 10 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Rosuvastatin_Calcium_10_Mg_Oral_Tablet_Crestor": {
-            "name": "Prescribe_Rosuvastatin_Calcium_10_Mg_Oral_Tablet_Crestor",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "859749",
-                    "display": "rosuvastatin calcium 10 MG Oral Tablet [Crestor]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Rosuvastatin_Calcium_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Rosuvastatin_Calcium_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "859751",
-                    "display": "rosuvastatin calcium 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Rosuvastatin_Calcium_20_Mg_Oral_Tablet_Crestor": {
-            "name": "Prescribe_Rosuvastatin_Calcium_20_Mg_Oral_Tablet_Crestor",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "859753",
-                    "display": "rosuvastatin calcium 20 MG Oral Tablet [Crestor]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Rosuvastatin_Calcium_40_Mg_Oral_Tablet": {
-            "name": "Prescribe_Rosuvastatin_Calcium_40_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "859419",
-                    "display": "rosuvastatin calcium 40 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Rosuvastatin_Calcium_40_Mg_Oral_Tablet_Crestor": {
-            "name": "Prescribe_Rosuvastatin_Calcium_40_Mg_Oral_Tablet_Crestor",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "859421",
-                    "display": "rosuvastatin calcium 40 MG Oral Tablet [Crestor]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Rosuvastatin_Calcium_5_Mg_Oral_Tablet": {
-            "name": "Prescribe_Rosuvastatin_Calcium_5_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "859424",
-                    "display": "rosuvastatin calcium 5 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Rosuvastatin_Calcium_5_Mg_Oral_Tablet_Crestor": {
-            "name": "Prescribe_Rosuvastatin_Calcium_5_Mg_Oral_Tablet_Crestor",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "859426",
-                    "display": "rosuvastatin calcium 5 MG Oral Tablet [Crestor]"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Simvastatin_10_Mg_Oral_Tablet": {
-            "name": "Prescribe_Simvastatin_10_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "314231",
-                    "display": "simvastatin 10 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Simvastatin_20_Mg_Oral_Tablet": {
-            "name": "Prescribe_Simvastatin_20_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "312961",
-                    "display": "simvastatin 20 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Simvastatin_40_Mg_Oral_Tablet": {
-            "name": "Prescribe_Simvastatin_40_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "198211",
-                    "display": "simvastatin 40 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Simvastatin_5_Mg_Oral_Tablet": {
-            "name": "Prescribe_Simvastatin_5_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "312962",
-                    "display": "simvastatin 5 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
-        },
-        "Prescribe_Simvastatin_80_Mg_Oral_Tablet": {
-            "name": "Prescribe_Simvastatin_80_Mg_Oral_Tablet",
-            "type": "MedicationOrder",
-            "assign_to_attribute": "statin",
-            "codes": [
-                {
-                    "system": "RxNorm",
-                    "code": "200345",
-                    "display": "simvastatin 80 MG Oral Tablet"
-                }
-            ],
-            "prescription": {
-                "refills": 0,
-                "as_needed": false
-            },
-            "direct_transition": "Terminal",
-            "chronic": false
+        {
+          "transition": "Terminal"
         }
+      ]
+    },
+    "Terminal": {
+      "type": "Terminal"
+    },
+    "Prescribe_Ingredient": {
+      "remarks": [
+        "======================================================================",
+        " MEDICATION INGREDIENT TABLE TRANSITION                               ",
+        "======================================================================",
+        "Ingredients in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 49.9% ] Atorvastatin",
+        "2. [ 0.5% ] Ezetimibe_Simvastatin",
+        "3. [ 4.3% ] Lovastatin",
+        "4. [ 0.6% ] Pitavastatin",
+        "5. [ 11.6% ] Pravastatin",
+        "6. [ 11.1% ] Rosuvastatin",
+        "7. [ 22.0% ] Simvastatin"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Atorvastatin",
+          "default_probability": 1,
+          "lookup_table_name": "statin_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Ezetimibe_Simvastatin",
+          "default_probability": 0,
+          "lookup_table_name": "statin_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Lovastatin",
+          "default_probability": 0,
+          "lookup_table_name": "statin_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Pitavastatin",
+          "default_probability": 0,
+          "lookup_table_name": "statin_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Pravastatin",
+          "default_probability": 0,
+          "lookup_table_name": "statin_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Rosuvastatin",
+          "default_probability": 0,
+          "lookup_table_name": "statin_ingredient_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Simvastatin",
+          "default_probability": 0,
+          "lookup_table_name": "statin_ingredient_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Atorvastatin": {
+      "remarks": [
+        "======================================================================",
+        " ATORVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 22.5% ] Atorvastatin_10_Mg_Oral_Tablet",
+        "2. [ 0.6% ] Atorvastatin_10_Mg_Oral_Tablet_Lipitor",
+        "3. [ 30.1% ] Atorvastatin_20_Mg_Oral_Tablet",
+        "4. [ 33.4% ] Atorvastatin_40_Mg_Oral_Tablet",
+        "5. [ 0.8% ] Atorvastatin_40_Mg_Oral_Tablet_Lipitor",
+        "6. [ 12.5% ] Atorvastatin_80_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Atorvastatin_10_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Atorvastatin_20_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Atorvastatin_40_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Atorvastatin_80_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Atorvastatin_40_Mg_Oral_Tablet_Lipitor",
+          "default_probability": 0,
+          "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Atorvastatin_10_Mg_Oral_Tablet_Lipitor",
+          "default_probability": 0,
+          "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Ezetimibe_Simvastatin": {
+      "remarks": [
+        "======================================================================",
+        " EZETIMIBE_SIMVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 28.5% ] Ezetimibe_10_Mg_Simvastatin_20_Mg_Oral_Tablet",
+        "2. [ 49.5% ] Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet",
+        "3. [ 10.8% ] Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet_Vytorin",
+        "4. [ 11.2% ] Ezetimibe_10_Mg_Simvastatin_80_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Ezetimibe_10_Mg_Simvastatin_20_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "statin_ezetimibe_simvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_ezetimibe_simvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Ezetimibe_10_Mg_Simvastatin_80_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_ezetimibe_simvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet_Vytorin",
+          "default_probability": 0,
+          "lookup_table_name": "statin_ezetimibe_simvastatin_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Lovastatin": {
+      "remarks": [
+        "======================================================================",
+        " LOVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 8.5% ] Lovastatin_10_Mg_Oral_Tablet",
+        "2. [ 46.9% ] Lovastatin_20_Mg_Oral_Tablet",
+        "3. [ 44.7% ] Lovastatin_40_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Lovastatin_10_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "statin_lovastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Lovastatin_20_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_lovastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Lovastatin_40_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_lovastatin_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Pitavastatin": {
+      "remarks": [
+        "======================================================================",
+        " PITAVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 9.9% ] Pitavastatin_Calcium_1_Mg_Oral_Tablet_Livalo",
+        "2. [ 67.7% ] Pitavastatin_Calcium_2_Mg_Oral_Tablet_Livalo",
+        "3. [ 22.3% ] Pitavastatin_Calcium_4_Mg_Oral_Tablet_Livalo"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Pitavastatin_Calcium_1_Mg_Oral_Tablet_Livalo",
+          "default_probability": 1,
+          "lookup_table_name": "statin_pitavastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Pitavastatin_Calcium_2_Mg_Oral_Tablet_Livalo",
+          "default_probability": 0,
+          "lookup_table_name": "statin_pitavastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Pitavastatin_Calcium_4_Mg_Oral_Tablet_Livalo",
+          "default_probability": 0,
+          "lookup_table_name": "statin_pitavastatin_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Pravastatin": {
+      "remarks": [
+        "======================================================================",
+        " PRAVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 6.1% ] Pravastatin_Sodium_10_Mg_Oral_Tablet",
+        "2. [ 32.7% ] Pravastatin_Sodium_20_Mg_Oral_Tablet",
+        "3. [ 49.5% ] Pravastatin_Sodium_40_Mg_Oral_Tablet",
+        "4. [ 0.3% ] Pravastatin_Sodium_40_Mg_Oral_Tablet_Pravachol",
+        "5. [ 11.4% ] Pravastatin_Sodium_80_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Pravastatin_Sodium_10_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "statin_pravastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Pravastatin_Sodium_20_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_pravastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Pravastatin_Sodium_40_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_pravastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Pravastatin_Sodium_80_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_pravastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Pravastatin_Sodium_40_Mg_Oral_Tablet_Pravachol",
+          "default_probability": 0,
+          "lookup_table_name": "statin_pravastatin_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Rosuvastatin": {
+      "remarks": [
+        "======================================================================",
+        " ROSUVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 31.2% ] Rosuvastatin_Calcium_10_Mg_Oral_Tablet",
+        "2. [ 3.6% ] Rosuvastatin_Calcium_10_Mg_Oral_Tablet_Crestor",
+        "3. [ 27.2% ] Rosuvastatin_Calcium_20_Mg_Oral_Tablet",
+        "4. [ 2.2% ] Rosuvastatin_Calcium_20_Mg_Oral_Tablet_Crestor",
+        "5. [ 16.6% ] Rosuvastatin_Calcium_40_Mg_Oral_Tablet",
+        "6. [ 0.8% ] Rosuvastatin_Calcium_40_Mg_Oral_Tablet_Crestor",
+        "7. [ 18.1% ] Rosuvastatin_Calcium_5_Mg_Oral_Tablet",
+        "8. [ 0.4% ] Rosuvastatin_Calcium_5_Mg_Oral_Tablet_Crestor"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Rosuvastatin_Calcium_10_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Rosuvastatin_Calcium_10_Mg_Oral_Tablet_Crestor",
+          "default_probability": 0,
+          "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Rosuvastatin_Calcium_20_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Rosuvastatin_Calcium_20_Mg_Oral_Tablet_Crestor",
+          "default_probability": 0,
+          "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Rosuvastatin_Calcium_40_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Rosuvastatin_Calcium_5_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Rosuvastatin_Calcium_40_Mg_Oral_Tablet_Crestor",
+          "default_probability": 0,
+          "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Rosuvastatin_Calcium_5_Mg_Oral_Tablet_Crestor",
+          "default_probability": 0,
+          "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Simvastatin": {
+      "remarks": [
+        "======================================================================",
+        " SIMVASTATIN MEDICATION PRODUCT TABLE TRANSITION  ",
+        "======================================================================",
+        "Products in lookup table:",
+        "#  [ % pop ] Name",
+        "-- --------- ----",
+        "1. [ 15.1% ] Simvastatin_10_Mg_Oral_Tablet",
+        "2. [ 41.7% ] Simvastatin_20_Mg_Oral_Tablet",
+        "3. [ 39.0% ] Simvastatin_40_Mg_Oral_Tablet",
+        "4. [ 0.9% ] Simvastatin_5_Mg_Oral_Tablet",
+        "5. [ 3.4% ] Simvastatin_80_Mg_Oral_Tablet"
+      ],
+      "type": "Simple",
+      "lookup_table_transition": [
+        {
+          "transition": "Prescribe_Simvastatin_10_Mg_Oral_Tablet",
+          "default_probability": 1,
+          "lookup_table_name": "statin_simvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Simvastatin_40_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_simvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Simvastatin_20_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_simvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Simvastatin_80_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_simvastatin_product_distribution.csv"
+        },
+        {
+          "transition": "Prescribe_Simvastatin_5_Mg_Oral_Tablet",
+          "default_probability": 0,
+          "lookup_table_name": "statin_simvastatin_product_distribution.csv"
+        }
+      ]
+    },
+    "Prescribe_Atorvastatin_10_Mg_Oral_Tablet": {
+      "remarks": [
+        "======================================================================",
+        " BEGIN MEDICATION ORDER STATES                                        ",
+        "======================================================================"
+      ],
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "617312",
+          "display": "atorvastatin 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Atorvastatin_10_Mg_Oral_Tablet_Lipitor": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "617314",
+          "display": "atorvastatin 10 MG Oral Tablet [Lipitor]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Atorvastatin_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "617310",
+          "display": "atorvastatin 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Atorvastatin_40_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "617311",
+          "display": "atorvastatin 40 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Atorvastatin_40_Mg_Oral_Tablet_Lipitor": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "617320",
+          "display": "atorvastatin 40 MG Oral Tablet [Lipitor]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Atorvastatin_80_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "259255",
+          "display": "atorvastatin 80 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Ezetimibe_10_Mg_Simvastatin_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "476349",
+          "display": "ezetimibe 10 MG / simvastatin 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "476350",
+          "display": "ezetimibe 10 MG / simvastatin 40 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet_Vytorin": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "1245441",
+          "display": "ezetimibe 10 MG / simvastatin 40 MG Oral Tablet [Vytorin]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Ezetimibe_10_Mg_Simvastatin_80_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "476351",
+          "display": "ezetimibe 10 MG / simvastatin 80 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Lovastatin_10_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "197903",
+          "display": "lovastatin 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Lovastatin_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "197904",
+          "display": "lovastatin 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Lovastatin_40_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "197905",
+          "display": "lovastatin 40 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Pitavastatin_Calcium_1_Mg_Oral_Tablet_Livalo": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "861646",
+          "display": "pitavastatin calcium 1 MG Oral Tablet [Livalo]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Pitavastatin_Calcium_2_Mg_Oral_Tablet_Livalo": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "861650",
+          "display": "pitavastatin calcium 2 MG Oral Tablet [Livalo]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Pitavastatin_Calcium_4_Mg_Oral_Tablet_Livalo": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "861654",
+          "display": "pitavastatin calcium 4 MG Oral Tablet [Livalo]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Pravastatin_Sodium_10_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "904458",
+          "display": "pravastatin sodium 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Pravastatin_Sodium_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "904467",
+          "display": "pravastatin sodium 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Pravastatin_Sodium_40_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "904475",
+          "display": "pravastatin sodium 40 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Pravastatin_Sodium_40_Mg_Oral_Tablet_Pravachol": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "904477",
+          "display": "pravastatin sodium 40 MG Oral Tablet [Pravachol]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Pravastatin_Sodium_80_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "904481",
+          "display": "pravastatin sodium 80 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Rosuvastatin_Calcium_10_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "859747",
+          "display": "rosuvastatin calcium 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Rosuvastatin_Calcium_10_Mg_Oral_Tablet_Crestor": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "859749",
+          "display": "rosuvastatin calcium 10 MG Oral Tablet [Crestor]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Rosuvastatin_Calcium_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "859751",
+          "display": "rosuvastatin calcium 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Rosuvastatin_Calcium_20_Mg_Oral_Tablet_Crestor": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "859753",
+          "display": "rosuvastatin calcium 20 MG Oral Tablet [Crestor]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Rosuvastatin_Calcium_40_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "859419",
+          "display": "rosuvastatin calcium 40 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Rosuvastatin_Calcium_40_Mg_Oral_Tablet_Crestor": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "859421",
+          "display": "rosuvastatin calcium 40 MG Oral Tablet [Crestor]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Rosuvastatin_Calcium_5_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "859424",
+          "display": "rosuvastatin calcium 5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Rosuvastatin_Calcium_5_Mg_Oral_Tablet_Crestor": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "859426",
+          "display": "rosuvastatin calcium 5 MG Oral Tablet [Crestor]"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Simvastatin_10_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "314231",
+          "display": "simvastatin 10 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Simvastatin_20_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "312961",
+          "display": "simvastatin 20 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Simvastatin_40_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "198211",
+          "display": "simvastatin 40 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Simvastatin_5_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "312962",
+          "display": "simvastatin 5 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
+    },
+    "Prescribe_Simvastatin_80_Mg_Oral_Tablet": {
+      "type": "MedicationOrder",
+      "assign_to_attribute": "statin",
+      "codes": [
+        {
+          "system": "RxNorm",
+          "code": "200345",
+          "display": "simvastatin 80 MG Oral Tablet"
+        }
+      ],
+      "prescription": {
+        "refills": 0,
+        "as_needed": false
+      },
+      "direct_transition": "Terminal",
+      "chronic": false
     }
+  }
 }

--- a/src/main/resources/modules/medications/statin.json
+++ b/src/main/resources/modules/medications/statin.json
@@ -111,37 +111,37 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Atorvastatin",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "statin_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Ezetimibe_Simvastatin",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Lovastatin",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Pitavastatin",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Pravastatin",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Rosuvastatin",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_ingredient_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Simvastatin",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_ingredient_distribution.csv"
                 }
             ]
@@ -166,32 +166,32 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Atorvastatin_10_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Atorvastatin_20_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Atorvastatin_40_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Atorvastatin_80_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Atorvastatin_40_Mg_Oral_Tablet_Lipitor",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Atorvastatin_10_Mg_Oral_Tablet_Lipitor",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_atorvastatin_product_distribution.csv"
                 }
             ]
@@ -214,22 +214,22 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Ezetimibe_10_Mg_Simvastatin_20_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "statin_ezetimibe_simvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_ezetimibe_simvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Ezetimibe_10_Mg_Simvastatin_80_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_ezetimibe_simvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Ezetimibe_10_Mg_Simvastatin_40_Mg_Oral_Tablet_Vytorin",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_ezetimibe_simvastatin_product_distribution.csv"
                 }
             ]
@@ -251,17 +251,17 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Lovastatin_10_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "statin_lovastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Lovastatin_20_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_lovastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Lovastatin_40_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_lovastatin_product_distribution.csv"
                 }
             ]
@@ -283,17 +283,17 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Pitavastatin_Calcium_1_Mg_Oral_Tablet_Livalo",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "statin_pitavastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Pitavastatin_Calcium_2_Mg_Oral_Tablet_Livalo",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_pitavastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Pitavastatin_Calcium_4_Mg_Oral_Tablet_Livalo",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_pitavastatin_product_distribution.csv"
                 }
             ]
@@ -317,27 +317,27 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Pravastatin_Sodium_10_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "statin_pravastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Pravastatin_Sodium_20_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_pravastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Pravastatin_Sodium_40_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_pravastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Pravastatin_Sodium_80_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_pravastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Pravastatin_Sodium_40_Mg_Oral_Tablet_Pravachol",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_pravastatin_product_distribution.csv"
                 }
             ]
@@ -364,42 +364,42 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Rosuvastatin_Calcium_10_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Rosuvastatin_Calcium_10_Mg_Oral_Tablet_Crestor",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Rosuvastatin_Calcium_20_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Rosuvastatin_Calcium_20_Mg_Oral_Tablet_Crestor",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Rosuvastatin_Calcium_40_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Rosuvastatin_Calcium_5_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Rosuvastatin_Calcium_40_Mg_Oral_Tablet_Crestor",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Rosuvastatin_Calcium_5_Mg_Oral_Tablet_Crestor",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_rosuvastatin_product_distribution.csv"
                 }
             ]
@@ -423,27 +423,27 @@
             "lookup_table_transition": [
                 {
                     "transition": "Prescribe_Simvastatin_10_Mg_Oral_Tablet",
-                    "default_probability": "1",
+                    "default_probability": 1,
                     "lookup_table_name": "statin_simvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Simvastatin_40_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_simvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Simvastatin_20_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_simvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Simvastatin_80_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_simvastatin_product_distribution.csv"
                 },
                 {
                     "transition": "Prescribe_Simvastatin_5_Mg_Oral_Tablet",
-                    "default_probability": "0",
+                    "default_probability": 0,
                     "lookup_table_name": "statin_simvastatin_product_distribution.csv"
                 }
             ]

--- a/src/main/resources/modules/mend_program.json
+++ b/src/main/resources/modules/mend_program.json
@@ -55,7 +55,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "End_Not_Referred_Wellness_Encounter"
         }
       ],

--- a/src/main/resources/modules/metabolic_syndrome_care.json
+++ b/src/main/resources/modules/metabolic_syndrome_care.json
@@ -402,7 +402,7 @@
               }
             ],
             "operator": "<",
-            "value": "7.0"
+            "value": 7.0
           },
           "addresses": [
             "diabetes_stage"
@@ -418,7 +418,7 @@
               }
             ],
             "operator": "<",
-            "value": "108"
+            "value": 108
           },
           "addresses": [
             "diabetes_stage"

--- a/src/main/resources/modules/myocardial_infarction.json
+++ b/src/main/resources/modules/myocardial_infarction.json
@@ -288,16 +288,6 @@
         "high": 10,
         "unit": "minutes"
       },
-      "distributed_transition": [
-        {
-          "transition": "NSTEACS",
-          "distribution": 0.6
-        },
-        {
-          "transition": "STEMI",
-          "distribution": 0.4
-        }
-      ],
       "direct_transition": "ACS_Arrival_Meds"
     },
     "MI_Onset": {

--- a/src/main/resources/modules/opioid_addiction.json
+++ b/src/main/resources/modules/opioid_addiction.json
@@ -42,14 +42,12 @@
               {
                 "condition_type": "Date",
                 "operator": ">=",
-                "year": 1990,
-                "value": 0
+                "year": 1990
               },
               {
                 "condition_type": "Date",
                 "operator": "<",
-                "year": 2014,
-                "value": 0
+                "year": 2014
               }
             ]
           }

--- a/src/main/resources/modules/osteoarthritis.json
+++ b/src/main/resources/modules/osteoarthritis.json
@@ -268,7 +268,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Non_Veteran"
         }
       ]
@@ -458,7 +457,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "OA_Pain_Medication"
         }
       ],

--- a/src/main/resources/modules/pregnancy.json
+++ b/src/main/resources/modules/pregnancy.json
@@ -1691,7 +1691,7 @@
     },
     "Miscarriage_In_Second_Trimester": {
       "type": "ConditionOnset",
-      "target_encounter": "Week_15_Visit",
+      "target_encounter": "Week_16_Visit",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -1800,7 +1800,7 @@
     },
     "Late_Fetal_Chromosomal_Anomaly": {
       "type": "ConditionOnset",
-      "target_encounter": "Week_15_Visit",
+      "target_encounter": "Week_16_Visit",
       "assign_to_attribute": "fatal_pregnancy_complication",
       "remarks": [
         "This is a separate state due to the limitation that a ConditionOnset must occur ",
@@ -1817,7 +1817,7 @@
     },
     "Uterine_Anomaly": {
       "type": "ConditionOnset",
-      "target_encounter": "Week_15_Visit",
+      "target_encounter": "Week_16_Visit",
       "assign_to_attribute": "fatal_pregnancy_complication",
       "codes": [
         {
@@ -1830,7 +1830,7 @@
     },
     "Unknown_Complication": {
       "type": "ConditionOnset",
-      "target_encounter": "Week_15_Visit",
+      "target_encounter": "Week_16_Visit",
       "assign_to_attribute": "fatal_pregnancy_complication",
       "codes": [
         {

--- a/src/main/resources/modules/prescribing_opioids_for_chronic_pain_and_treatment_of_oud.json
+++ b/src/main/resources/modules/prescribing_opioids_for_chronic_pain_and_treatment_of_oud.json
@@ -3099,8 +3099,7 @@
           {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 2014,
-            "value": 0
+            "year": 2014
           }
         ]
       },

--- a/src/main/resources/modules/sleep_apnea.json
+++ b/src/main/resources/modules/sleep_apnea.json
@@ -81,7 +81,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Terminal"
         }
       ]
@@ -378,7 +377,6 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "Set Device CPAP"
         },
         {
@@ -759,14 +757,6 @@
         "code": 702172008,
         "display": "Home continuous positive airway pressure unit (physical object)"
       },
-      "distributed_transition": [
-        {
-          "distribution": 0.5
-        },
-        {
-          "distribution": 0.5
-        }
-      ],
       "direct_transition": "Stop_previous_humidifier"
     },
     "Intraoral_Appliance": {

--- a/src/main/resources/modules/stable_ischemic_heart_disease.json
+++ b/src/main/resources/modules/stable_ischemic_heart_disease.json
@@ -152,8 +152,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 1997,
-            "value": 0
+            "year": 1997
           }
         },
         {
@@ -161,8 +160,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 1991,
-            "value": 0
+            "year": 1991
           }
         },
         {
@@ -170,8 +168,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">=",
-            "year": 1978,
-            "value": 0
+            "year": 1978
           }
         },
         {

--- a/src/main/resources/modules/urinary_tract_infections.json
+++ b/src/main/resources/modules/urinary_tract_infections.json
@@ -18,12 +18,10 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "Wait Unit 15",
-      "name": "Initial"
+      "direct_transition": "Wait Unit 15"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "Wait Unit 15": {
       "type": "Guard",
@@ -34,12 +32,10 @@
         "unit": "years",
         "value": 0
       },
-      "direct_transition": "Urinary Tract Infection",
-      "name": "Wait Unit 15"
+      "direct_transition": "Urinary Tract Infection"
     },
     "Urinary Tract Infection": {
       "type": "Simple",
-      "name": "Urinary Tract Infection",
       "lookup_table_transition": [
         {
           "transition": "Cystitis",
@@ -60,7 +56,6 @@
     },
     "Cystitis": {
       "type": "ConditionOnset",
-      "target_encounter": "",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -70,12 +65,10 @@
         }
       ],
       "direct_transition": "Care Pathways",
-      "name": "Cystitis",
       "assign_to_attribute": "uti"
     },
     "Pyelonephritis": {
       "type": "ConditionOnset",
-      "target_encounter": "",
       "codes": [
         {
           "system": "SNOMED-CT",
@@ -85,12 +78,10 @@
         }
       ],
       "direct_transition": "Care Pathways",
-      "name": "Pyelonephritis",
       "assign_to_attribute": "uti"
     },
     "Care Pathways": {
       "type": "Simple",
-      "name": "Care Pathways",
       "type_of_care_transition": {
         "ambulatory": "Ambulatory",
         "emergency": "ED",
@@ -107,41 +98,34 @@
         }
       },
       "unit": "months",
-      "direct_transition": "Urinary Tract Infection",
-      "name": "Wait_for_UTI"
+      "direct_transition": "Urinary Tract Infection"
     },
     "Telemedicine": {
       "type": "Simple",
-      "direct_transition": "UTI Telemed Sub",
-      "name": "Telemedicine"
+      "direct_transition": "UTI Telemed Sub"
     },
     "Ambulatory": {
       "type": "Simple",
-      "direct_transition": "UTI Ambulatory Sub",
-      "name": "Ambulatory"
+      "direct_transition": "UTI Ambulatory Sub"
     },
     "ED": {
       "type": "Simple",
-      "direct_transition": "UTI ED Sub",
-      "name": "ED"
+      "direct_transition": "UTI ED Sub"
     },
     "UTI Telemed Sub": {
       "type": "CallSubmodule",
       "submodule": "uti/telemed_path",
-      "direct_transition": "Time Delay",
-      "name": "UTI Telemed Sub"
+      "direct_transition": "Time Delay"
     },
     "UTI Ambulatory Sub": {
       "type": "CallSubmodule",
       "submodule": "uti/ambulatory_path",
-      "direct_transition": "Time Delay",
-      "name": "UTI Ambulatory Sub"
+      "direct_transition": "Time Delay"
     },
     "UTI ED Sub": {
       "type": "CallSubmodule",
       "submodule": "uti/ed_path",
-      "direct_transition": "Time Delay",
-      "name": "UTI ED Sub"
+      "direct_transition": "Time Delay"
     },
     "Time Delay": {
       "type": "Delay",
@@ -153,12 +137,10 @@
         }
       },
       "unit": "hours",
-      "direct_transition": "Clear ESI",
-      "name": "Time Delay"
+      "direct_transition": "Clear ESI"
     },
     "End UTI Tx": {
       "type": "MedicationEnd",
-      "name": "End UTI Tx",
       "referenced_by_attribute": "UTI_Tx",
       "distributed_transition": [
         {
@@ -174,66 +156,55 @@
     "Clear ESI": {
       "type": "SetAttribute",
       "attribute": "esi",
-      "direct_transition": "Clear BldCx",
-      "name": "Clear ESI"
+      "direct_transition": "Clear BldCx"
     },
     "Clear BldCx": {
       "type": "SetAttribute",
       "attribute": "UTI_Positive_BldCx",
-      "direct_transition": "Clear UTI ED",
-      "name": "Clear BldCx"
+      "direct_transition": "Clear UTI ED"
     },
     "Clear UTI ED": {
       "type": "SetAttribute",
       "attribute": "UTI_ED",
-      "direct_transition": "Clear UTI_Care_Referral",
-      "name": "Clear UTI ED"
+      "direct_transition": "Clear UTI_Care_Referral"
     },
     "Clear UTI_Care_Referral": {
       "type": "SetAttribute",
       "attribute": "UTI_Care_Referral",
-      "direct_transition": "Clear UTI_Lab_SendOut",
-      "name": "Clear UTI_Care_Referral"
+      "direct_transition": "Clear UTI_Lab_SendOut"
     },
     "Clear UTI_Lab_SendOut": {
       "type": "SetAttribute",
       "attribute": "UTI_Lab_SendOut",
-      "direct_transition": "Clear GU_Pregnancy_Check",
-      "name": "Clear UTI_Lab_SendOut"
+      "direct_transition": "Clear GU_Pregnancy_Check"
     },
     "Clear GU_Pregnancy_Check": {
       "type": "SetAttribute",
       "attribute": "GU_Pregnancy_Check",
-      "direct_transition": "Clear UTI_Labs",
-      "name": "Clear GU_Pregnancy_Check"
+      "direct_transition": "Clear UTI_Labs"
     },
     "Clear UTI_Labs": {
       "type": "SetAttribute",
       "attribute": "UTI_Labs",
-      "direct_transition": "Clear UTI_Bacteria",
-      "name": "Clear UTI_Labs"
+      "direct_transition": "Clear UTI_Bacteria"
     },
     "Clear UTI_Bacteria": {
       "type": "SetAttribute",
       "attribute": "UTI_Bacteria",
-      "direct_transition": "Clear UTI_Telemed",
-      "name": "Clear UTI_Bacteria"
+      "direct_transition": "Clear UTI_Telemed"
     },
     "Clear UTI_Telemed": {
       "type": "SetAttribute",
       "attribute": "UTI_Telemed",
-      "direct_transition": "Clear UTI_Ambulatory",
-      "name": "Clear UTI_Telemed"
+      "direct_transition": "Clear UTI_Ambulatory"
     },
     "Clear UTI_Ambulatory": {
       "type": "SetAttribute",
       "attribute": "UTI_Ambulatory",
-      "direct_transition": "End UTI Tx",
-      "name": "Clear UTI_Ambulatory"
+      "direct_transition": "End UTI Tx"
     },
     "End UTI": {
       "type": "ConditionEnd",
-      "name": "End UTI",
       "referenced_by_attribute": "uti",
       "complex_transition": [
         {
@@ -280,8 +251,7 @@
         }
       },
       "unit": "months",
-      "direct_transition": "Recurrent UTI",
-      "name": "Recurrence Delay"
+      "direct_transition": "Recurrent UTI"
     },
     "Recurrent UTI": {
       "type": "ConditionOnset",
@@ -304,8 +274,7 @@
           "default_probability": 0.1,
           "lookup_table_name": "uti_recurrence.csv"
         }
-      ],
-      "name": "Recurrent UTI"
+      ]
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/uti/abx_tx.json
+++ b/src/main/resources/modules/uti/abx_tx.json
@@ -3,7 +3,6 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "name": "Initial",
       "conditional_transition": [
         {
           "transition": "Female",
@@ -22,12 +21,10 @@
       ]
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "Male": {
       "type": "Simple",
-      "name": "Male",
       "conditional_transition": [
         {
           "transition": "Male with Pyelo",
@@ -59,7 +56,6 @@
     },
     "Female": {
       "type": "Simple",
-      "name": "Female",
       "conditional_transition": [
         {
           "transition": "Pregnant Female with Cystitis",
@@ -110,7 +106,6 @@
     },
     "Male with Pyelo": {
       "type": "Simple",
-      "name": "Male with Pyelo",
       "complex_transition": [
         {
           "condition": {
@@ -181,7 +176,6 @@
     },
     "Male with Cystitis": {
       "type": "Simple",
-      "name": "Male with Cystitis",
       "complex_transition": [
         {
           "condition": {
@@ -265,7 +259,6 @@
       ],
       "reason": "uti",
       "direct_transition": "ED Check",
-      "name": "Nitro 5 day",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -291,7 +284,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Nitro 7 day",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -318,7 +310,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Fosfo",
       "prescription": {
         "dosage": {
           "amount": 1,
@@ -345,7 +336,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Sulfa 3 day",
       "prescription": {
         "dosage": {
           "amount": 1,
@@ -372,7 +362,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Sulfa 7 day",
       "prescription": {
         "dosage": {
           "amount": 1,
@@ -399,7 +388,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Sulfa 10 day",
       "prescription": {
         "dosage": {
           "amount": 1,
@@ -426,7 +414,6 @@
         }
       ],
       "reason": "uti",
-      "name": "AmxClav 500, 5 day",
       "assign_to_attribute": "UTI_Tx",
       "direct_transition": "ED Check"
     },
@@ -441,7 +428,6 @@
         }
       ],
       "reason": "uti",
-      "name": "AmxClav 875, 7 day",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -468,7 +454,6 @@
         }
       ],
       "reason": "uti",
-      "name": "AmxClav 875, 10 day",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -495,7 +480,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Amox 7 day",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -522,7 +506,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Cepha 5 day",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -549,7 +532,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Cepha 10 day",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -576,7 +558,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Cepha 7 day",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -603,7 +584,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Cipro 250, 3 day",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -630,7 +610,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Cipro 500, 5 day",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -657,7 +636,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Cipro_500 7 day",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -684,7 +662,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Cefpo 100",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -711,7 +688,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Cefpo 200",
       "assign_to_attribute": "UTI_Tx",
       "prescription": {
         "dosage": {
@@ -738,7 +714,6 @@
         }
       ],
       "reason": "uti",
-      "name": "Ceftriaxone",
       "prescription": {
         "dosage": {
           "amount": 1,
@@ -756,7 +731,6 @@
     },
     "ED Check": {
       "type": "Simple",
-      "name": "ED Check",
       "complex_transition": [
         {
           "condition": {
@@ -798,7 +772,6 @@
     },
     "Female_with_Cystitis": {
       "type": "Simple",
-      "name": "Female_with_Cystitis",
       "complex_transition": [
         {
           "condition": {
@@ -953,12 +926,10 @@
             }
           ]
         }
-      ],
-      "name": "Pregnant Female with Cystitis"
+      ]
     },
     "Female with Pyelo": {
       "type": "Simple",
-      "name": "Female with Pyelo",
       "complex_transition": [
         {
           "condition": {
@@ -1068,8 +1039,7 @@
         {
           "transition": "Ceftriaxone"
         }
-      ],
-      "name": "ED and Pyelo"
+      ]
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/uti/abx_tx.json
+++ b/src/main/resources/modules/uti/abx_tx.json
@@ -792,7 +792,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Terminal"
         }
       ]

--- a/src/main/resources/modules/uti/ambulatory_eval.json
+++ b/src/main/resources/modules/uti/ambulatory_eval.json
@@ -3,12 +3,10 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "name": "Initial",
       "direct_transition": "Eval Procedure"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "Eval Procedure": {
       "type": "Procedure",
@@ -27,7 +25,6 @@
         }
       },
       "unit": "minutes",
-      "name": "Eval Procedure",
       "complex_transition": [
         {
           "condition": {
@@ -50,14 +47,12 @@
     "GU_Pregnancy_Check": {
       "type": "CallSubmodule",
       "submodule": "uti/gu_pregnancy_check",
-      "direct_transition": "UTI_Labs",
-      "name": "GU_Pregnancy_Check"
+      "direct_transition": "UTI_Labs"
     },
     "UTI_Labs": {
       "type": "CallSubmodule",
       "submodule": "uti/labs",
-      "direct_transition": "Abx Therapy",
-      "name": "UTI_Labs"
+      "direct_transition": "Abx Therapy"
     },
     "Abx Therapy": {
       "type": "Procedure",
@@ -76,14 +71,12 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "UTI_Abx",
-      "name": "Abx Therapy"
+      "direct_transition": "UTI_Abx"
     },
     "UTI_Abx": {
       "type": "CallSubmodule",
       "submodule": "uti/abx_tx",
-      "direct_transition": "Terminal",
-      "name": "UTI_Abx"
+      "direct_transition": "Terminal"
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/uti/ambulatory_path.json
+++ b/src/main/resources/modules/uti/ambulatory_path.json
@@ -3,12 +3,10 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "name": "Initial",
       "direct_transition": "UTI Diagnosis"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "Evaluation": {
       "type": "Procedure",
@@ -28,7 +26,6 @@
         }
       },
       "unit": "minutes",
-      "name": "Evaluation",
       "direct_transition": "End Ambulatory Encounter",
       "assign_to_attribute": "UTI_Care_Referral"
     },
@@ -49,13 +46,11 @@
         }
       },
       "unit": "minutes",
-      "name": "Exam",
       "direct_transition": "Risk Check"
     },
     "UTI_Ambulatory_Eval": {
       "type": "CallSubmodule",
       "submodule": "uti/ambulatory_eval",
-      "name": "UTI_Ambulatory_Eval",
       "direct_transition": "End Ambulatory Encounter"
     },
     "Risk Check": {
@@ -97,12 +92,10 @@
             }
           ]
         }
-      ],
-      "name": "Risk Check"
+      ]
     },
     "End Ambulatory Encounter": {
       "type": "EncounterEnd",
-      "name": "End Ambulatory Encounter",
       "conditional_transition": [
         {
           "transition": "Delay 24 to 48 hours",
@@ -135,8 +128,7 @@
         }
       },
       "unit": "hours",
-      "direct_transition": "Telephone Encounter",
-      "name": "Delay 24 to 48 hours"
+      "direct_transition": "Telephone Encounter"
     },
     "Delay 0 to 48 hours": {
       "type": "Delay",
@@ -148,8 +140,7 @@
         }
       },
       "unit": "hours",
-      "direct_transition": "Emergency Follow-up",
-      "name": "Delay 0 to 48 hours"
+      "direct_transition": "Emergency Follow-up"
     },
     "Telephone Encounter": {
       "type": "Encounter",
@@ -164,19 +155,16 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "UTI_Lab_FollowUp",
-      "name": "Telephone Encounter"
+      "direct_transition": "UTI_Lab_FollowUp"
     },
     "UTI_Lab_FollowUp": {
       "type": "CallSubmodule",
       "submodule": "uti/lab_follow_up",
-      "direct_transition": "End Telephone Encounter",
-      "name": "UTI_Lab_FollowUp"
+      "direct_transition": "End Telephone Encounter"
     },
     "End Telephone Encounter": {
       "type": "EncounterEnd",
-      "direct_transition": "Terminal",
-      "name": "End Telephone Encounter"
+      "direct_transition": "Terminal"
     },
     "Emergency Follow-up": {
       "type": "Encounter",
@@ -190,25 +178,21 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Set UTI_ED",
-      "name": "Emergency Follow-up"
+      "direct_transition": "Set UTI_ED"
     },
     "UTI_ED_Eval": {
       "type": "CallSubmodule",
       "submodule": "uti/ed_eval",
-      "direct_transition": "End ED Follow-up",
-      "name": "UTI_ED_Eval"
+      "direct_transition": "End ED Follow-up"
     },
     "End ED Follow-up": {
       "type": "EncounterEnd",
-      "direct_transition": "Terminal",
-      "name": "End ED Follow-up"
+      "direct_transition": "Terminal"
     },
     "Set UTI_ED": {
       "type": "SetAttribute",
       "attribute": "UTI_ED",
       "direct_transition": "UTI_ED_Eval",
-      "name": "Set UTI_ED",
       "value": true
     },
     "UTI Diagnosis": {
@@ -224,14 +208,12 @@
           "value_set": ""
         }
       ],
-      "name": "UTI Diagnosis",
       "direct_transition": "UTI_HPI"
     },
     "UTI_HPI": {
       "type": "CallSubmodule",
       "submodule": "uti/hpi",
-      "direct_transition": "Exam",
-      "name": "UTI_HPI"
+      "direct_transition": "Exam"
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/uti/ambulatory_path.json
+++ b/src/main/resources/modules/uti/ambulatory_path.json
@@ -83,7 +83,6 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "Evaluation"
         },
         {

--- a/src/main/resources/modules/uti/ed_bundle.json
+++ b/src/main/resources/modules/uti/ed_bundle.json
@@ -394,7 +394,8 @@
           "code": "2708-6",
           "display": "Oxygen saturation in Arterial blood",
           "value_set": ""
-        },{
+        },
+        {
           "system": "LOINC",
           "code": "59408-5",
           "display": "Oxygen saturation in Arterial blood by Pulse oximetry"
@@ -459,7 +460,8 @@
           "code": "2708-6",
           "display": "Oxygen saturation in Arterial blood",
           "value_set": ""
-        },{
+        },
+        {
           "system": "LOINC",
           "code": "59408-5",
           "display": "Oxygen saturation in Arterial blood by Pulse oximetry"
@@ -591,7 +593,8 @@
           "code": "2708-6",
           "display": "Oxygen saturation in Arterial blood",
           "value_set": ""
-        },{
+        },
+        {
           "system": "LOINC",
           "code": "59408-5",
           "display": "Oxygen saturation in Arterial blood by Pulse oximetry"
@@ -702,7 +705,8 @@
           "code": "2708-6",
           "display": "Oxygen saturation in Arterial blood",
           "value_set": ""
-        },{
+        },
+        {
           "system": "LOINC",
           "code": "59408-5",
           "display": "Oxygen saturation in Arterial blood by Pulse oximetry"
@@ -1402,7 +1406,6 @@
             "operator": "<=",
             "value": 2
           },
-          "distributions": [],
           "transition": "CMP"
         },
         {
@@ -1451,7 +1454,6 @@
             "operator": ">=",
             "value": 1
           },
-          "distributions": [],
           "transition": "Comprehensive_Metabolic_Panel_with_Kidney_Damage"
         },
         {
@@ -1518,7 +1520,6 @@
             "operator": ">=",
             "value": 1
           },
-          "distributions": [],
           "transition": "Basic_Metabolic_Panel_with_Kidney Damage"
         },
         {
@@ -1528,7 +1529,6 @@
             "operator": "<=",
             "value": 2
           },
-          "distributions": [],
           "transition": "Basic_Metabolic_Panel_with_Normal_Kidney"
         },
         {

--- a/src/main/resources/modules/uti/ed_bundle.json
+++ b/src/main/resources/modules/uti/ed_bundle.json
@@ -3,12 +3,10 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "Triage",
-      "name": "Initial"
+      "direct_transition": "Triage"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "Triage": {
       "type": "Procedure",
@@ -27,8 +25,7 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "Vitals",
-      "name": "Triage"
+      "direct_transition": "Vitals"
     },
     "Vitals": {
       "type": "Procedure",
@@ -47,7 +44,6 @@
         }
       },
       "unit": "minutes",
-      "name": "Vitals",
       "conditional_transition": [
         {
           "transition": "Pyelo",
@@ -79,7 +75,6 @@
     },
     "Cystitis": {
       "type": "Simple",
-      "name": "Cystitis",
       "distributed_transition": [
         {
           "transition": "ESI-3",
@@ -97,7 +92,6 @@
     },
     "Pyelo": {
       "type": "Simple",
-      "name": "Pyelo",
       "complex_transition": [
         {
           "condition": {
@@ -167,7 +161,6 @@
         }
       ],
       "direct_transition": "ESI_State 1",
-      "name": "ESI-1",
       "value_code": {
         "system": "LOINC",
         "code": "LA21567-5",
@@ -186,7 +179,6 @@
           "value_set": ""
         }
       ],
-      "name": "ESI-2",
       "value_code": {
         "system": "LOINC",
         "code": "LA21752-3",
@@ -206,7 +198,6 @@
           "value_set": ""
         }
       ],
-      "name": "ESI-3",
       "value_code": {
         "system": "LOINC",
         "code": "LA21753-1",
@@ -226,7 +217,6 @@
           "value_set": ""
         }
       ],
-      "name": "ESI-4",
       "value_code": {
         "system": "LOINC",
         "code": "LA21754-9",
@@ -246,7 +236,6 @@
           "value_set": ""
         }
       ],
-      "name": "ESI-5",
       "value_code": {
         "system": "LOINC",
         "code": "LA21755-6",
@@ -297,7 +286,6 @@
           }
         }
       ],
-      "name": "Record_BP_4_5",
       "direct_transition": "Record_Heart_Rate_4_5"
     },
     "Record_BP_3": {
@@ -343,7 +331,6 @@
           }
         }
       ],
-      "name": "Record_BP_3",
       "direct_transition": "Record_Heart_Rate_3"
     },
     "Record_Heart_Rate_4_5": {
@@ -358,7 +345,6 @@
           "value_set": ""
         }
       ],
-      "name": "Record_Heart_Rate_4_5",
       "direct_transition": "Record_Respiratory_Rate_4_5",
       "range": {
         "low": 60,
@@ -377,7 +363,6 @@
           "value_set": ""
         }
       ],
-      "name": "Record_Respiratory_Rate_4_5",
       "direct_transition": "O2_4_5",
       "range": {
         "low": 12,
@@ -409,8 +394,7 @@
           "low": 99
         }
       },
-      "direct_transition": "Take_Temperature_4_5",
-      "name": "O2_4_5"
+      "direct_transition": "Take_Temperature_4_5"
     },
     "Record_Heart_Rate_3": {
       "type": "Observation",
@@ -424,7 +408,6 @@
           "value_set": ""
         }
       ],
-      "name": "Record_Heart_Rate_3",
       "range": {
         "low": 60,
         "high": 99
@@ -443,7 +426,6 @@
           "value_set": ""
         }
       ],
-      "name": "Record_Respiratory_Rate_3",
       "range": {
         "low": 12,
         "high": 20
@@ -475,7 +457,6 @@
           "low": 97
         }
       },
-      "name": "O2_3",
       "direct_transition": "Take_Temperature_3"
     },
     "History and Physical Exam": {
@@ -496,8 +477,7 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "Check CBC",
-      "name": "History and Physical Exam"
+      "direct_transition": "Check CBC"
     },
     "Record_BP_2": {
       "type": "MultiObservation",
@@ -542,7 +522,6 @@
           }
         }
       ],
-      "name": "Record_BP_2",
       "direct_transition": "Record_Heart_Rate_2"
     },
     "Record_Heart_Rate_2": {
@@ -557,7 +536,6 @@
           "value_set": ""
         }
       ],
-      "name": "Record_Heart_Rate_2",
       "range": {
         "low": 80,
         "high": 130
@@ -576,7 +554,6 @@
           "value_set": ""
         }
       ],
-      "name": "Record_Respiratory_Rate_2",
       "range": {
         "low": 21,
         "high": 25
@@ -608,7 +585,6 @@
           "low": 89
         }
       },
-      "name": "O2_2",
       "direct_transition": "Take_Temperature_2"
     },
     "Record_BP_1": {
@@ -654,7 +630,6 @@
           }
         }
       ],
-      "name": "Record_BP_1",
       "direct_transition": "Record_Heart_Rate_1"
     },
     "Record_Heart_Rate_1": {
@@ -669,7 +644,6 @@
           "value_set": ""
         }
       ],
-      "name": "Record_Heart_Rate_1",
       "range": {
         "low": 80,
         "high": 130
@@ -688,7 +662,6 @@
           "value_set": ""
         }
       ],
-      "name": "Record_Respiratory_Rate_1",
       "range": {
         "low": 25,
         "high": 30
@@ -720,12 +693,10 @@
           "low": 70
         }
       },
-      "name": "O2_1",
       "direct_transition": "Take_Temperature_1"
     },
     "Check CBC": {
       "type": "Simple",
-      "name": "Check CBC",
       "conditional_transition": [
         {
           "transition": "CBC",
@@ -743,7 +714,6 @@
     },
     "Electrolyte Check": {
       "type": "Simple",
-      "name": "Electrolyte Check",
       "conditional_transition": [
         {
           "transition": "Provider Choice",
@@ -776,7 +746,6 @@
         }
       },
       "unit": "minutes",
-      "name": "CBC",
       "complex_transition": [
         {
           "condition": {
@@ -867,7 +836,6 @@
           "value_set": ""
         }
       ],
-      "name": "Take_Temperature_4_5",
       "direct_transition": "History and Physical Exam"
     },
     "Take_Temperature_3": {
@@ -895,7 +863,6 @@
           "value_set": ""
         }
       ],
-      "name": "Take_Temperature_3",
       "direct_transition": "History and Physical Exam"
     },
     "Take_Temperature_1": {
@@ -923,7 +890,6 @@
           "value_set": ""
         }
       ],
-      "name": "Take_Temperature_1",
       "direct_transition": "History and Physical Exam"
     },
     "Take_Temperature_2": {
@@ -951,41 +917,35 @@
           "value_set": ""
         }
       ],
-      "name": "Take_Temperature_2",
       "direct_transition": "History and Physical Exam"
     },
     "ESI State 5": {
       "type": "SetAttribute",
       "attribute": "esi",
       "direct_transition": "Record_BP_4_5",
-      "name": "ESI State 5",
       "value": 5
     },
     "ESI_State 4": {
       "type": "SetAttribute",
       "attribute": "esi",
-      "name": "ESI_State 4",
       "value": 4,
       "direct_transition": "Record_BP_4_5"
     },
     "ESI_State 3": {
       "type": "SetAttribute",
       "attribute": "esi",
-      "name": "ESI_State 3",
       "value": 3,
       "direct_transition": "Record_BP_3"
     },
     "ESI_State 2": {
       "type": "SetAttribute",
       "attribute": "esi",
-      "name": "ESI_State 2",
       "value": 2,
       "direct_transition": "Record_BP_2"
     },
     "ESI_State 1": {
       "type": "SetAttribute",
       "attribute": "esi",
-      "name": "ESI_State 1",
       "value": 1,
       "direct_transition": "Record_BP_1"
     },
@@ -1167,7 +1127,6 @@
           }
         }
       ],
-      "name": "Record_CBC_Panel",
       "direct_transition": "Electrolyte Check"
     },
     "Record_Abnormal CBC_Panel": {
@@ -1348,12 +1307,10 @@
           }
         }
       ],
-      "name": "Record_Abnormal CBC_Panel",
       "direct_transition": "Electrolyte Check"
     },
     "Blood Culture Check": {
       "type": "Simple",
-      "name": "Blood Culture Check",
       "conditional_transition": [
         {
           "transition": "Blood Culture",
@@ -1386,18 +1343,15 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "Labs Submodule",
-      "name": "Urinalysis"
+      "direct_transition": "Labs Submodule"
     },
     "Labs Submodule": {
       "type": "CallSubmodule",
       "submodule": "uti/labs",
-      "direct_transition": "Terminal",
-      "name": "Labs Submodule"
+      "direct_transition": "Terminal"
     },
     "Provider Choice": {
       "type": "Simple",
-      "name": "Provider Choice",
       "complex_transition": [
         {
           "condition": {
@@ -1445,7 +1399,6 @@
         }
       },
       "unit": "minutes",
-      "name": "CMP",
       "complex_transition": [
         {
           "condition": {
@@ -1511,7 +1464,6 @@
         }
       },
       "unit": "minutes",
-      "name": "BMP",
       "complex_transition": [
         {
           "condition": {
@@ -1767,7 +1719,6 @@
           }
         }
       ],
-      "name": "Comprehensive_Metabolic_Panel",
       "direct_transition": "Blood Culture Check"
     },
     "Comprehensive_Metabolic_Panel_with_Kidney_Damage": {
@@ -1986,7 +1937,6 @@
           }
         }
       ],
-      "name": "Comprehensive_Metabolic_Panel_with_Kidney_Damage",
       "direct_transition": "Blood Culture Check"
     },
     "Basic_Metabolic_Panel_with_Normal_Kidney": {
@@ -2115,8 +2065,7 @@
           }
         }
       ],
-      "direct_transition": "Blood Culture Check",
-      "name": "Basic_Metabolic_Panel_with_Normal_Kidney"
+      "direct_transition": "Blood Culture Check"
     },
     "Basic_Metabolic_Panel_with_Kidney Damage": {
       "type": "DiagnosticReport",
@@ -2244,7 +2193,6 @@
           }
         }
       ],
-      "name": "Basic_Metabolic_Panel_with_Kidney Damage",
       "direct_transition": "Blood Culture Check"
     },
     "Blood Culture": {
@@ -2265,7 +2213,6 @@
         }
       },
       "unit": "minutes",
-      "name": "Blood Culture",
       "distributed_transition": [
         {
           "transition": "Positive_Blood_Culture",
@@ -2290,7 +2237,6 @@
         }
       ],
       "direct_transition": "Urinalysis",
-      "name": "Negative Blood Culture",
       "value_code": {
         "system": "SNOMED-CT",
         "code": 708118007,
@@ -2309,7 +2255,6 @@
           "value_set": ""
         }
       ],
-      "name": "Positive_Blood_Culture",
       "value_code": {
         "system": "SNOMED-CT",
         "code": 8730001000004107,
@@ -2321,7 +2266,6 @@
       "type": "SetAttribute",
       "attribute": "UTI_Positive_BldCx",
       "direct_transition": "Urinalysis",
-      "name": "Set BldCx",
       "value": true
     }
   },

--- a/src/main/resources/modules/uti/ed_eval.json
+++ b/src/main/resources/modules/uti/ed_eval.json
@@ -37,7 +37,6 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "Hospital admission"
         },
         {
@@ -46,7 +45,6 @@
             "attribute": "UTI_Positive_BldCx",
             "operator": "is not nil"
           },
-          "distributions": [],
           "transition": "Hospital admission"
         },
         {
@@ -68,7 +66,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Hospital admission",
           "condition": {
             "condition_type": "Attribute",
@@ -78,7 +75,6 @@
           }
         },
         {
-          "distributions": [],
           "transition": "Antibiotic therapy"
         }
       ]

--- a/src/main/resources/modules/uti/ed_eval.json
+++ b/src/main/resources/modules/uti/ed_eval.json
@@ -3,17 +3,14 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "UTI_ED_Bundle",
-      "name": "Initial"
+      "direct_transition": "UTI_ED_Bundle"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "UTI_ED_Bundle": {
       "type": "CallSubmodule",
       "submodule": "uti/ed_bundle",
-      "name": "UTI_ED_Bundle",
       "complex_transition": [
         {
           "condition": {
@@ -96,14 +93,12 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "UTI_Abx",
-      "name": "Antibiotic therapy"
+      "direct_transition": "UTI_Abx"
     },
     "UTI_Abx": {
       "type": "CallSubmodule",
       "submodule": "uti/abx_tx",
-      "direct_transition": "Patient discharge",
-      "name": "UTI_Abx"
+      "direct_transition": "Patient discharge"
     },
     "Patient discharge": {
       "type": "Procedure",
@@ -122,13 +117,11 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "Terminal",
-      "name": "Patient discharge"
+      "direct_transition": "Terminal"
     },
     "Hospital admission": {
       "type": "Simple",
-      "direct_transition": "Antibiotic therapy",
-      "name": "Hospital admission"
+      "direct_transition": "Antibiotic therapy"
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/uti/ed_path.json
+++ b/src/main/resources/modules/uti/ed_path.json
@@ -3,12 +3,10 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "UTI Diagnosis",
-      "name": "Initial"
+      "direct_transition": "UTI Diagnosis"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "UTI Diagnosis": {
       "type": "Encounter",
@@ -23,31 +21,26 @@
         }
       ],
       "direct_transition": "Set_UTI_ED",
-      "name": "UTI Diagnosis",
       "reason": "uti"
     },
     "Set_UTI_ED": {
       "type": "SetAttribute",
       "attribute": "UTI_ED",
-      "name": "Set_UTI_ED",
       "value": true,
       "direct_transition": "UTI_HPI"
     },
     "UTI_ED_Eval": {
       "type": "CallSubmodule",
       "submodule": "uti/ed_eval",
-      "name": "UTI_ED_Eval",
       "direct_transition": "End_ED_Follow_up"
     },
     "End_ED_Follow_up": {
       "type": "EncounterEnd",
-      "name": "End_ED_Follow_up",
       "direct_transition": "Terminal"
     },
     "UTI_HPI": {
       "type": "CallSubmodule",
       "submodule": "uti/hpi",
-      "name": "UTI_HPI",
       "direct_transition": "UTI_ED_Eval"
     }
   },

--- a/src/main/resources/modules/uti/gu_pregnancy_check.json
+++ b/src/main/resources/modules/uti/gu_pregnancy_check.json
@@ -11,7 +11,6 @@
             "attribute": "UTI_Telemed",
             "operator": "is not nil"
           },
-          "distributions": [],
           "transition": "Discuss Pregnancy"
         },
         {

--- a/src/main/resources/modules/uti/gu_pregnancy_check.json
+++ b/src/main/resources/modules/uti/gu_pregnancy_check.json
@@ -3,7 +3,6 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "name": "Initial",
       "complex_transition": [
         {
           "condition": {
@@ -50,8 +49,7 @@
       ]
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "Pregnancy Test": {
       "type": "Procedure",
@@ -70,7 +68,6 @@
         }
       },
       "unit": "minutes",
-      "name": "Pregnancy Test",
       "conditional_transition": [
         {
           "transition": "Positive Result",
@@ -103,8 +100,7 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "Terminal",
-      "name": "Discuss Pregnancy"
+      "direct_transition": "Terminal"
     },
     "Negative Result": {
       "type": "Observation",
@@ -119,7 +115,6 @@
         }
       ],
       "direct_transition": "Terminal",
-      "name": "Negative Result",
       "value_code": {
         "system": "SNOMED-CT",
         "code": 260385009,
@@ -138,7 +133,6 @@
           "value_set": ""
         }
       ],
-      "name": "Positive Result",
       "value_code": {
         "system": "SNOMED-CT",
         "code": 10828004,

--- a/src/main/resources/modules/uti/hpi.json
+++ b/src/main/resources/modules/uti/hpi.json
@@ -6,12 +6,10 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "History Taking",
-      "name": "Initial"
+      "direct_transition": "History Taking"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "History Taking": {
       "type": "Procedure",
@@ -31,8 +29,7 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "Dysuria",
-      "name": "History Taking"
+      "direct_transition": "Dysuria"
     },
     "Dysuria": {
       "type": "Symptom",
@@ -45,8 +42,7 @@
           "value": 0.5
         }
       },
-      "direct_transition": "Increased frequency of urination",
-      "name": "Dysuria"
+      "direct_transition": "Increased frequency of urination"
     },
     "Increased frequency of urination": {
       "type": "Symptom",
@@ -59,8 +55,7 @@
           "value": 1
         }
       },
-      "direct_transition": "Urgent desire to urinate",
-      "name": "Increased frequency of urination"
+      "direct_transition": "Urgent desire to urinate"
     },
     "Urgent desire to urinate": {
       "type": "Symptom",
@@ -73,8 +68,7 @@
           "value": 1
         }
       },
-      "direct_transition": "Suprapubic pain",
-      "name": "Urgent desire to urinate"
+      "direct_transition": "Suprapubic pain"
     },
     "Suprapubic pain": {
       "type": "Symptom",
@@ -87,7 +81,6 @@
           "value": 1
         }
       },
-      "name": "Suprapubic pain",
       "conditional_transition": [
         {
           "transition": "Renal angle tenderness",
@@ -125,8 +118,7 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "Terminal",
-      "name": "Discussion about signs and symptoms"
+      "direct_transition": "Terminal"
     },
     "Renal angle tenderness": {
       "type": "Symptom",
@@ -139,8 +131,7 @@
           "value": 1
         }
       },
-      "direct_transition": "Flank pain",
-      "name": "Renal angle tenderness"
+      "direct_transition": "Flank pain"
     },
     "Flank pain": {
       "type": "Symptom",
@@ -153,8 +144,7 @@
           "value": 1
         }
       },
-      "direct_transition": "Fever",
-      "name": "Flank pain"
+      "direct_transition": "Fever"
     },
     "Fever": {
       "type": "Symptom",
@@ -167,8 +157,7 @@
           "value": 1
         }
       },
-      "direct_transition": "Tendency to nausea and vomiting",
-      "name": "Fever"
+      "direct_transition": "Tendency to nausea and vomiting"
     },
     "Tendency to nausea and vomiting": {
       "type": "Symptom",
@@ -181,8 +170,7 @@
           "value": 1
         }
       },
-      "direct_transition": "Discussion about signs and symptoms",
-      "name": "Tendency to nausea and vomiting"
+      "direct_transition": "Discussion about signs and symptoms"
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/uti/lab_follow_up.json
+++ b/src/main/resources/modules/uti/lab_follow_up.json
@@ -3,12 +3,10 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "Inform Patient",
-      "name": "Initial"
+      "direct_transition": "Inform Patient"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "Inform Patient": {
       "type": "Procedure",
@@ -27,8 +25,7 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "Lab Finding Education",
-      "name": "Inform Patient"
+      "direct_transition": "Lab Finding Education"
     },
     "Lab Finding Education": {
       "type": "Procedure",
@@ -47,8 +44,7 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "Discussion",
-      "name": "Lab Finding Education"
+      "direct_transition": "Discussion"
     },
     "Discussion": {
       "type": "Procedure",
@@ -67,7 +63,6 @@
         }
       },
       "unit": "minutes",
-      "name": "Discussion",
       "conditional_transition": [
         {
           "transition": "Evaluate Abx Response",
@@ -99,14 +94,12 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "UTI Abx Tx Sub",
-      "name": "Prescribe Abx"
+      "direct_transition": "UTI Abx Tx Sub"
     },
     "UTI Abx Tx Sub": {
       "type": "CallSubmodule",
       "submodule": "uti/abx_tx",
-      "direct_transition": "Terminal",
-      "name": "UTI Abx Tx Sub"
+      "direct_transition": "Terminal"
     },
     "Evaluate Abx Response": {
       "type": "Procedure",
@@ -125,7 +118,6 @@
         }
       },
       "unit": "minutes",
-      "name": "Evaluate Abx Response",
       "distributed_transition": [
         {
           "transition": "Stop UTI Abx",
@@ -140,7 +132,6 @@
     "Stop UTI Abx": {
       "type": "MedicationEnd",
       "direct_transition": "Change Treatment",
-      "name": "Stop UTI Abx",
       "referenced_by_attribute": "UTI_Tx"
     },
     "Change Treatment": {
@@ -160,8 +151,7 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "UTI Abx Tx Sub",
-      "name": "Change Treatment"
+      "direct_transition": "UTI Abx Tx Sub"
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/uti/labs.json
+++ b/src/main/resources/modules/uti/labs.json
@@ -245,7 +245,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Terminal"
         }
       ]

--- a/src/main/resources/modules/uti/labs.json
+++ b/src/main/resources/modules/uti/labs.json
@@ -3,12 +3,10 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "Collection",
-      "name": "Initial"
+      "direct_transition": "Collection"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "Collection": {
       "type": "Procedure",
@@ -27,7 +25,6 @@
         }
       },
       "unit": "minutes",
-      "name": "Collection",
       "conditional_transition": [
         {
           "transition": "Dipstick",
@@ -59,8 +56,7 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "Record_Urinalysis",
-      "name": "Dipstick"
+      "direct_transition": "Record_Urinalysis"
     },
     "Record_Urinalysis": {
       "type": "DiagnosticReport",
@@ -198,7 +194,6 @@
           }
         }
       ],
-      "name": "Record_Urinalysis",
       "complex_transition": [
         {
           "condition": {
@@ -266,8 +261,7 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "Record_Urinalysis_Micro",
-      "name": "Urinalysis Micro"
+      "direct_transition": "Record_Urinalysis_Micro"
     },
     "Record_Urinalysis_Micro": {
       "type": "DiagnosticReport",
@@ -498,7 +492,6 @@
           }
         }
       ],
-      "name": "Record_Urinalysis_Micro",
       "direct_transition": "Urine Culture Result"
     },
     "Urine Culture": {
@@ -519,12 +512,10 @@
       },
       "unit": "minutes",
       "direct_transition": "Urine Culture Result",
-      "name": "Urine Culture",
       "assign_to_attribute": "UTI_Lab_Send_Out"
     },
     "Urine Culture Result": {
       "type": "Simple",
-      "name": "Urine Culture Result",
       "complex_transition": [
         {
           "condition": {
@@ -591,56 +582,48 @@
       "type": "SetAttribute",
       "attribute": "UTI_Bacteria",
       "direct_transition": "Observe Bacteria",
-      "name": "E Coli",
       "value": "Greater than 100,000 colony forming units per mL Escherichia coli"
     },
     "Klebsiella": {
       "type": "SetAttribute",
       "attribute": "UTI_Bacteria",
       "direct_transition": "Observe Bacteria",
-      "name": "Klebsiella",
       "value": "Greater than 100,000 colony forming units per mL Klebsiella pneumoniae"
     },
     "Enterococcus": {
       "type": "SetAttribute",
       "attribute": "UTI_Bacteria",
       "direct_transition": "Observe Bacteria",
-      "name": "Enterococcus",
       "value": "Greater than 100,000 colony forming units per mL Enterococcus faecalis"
     },
     "Proteus": {
       "type": "SetAttribute",
       "attribute": "UTI_Bacteria",
       "direct_transition": "Observe Bacteria",
-      "name": "Proteus",
       "value": "Greater than 100,000 colony forming units per mL Proteus mirabilis"
     },
     "Pseudomonas": {
       "type": "SetAttribute",
       "attribute": "UTI_Bacteria",
       "direct_transition": "Observe Bacteria",
-      "name": "Pseudomonas",
       "value": "Greater than 100,000 colony forming units per mL Pseudomonas aeruginosa"
     },
     "Klebsiella oxytoca": {
       "type": "SetAttribute",
       "attribute": "UTI_Bacteria",
       "direct_transition": "Observe Bacteria",
-      "name": "Klebsiella oxytoca",
       "value": "Greater than 100,000 colony forming units per mL Klebsiella oxytoca"
     },
     "Citrobacter": {
       "type": "SetAttribute",
       "attribute": "UTI_Bacteria",
       "direct_transition": "Observe Bacteria",
-      "name": "Citrobacter",
       "value": "Greater than 100,000 colony forming units per mL Citrobacter freundii complex"
     },
     "Staphylococcus": {
       "type": "SetAttribute",
       "attribute": "UTI_Bacteria",
       "direct_transition": "Observe Bacteria",
-      "name": "Staphylococcus",
       "value": "Greater than 100,000 colony forming units per mL Staphylococcus aureus"
     },
     "No Growth": {
@@ -656,7 +639,6 @@
         }
       ],
       "direct_transition": "Terminal",
-      "name": "No Growth",
       "value_code": {
         "system": "SNOMED-CT",
         "code": 264868006,
@@ -676,7 +658,6 @@
         }
       ],
       "direct_transition": "Terminal",
-      "name": "Observe Bacteria",
       "attribute": "UTI_Bacteria"
     }
   },

--- a/src/main/resources/modules/uti/telemed_path.json
+++ b/src/main/resources/modules/uti/telemed_path.json
@@ -3,7 +3,6 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "name": "Initial",
       "distributed_transition": [
         {
           "transition": "UTI_Diagnosis_Encounter",
@@ -16,8 +15,7 @@
       ]
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "UTI_Diagnosis_Encounter_Audio_Only": {
       "type": "Encounter",
@@ -32,8 +30,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Telemed_Procedure",
-      "name": "UTI_Diagnosis_Encounter_Audio_Only"
+      "direct_transition": "Telemed_Procedure"
     },
     "UTI_Diagnosis_Encounter": {
       "type": "Encounter",
@@ -48,8 +45,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Telemed_Procedure",
-      "name": "UTI_Diagnosis_Encounter"
+      "direct_transition": "Telemed_Procedure"
     },
     "Telemed_Procedure": {
       "type": "Procedure",
@@ -69,12 +65,10 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "UTI_HPI",
-      "name": "Telemed_Procedure"
+      "direct_transition": "UTI_HPI"
     },
     "Risk_Check": {
       "type": "Simple",
-      "name": "Risk_Check",
       "complex_transition": [
         {
           "condition": {
@@ -156,7 +150,6 @@
       },
       "unit": "minutes",
       "direct_transition": "End_UTI_Diagnosis",
-      "name": "Referral_to_Ambulatory",
       "assign_to_attribute": "UTI_Care_Referral"
     },
     "Evaluation": {
@@ -177,7 +170,6 @@
         }
       },
       "unit": "minutes",
-      "name": "Evaluation",
       "distributed_transition": [
         {
           "transition": "Referral_to_Labs",
@@ -207,12 +199,10 @@
       },
       "unit": "minutes",
       "direct_transition": "End_UTI_Diagnosis",
-      "name": "Referral_to_Labs",
       "assign_to_attribute": "UTI_Labs"
     },
     "End_UTI_Diagnosis": {
       "type": "EncounterEnd",
-      "name": "End_UTI_Diagnosis",
       "conditional_transition": [
         {
           "transition": "Time Delay",
@@ -254,8 +244,7 @@
         }
       },
       "unit": "minutes",
-      "direct_transition": "UTI_Abx",
-      "name": "Antibiotics"
+      "direct_transition": "UTI_Abx"
     },
     "UTI_HPI": {
       "type": "CallSubmodule",
@@ -280,14 +269,12 @@
         {
           "transition": "Risk_Check"
         }
-      ],
-      "name": "UTI_HPI"
+      ]
     },
     "GU_Pregnancy_Check": {
       "type": "CallSubmodule",
       "submodule": "uti/gu_pregnancy_check",
-      "direct_transition": "Risk_Check",
-      "name": "GU_Pregnancy_Check"
+      "direct_transition": "Risk_Check"
     },
     "UTI_Abx": {
       "type": "CallSubmodule",
@@ -301,8 +288,7 @@
           "transition": "Referral_to_Labs",
           "distribution": 0.05
         }
-      ],
-      "name": "UTI_Abx"
+      ]
     },
     "Time Delay": {
       "type": "Delay",
@@ -314,7 +300,6 @@
         }
       },
       "unit": "hours",
-      "name": "Time Delay",
       "conditional_transition": [
         {
           "transition": "Lab Encounter",
@@ -347,19 +332,16 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Labs Sub",
-      "name": "Lab Encounter"
+      "direct_transition": "Labs Sub"
     },
     "Labs Sub": {
       "type": "CallSubmodule",
       "submodule": "uti/labs",
-      "direct_transition": "End Labs Encounter",
-      "name": "Labs Sub"
+      "direct_transition": "End Labs Encounter"
     },
     "End Labs Encounter": {
       "type": "EncounterEnd",
-      "direct_transition": "Result Delay",
-      "name": "End Labs Encounter"
+      "direct_transition": "Result Delay"
     },
     "Result Delay": {
       "type": "Delay",
@@ -371,8 +353,7 @@
         }
       },
       "unit": "hours",
-      "direct_transition": "Lab Result Encounter",
-      "name": "Result Delay"
+      "direct_transition": "Lab Result Encounter"
     },
     "Lab Result Encounter": {
       "type": "Encounter",
@@ -387,23 +368,19 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Follow Up",
-      "name": "Lab Result Encounter"
+      "direct_transition": "Follow Up"
     },
     "Follow Up": {
       "type": "CallSubmodule",
       "submodule": "uti/lab_follow_up",
-      "direct_transition": "End Results Encounter",
-      "name": "Follow Up"
+      "direct_transition": "End Results Encounter"
     },
     "End Results Encounter": {
       "type": "EncounterEnd",
-      "direct_transition": "Terminal",
-      "name": "End Results Encounter"
+      "direct_transition": "Terminal"
     },
     "Patient Choice": {
       "type": "Simple",
-      "name": "Patient Choice",
       "complex_transition": [
         {
           "condition": {
@@ -446,7 +423,6 @@
     "Ambulatory Eval": {
       "type": "CallSubmodule",
       "submodule": "uti/ambulatory_eval",
-      "name": "Ambulatory Eval",
       "direct_transition": "End Ambulatory"
     },
     "Ambulatory Encounter": {
@@ -462,14 +438,12 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Set UTI_Ambulatory",
-      "name": "Ambulatory Encounter"
+      "direct_transition": "Set UTI_Ambulatory"
     },
     "Set UTI_Ambulatory": {
       "type": "SetAttribute",
       "attribute": "UTI_Ambulatory",
       "direct_transition": "Ambulatory Eval",
-      "name": "Set UTI_Ambulatory",
       "value": true
     },
     "End Ambulatory": {
@@ -486,8 +460,7 @@
         {
           "transition": "Terminal"
         }
-      ],
-      "name": "End Ambulatory"
+      ]
     },
     "Emergency Follow Up": {
       "type": "Encounter",
@@ -502,25 +475,21 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Set UTI_ED",
-      "name": "Emergency Follow Up"
+      "direct_transition": "Set UTI_ED"
     },
     "ED Eval": {
       "type": "CallSubmodule",
       "submodule": "uti/ed_eval",
-      "direct_transition": "End ED Encounter",
-      "name": "ED Eval"
+      "direct_transition": "End ED Encounter"
     },
     "End ED Encounter": {
       "type": "EncounterEnd",
-      "direct_transition": "Terminal",
-      "name": "End ED Encounter"
+      "direct_transition": "Terminal"
     },
     "Set UTI_ED": {
       "type": "SetAttribute",
       "attribute": "UTI_ED",
       "direct_transition": "ED Eval",
-      "name": "Set UTI_ED",
       "value": true
     }
   },

--- a/src/main/resources/modules/uti/telemed_path.json
+++ b/src/main/resources/modules/uti/telemed_path.json
@@ -87,7 +87,6 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "Evaluation"
         },
         {
@@ -135,7 +134,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Evaluation"
         }
       ]
@@ -280,7 +278,6 @@
           ]
         },
         {
-          "distributions": [],
           "transition": "Risk_Check"
         }
       ],
@@ -430,7 +427,6 @@
               }
             ]
           },
-          "distributions": [],
           "transition": "Emergency Follow Up"
         },
         {

--- a/src/main/resources/modules/veteran.json
+++ b/src/main/resources/modules/veteran.json
@@ -105,8 +105,7 @@
           "condition": {
             "condition_type": "Date",
             "operator": ">",
-            "year": 1961,
-            "value": 0
+            "year": 1961
           }
         },
         {

--- a/src/main/resources/modules/veteran_hyperlipidemia.json
+++ b/src/main/resources/modules/veteran_hyperlipidemia.json
@@ -82,15 +82,7 @@
     },
     "Hyperlipidemia initial workup encounter": {
       "type": "Encounter",
-      "encounter_class": "ambulatory",
       "reason": "hyperlipidemia",
-      "codes": [
-        {
-          "system": "SNOMED-CT",
-          "code": 185345009,
-          "display": "Encounter for symptom"
-        }
-      ],
       "direct_transition": "Record_LipidPanel",
       "wellness": true
     },

--- a/src/main/resources/modules/veteran_mdd.json
+++ b/src/main/resources/modules/veteran_mdd.json
@@ -579,8 +579,7 @@
           "condition": {
             "condition_type": "Attribute",
             "attribute": "ssri",
-            "operator": "is not nil",
-            "value": 0
+            "operator": "is not nil"
           }
         },
         {

--- a/src/main/resources/modules/veteran_ptsd.json
+++ b/src/main/resources/modules/veteran_ptsd.json
@@ -508,7 +508,6 @@
     "end re_evaluation_medication": {
       "type": "MedicationEnd",
       "direct_transition": "PTSD Medication Order",
-      "medication_order": "",
       "referenced_by_attribute": "SSRI"
     },
     "end_PTSD_Re_evaluation_Encounter": {

--- a/src/main/resources/modules/veteran_ptsd.json
+++ b/src/main/resources/modules/veteran_ptsd.json
@@ -353,8 +353,7 @@
           "condition": {
             "condition_type": "Attribute",
             "attribute": "SSRI",
-            "operator": "is not nil",
-            "value": "Vicodin"
+            "operator": "is not nil"
           }
         },
         {
@@ -1229,8 +1228,7 @@
           "condition": {
             "condition_type": "Attribute",
             "attribute": "SSRI",
-            "operator": "is nil",
-            "value": "Vicodin"
+            "operator": "is nil"
           }
         }
       ],
@@ -1303,8 +1301,7 @@
       "allow": {
         "condition_type": "Date",
         "operator": ">=",
-        "year": 1999,
-        "value": 0
+        "year": 1999
       },
       "direct_transition": "PTSD_Encounter",
       "name": "Wait_For_PHQ"

--- a/src/main/resources/modules/veteran_ptsd.json
+++ b/src/main/resources/modules/veteran_ptsd.json
@@ -6,12 +6,10 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "age guard",
-      "name": "Initial"
+      "direct_transition": "age guard"
     },
     "Terminal": {
-      "type": "Terminal",
-      "name": "Terminal"
+      "type": "Terminal"
     },
     "Female": {
       "type": "Simple",
@@ -44,8 +42,7 @@
       "remarks": [
         "The prevalence data presented here come from the seminal report on VHA health care delivery systems and management processes.  It can be accessed here: https://www.va.gov/opa/choiceact/documents/assessments/integrated_report.pdf",
         ""
-      ],
-      "name": "Female"
+      ]
     },
     "Male": {
       "type": "Simple",
@@ -77,8 +74,7 @@
       ],
       "remarks": [
         "The prevalence data presented here come from the seminal report on VHA health care delivery systems and management processes.  It can be accessed here: https://www.va.gov/opa/choiceact/documents/assessments/integrated_report.pdf"
-      ],
-      "name": "Male"
+      ]
     },
     "Veteran": {
       "type": "Simple",
@@ -97,13 +93,11 @@
             "gender": "M"
           }
         }
-      ],
-      "name": "Veteran"
+      ]
     },
     "Non_Veteran": {
       "type": "Simple",
-      "direct_transition": "Terminal",
-      "name": "Non_Veteran"
+      "direct_transition": "Terminal"
     },
     "Onset_age_30_to_39_Male": {
       "type": "Delay",
@@ -112,8 +106,7 @@
         "low": 9,
         "high": 18,
         "unit": "years"
-      },
-      "name": "Onset_age_30_to_39_Male"
+      }
     },
     "Onset_age_30_to_39_Female": {
       "type": "Delay",
@@ -122,8 +115,7 @@
         "low": 9,
         "high": 18,
         "unit": "years"
-      },
-      "name": "Onset_age_30_to_39_Female"
+      }
     },
     "Onset_age_40_to_49_Male": {
       "type": "Delay",
@@ -132,8 +124,7 @@
         "low": 19,
         "high": 28,
         "unit": "years"
-      },
-      "name": "Onset_age_40_to_49_Male"
+      }
     },
     "Onset_age_40_to_49_Female": {
       "type": "Delay",
@@ -142,8 +133,7 @@
         "low": 19,
         "high": 28,
         "unit": "years"
-      },
-      "name": "Onset_age_40_to_49_Female"
+      }
     },
     "Onset_age_50_to_59_Female": {
       "type": "Delay",
@@ -152,8 +142,7 @@
         "low": 29,
         "high": 38,
         "unit": "years"
-      },
-      "name": "Onset_age_50_to_59_Female"
+      }
     },
     "Onset_age_50_to_59_Male": {
       "type": "Delay",
@@ -162,8 +151,7 @@
         "low": 29,
         "high": 38,
         "unit": "years"
-      },
-      "name": "Onset_age_50_to_59_Male"
+      }
     },
     "PTSD Episode": {
       "type": "ConditionOnset",
@@ -177,8 +165,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Wait_For_PHQ",
-      "name": "PTSD Episode"
+      "direct_transition": "Wait_For_PHQ"
     },
     "PTSD_Initial_Careplan": {
       "type": "CarePlanStart",
@@ -198,8 +185,7 @@
           "display": "Initial psychiatric interview with mental status and evaluation"
         }
       ],
-      "direct_transition": "end_PTSD_Encounter",
-      "name": "PTSD_Initial_Careplan"
+      "direct_transition": "end_PTSD_Encounter"
     },
     "Initial_Psychiatric_PTSD_Encounter": {
       "type": "Encounter",
@@ -213,8 +199,7 @@
         }
       ],
       "reason": "ptsd",
-      "direct_transition": "PHQ2_Q9 Assessment",
-      "name": "Initial_Psychiatric_PTSD_Encounter"
+      "direct_transition": "PHQ2_Q9 Assessment"
     },
     "PTSD_Careplan_Psych_and_Rx": {
       "type": "CarePlanStart",
@@ -281,8 +266,7 @@
             "operator": "is nil"
           }
         }
-      ],
-      "name": "PTSD_Careplan_Psych_and_Rx"
+      ]
     },
     "PTSD_Careplan_Psych": {
       "type": "CarePlanStart",
@@ -328,14 +312,12 @@
           "code": 719858009,
           "display": "Telehealth monitoring (regime/therapy)"
         }
-      ],
-      "name": "PTSD_Careplan_Psych"
+      ]
     },
     "Change_Dx_Not_PTSD": {
       "type": "ConditionEnd",
       "direct_transition": "Pain_Vital_3",
-      "referenced_by_attribute": "ptsd",
-      "name": "Change_Dx_Not_PTSD"
+      "referenced_by_attribute": "ptsd"
     },
     "PTSD_Careplan_Rx_ONLY": {
       "type": "CarePlanStart",
@@ -366,8 +348,7 @@
         }
       ],
       "reason": "ptsd",
-      "assign_to_attribute": "ptsd_careplan",
-      "name": "PTSD_Careplan_Rx_ONLY"
+      "assign_to_attribute": "ptsd_careplan"
     },
     "PTSD Diagnosis": {
       "type": "ConditionOnset",
@@ -409,8 +390,7 @@
       "remarks": [
         "estimate of percents of patients falling into larger categories of treatment models (e.g. Rx only, Rx + Psychology or Psych only) provided by Jodie Trafton, PhD.",
         ""
-      ],
-      "name": "PTSD Diagnosis"
+      ]
     },
     "end_PTSD_Encounter": {
       "type": "EncounterEnd",
@@ -419,8 +399,7 @@
         "system": "NUBC",
         "code": "01",
         "display": "Discharged home safe"
-      },
-      "name": "end_PTSD_Encounter"
+      }
     },
     "Evaluation Gate delay": {
       "type": "Delay",
@@ -428,8 +407,7 @@
         "quantity": 1,
         "unit": "weeks"
       },
-      "direct_transition": "PTSD_Re_evaluation Encounter",
-      "name": "Evaluation Gate delay"
+      "direct_transition": "PTSD_Re_evaluation Encounter"
     },
     "PTSD_Re_evaluation Encounter": {
       "type": "Encounter",
@@ -472,8 +450,7 @@
           "distribution": 0.15
         }
       ],
-      "reason": "ptsd",
-      "name": "PTSD_Re_evaluation Encounter"
+      "reason": "ptsd"
     },
     "end_Psych_encounter": {
       "type": "EncounterEnd",
@@ -499,8 +476,7 @@
         {
           "transition": "therapy delay"
         }
-      ],
-      "name": "end_Psych_encounter"
+      ]
     },
     "PTSD Medication Order": {
       "type": "MedicationOrder",
@@ -527,15 +503,13 @@
       "remarks": [
         "most common Rx ordered tied to mental health conditions like PTSD are SSRIs (per VA CDW data analysis)",
         ""
-      ],
-      "name": "PTSD Medication Order"
+      ]
     },
     "end re_evaluation_medication": {
       "type": "MedicationEnd",
       "direct_transition": "PTSD Medication Order",
       "medication_order": "",
-      "referenced_by_attribute": "SSRI",
-      "name": "end re_evaluation_medication"
+      "referenced_by_attribute": "SSRI"
     },
     "end_PTSD_Re_evaluation_Encounter": {
       "type": "EncounterEnd",
@@ -551,8 +525,7 @@
         {
           "transition": "Terminal"
         }
-      ],
-      "name": "end_PTSD_Re_evaluation_Encounter"
+      ]
     },
     "age guard": {
       "type": "Delay",
@@ -580,8 +553,7 @@
             "operator": "is nil"
           }
         }
-      ],
-      "name": "age guard"
+      ]
     },
     "PTSD Chronic Pain Med": {
       "type": "MedicationOrder",
@@ -597,14 +569,12 @@
       "reason": "ptsd",
       "remarks": [
         "per Dr Trafton and other sources"
-      ],
-      "name": "PTSD Chronic Pain Med"
+      ]
     },
     "end_follow_up_careplan": {
       "type": "CarePlanEnd",
       "direct_transition": "Terminal",
-      "referenced_by_attribute": "ptsd_careplan",
-      "name": "end_follow_up_careplan"
+      "referenced_by_attribute": "ptsd_careplan"
     },
     "time gate": {
       "type": "Delay",
@@ -616,8 +586,7 @@
       "remarks": [
         "estimate provided by Jodie Trafton, PhD",
         ""
-      ],
-      "name": "time gate"
+      ]
     },
     "Columbia Suicide Risk Assessment": {
       "type": "Procedure",
@@ -648,8 +617,7 @@
       "remarks": [
         "per new VA protocol identified by Jodie Trafton, PhD",
         ""
-      ],
-      "name": "Columbia Suicide Risk Assessment"
+      ]
     },
     "PHQ2_Q9 Assessment": {
       "type": "Procedure",
@@ -680,8 +648,7 @@
       "remarks": [
         "estimate of 10% of patients who initially screened positive for PTSD to not ultimately screen in by a mental health expert, provided in consultation with Jodie Trafton, PhD",
         ""
-      ],
-      "name": "PHQ2_Q9 Assessment"
+      ]
     },
     "At Risk for suicide": {
       "type": "ConditionOnset",
@@ -695,8 +662,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Inpatient Suicide Assessment",
-      "name": "At Risk for suicide"
+      "direct_transition": "Inpatient Suicide Assessment"
     },
     "Inpatient Suicide Assessment": {
       "type": "Encounter",
@@ -710,8 +676,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Inpatient Suicide Risk Assessment",
-      "name": "Inpatient Suicide Assessment"
+      "direct_transition": "Inpatient Suicide Risk Assessment"
     },
     "Inpatient_admission": {
       "type": "Encounter",
@@ -725,8 +690,7 @@
         }
       ],
       "direct_transition": "Pain_Vital_2",
-      "reason": "suicide_risk",
-      "name": "Inpatient_admission"
+      "reason": "suicide_risk"
     },
     "Inpatient Suicide Risk Assessment": {
       "type": "Procedure",
@@ -744,13 +708,11 @@
         "unit": "minutes"
       },
       "reason": "ptsd",
-      "direct_transition": "emergency_encounter end",
-      "name": "Inpatient Suicide Risk Assessment"
+      "direct_transition": "emergency_encounter end"
     },
     "emergency_encounter end": {
       "type": "EncounterEnd",
-      "direct_transition": "Inpatient_admission",
-      "name": "emergency_encounter end"
+      "direct_transition": "Inpatient_admission"
     },
     "Inpatient Suicide Care Plan": {
       "type": "CarePlanStart",
@@ -775,8 +737,7 @@
           "code": 183401008,
           "display": "Anti-suicide psychotherapy (regime/therapy)"
         }
-      ],
-      "name": "Inpatient Suicide Care Plan"
+      ]
     },
     "time delay": {
       "type": "Delay",
@@ -784,14 +745,12 @@
         "quantity": 3,
         "unit": "days"
       },
-      "direct_transition": "Inpatient Suicide Care Plan_2",
-      "name": "time delay"
+      "direct_transition": "Inpatient Suicide Care Plan_2"
     },
     "Inpatient Suicide Care Plan_2": {
       "type": "CarePlanEnd",
       "direct_transition": "PTSD_Re_evaluation Encounter",
-      "careplan": "Inpatient Suicide Care Plan",
-      "name": "Inpatient Suicide Care Plan_2"
+      "careplan": "Inpatient Suicide Care Plan"
     },
     "Onset_age_21_to_29_Male": {
       "type": "Delay",
@@ -800,8 +759,7 @@
         "low": 0,
         "high": 9,
         "unit": "years"
-      },
-      "name": "Onset_age_21_to_29_Male"
+      }
     },
     "Onset_age_60_to_99_Male": {
       "type": "Delay",
@@ -810,8 +768,7 @@
         "low": 39,
         "high": 68,
         "unit": "years"
-      },
-      "name": "Onset_age_60_to_99_Male"
+      }
     },
     "Onset_age_21_to_29_Female": {
       "type": "Delay",
@@ -820,8 +777,7 @@
         "low": 0,
         "high": 9,
         "unit": "years"
-      },
-      "name": "Onset_age_21_to_29_Female"
+      }
     },
     "Onset_age_60_to_99_Female": {
       "type": "Delay",
@@ -830,8 +786,7 @@
         "low": 39,
         "high": 68,
         "unit": "years"
-      },
-      "name": "Onset_age_60_to_99_Female"
+      }
     },
     "PTSD_Encounter": {
       "type": "Encounter",
@@ -845,8 +800,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "PC-PTSD Screen",
-      "name": "PTSD_Encounter"
+      "direct_transition": "PC-PTSD Screen"
     },
     "Telehealth_Visit": {
       "type": "Encounter",
@@ -864,8 +818,7 @@
       "remarks": [
         "careplan to include regular telephone psychotherapy.  workflow recommendation provided by Brian Marx, PhD, SME for PTSD within VA",
         ""
-      ],
-      "name": "Telehealth_Visit"
+      ]
     },
     "therapy delay": {
       "type": "Delay",
@@ -894,8 +847,7 @@
         {
           "transition": "Therapy_Visit"
         }
-      ],
-      "name": "therapy delay"
+      ]
     },
     "Therapy_Visit": {
       "type": "Encounter",
@@ -909,8 +861,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Therapy Note",
-      "name": "Therapy_Visit"
+      "direct_transition": "Therapy Note"
     },
     "telehealth delay": {
       "type": "Delay",
@@ -918,8 +869,7 @@
         "quantity": 1,
         "unit": "weeks"
       },
-      "direct_transition": "Telehealth_Visit",
-      "name": "telehealth delay"
+      "direct_transition": "Telehealth_Visit"
     },
     "Telehealth_Observations": {
       "type": "Observation",
@@ -936,8 +886,7 @@
       "exact": {
         "quantity": 1
       },
-      "direct_transition": "end telehealth",
-      "name": "Telehealth_Observations"
+      "direct_transition": "end telehealth"
     },
     "Therapy Note": {
       "type": "Observation",
@@ -954,13 +903,11 @@
       "exact": {
         "quantity": 1
       },
-      "direct_transition": "end therapy visit",
-      "name": "Therapy Note"
+      "direct_transition": "end therapy visit"
     },
     "end therapy visit": {
       "type": "EncounterEnd",
-      "direct_transition": "telehealth delay",
-      "name": "end therapy visit"
+      "direct_transition": "telehealth delay"
     },
     "end telehealth": {
       "type": "EncounterEnd",
@@ -979,8 +926,7 @@
         {
           "transition": "Evaluation Gate delay"
         }
-      ],
-      "name": "end telehealth"
+      ]
     },
     "PHQ2_Q9_Assessment": {
       "type": "Procedure",
@@ -1002,8 +948,7 @@
       "remarks": [
         "per new VA protocol identified by Jodie Trafton, PhD",
         ""
-      ],
-      "name": "PHQ2_Q9_Assessment"
+      ]
     },
     "Columbia_Suicide_Risk_Assessment": {
       "type": "Procedure",
@@ -1024,8 +969,7 @@
       "direct_transition": "PTSD_Initial_Careplan",
       "remarks": [
         "per new VA protocol identified by Jodie Trafton, PhD"
-      ],
-      "name": "Columbia_Suicide_Risk_Assessment"
+      ]
     },
     "mTBI check": {
       "type": "Simple",
@@ -1062,8 +1006,7 @@
         "https://www.ncbi.nlm.nih.gov/books/NBK326723/",
         "",
         ""
-      ],
-      "name": "mTBI check"
+      ]
     },
     "Pain_Vital": {
       "type": "Observation",
@@ -1082,8 +1025,7 @@
         "low": 4,
         "high": 8
       },
-      "direct_transition": "end_Psych_encounter",
-      "name": "Pain_Vital"
+      "direct_transition": "end_Psych_encounter"
     },
     "Pain_Vital_2": {
       "type": "Observation",
@@ -1102,8 +1044,7 @@
         "low": 4,
         "high": 8
       },
-      "direct_transition": "Inpatient Suicide Care Plan",
-      "name": "Pain_Vital_2"
+      "direct_transition": "Inpatient Suicide Care Plan"
     },
     "Pain_Vital_3": {
       "type": "Observation",
@@ -1122,8 +1063,7 @@
         "low": 0,
         "high": 3
       },
-      "direct_transition": "end_PTSD_Re_evaluation_Encounter",
-      "name": "Pain_Vital_3"
+      "direct_transition": "end_PTSD_Re_evaluation_Encounter"
     },
     "Pain_Vital_4": {
       "type": "Observation",
@@ -1142,8 +1082,7 @@
         "low": 1,
         "high": 4
       },
-      "direct_transition": "end_Psych_encounter",
-      "name": "Pain_Vital_4"
+      "direct_transition": "end_Psych_encounter"
     },
     "PC-PTSD Screen": {
       "type": "Procedure",
@@ -1163,8 +1102,7 @@
       "direct_transition": "PHQ2_Q9_Assessment",
       "remarks": [
         "workflow approach provided by Brian "
-      ],
-      "name": "PC-PTSD Screen"
+      ]
     },
     "PTSD_Careplan_Telehealth_Psych_and_Rx": {
       "type": "CarePlanStart",
@@ -1231,8 +1169,7 @@
             "operator": "is nil"
           }
         }
-      ],
-      "name": "PTSD_Careplan_Telehealth_Psych_and_Rx"
+      ]
     },
     "PTSD_Careplan_Telehealth_Psych": {
       "type": "CarePlanStart",
@@ -1278,8 +1215,7 @@
           "display": "Telehealth monitoring (regime/therapy)"
         }
       ],
-      "direct_transition": "end_Psych_encounter",
-      "name": "PTSD_Careplan_Telehealth_Psych"
+      "direct_transition": "end_Psych_encounter"
     },
     "Therapy_Visit_Telehealth": {
       "type": "Encounter",
@@ -1293,8 +1229,7 @@
           "value_set": ""
         }
       ],
-      "direct_transition": "Therapy Note",
-      "name": "Therapy_Visit_Telehealth"
+      "direct_transition": "Therapy Note"
     },
     "Wait_For_PHQ": {
       "type": "Guard",
@@ -1303,8 +1238,7 @@
         "operator": ">=",
         "year": 1999
       },
-      "direct_transition": "PTSD_Encounter",
-      "name": "Wait_For_PHQ"
+      "direct_transition": "PTSD_Encounter"
     }
   },
   "gmf_version": 2

--- a/src/main/resources/modules/veteran_self_harm.json
+++ b/src/main/resources/modules/veteran_self_harm.json
@@ -537,7 +537,6 @@
     },
     "Suicidal_Thoughts": {
       "type": "ConditionOnset",
-      "target_encounter": "",
       "codes": [
         {
           "system": "SNOMED-CT",

--- a/src/main/resources/modules/vhd_aortic.json
+++ b/src/main/resources/modules/vhd_aortic.json
@@ -28,7 +28,6 @@
     "Aortic Valve Regurgitation": {
       "type": "ConditionOnset",
       "assign_to_attribute": "vhd_diagnosis",
-      "target_encounter": "",
       "codes": [
         {
           "system": "SNOMED-CT",

--- a/src/main/resources/modules/weight_loss/mend_week.json
+++ b/src/main/resources/modules/weight_loss/mend_week.json
@@ -7,8 +7,7 @@
   "states": {
     "Initial": {
       "type": "Initial",
-      "direct_transition": "Wait_For_First",
-      "name": "Initial"
+      "direct_transition": "Wait_For_First"
     },
     "Nutrition_Intervention_Procedure": {
       "type": "Procedure",
@@ -25,8 +24,7 @@
         "low": 45,
         "high": 60,
         "unit": "minutes"
-      },
-      "name": "Nutrition_Intervention_Procedure"
+      }
     },
     "Exercise_Intervention_Procedure": {
       "type": "Procedure",
@@ -43,13 +41,11 @@
         "high": 60,
         "unit": "minutes"
       },
-      "direct_transition": "End_Exercise_Intervention",
-      "name": "Exercise_Intervention_Procedure"
+      "direct_transition": "End_Exercise_Intervention"
     },
     "End_Exercise_Intervention": {
       "type": "EncounterEnd",
-      "direct_transition": "Check_For_End",
-      "name": "End_Exercise_Intervention"
+      "direct_transition": "Check_For_End"
     },
     "MEND_Encounter": {
       "type": "Encounter",
@@ -63,25 +59,21 @@
           "display": "Encounter for problem"
         }
       ],
-      "direct_transition": "MEND_Vitals",
-      "name": "MEND_Encounter"
+      "direct_transition": "MEND_Vitals"
     },
     "End_MEND_Week": {
-      "type": "Terminal",
-      "name": "End_MEND_Week"
+      "type": "Terminal"
     },
     "MEND_Vitals": {
       "type": "CallSubmodule",
       "submodule": "encounter/vitals",
-      "direct_transition": "Nutrition_Intervention_Procedure",
-      "name": "MEND_Vitals"
+      "direct_transition": "Nutrition_Intervention_Procedure"
     },
     "Reset_Visit_Counter": {
       "type": "SetAttribute",
       "attribute": "mend_weekly_visit_count",
       "direct_transition": "Increment_MEND_Visit",
-      "value": 0,
-      "name": "Reset_Visit_Counter"
+      "value": 0
     },
     "Increment_MEND_Visit": {
       "type": "Counter",
@@ -118,8 +110,7 @@
             }
           ]
         }
-      ],
-      "name": "Increment_MEND_Visit"
+      ]
     },
     "Wait_For_Next_Visit": {
       "type": "Delay",
@@ -127,8 +118,7 @@
         "quantity": 3,
         "unit": "days"
       },
-      "direct_transition": "Increment_MEND_Visit",
-      "name": "Wait_For_Next_Visit"
+      "direct_transition": "Increment_MEND_Visit"
     },
     "Wait_For_Week_To_End": {
       "type": "Delay",
@@ -136,8 +126,7 @@
         "quantity": 2,
         "unit": "days"
       },
-      "direct_transition": "End_MEND_Week",
-      "name": "Wait_For_Week_To_End"
+      "direct_transition": "End_MEND_Week"
     },
     "Check_For_End": {
       "type": "Simple",
@@ -154,8 +143,7 @@
         {
           "transition": "Wait_For_Next_Visit"
         }
-      ],
-      "name": "Check_For_End"
+      ]
     },
     "Wait_For_First": {
       "type": "Delay",
@@ -163,8 +151,7 @@
         "quantity": 2,
         "unit": "days"
       },
-      "direct_transition": "Reset_Visit_Counter",
-      "name": "Wait_For_First"
+      "direct_transition": "Reset_Visit_Counter"
     }
   }
 }


### PR DESCRIPTION
This pull request targets module syntax cleanliness.

Some of these changes are not functional, for example, removing unused extra fields from the JSON.

Some of them are errors that were luckily avoided during runtime, due to code preferring one parameter to another, or relying on defaults or not.

Many of these syntax issues are artifacts of the module builder. For example, copying & pasting modules rather than "downloading" them results in extra `name` fields. Inserting a state into a model can shift a transition, leaving a state with two transitions (but only rendering the last one), and so forth.