### PR TITLE
Fix issue with setting config via CLI

### DIFF
--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -109,7 +109,7 @@ public abstract class Exporter {
     private List<Mapping> flexporterMappings;
 
     public ExporterRuntimeOptions() {
-      yearsOfHistory = Integer.parseInt(Config.get("exporter.years_of_history"));
+      yearsOfHistory = Config.getAsInteger("exporter.years_of_history", 10);
     }
 
     /**


### PR DESCRIPTION
This addresses an issue where certain config settings, ie `exporter.years_of_history` don't work when set via the command line args.
I think we've seen a few times and have put fixes on various branches: https://github.com/synthetichealth/synthea/pull/1357/commits/d10d07e8f4c2dff820da8b2c5f4ef7f0f564b725 , https://github.com/synthetichealth/synthea/commit/d0e43719ea54573a6ad4a5050ace749f8490d336#diff-a6b8b70e408cd3e34b8db02476445bfd607cad475dd9e80a5b62bc82c583b3b2

This is still a bandage though and we'll probably run into this again, but it should work as a quick fix. The longer andmore permanent fix would be to keep separate variables for the things the cli args can set, and only instantiate the 2 Options objects after all args have been parsed.

Fixes #1476 