### PR TITLE
Fix ids for flexporter executeScript

### DIFF
--- a/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
+++ b/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
@@ -760,7 +760,7 @@ public abstract class Actions {
     Bundle newBundle = parser.parseResource(Bundle.class, outBundleJson);
     for (BundleEntryComponent bec : newBundle.getEntry()) {
       Resource r = bec.getResource();
-      if (r.getId().startsWith("urn:uuid:")) {
+      if (r.getId() != null && r.getId().startsWith("urn:uuid:")) {
         // HAPI does some weird stuff with IDs
         // by default in Synthea they are just plain UUIDs
         // and the entry.fullUrl is urn:uuid:(id)

--- a/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
+++ b/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
@@ -758,6 +758,18 @@ public abstract class Actions {
     String outBundleJson = fjContext.getBundle();
 
     Bundle newBundle = parser.parseResource(Bundle.class, outBundleJson);
+    for (BundleEntryComponent bec : newBundle.getEntry()) {
+      Resource r = bec.getResource();
+      if (r.getId().startsWith("urn:uuid:")) {
+        // HAPI does some weird stuff with IDs
+        // by default in Synthea they are just plain UUIDs
+        // and the entry.fullUrl is urn:uuid:(id)
+        // but somehow when they get parsed back in, the id is urn:uuid:etc
+        // which then doesn't get written back out at the end
+        // so this removes the "urn:uuid:" bit if it got added
+        r.setId(r.getId().substring(9));
+      }
+    }
 
     return newBundle;
   }


### PR DESCRIPTION
# Summary
Fixes an issue with the flexporter where mappings that use `execute_script` export files without ids on the resources.

## New behavior
Resets ids by searching for and removing `urn:uuid:`. Now flexporter run appropriately exports resources with ids when executing a script during mapping.

## Code changes
Copies code from [line 151 of RunFlexporter.java](https://github.com/synthetichealth/synthea/blob/055d977ec40f52cd5d386395297930241ad4e34c/src/main/java/RunFlexporter.java#L151) which is used to fix an issue with HAPI ids. (Thanks for the fix @dehall!)

# Testing guidance
Run the synthea flexporter with something like `./run_synthea -fm {mapping_file.yaml}` where the mapping file contains some `execute_script` mapping as described in the [flexporter wiki](https://github.com/synthetichealth/synthea/wiki/Flexporter#execute-script). Look at the output patient file in output/fhir and confirm that the appropriate resources are exported with id fields. 
