### PR TITLE
Flexporter updates - October 2024

### DIFF
--- a/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
+++ b/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
@@ -424,6 +424,12 @@ public abstract class Actions {
       String location = (String)field.get("location");
       Object valueDef = field.get("value");
       String transform = (String)field.get("transform");
+      String ifDef = (String)field.get("if");
+
+      if (ifDef != null && !FhirPathUtils.appliesToResource(sourceResource, ifDef)) {
+        // The "if" condition returned falsy, so don't evaluate this value/set this field
+        continue;
+      }
 
       if (valueDef == null) {
         // do nothing, leave it null

--- a/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
+++ b/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
@@ -655,13 +655,9 @@ public abstract class Actions {
    * Cascade (current), Delete reference field but leave object, Do nothing
    *
    * @param bundle FHIR Bundle to filter
-   * @param list List of resource types to delete, other types not listed will be kept
+   * @param list List of resource types or FHIRPath to delete, other types not listed will be kept
    */
   public static void deleteResources(Bundle bundle, List<String> list) {
-    // TODO: make this FHIRPath instead of just straight resource types
-
-    Set<String> resourceTypesToDelete = new HashSet<>(list);
-
     Set<String> deletedResourceIDs = new HashSet<>();
 
     Iterator<BundleEntryComponent> itr = bundle.getEntry().iterator();
@@ -671,9 +667,14 @@ public abstract class Actions {
 
       Resource resource = entry.getResource();
       String resourceType = resource.getResourceType().toString();
-      if (resourceTypesToDelete.contains(resourceType)) {
-        deletedResourceIDs.add(resource.getId());
-        itr.remove();
+
+      for (String applicability : list) {
+        if (applicability.equals(resourceType)
+            || FhirPathUtils.appliesToResource(resource, applicability)) {
+          deletedResourceIDs.add(resource.getId());
+          itr.remove();
+          break;
+        }
       }
     }
 

--- a/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
+++ b/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
@@ -463,12 +463,15 @@ public abstract class Actions {
       } else if (valueDef instanceof Map<?,?>) {
         Map<String,Object> valueMap = (Map<String, Object>) valueDef;
 
-        populateFhirPathMapping(fhirPathMapping, location, valueMap);
+        populateFhirPathMapping(fhirPathMapping, location, valueMap, sourceBundle, sourceResource,
+            person, fjContext);
 
       } else if (valueDef instanceof List<?>) {
         List<Object> valueList = (List<Object>) valueDef;
 
-        populateFhirPathMapping(fhirPathMapping, location, valueList);
+        populateFhirPathMapping(fhirPathMapping, location, valueList, sourceBundle, sourceResource,
+            person, fjContext);
+
       } else {
         // unexpected type here - is it even possible to get anything else?
         String type = valueDef == null ? "null" : valueDef.getClass().toGenericString();
@@ -480,7 +483,8 @@ public abstract class Actions {
   }
 
   private static void populateFhirPathMapping(Map<String, Object> fhirPathMapping, String basePath,
-      Map<String, Object> valueMap) {
+      Map<String, Object> valueMap, Bundle sourceBundle, Resource sourceResource, Person person,
+      FlexporterJavascriptContext fjContext) {
     for (Map.Entry<String,Object> entry : valueMap.entrySet()) {
       String key = entry.getKey();
       Object value = entry.getValue();
@@ -488,13 +492,23 @@ public abstract class Actions {
       String path = basePath + "." + key;
 
       if (value instanceof String) {
+        String valueString = (String)value;
+
+        if (valueString.startsWith("$")) {
+          value = getValue(sourceBundle, valueString, sourceResource, person, fjContext);
+        }
+      }
+
+      if (value instanceof String || value instanceof Base) {
         fhirPathMapping.put(path, value);
       } else if (value instanceof Number) {
         fhirPathMapping.put(path, value.toString());
       } else if (value instanceof Map<?,?>) {
-        populateFhirPathMapping(fhirPathMapping, path, (Map<String, Object>) value);
+        populateFhirPathMapping(fhirPathMapping, path, (Map<String, Object>) value, sourceBundle,
+            sourceResource, person, fjContext);
       } else if (value instanceof List<?>) {
-        populateFhirPathMapping(fhirPathMapping, path, (List<Object>) value);
+        populateFhirPathMapping(fhirPathMapping, path, (List<Object>) value, sourceBundle,
+            sourceResource, person, fjContext);
       } else if (value != null) {
         System.err
             .println("Unexpected class found in populateFhirPathMapping[map]: " + value.getClass());
@@ -503,20 +517,23 @@ public abstract class Actions {
   }
 
   private static void populateFhirPathMapping(Map<String, Object> fhirPathMapping, String basePath,
-      List<Object> valueList) {
+      List<Object> valueList, Bundle sourceBundle, Resource sourceResource, Person person,
+      FlexporterJavascriptContext fjContext) {
     for (int i = 0; i < valueList.size(); i++) {
       Object value = valueList.get(i);
 
       String path = basePath + "[" + i + "]";
 
-      if (value instanceof String) {
+      if (value instanceof String || value instanceof Base) {
         fhirPathMapping.put(path, value);
       } else if (value instanceof Number) {
         fhirPathMapping.put(path, value.toString());
       } else if (value instanceof Map<?,?>) {
-        populateFhirPathMapping(fhirPathMapping, path, (Map<String, Object>) value);
+        populateFhirPathMapping(fhirPathMapping, path, (Map<String, Object>) value, sourceBundle,
+            sourceResource, person, fjContext);
       } else if (value instanceof List<?>) {
-        populateFhirPathMapping(fhirPathMapping, path, (List<Object>) value);
+        populateFhirPathMapping(fhirPathMapping, path, (List<Object>) value, sourceBundle,
+            sourceResource, person, fjContext);
       } else if (value != null) {
         System.err
             .println("Unexpected class found in populateFhirPathMapping[list]:" + value.getClass());

--- a/src/test/java/org/mitre/synthea/export/flexporter/ActionsTest.java
+++ b/src/test/java/org/mitre/synthea/export/flexporter/ActionsTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import ca.uhn.fhir.parser.IParser;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -59,8 +61,6 @@ import org.mitre.synthea.engine.Module;
 import org.mitre.synthea.engine.State;
 import org.mitre.synthea.export.FhirR4;
 import org.mitre.synthea.world.agents.Person;
-
-import ca.uhn.fhir.parser.IParser;
 
 public class ActionsTest {
 
@@ -514,8 +514,8 @@ public class ActionsTest {
     // this would work as of today but not guaranteed
     // assertTrue(r == c3);
     assertTrue(r instanceof Condition);
-    Condition cOut = (Condition)r;
-    assertEquals("49727002", cOut.getCode().getCodingFirstRep().getCode());
+    Condition conditionOut = (Condition)r;
+    assertEquals("49727002", conditionOut.getCode().getCodingFirstRep().getCode());
   }
 
   @Test

--- a/src/test/java/org/mitre/synthea/export/flexporter/ActionsTest.java
+++ b/src/test/java/org/mitre/synthea/export/flexporter/ActionsTest.java
@@ -752,6 +752,32 @@ public class ActionsTest {
     assertEquals(120_000L, mr.getAuthoredOn().toInstant().toEpochMilli());
   }
 
+  @Test
+  public void testCreateResources_if() throws Exception {
+    Bundle b = new Bundle();
+    b.setType(BundleType.COLLECTION);
+
+    Procedure p1 = new Procedure();
+    p1.setPerformed(new Period().setStart(new Date(0)));
+    b.addEntry().setResource(p1);
+
+    Procedure p2 = new Procedure();
+    p2.setPerformed(new DateTimeType("2024-10-01T12:34:56"));
+    b.addEntry().setResource(p2);
+
+    Map<String, Object> action = getActionByName("testCreateResources_if");
+
+    Actions.applyAction(b, action, null, null);
+
+    assertEquals(4, b.getEntry().size());
+
+    ServiceRequest sr1 = (ServiceRequest)b.getEntry().get(2).getResource();
+    assertTrue(sr1.getAuthoredOn().getTime() == 0);
+
+    ServiceRequest sr2 = (ServiceRequest)b.getEntry().get(3).getResource();
+    DateTimeType sr2AuthoredOn = sr2.getAuthoredOnElement();
+    assertEquals("2024-10-01T12:34:56", sr2AuthoredOn.getValueAsString());
+  }
 
   @Test
   public void testGetAttribute() throws Exception {

--- a/src/test/resources/flexporter/test_mapping.yaml
+++ b/src/test/resources/flexporter/test_mapping.yaml
@@ -267,6 +267,20 @@ actions:
          - location: Patient.name.family
            value: $getAttribute([last_name])
 
+ - name: testCreateResources_if
+   create_resource:
+     - resourceType: ServiceRequest
+       based_on:
+         resource: Procedure
+       fields:
+         - if: Procedure.performed.ofType(Period)
+           location: ServiceRequest.authoredOn
+           value: $getField([Procedure.performed.start]) # period choice type
+         - if: Procedure.performed.ofType(dateTime)
+           location: ServiceRequest.authoredOn
+           value: $getField([Procedure.performed]) # datetime choice type
+
+
  - name: testExecuteScript
    execute_script:
      - apply_to: bundle

--- a/src/test/resources/flexporter/test_mapping.yaml
+++ b/src/test/resources/flexporter/test_mapping.yaml
@@ -314,6 +314,7 @@ actions:
  - name: testDeleteResources
    delete_resources:
      - Provenance
+     - Condition.code.coding.where($this.code in ('15777000' | '444814009'))
 
  - name: testDeleteResourcesCascade
    delete_resources:


### PR DESCRIPTION
A few new features for the flexporter:

1. A new `if` field that can be used in `create_resource` to conditionally set a field. The use case that inspired this is shown in the unit test - creating ServiceRequest based on Procedure, setting ServiceRequest.authoredOn = Procedure.performed, but Procedure.performed is either a dateTime (ie, primitive) or a Period (ie, an object) so the types need different handling. Previously the only way to do this was with two separate actions with different applicability.
2. Allow deleting resources by FHIRPath instead of just by resource type. The use case that inspired this is deleting some of the SDOH conditions to clean up a record for a demo
3. Allow functions to be nested within definitions. Previously a function call such as `getAttribute` could only be used as the top-level `value`, now `value` can be a map and one of the sub-values can be the function.