### PR TITLE
Flexporter - Update randomCode fn to take output type as an optional second param

### DIFF
--- a/src/main/java/App.java
+++ b/src/main/java/App.java
@@ -220,6 +220,8 @@ public class App {
             if (flexporterMappingFile.exists()) {
               Mapping mapping = Mapping.parseMapping(flexporterMappingFile);
               exportOptions.addFlexporterMapping(mapping);
+              mapping.loadValueSets();
+
               // disable the graalVM warning when FlexporterJavascriptContext is instantiated
               System.getProperties().setProperty("polyglot.engine.WarnInterpreterOnly", "false");
             } else {

--- a/src/main/java/RunFlexporter.java
+++ b/src/main/java/RunFlexporter.java
@@ -1,9 +1,6 @@
 import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.parser.IParser;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -14,7 +11,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Queue;
 
 import org.apache.commons.io.FilenameUtils;
@@ -125,6 +121,7 @@ public class RunFlexporter {
       throws IOException {
 
     Mapping mapping = Mapping.parseMapping(mappingFile);
+    mapping.loadValueSets();
 
     if (igDirectory != null) {
       loadIG(igDirectory);

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -3385,7 +3385,7 @@ public class FhirR4 {
    * @param system The system identifier, such as a URI. Optional; may be null.
    * @return The converted CodeableConcept
    */
-  private static CodeableConcept mapCodeToCodeableConcept(Code from, String system) {
+  public static CodeableConcept mapCodeToCodeableConcept(Code from, String system) {
     CodeableConcept to = new CodeableConcept();
     system = system == null ? null : ExportHelper.getSystemURI(system);
     from.system = ExportHelper.getSystemURI(from.system);

--- a/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
+++ b/src/main/java/org/mitre/synthea/export/flexporter/Actions.java
@@ -26,6 +26,7 @@ import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryRequestComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
 import org.hl7.fhir.r4.model.Bundle.HTTPVerb;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Meta;
@@ -822,7 +823,7 @@ public abstract class Actions {
     } else if (flag.equals("getAttribute")) {
       return getAttribute(person, flagValues);
     } else if (flag.equals("randomCode")) {
-      return randomCode(flagValues[0]);
+      return randomCode(flagValues);
     }
 
     return null;
@@ -900,13 +901,22 @@ public abstract class Actions {
     return fieldValues.get(0);
   }
 
-  private static Map<String, String> randomCode(String valueSetUrl) {
+  private static Object randomCode(String... args) {
+    String valueSetUrl = args[0];
+    String outputType = (args.length > 1) ? args[1] : "Coding";
     Code code = RandomCodeGenerator.getCode(valueSetUrl,
         (int) (Math.random() * Integer.MAX_VALUE));
-    Map<String, String> codeAsMap = Map.of(
-         "system", code.system,
-         "code", code.code,
-         "display", code.display == null ? "" : code.display);
-    return codeAsMap;
+
+    if (outputType.equalsIgnoreCase("code")) {
+      return code.code;
+    } else if (outputType.equalsIgnoreCase("Coding")) {
+      return new Coding(code.system, code.code, code.display);
+    } else if (outputType.equalsIgnoreCase("CodeableConcept")) {
+      return FhirR4.mapCodeToCodeableConcept(code, null);
+    } else {
+      throw new IllegalArgumentException("Unexpected output type for randomCode: " + outputType
+          + ". Valid values are: code, Coding, CodeableConcept");
+    }
+
   }
 }

--- a/src/test/java/org/mitre/synthea/export/flexporter/ActionsTest.java
+++ b/src/test/java/org/mitre/synthea/export/flexporter/ActionsTest.java
@@ -85,6 +85,7 @@ public class ActionsTest {
     File file = new File(classLoader.getResource("flexporter/test_mapping.yaml").getFile());
 
     testMapping = Mapping.parseMapping(file);
+    testMapping.loadValueSets();
   }
 
   @AfterClass
@@ -825,21 +826,6 @@ public class ActionsTest {
     Bundle b = new Bundle();
     b.setType(BundleType.COLLECTION);
 
-    ValueSet statusVs = constructValueSet(
-        "http://hl7.org/fhir/encounter-status",
-        "planned", "finished", "cancelled");
-    RandomCodeGenerator.loadValueSet("http://example.org/encounterStatus", statusVs);
-
-    ValueSet classVs = constructValueSet(
-        "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-        "AMB", "EMER", "ACUTE");
-    RandomCodeGenerator.loadValueSet("http://example.org/encounterClass", classVs);
-
-    ValueSet typeVs = constructValueSet(
-        "http://terminology.hl7.org/CodeSystem/encounter-type",
-        "ADMS", "OKI");
-    RandomCodeGenerator.loadValueSet("http://example.org/encounterType", typeVs);
-
     Map<String, Object> action = getActionByName("testRandomCode");
     Actions.applyAction(b, action, null, null);
 
@@ -865,20 +851,4 @@ public class ActionsTest {
     code = typeCoding.getCode();
     assertTrue(code.equals("ADMS") || code.equals("OKI"));
   }
-
-  private ValueSet constructValueSet(String system, String... codes) {
-    ValueSet vs = new ValueSet();
-
-    // populates the codes so that they can be read in RandomCodeGenerator.loadValueSet
-    ConceptSetComponent csc = new ConceptSetComponent();
-    csc.setSystem(system);
-    for (String code : codes) {
-      csc.addConcept().setCode(code).setDisplay(code);
-    }
-
-    vs.getCompose().getInclude().add(csc);
-
-    return vs;
-  }
-
 }

--- a/src/test/resources/flexporter/test_mapping.yaml
+++ b/src/test/resources/flexporter/test_mapping.yaml
@@ -6,6 +6,49 @@ name: Random Testing
 # for now the assumption is 1 file = 1 synthea patient bundle.
 applicability: true
 
+# Not a huge fan of this format, but it's better than defining yet another custom syntax
+customValueSets:
+ - url: whats-for-dinner
+   compose:
+     include:
+       - system: http://snomed.info/sct
+         concept:
+           - code: 227360002
+             display: Pinto beans (substance)
+           - code: 227319009
+             display: Baked beans canned in tomato sauce with burgers (substance) 
+ - url: http://example.org/encounterStatus
+   compose:
+     include:
+       - system: http://hl7.org/fhir/encounter-status
+         concept:
+           - code: planned
+             display: Planned
+           - code: finished
+             display: Finished
+           - code: cancelled
+             display: Cancelled
+ - url: http://example.org/encounterClass
+   compose:
+     include:
+       - system: http://terminology.hl7.org/CodeSystem/v3-ActCode
+         concept:
+           - code: AMB
+             display: ambulatory
+           - code: EMER
+             display: emergency
+           - code: ACUTE
+             display: inpatient acute
+ - url: http://example.org/encounterType
+   compose:
+     include:
+       - system: http://terminology.hl7.org/CodeSystem/encounter-type
+         concept:
+           - code: ADMS
+             display: Annual diabetes mellitus screening
+           - code: OKI
+             display: Outpatient Kenacort injection
+
 actions:
  - name: Apply Profiles
    # v1: define specific profiles and an applicability statement on when to apply them

--- a/src/test/resources/flexporter/test_mapping.yaml
+++ b/src/test/resources/flexporter/test_mapping.yaml
@@ -280,6 +280,17 @@ actions:
            location: ServiceRequest.authoredOn
            value: $getField([Procedure.performed]) # datetime choice type
 
+ - name: testRandomCode
+   create_resource: 
+     - resourceType: Encounter
+       fields:
+         - location: Encounter.status
+           value: $randomCode([http://example.org/encounterStatus,code])
+         - location: Encounter.class
+           value: $randomCode([http://example.org/encounterClass])
+         - location: Encounter.type
+           value: $randomCode([http://example.org/encounterType,CodeableConcept])
+
 
  - name: testExecuteScript
    execute_script:


### PR DESCRIPTION
Updates to address flexporter issues identified by @elsaperelli :

1. I realized the `randomCode` function was improperly named since technically it produces a Coding not a code. Rather than rename it and break backwards compatibility, this gives it an optional second parameter for "return type". This can be "code" to return a string, "Coding" to return a Coding (ie `{system, code, display}`), or "CodeableConcept" to return a CodeableConcept. Default if unspecified is Coding, for backwards compatibility.

2. Adds support for defining custom ValueSets in a flexporter mapping file, so that you can select a randomCode from your handpicked set of codes rather than having to use a terminology server and pre-existing VS. The syntax is a YAML version of the ValueSet resource, to minimize inventing new things. There are some quirks to this though so I'm open to suggestions here:
    - Our YAML parser doesn't work with the HAPI FHIR model classes, so this uses a roundabout way of loading that parses the YAML to `Map<String,Object>`, serializes that to JSON, then parses the JSON as FHIR. The alternative here would be to define a custom new model to represent a VS, or to re-implement the ValueSet class.
    - The ValueSets need to be loaded once per mapping file, so I added a new function to be called in the main flexporter entrypoints (App and RunFlexporter). Trying to load them multiple times wouldn't break anything but I don't want to do that (YAML) -> (JSON) -> (FHIR classes) sequence multiple times unnecessarily.

3. Added some extra error handling for the value set $expand operation, to assist in debugging when it returns an OperationOutcome