### PR TITLE
Update two common encounter codes for relevancy

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -535,7 +535,7 @@ public class FhirDstu2 {
     encounterResource.setStatus(EncounterStateEnum.FINISHED);
     if (encounter.codes.isEmpty()) {
       // wellness encounter
-      encounterResource.addType().addCoding().setCode("185349003")
+      encounterResource.addType().addCoding().setCode("86013001")
           .setDisplay("Encounter for check up").setSystem(SNOMED_URI);
     } else {
       Code code = encounter.codes.get(0);

--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -536,7 +536,7 @@ public class FhirDstu2 {
     if (encounter.codes.isEmpty()) {
       // wellness encounter
       encounterResource.addType().addCoding().setCode("86013001")
-          .setDisplay("Encounter for check up").setSystem(SNOMED_URI);
+          .setDisplay("Periodic reevaluation and management of healthy individual (procedure)").setSystem(SNOMED_URI);
     } else {
       Code code = encounter.codes.get(0);
       encounterResource.addType(mapCodeToCodeableConcept(code, SNOMED_URI));

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -901,7 +901,7 @@ public class FhirR4 {
     if (encounter.codes.isEmpty()) {
       // wellness encounter
       encounterResource.addType().addCoding().setCode("86013001")
-          .setDisplay("Encounter for check up").setSystem(SNOMED_URI);
+          .setDisplay("Periodic reevaluation and management of healthy individual (procedure)").setSystem(SNOMED_URI);
     } else {
       Code code = encounter.codes.get(0);
       encounterResource.addType(mapCodeToCodeableConcept(code, SNOMED_URI));

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -900,7 +900,7 @@ public class FhirR4 {
     encounterResource.setStatus(EncounterStatus.FINISHED);
     if (encounter.codes.isEmpty()) {
       // wellness encounter
-      encounterResource.addType().addCoding().setCode("185349003")
+      encounterResource.addType().addCoding().setCode("86013001")
           .setDisplay("Encounter for check up").setSystem(SNOMED_URI);
     } else {
       Code code = encounter.codes.get(0);

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -583,7 +583,7 @@ public class FhirStu3 {
     encounterResource.setStatus(EncounterStatus.FINISHED);
     if (encounter.codes.isEmpty()) {
       // wellness encounter
-      encounterResource.addType().addCoding().setCode("185349003")
+      encounterResource.addType().addCoding().setCode("86013001")
           .setDisplay("Encounter for check up").setSystem(SNOMED_URI);
 
     } else {

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -584,7 +584,7 @@ public class FhirStu3 {
     if (encounter.codes.isEmpty()) {
       // wellness encounter
       encounterResource.addType().addCoding().setCode("86013001")
-          .setDisplay("Encounter for check up").setSystem(SNOMED_URI);
+          .setDisplay("Periodic reevaluation and management of healthy individual (procedure)").setSystem(SNOMED_URI);
 
     } else {
       Code code = encounter.codes.get(0);

--- a/src/main/java/org/mitre/synthea/export/TextExporter.java
+++ b/src/main/java/org/mitre/synthea/export/TextExporter.java
@@ -71,9 +71,9 @@ import org.mitre.synthea.world.concepts.HealthRecord.Report;
  * 2017-11-01 : Body Height                              181.6 cm
  * --------------------------------------------------------------------------------
  * ENCOUNTERS:
- * 2017-11-01 : Encounter for check up (procedure)
+ * 2017-11-01 : Periodic reevaluation and management of healthy individual (procedure)
  * 2016-12-28 : Encounter for Viral sinusitis (disorder)
- * 2016-10-26 : Encounter for check up (procedure)
+ * 2016-10-26 : Periodic reevaluation and management of healthy individual (procedure)
  * </pre>
 
  * Exporter for a simple human-readable text format per encounter.

--- a/src/main/java/org/mitre/synthea/modules/EncounterModule.java
+++ b/src/main/java/org/mitre/synthea/modules/EncounterModule.java
@@ -34,8 +34,8 @@ public final class EncounterModule extends Module {
   public static final int EMERGENCY_SYMPTOM_THRESHOLD = 500;
   public static final String LAST_VISIT_SYMPTOM_TOTAL = "last_visit_symptom_total";
 
-  public static final Code ENCOUNTER_CHECKUP = new Code("SNOMED-CT", "185349003",
-      "Encounter for check up (procedure)");
+  public static final Code ENCOUNTER_CHECKUP = new Code("SNOMED-CT", "86013001",
+      "Periodic reevaluation and management of healthy individual (procedure)");
   public static final Code ENCOUNTER_EMERGENCY = new Code("SNOMED-CT", "50849002",
       "Emergency room admission (procedure)");
   public static final Code WELL_CHILD_VISIT = new Code("SNOMED-CT", "410620009",

--- a/src/main/resources/costs/encounters.csv
+++ b/src/main/resources/costs/encounters.csv
@@ -1,8 +1,8 @@
 CODE,MIN,MODE,MAX,COMMENTS
 185317003,75,75,75,Telephone encounter (procedure) - Prior costs update source
 185345009,75,75,75,Encounter for symptom - Prior costs update source
-185347001,75,75,75,Encounter for problem - Prior costs update source
-185349003,75,75,75,Encounter for 'check-up' - Prior costs update source
+281036007,75,75,75,Follow-up consultation (procedure) - Prior costs update source
+86013001,75,75,75,Periodic reevaluation and management of healthy individual (procedure) - Prior costs update source
 185389009,75,75,75,Follow-up visit (encounter) - Prior costs update source
 183452005,75,75,75,Encounter Inpatient - Prior costs update source
 270427003,75,75,75,Patient-initiated encounter - Prior costs update source

--- a/src/main/resources/costs/encounters.csv
+++ b/src/main/resources/costs/encounters.csv
@@ -1,7 +1,7 @@
 CODE,MIN,MODE,MAX,COMMENTS
 185317003,75,75,75,Telephone encounter (procedure) - Prior costs update source
 185345009,75,75,75,Encounter for symptom - Prior costs update source
-281036007,75,75,75,Follow-up consultation (procedure) - Prior costs update source
+270427003,75,75,75,Patient-initiated encounter (procedure) - Prior costs update source
 86013001,75,75,75,Periodic reevaluation and management of healthy individual (procedure) - Prior costs update source
 185389009,75,75,75,Follow-up visit (encounter) - Prior costs update source
 183452005,75,75,75,Encounter Inpatient - Prior costs update source

--- a/src/main/resources/modules/acute_myeloid_leukemia.json
+++ b/src/main/resources/modules/acute_myeloid_leukemia.json
@@ -386,8 +386,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Wait for Treatment"

--- a/src/main/resources/modules/acute_myeloid_leukemia.json
+++ b/src/main/resources/modules/acute_myeloid_leukemia.json
@@ -386,8 +386,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Wait for Treatment"

--- a/src/main/resources/modules/allergies.json
+++ b/src/main/resources/modules/allergies.json
@@ -101,8 +101,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/allergies.json
+++ b/src/main/resources/modules/allergies.json
@@ -101,8 +101,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/anemia/anemia_sub.json
+++ b/src/main/resources/modules/anemia/anemia_sub.json
@@ -265,8 +265,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "conditional_transition": [
@@ -1010,8 +1010,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/anemia/anemia_sub.json
+++ b/src/main/resources/modules/anemia/anemia_sub.json
@@ -265,8 +265,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "conditional_transition": [
@@ -1010,8 +1010,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/appendicitis.json
+++ b/src/main/resources/modules/appendicitis.json
@@ -262,8 +262,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Appendectomy"

--- a/src/main/resources/modules/appendicitis.json
+++ b/src/main/resources/modules/appendicitis.json
@@ -262,8 +262,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Appendectomy"

--- a/src/main/resources/modules/attention_deficit_disorder.json
+++ b/src/main/resources/modules/attention_deficit_disorder.json
@@ -74,8 +74,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "ADD_Symptom1"
@@ -194,8 +194,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Behavior_Treatment_Procedure"

--- a/src/main/resources/modules/attention_deficit_disorder.json
+++ b/src/main/resources/modules/attention_deficit_disorder.json
@@ -74,8 +74,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "ADD_Symptom1"
@@ -194,8 +194,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Behavior_Treatment_Procedure"

--- a/src/main/resources/modules/breast_cancer.json
+++ b/src/main/resources/modules/breast_cancer.json
@@ -1522,8 +1522,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Chemotherapy Drugs",
@@ -1768,8 +1768,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Chemotherapy Drugs"

--- a/src/main/resources/modules/breast_cancer.json
+++ b/src/main/resources/modules/breast_cancer.json
@@ -1522,8 +1522,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Chemotherapy Drugs",
@@ -1768,8 +1768,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Chemotherapy Drugs"

--- a/src/main/resources/modules/breast_cancer/chemotherapy_breast.json
+++ b/src/main/resources/modules/breast_cancer/chemotherapy_breast.json
@@ -163,8 +163,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Choose Chemo Drug"

--- a/src/main/resources/modules/breast_cancer/chemotherapy_breast.json
+++ b/src/main/resources/modules/breast_cancer/chemotherapy_breast.json
@@ -163,8 +163,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Choose Chemo Drug"

--- a/src/main/resources/modules/breast_cancer/hormonetherapy_breast.json
+++ b/src/main/resources/modules/breast_cancer/hormonetherapy_breast.json
@@ -395,8 +395,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/breast_cancer/hormonetherapy_breast.json
+++ b/src/main/resources/modules/breast_cancer/hormonetherapy_breast.json
@@ -395,8 +395,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/breast_cancer/surgery_therapy_breast.json
+++ b/src/main/resources/modules/breast_cancer/surgery_therapy_breast.json
@@ -437,8 +437,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "conditional_transition": [
@@ -500,8 +500,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "complex_transition": [
@@ -677,8 +677,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "complex_transition": [
@@ -972,8 +972,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Advanced_drugs"
@@ -1038,8 +1038,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/breast_cancer/surgery_therapy_breast.json
+++ b/src/main/resources/modules/breast_cancer/surgery_therapy_breast.json
@@ -437,8 +437,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "conditional_transition": [
@@ -500,8 +500,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "complex_transition": [
@@ -677,8 +677,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "complex_transition": [
@@ -972,8 +972,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Advanced_drugs"
@@ -1038,8 +1038,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/colorectal_cancer.json
+++ b/src/main/resources/modules/colorectal_cancer.json
@@ -105,8 +105,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "Routine_Colonoscopy_Procedure",
@@ -421,8 +421,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "End_Biopsy_Followup"
@@ -467,8 +467,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "Followup_Colonoscopy_Procedure",
@@ -714,8 +714,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "Diagnostic_Colonoscopy_Procedure",
@@ -1039,8 +1039,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Colorectal_Cancer_CarePlan"
@@ -1192,8 +1192,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Partial_Colectomy_Procedure"
@@ -1325,8 +1325,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Diverting_Colostomy_Procedure"
@@ -1455,8 +1455,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Pain_Vital_4"
@@ -1550,8 +1550,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "End_Colorectal_Cancer_CarePlan"

--- a/src/main/resources/modules/colorectal_cancer.json
+++ b/src/main/resources/modules/colorectal_cancer.json
@@ -421,8 +421,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "End_Biopsy_Followup"
@@ -1039,8 +1039,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Colorectal_Cancer_CarePlan"
@@ -1192,8 +1192,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Partial_Colectomy_Procedure"
@@ -1325,8 +1325,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Diverting_Colostomy_Procedure"
@@ -1455,8 +1455,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Pain_Vital_4"

--- a/src/main/resources/modules/congestive_heart_failure.json
+++ b/src/main/resources/modules/congestive_heart_failure.json
@@ -53,8 +53,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Recorded Symptom 1"
@@ -183,8 +183,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Oxygen_Saturation",
@@ -938,8 +938,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Echocardiography"

--- a/src/main/resources/modules/congestive_heart_failure.json
+++ b/src/main/resources/modules/congestive_heart_failure.json
@@ -53,8 +53,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Recorded Symptom 1"
@@ -183,8 +183,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Oxygen_Saturation",
@@ -938,8 +938,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Echocardiography"

--- a/src/main/resources/modules/cystic_fibrosis.json
+++ b/src/main/resources/modules/cystic_fibrosis.json
@@ -736,8 +736,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/dementia.json
+++ b/src/main/resources/modules/dementia.json
@@ -428,8 +428,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "270427003",
-          "display": "Patient-initiated encounter (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "ModeratelySevere_MMSE_Score"
@@ -574,8 +574,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "270427003",
-          "display": "Patient-initiated encounter (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Severe_MMSE_Score"
@@ -625,8 +625,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "270427003",
-          "display": "Patient-initiated encounter (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "VerySevere_MMSE_Score"

--- a/src/main/resources/modules/dementia.json
+++ b/src/main/resources/modules/dementia.json
@@ -428,8 +428,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "ModeratelySevere_MMSE_Score"
@@ -574,8 +574,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Severe_MMSE_Score"
@@ -625,8 +625,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "VerySevere_MMSE_Score"

--- a/src/main/resources/modules/dental_and_oral_examination.json
+++ b/src/main/resources/modules/dental_and_oral_examination.json
@@ -861,8 +861,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "Dental consultation and report"

--- a/src/main/resources/modules/dentures.json
+++ b/src/main/resources/modules/dentures.json
@@ -48,8 +48,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Dental_consultation_and_report"

--- a/src/main/resources/modules/dentures.json
+++ b/src/main/resources/modules/dentures.json
@@ -48,8 +48,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Dental_consultation_and_report"

--- a/src/main/resources/modules/dermatitis.json
+++ b/src/main/resources/modules/dermatitis.json
@@ -194,8 +194,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Dermatitis_Symptom1"
@@ -287,8 +287,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "complex_transition": [
@@ -524,8 +524,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/dermatitis.json
+++ b/src/main/resources/modules/dermatitis.json
@@ -194,8 +194,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Dermatitis_Symptom1"
@@ -287,8 +287,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "complex_transition": [
@@ -524,8 +524,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/dialysis.json
+++ b/src/main/resources/modules/dialysis.json
@@ -35,8 +35,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Dialysis",
@@ -96,8 +96,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Record_CMP",

--- a/src/main/resources/modules/dialysis.json
+++ b/src/main/resources/modules/dialysis.json
@@ -35,8 +35,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Dialysis",
@@ -96,8 +96,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Record_CMP",

--- a/src/main/resources/modules/fibromyalgia.json
+++ b/src/main/resources/modules/fibromyalgia.json
@@ -107,8 +107,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Fibromyalgia_Symptom1"

--- a/src/main/resources/modules/fibromyalgia.json
+++ b/src/main/resources/modules/fibromyalgia.json
@@ -107,8 +107,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Fibromyalgia_Symptom1"

--- a/src/main/resources/modules/food_allergies.json
+++ b/src/main/resources/modules/food_allergies.json
@@ -120,8 +120,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/food_allergies.json
+++ b/src/main/resources/modules/food_allergies.json
@@ -120,8 +120,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/gallstones.json
+++ b/src/main/resources/modules/gallstones.json
@@ -610,8 +610,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "End_Postoperative_Follow-up",
@@ -623,8 +623,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "reason": "Open_Cholecystectomy",

--- a/src/main/resources/modules/gout.json
+++ b/src/main/resources/modules/gout.json
@@ -126,8 +126,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Pain_Vital"

--- a/src/main/resources/modules/gout.json
+++ b/src/main/resources/modules/gout.json
@@ -126,8 +126,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Pain_Vital"

--- a/src/main/resources/modules/heart/avrr/avrr_referral.json
+++ b/src/main/resources/modules/heart/avrr/avrr_referral.json
@@ -18,8 +18,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Liaising with referral source",

--- a/src/main/resources/modules/heart/avrr/avrr_referral.json
+++ b/src/main/resources/modules/heart/avrr/avrr_referral.json
@@ -18,8 +18,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Liaising with referral source",

--- a/src/main/resources/modules/heart/avrr/sequence.json
+++ b/src/main/resources/modules/heart/avrr/sequence.json
@@ -19,8 +19,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "History & Physical Exam"

--- a/src/main/resources/modules/heart/avrr/sequence.json
+++ b/src/main/resources/modules/heart/avrr/sequence.json
@@ -19,8 +19,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "History & Physical Exam"

--- a/src/main/resources/modules/heart/cabg/cabg_referral.json
+++ b/src/main/resources/modules/heart/cabg/cabg_referral.json
@@ -358,8 +358,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/heart/cabg/cabg_referral.json
+++ b/src/main/resources/modules/heart/cabg/cabg_referral.json
@@ -358,8 +358,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/heart/cabg_sequence.json
+++ b/src/main/resources/modules/heart/cabg_sequence.json
@@ -61,8 +61,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "CABG"

--- a/src/main/resources/modules/heart/cabg_sequence.json
+++ b/src/main/resources/modules/heart/cabg_sequence.json
@@ -61,8 +61,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "CABG"

--- a/src/main/resources/modules/hiv_care.json
+++ b/src/main/resources/modules/hiv_care.json
@@ -30,8 +30,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "conditional_transition": [
@@ -116,8 +116,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Exam"
@@ -467,8 +467,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Monitoring Exam"

--- a/src/main/resources/modules/hiv_care.json
+++ b/src/main/resources/modules/hiv_care.json
@@ -30,8 +30,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "conditional_transition": [
@@ -116,8 +116,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Exam"
@@ -467,8 +467,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Monitoring Exam"

--- a/src/main/resources/modules/hiv_diagnosis.json
+++ b/src/main/resources/modules/hiv_diagnosis.json
@@ -156,8 +156,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Screening Submodule",
@@ -169,8 +169,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Screening_Submodule",

--- a/src/main/resources/modules/hiv_diagnosis.json
+++ b/src/main/resources/modules/hiv_diagnosis.json
@@ -156,8 +156,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Screening Submodule",
@@ -169,8 +169,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Screening_Submodule",

--- a/src/main/resources/modules/hypothyroidism.json
+++ b/src/main/resources/modules/hypothyroidism.json
@@ -86,8 +86,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "fT4 panel results"
@@ -127,8 +127,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Synthroid Medication Order"

--- a/src/main/resources/modules/hypothyroidism.json
+++ b/src/main/resources/modules/hypothyroidism.json
@@ -86,8 +86,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "fT4 panel results"
@@ -127,8 +127,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Synthroid Medication Order"

--- a/src/main/resources/modules/injuries.json
+++ b/src/main/resources/modules/injuries.json
@@ -523,8 +523,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Spinal_Injury_Prescribe_Opioid"
@@ -2624,8 +2624,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Shoulder_Injury_CarePlan"

--- a/src/main/resources/modules/injuries.json
+++ b/src/main/resources/modules/injuries.json
@@ -523,8 +523,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Spinal_Injury_Prescribe_Opioid"
@@ -554,8 +554,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "End_Spinal_Injury"
@@ -734,8 +734,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "Gunshot_Wound_Ends"
@@ -913,8 +913,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "End_Concussion_Injury"
@@ -1712,8 +1712,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "End DME"
@@ -1990,8 +1990,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "End_Burn_Injury"
@@ -2624,8 +2624,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Shoulder_Injury_CarePlan"
@@ -2736,8 +2736,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "End_Shoulder_Injury"

--- a/src/main/resources/modules/injuries/broken_jaw.json
+++ b/src/main/resources/modules/injuries/broken_jaw.json
@@ -390,8 +390,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "Oral examination"

--- a/src/main/resources/modules/kidney_transplant.json
+++ b/src/main/resources/modules/kidney_transplant.json
@@ -202,8 +202,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Consultation_MetabolicPanel"

--- a/src/main/resources/modules/kidney_transplant.json
+++ b/src/main/resources/modules/kidney_transplant.json
@@ -202,8 +202,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Consultation_MetabolicPanel"

--- a/src/main/resources/modules/lung_cancer.json
+++ b/src/main/resources/modules/lung_cancer.json
@@ -249,8 +249,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Chest CT Scan"
@@ -344,8 +344,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "distributed_transition": [
@@ -711,8 +711,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Lung_Cancer_CarePlan"
@@ -806,8 +806,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Record_CMP_2"
@@ -908,8 +908,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Record_CMP",

--- a/src/main/resources/modules/lung_cancer.json
+++ b/src/main/resources/modules/lung_cancer.json
@@ -249,8 +249,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Chest CT Scan"
@@ -344,8 +344,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "distributed_transition": [
@@ -711,8 +711,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Lung_Cancer_CarePlan"
@@ -806,8 +806,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Record_CMP_2"
@@ -908,8 +908,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Record_CMP",

--- a/src/main/resources/modules/lupus.json
+++ b/src/main/resources/modules/lupus.json
@@ -90,8 +90,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Lupus_Symptom1"
@@ -258,8 +258,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Immune_Suppressant"

--- a/src/main/resources/modules/lupus.json
+++ b/src/main/resources/modules/lupus.json
@@ -90,8 +90,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Lupus_Symptom1"
@@ -258,8 +258,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Immune_Suppressant"

--- a/src/main/resources/modules/metabolic_syndrome/amputations.json
+++ b/src/main/resources/modules/metabolic_syndrome/amputations.json
@@ -20,8 +20,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "reason": "diabetic_neuropathy",

--- a/src/main/resources/modules/metabolic_syndrome/amputations.json
+++ b/src/main/resources/modules/metabolic_syndrome/amputations.json
@@ -20,8 +20,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "reason": "diabetic_neuropathy",

--- a/src/main/resources/modules/opioid_addiction.json
+++ b/src/main/resources/modules/opioid_addiction.json
@@ -586,8 +586,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Recovery Rehab",

--- a/src/main/resources/modules/opioid_addiction.json
+++ b/src/main/resources/modules/opioid_addiction.json
@@ -586,8 +586,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Recovery Rehab",

--- a/src/main/resources/modules/osteoarthritis.json
+++ b/src/main/resources/modules/osteoarthritis.json
@@ -95,8 +95,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Pain Vital"

--- a/src/main/resources/modules/osteoarthritis.json
+++ b/src/main/resources/modules/osteoarthritis.json
@@ -95,8 +95,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Pain Vital"

--- a/src/main/resources/modules/prescribing_opioids_for_chronic_pain_and_treatment_of_oud.json
+++ b/src/main/resources/modules/prescribing_opioids_for_chronic_pain_and_treatment_of_oud.json
@@ -1570,8 +1570,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "PEG_Assessment_Score_1",
@@ -2015,8 +2015,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "PEG_Assessment_Score_4",
@@ -2628,8 +2628,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Condition_OUD_2"

--- a/src/main/resources/modules/prescribing_opioids_for_chronic_pain_and_treatment_of_oud.json
+++ b/src/main/resources/modules/prescribing_opioids_for_chronic_pain_and_treatment_of_oud.json
@@ -1570,8 +1570,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "PEG_Assessment_Score_1",
@@ -2015,8 +2015,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "PEG_Assessment_Score_4",
@@ -2628,8 +2628,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Condition_OUD_2"

--- a/src/main/resources/modules/rheumatoid_arthritis.json
+++ b/src/main/resources/modules/rheumatoid_arthritis.json
@@ -111,8 +111,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "RA_CarePlan"

--- a/src/main/resources/modules/rheumatoid_arthritis.json
+++ b/src/main/resources/modules/rheumatoid_arthritis.json
@@ -111,8 +111,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "RA_CarePlan"

--- a/src/main/resources/modules/self_harm.json
+++ b/src/main/resources/modules/self_harm.json
@@ -444,8 +444,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Suicide_CarePlan_Selector"
@@ -635,8 +635,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Autopsy_Examination"

--- a/src/main/resources/modules/self_harm.json
+++ b/src/main/resources/modules/self_harm.json
@@ -444,8 +444,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Suicide_CarePlan_Selector"
@@ -635,8 +635,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Autopsy_Examination"

--- a/src/main/resources/modules/sepsis.json
+++ b/src/main/resources/modules/sepsis.json
@@ -425,8 +425,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Blood_Cultures"

--- a/src/main/resources/modules/sepsis.json
+++ b/src/main/resources/modules/sepsis.json
@@ -425,8 +425,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Blood_Cultures"

--- a/src/main/resources/modules/sleep_apnea.json
+++ b/src/main/resources/modules/sleep_apnea.json
@@ -137,8 +137,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "2nd Assessment"

--- a/src/main/resources/modules/sleep_apnea.json
+++ b/src/main/resources/modules/sleep_apnea.json
@@ -137,8 +137,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "2nd Assessment"

--- a/src/main/resources/modules/total_joint_replacement.json
+++ b/src/main/resources/modules/total_joint_replacement.json
@@ -246,8 +246,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185349003",
-          "display": "Encounter for check up (procedure)"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         }
       ],
       "direct_transition": "Functional_Status_Assessments",

--- a/src/main/resources/modules/uti/ambulatory_path.json
+++ b/src/main/resources/modules/uti/ambulatory_path.json
@@ -148,8 +148,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "UTI_Lab_FollowUp"
@@ -170,8 +170,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Set UTI_ED"

--- a/src/main/resources/modules/uti/ambulatory_path.json
+++ b/src/main/resources/modules/uti/ambulatory_path.json
@@ -148,8 +148,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "UTI_Lab_FollowUp"
@@ -170,8 +170,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Set UTI_ED"

--- a/src/main/resources/modules/uti/telemed_path.json
+++ b/src/main/resources/modules/uti/telemed_path.json
@@ -320,8 +320,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Labs Sub"

--- a/src/main/resources/modules/uti/telemed_path.json
+++ b/src/main/resources/modules/uti/telemed_path.json
@@ -320,8 +320,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Labs Sub"

--- a/src/main/resources/modules/veteran_lung_cancer.json
+++ b/src/main/resources/modules/veteran_lung_cancer.json
@@ -149,8 +149,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Chest CT Scan"
@@ -244,8 +244,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "distributed_transition": [
@@ -598,8 +598,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Lung_Cancer_CarePlan"
@@ -693,8 +693,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Set_SCLC_LOS"
@@ -795,8 +795,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Set_NSCLC_LOS",

--- a/src/main/resources/modules/veteran_lung_cancer.json
+++ b/src/main/resources/modules/veteran_lung_cancer.json
@@ -149,8 +149,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Chest CT Scan"
@@ -244,8 +244,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "distributed_transition": [
@@ -598,8 +598,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Lung_Cancer_CarePlan"
@@ -693,8 +693,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Set_SCLC_LOS"
@@ -795,8 +795,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Set_NSCLC_LOS",

--- a/src/main/resources/modules/veteran_mdd.json
+++ b/src/main/resources/modules/veteran_mdd.json
@@ -719,8 +719,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Therapy_Note"

--- a/src/main/resources/modules/veteran_mdd.json
+++ b/src/main/resources/modules/veteran_mdd.json
@@ -719,8 +719,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Therapy_Note"

--- a/src/main/resources/modules/veteran_prostate_cancer.json
+++ b/src/main/resources/modules/veteran_prostate_cancer.json
@@ -536,8 +536,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "distributed_transition": [

--- a/src/main/resources/modules/veteran_prostate_cancer.json
+++ b/src/main/resources/modules/veteran_prostate_cancer.json
@@ -536,8 +536,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "distributed_transition": [

--- a/src/main/resources/modules/veteran_ptsd.json
+++ b/src/main/resources/modules/veteran_ptsd.json
@@ -659,8 +659,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Inpatient Suicide Risk Assessment"
@@ -838,8 +838,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Therapy Note"
@@ -1200,8 +1200,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Therapy Note"

--- a/src/main/resources/modules/veteran_ptsd.json
+++ b/src/main/resources/modules/veteran_ptsd.json
@@ -659,8 +659,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Inpatient Suicide Risk Assessment"
@@ -838,8 +838,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Therapy Note"
@@ -1200,8 +1200,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Therapy Note"

--- a/src/main/resources/modules/veteran_self_harm.json
+++ b/src/main/resources/modules/veteran_self_harm.json
@@ -117,8 +117,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Suicide_CarePlan_Selector"
@@ -308,8 +308,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Autopsy_Examination"

--- a/src/main/resources/modules/veteran_self_harm.json
+++ b/src/main/resources/modules/veteran_self_harm.json
@@ -117,8 +117,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Suicide_CarePlan_Selector"
@@ -308,8 +308,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Autopsy_Examination"

--- a/src/main/resources/modules/vhd_aortic.json
+++ b/src/main/resources/modules/vhd_aortic.json
@@ -44,8 +44,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/vhd_aortic.json
+++ b/src/main/resources/modules/vhd_aortic.json
@@ -44,8 +44,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "conditional_transition": [

--- a/src/main/resources/modules/vhd_mitral.json
+++ b/src/main/resources/modules/vhd_mitral.json
@@ -78,8 +78,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Transthoracic_Echo MVR"
@@ -150,8 +150,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "End Placeholder MVS Treatment"

--- a/src/main/resources/modules/vhd_mitral.json
+++ b/src/main/resources/modules/vhd_mitral.json
@@ -78,8 +78,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Transthoracic_Echo MVR"
@@ -150,8 +150,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "End Placeholder MVS Treatment"

--- a/src/main/resources/modules/vhd_pulmonic.json
+++ b/src/main/resources/modules/vhd_pulmonic.json
@@ -100,8 +100,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Transthoracic Echo PVR"
@@ -150,8 +150,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "End_Encounter_PVS"

--- a/src/main/resources/modules/vhd_pulmonic.json
+++ b/src/main/resources/modules/vhd_pulmonic.json
@@ -100,8 +100,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Transthoracic Echo PVR"
@@ -150,8 +150,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "End_Encounter_PVS"

--- a/src/main/resources/modules/vhd_tricuspid.json
+++ b/src/main/resources/modules/vhd_tricuspid.json
@@ -78,8 +78,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Transthoracic Echo TVR"
@@ -154,8 +154,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "End_Encounter_TVS"

--- a/src/main/resources/modules/vhd_tricuspid.json
+++ b/src/main/resources/modules/vhd_tricuspid.json
@@ -78,8 +78,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Transthoracic Echo TVR"
@@ -154,8 +154,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "End_Encounter_TVS"

--- a/src/main/resources/modules/weight_loss/mend_week.json
+++ b/src/main/resources/modules/weight_loss/mend_week.json
@@ -55,8 +55,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "MEND_Vitals"

--- a/src/main/resources/modules/weight_loss/mend_week.json
+++ b/src/main/resources/modules/weight_loss/mend_week.json
@@ -55,8 +55,8 @@
       "codes": [
         {
           "system": "SNOMED-CT",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "MEND_Vitals"

--- a/src/test/resources/flexporter/sample_complete_patient.json
+++ b/src/test/resources/flexporter/sample_complete_patient.json
@@ -1352,10 +1352,10 @@
       "type": [ {
         "coding": [ {
           "system": "http://snomed.info/sct",
-          "code": "185347001",
-          "display": "Encounter for problem"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         } ],
-        "text": "Encounter for problem"
+        "text": "Follow-up consultation (procedure)"
       } ],
       "subject": {
         "reference": "urn:uuid:d5582579-7193-4866-5560-a01e723b6552",
@@ -1485,10 +1485,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "185347001",
-            "display": "Encounter for problem"
+            "code": "281036007",
+            "display": "Follow-up consultation (procedure)"
           } ],
-          "text": "Encounter for problem"
+          "text": "Follow-up consultation (procedure)"
         },
         "encounter": [ {
           "reference": "urn:uuid:ece9e706-21d8-e2bc-02fd-6df6a7e90c5a"
@@ -1671,10 +1671,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "185347001",
-            "display": "Encounter for problem"
+            "code": "281036007",
+            "display": "Follow-up consultation (procedure)"
           } ],
-          "text": "Encounter for problem"
+          "text": "Follow-up consultation (procedure)"
         },
         "encounter": [ {
           "reference": "urn:uuid:ece9e706-21d8-e2bc-02fd-6df6a7e90c5a"
@@ -1794,10 +1794,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "185347001",
-            "display": "Encounter for problem"
+            "code": "281036007",
+            "display": "Follow-up consultation (procedure)"
           } ],
-          "text": "Encounter for problem"
+          "text": "Follow-up consultation (procedure)"
         },
         "servicedPeriod": {
           "start": "1985-01-09T14:59:56-05:00",
@@ -4744,10 +4744,10 @@
       "type": [ {
         "coding": [ {
           "system": "http://snomed.info/sct",
-          "code": "185347001",
-          "display": "Encounter for problem (procedure)"
+          "code": "281036007",
+          "display": "Follow-up consultation (procedure)"
         } ],
-        "text": "Encounter for problem (procedure)"
+        "text": "Follow-up consultation (procedure)"
       } ],
       "subject": {
         "reference": "urn:uuid:d5582579-7193-4866-5560-a01e723b6552",
@@ -5019,10 +5019,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "185347001",
-            "display": "Encounter for problem (procedure)"
+            "code": "281036007",
+            "display": "Follow-up consultation (procedure)"
           } ],
-          "text": "Encounter for problem (procedure)"
+          "text": "Follow-up consultation (procedure)"
         },
         "encounter": [ {
           "reference": "urn:uuid:51a99f1e-54c9-160e-0023-693a55c9a6d2"
@@ -5165,10 +5165,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "185347001",
-            "display": "Encounter for problem (procedure)"
+            "code": "281036007",
+            "display": "Follow-up consultation (procedure)"
           } ],
-          "text": "Encounter for problem (procedure)"
+          "text": "Follow-up consultation (procedure)"
         },
         "servicedPeriod": {
           "start": "2006-12-10T21:36:43-05:00",
@@ -13859,10 +13859,10 @@
       "type": [ {
         "coding": [ {
           "system": "http://snomed.info/sct",
-          "code": "185349003",
-          "display": "Encounter for 'check-up'"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         } ],
-        "text": "Encounter for 'check-up'"
+        "text": "Periodic reevaluation and management of healthy individual (procedure)"
       } ],
       "subject": {
         "reference": "urn:uuid:d5582579-7193-4866-5560-a01e723b6552",
@@ -14115,10 +14115,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "185349003",
-            "display": "Encounter for 'check-up'"
+            "code": "86013001",
+            "display": "Periodic reevaluation and management of healthy individual (procedure)"
           } ],
-          "text": "Encounter for 'check-up'"
+          "text": "Periodic reevaluation and management of healthy individual (procedure)"
         },
         "encounter": [ {
           "reference": "urn:uuid:4194a4b1-ab19-d741-b807-a9e5d81778e3"
@@ -14253,10 +14253,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "185349003",
-            "display": "Encounter for 'check-up'"
+            "code": "86013001",
+            "display": "Periodic reevaluation and management of healthy individual (procedure)"
           } ],
-          "text": "Encounter for 'check-up'"
+          "text": "Periodic reevaluation and management of healthy individual (procedure)"
         },
         "servicedPeriod": {
           "start": "2012-01-26T13:13:18-05:00",
@@ -18808,10 +18808,10 @@
       "type": [ {
         "coding": [ {
           "system": "http://snomed.info/sct",
-          "code": "185349003",
-          "display": "Encounter for 'check-up'"
+          "code": "86013001",
+          "display": "Periodic reevaluation and management of healthy individual (procedure)"
         } ],
-        "text": "Encounter for 'check-up'"
+        "text": "Periodic reevaluation and management of healthy individual (procedure)"
       } ],
       "subject": {
         "reference": "urn:uuid:d5582579-7193-4866-5560-a01e723b6552",
@@ -19064,10 +19064,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "185349003",
-            "display": "Encounter for 'check-up'"
+            "code": "86013001",
+            "display": "Periodic reevaluation and management of healthy individual (procedure)"
           } ],
-          "text": "Encounter for 'check-up'"
+          "text": "Periodic reevaluation and management of healthy individual (procedure)"
         },
         "encounter": [ {
           "reference": "urn:uuid:ef0d56f0-bc71-e944-941f-1a3aef63996a"
@@ -19202,10 +19202,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "185349003",
-            "display": "Encounter for 'check-up'"
+            "code": "86013001",
+            "display": "Periodic reevaluation and management of healthy individual (procedure)"
           } ],
-          "text": "Encounter for 'check-up'"
+          "text": "Periodic reevaluation and management of healthy individual (procedure)"
         },
         "servicedPeriod": {
           "start": "2017-01-24T13:52:24-05:00",

--- a/src/test/resources/flexporter/sample_complete_patient.json
+++ b/src/test/resources/flexporter/sample_complete_patient.json
@@ -1352,10 +1352,10 @@
       "type": [ {
         "coding": [ {
           "system": "http://snomed.info/sct",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         } ],
-        "text": "Follow-up consultation (procedure)"
+        "text": "Patient-initiated encounter (procedure)"
       } ],
       "subject": {
         "reference": "urn:uuid:d5582579-7193-4866-5560-a01e723b6552",
@@ -1485,10 +1485,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "281036007",
-            "display": "Follow-up consultation (procedure)"
+            "code": "270427003",
+            "display": "Patient-initiated encounter (procedure)"
           } ],
-          "text": "Follow-up consultation (procedure)"
+          "text": "Patient-initiated encounter (procedure)"
         },
         "encounter": [ {
           "reference": "urn:uuid:ece9e706-21d8-e2bc-02fd-6df6a7e90c5a"
@@ -1671,10 +1671,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "281036007",
-            "display": "Follow-up consultation (procedure)"
+            "code": "270427003",
+            "display": "Patient-initiated encounter (procedure)"
           } ],
-          "text": "Follow-up consultation (procedure)"
+          "text": "Patient-initiated encounter (procedure)"
         },
         "encounter": [ {
           "reference": "urn:uuid:ece9e706-21d8-e2bc-02fd-6df6a7e90c5a"
@@ -1794,10 +1794,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "281036007",
-            "display": "Follow-up consultation (procedure)"
+            "code": "270427003",
+            "display": "Patient-initiated encounter (procedure)"
           } ],
-          "text": "Follow-up consultation (procedure)"
+          "text": "Patient-initiated encounter (procedure)"
         },
         "servicedPeriod": {
           "start": "1985-01-09T14:59:56-05:00",
@@ -4744,10 +4744,10 @@
       "type": [ {
         "coding": [ {
           "system": "http://snomed.info/sct",
-          "code": "281036007",
-          "display": "Follow-up consultation (procedure)"
+          "code": "270427003",
+          "display": "Patient-initiated encounter (procedure)"
         } ],
-        "text": "Follow-up consultation (procedure)"
+        "text": "Patient-initiated encounter (procedure)"
       } ],
       "subject": {
         "reference": "urn:uuid:d5582579-7193-4866-5560-a01e723b6552",
@@ -5019,10 +5019,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "281036007",
-            "display": "Follow-up consultation (procedure)"
+            "code": "270427003",
+            "display": "Patient-initiated encounter (procedure)"
           } ],
-          "text": "Follow-up consultation (procedure)"
+          "text": "Patient-initiated encounter (procedure)"
         },
         "encounter": [ {
           "reference": "urn:uuid:51a99f1e-54c9-160e-0023-693a55c9a6d2"
@@ -5165,10 +5165,10 @@
         "productOrService": {
           "coding": [ {
             "system": "http://snomed.info/sct",
-            "code": "281036007",
-            "display": "Follow-up consultation (procedure)"
+            "code": "270427003",
+            "display": "Patient-initiated encounter (procedure)"
           } ],
-          "text": "Follow-up consultation (procedure)"
+          "text": "Patient-initiated encounter (procedure)"
         },
         "servicedPeriod": {
           "start": "2006-12-10T21:36:43-05:00",

--- a/src/test/resources/generic/calls_submodule.json
+++ b/src/test/resources/generic/calls_submodule.json
@@ -17,7 +17,7 @@
         {
           "system": "SNOMED-CT",
           "code": "12345678",
-          "display": "Follow-up consultation (procedure)"
+          "display": "Patient-initiated encounter (procedure)"
         }
       ],
       "direct_transition": "Examplitis"

--- a/src/test/resources/generic/calls_submodule.json
+++ b/src/test/resources/generic/calls_submodule.json
@@ -17,7 +17,7 @@
         {
           "system": "SNOMED-CT",
           "code": "12345678",
-          "display": "Encounter for problem"
+          "display": "Follow-up consultation (procedure)"
         }
       ],
       "direct_transition": "Examplitis"


### PR DESCRIPTION
In testing synthea-generated patients against eCQMs, we noticed that synthea encounter codes are often not relevant to the expected valuesets. Some valuesets we would expect to see codes in for common encounters include:
- https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.526.3.1240 (Annual Wellness Visit)
- https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.464.1003.101.12.1001 (Office Visit)
- https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.464.1003.101.12.1008 (Outpatient Consultation)
These are some of the codes that we might expect to see in real world patient data as patients are expected to calculate into many measure initial populations if they get typical care.

As such, I'm suggesting a full replace of two synthea encounter codes that are used for common encounters: 

Code 86013001 "Periodic reevaluation and management of healthy individual (procedure)" from SNOMEDCT selected from valueset "Annual Wellness Visit" 2.16.840.1.113883.3.526.3.1240 to replace 185349003	"Encounter for check up (procedure)" from SNOMED-CT

~Code 281036007 "Follow-up consultation (procedure)" from SNOMEDCT selected from valueset "Outpatient Consultation" 2.16.840.1.113883.3.464.1003.101.12.1008~ to replace 185347001 "Encounter for problem (procedure)" from SNOMED-CT
Instead, recommending replacing this code with 270427003 ("Patient-initiated encounter (procedure)") from 2.16.840.1.113883.3.526.3.1012 ("Patient Provider Interaction") as it is more closely aligned with the original intent of this code.

Please let me know if you have concerns about these code replacements or other thoughts on how to select the best codes.