### PR TITLE
Defaults for some missing configuration settings

### DIFF
--- a/src/main/java/org/mitre/synthea/world/agents/PayerManager.java
+++ b/src/main/java/org/mitre/synthea/world/agents/PayerManager.java
@@ -256,7 +256,6 @@ public class PayerManager {
       // Return without an error, because the given payer might only exist in another state.
       return;
     }
-    String planName = line.remove(NAME).trim();
     Set<String> servicesCovered
         = commaSeparatedStringToHashSet(line.remove(SERVICES_COVERED).trim());
     BigDecimal deductible = new BigDecimal(line.remove(DEDUCTIBLE).trim());
@@ -264,16 +263,17 @@ public class PayerManager {
     BigDecimal defaultCopay = new BigDecimal(line.remove(COPAY).trim());
     BigDecimal monthlyPremium = new BigDecimal(line.remove(MONTHLY_PREMIUM).trim());
     boolean medicareSupplement = Boolean.parseBoolean(line.remove(MEDICARE_SUPPLEMENT).trim());
-    boolean isACA = Boolean.parseBoolean(line.remove(ACA).trim());
-    boolean incomeBasedPremium = Boolean.parseBoolean(line.remove(INCOME_BASED_PREMIUM).trim());
+    boolean isACA = Boolean.parseBoolean(line.getOrDefault(ACA, "false").trim());
+    boolean incomeBasedPremium
+        = Boolean.parseBoolean(line.getOrDefault(INCOME_BASED_PREMIUM, "false").trim());
     String yearStartStr = line.remove(START_YEAR).trim();
     int yearStart = yearStartStr.equals("") ? 0 : Integer.parseInt(yearStartStr);
     String yearEndStr = line.remove(END_YEAR).trim();
     int yearEnd = StringUtils.isBlank(yearEndStr)
         ? Integer.MAX_VALUE : Integer.parseInt(yearEndStr);
-    BigDecimal maxOutOfPocket = new BigDecimal(line.remove(MAX_OOP).trim());
+    BigDecimal maxOutOfPocket = new BigDecimal(line.getOrDefault(MAX_OOP, "0").trim());
     // If the priority is blank, give it minimum priority (maximum int value).
-    String priorityString = line.remove(PRIORITY_LEVEL).trim();
+    String priorityString = line.getOrDefault(PRIORITY_LEVEL,"").trim();
     int priority = StringUtils.isBlank(priorityString)
         ? Integer.MAX_VALUE : Integer.parseInt(priorityString);
     String eligibilityName = line.remove(ELIGIBILITY_POLICY);

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/providerfinder/ProviderFinderNearest.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/providerfinder/ProviderFinderNearest.java
@@ -30,11 +30,11 @@ public class ProviderFinderNearest implements IProviderFinder {
         || !(service.equals(EncounterType.URGENTCARE) || service.equals(EncounterType.EMERGENCY))) {
       // Filter to only VA Facilities if the person is a veteran
       if (person.attributes.containsKey(Person.VETERAN)) {
-        options = options.filter(p -> ProviderType.VETERAN.equals(p.type));
-      }
-
-      // Filter out IHS facilities if someone is not Native American
-      if (! "native".equals(person.attributes.get(Person.RACE))) {
+        if (providers.stream().anyMatch(p -> ProviderType.VETERAN.equals(p.type))) {
+          options = options.filter(p -> ProviderType.VETERAN.equals(p.type));
+        }
+      } else if (! "native".equals(person.attributes.get(Person.RACE))) {
+        // Filter out IHS facilities if someone is not Native American
         options = options.filter(p -> ! ProviderType.IHS.equals(p.type));
       }
     }

--- a/src/main/java/org/mitre/synthea/world/concepts/healthinsurance/InsurancePlan.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/healthinsurance/InsurancePlan.java
@@ -158,7 +158,7 @@ public class InsurancePlan implements Serializable {
         && (!this.payer.isGovernmentPayer() && !this.isACA)) {
       // If this is a private plan non-ACA plan, then employers will provide coverage.
       double employeeContribution
-          = 1.0 - Config.getAsDouble("generate.insurance.employer_coverage");
+          = 1.0 - Config.getAsDouble("generate.insurance.employer_coverage", 0.83);
       premiumPrice = premiumPrice.multiply(new BigDecimal(employeeContribution));
     }
     return premiumPrice;

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -172,6 +172,16 @@ public class Location implements Serializable {
         averages.put(determinant, (probability / socialDeterminantsOfHealth.keySet().size()));
       }
       socialDeterminantsOfHealth.put("AVERAGE", averages);
+    } else {
+      // An SDoH file was not provided, and a non-fatal exception was caught above.
+      // This can occur with older synthea-international configurations.
+      String[] determinants = { Person.FOOD_INSECURITY, Person.SEVERE_HOUSING_COST_BURDEN,
+          Person.UNEMPLOYED, Person.NO_VEHICLE_ACCESS, Person.UNINSURED };
+      Map<String, Double> averages = new HashMap<String, Double>();
+      for (String determinant : determinants) {
+        averages.put(determinant, 0.5);
+      }
+      socialDeterminantsOfHealth.put("AVERAGE", averages);
     }
   }
 


### PR DESCRIPTION
This PR adds a few small updates to add defaults for missing data or configuration settings, mostly applicable to synthea-international configurations.

This PR pairs with https://github.com/synthetichealth/synthea-international/pull/20