### PR TITLE
feat(provider_finder): Add 'prefer_one' provider finding strategy

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -43,6 +43,7 @@ import org.mitre.synthea.modules.LifecycleModule;
 import org.mitre.synthea.world.agents.PayerManager;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.agents.behaviors.providerfinder.ProviderFinderPreferOne;
 import org.mitre.synthea.world.concepts.Costs;
 import org.mitre.synthea.world.concepts.HealthRecord.Encounter;
 import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
@@ -211,7 +212,11 @@ public class Generator {
 
   private void init() {
     if (options.state == null) {
-      options.state = DEFAULT_STATE;
+      if (ProviderFinderPreferOne.isUsingPreferredProvider()) {
+        options.state = Provider.findProviderStateByNPI(ProviderFinderPreferOne.getPreferredNPI());
+      } else {
+        options.state = DEFAULT_STATE;
+      }
     }
     int stateIndex = Location.getIndex(options.state);
     if (Config.getAsBoolean("exporter.cdw.export")) {
@@ -646,6 +651,10 @@ public class Generator {
     // Initialize person.
     Person person = new Person(personSeed);
     person.populationSeed = this.options.seed;
+
+    // Check if we need to override demographics based on preferred provider setting
+    ProviderFinderPreferOne.overrideDemographicsIfPreferredProvider(demoAttributes);
+
     person.attributes.putAll(demoAttributes);
     person.attributes.put(Person.LOCATION, this.location);
     person.lastUpdated = (long) demoAttributes.get(Person.BIRTHDATE);

--- a/src/main/java/org/mitre/synthea/world/agents/behaviors/providerfinder/ProviderFinderPreferOne.java
+++ b/src/main/java/org/mitre/synthea/world/agents/behaviors/providerfinder/ProviderFinderPreferOne.java
@@ -1,0 +1,152 @@
+package org.mitre.synthea.world.agents.behaviors.providerfinder;
+
+import java.util.HashSet;
+import java.util.List;
+
+import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.world.agents.Person;
+import java.util.Map;
+import java.util.Set;
+
+import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
+
+/**
+ * Finder that prioritizes a single provider based on NPI specified in configuration.
+ * Also provides a static method to override initial person demographics based on this preference.
+ * If the preferred provider is not available or suitable, it falls back to the nearest provider.
+ */
+public class ProviderFinderPreferOne implements IProviderFinder {
+
+  private static final String PREFER_ONE_NPI = "generate.providers.prefer_one.npi";
+  private static final String PREFER_ONE_IGNORE_SUITABLE = "generate.providers.prefer_one.ignore_suitable";
+  // Fallback finder if the preferred one isn't suitable during encounter finding
+  private final IProviderFinder fallbackFinder = new ProviderFinderNearest();
+
+  public static boolean isUsingPreferredProvider() {
+    return Config.get("generate.providers.selection_behavior", "nearest").equals(Provider.PREFER_ONE);
+  }
+
+  public static boolean isIgnoringSuitable() {
+    return Boolean.valueOf(Config.get(PREFER_ONE_IGNORE_SUITABLE, "false"));
+  }
+
+  public static String getPreferredNPI() {
+    return Config.get(PREFER_ONE_NPI, null);
+  }
+
+  public static Provider getPreferredProvider() {
+
+    if (!isUsingPreferredProvider()) return null;
+
+
+    String preferredNpi = getPreferredNPI();
+    if (preferredNpi == null || preferredNpi.isEmpty()) {
+      System.err.println("WARNING: generate.providers.selection_behavior=PreferOne but " + PREFER_ONE_NPI + " is not set. Using demographic location.");
+      return null; // NPI not configured, do nothing.
+    }
+
+    Provider preferredProvider = null;
+    // Find the preferred provider by NPI from the loaded list
+    // Note: This assumes the provider is within the initially loaded set.
+    for (Provider p : Provider.getProviderList()) {
+      if (preferredNpi.equals(p.npi)) {
+        preferredProvider = p;
+        break;
+      }
+    }
+    return preferredProvider;
+  }
+
+  /**
+   * Checks configuration for the PreferOne provider setting. If enabled and the
+   * preferred provider is found, overrides the City, State, and Coordinate
+   * entries in the provided demographics map with the provider's location.
+   * Logs warnings if the provider or its location data is not found.
+   *
+   * @param demoAttributes The map of demographic attributes to potentially modify.
+   */
+  public static void overrideDemographicsIfPreferredProvider(Map<String, Object> demoAttributes) {
+
+    Provider preferredProvider = getPreferredProvider();
+
+    if (preferredProvider != null) {
+      // Override demographics with preferred provider's location data
+      boolean cityOverridden = false;
+      boolean stateOverridden = false;
+      boolean coordsOverridden = false;
+
+      if (preferredProvider.city != null && !preferredProvider.city.isEmpty()) {
+        demoAttributes.put(Person.CITY, preferredProvider.city);
+        cityOverridden = true;
+      }
+      if (preferredProvider.state != null && !preferredProvider.state.isEmpty()) {
+        demoAttributes.put(Person.STATE, preferredProvider.state);
+        stateOverridden = true;
+      }
+      // IMPORTANT: Update coordinates as well for provider finding logic
+      java.awt.geom.Point2D.Double providerCoords = preferredProvider.getLonLat();
+      if (providerCoords != null) {
+        // Create a new Point2D object to avoid modifying the provider's instance
+        demoAttributes.put(Person.COORDINATE,
+            new java.awt.geom.Point2D.Double(providerCoords.getX(), providerCoords.getY()));
+        coordsOverridden = true;
+      }
+
+      if (!cityOverridden || !stateOverridden || !coordsOverridden) {
+        System.err.println("WARNING: Preferred provider NPI '" + preferredProvider.npi
+            + "' found, but missing location data (City: " + preferredProvider.city
+            + ", State: " + preferredProvider.state + ", Coords: " + providerCoords
+            + "). Not all location attributes were overridden.");
+      }
+      // TODO: Consider updating Person.COUNTY if available? Provider doesn't store it.
+
+    } else {
+      // Log a warning if the provider wasn't found
+      System.err.println("WARNING: Preferred provider NPI '" + getPreferredNPI() + "' configured but provider not found in loaded list. Using demographic location.");
+    }
+  }
+
+
+  @Override
+  public Provider find(List<Provider> providers, Person person, EncounterType service, long time) {
+
+    String preferredNpi = Config.get(PREFER_ONE_NPI, null);
+
+    System.out.println("PreferredNpi: " + preferredNpi);
+
+    if (preferredNpi != null && !preferredNpi.isEmpty()) {
+      // first check the list passed in (if the states line up with the detault state, e.g., MA, then it may be found in the list)
+      // if it's not found in the list then look across all providers. The state will be updated on the patient and generator.
+      Provider provider = findPreferredProvider(providers, preferredNpi, person, service, time);
+      if (provider == null) provider = findPreferredProvider(Provider.getProviderList(), preferredNpi, person, service, time);
+      if (provider != null) return provider;
+    }
+
+    // If preferred NPI not set, not found in the list, or not suitable, use the fallback finder.
+    return fallbackFinder.find(providers, person, service, time);
+  }
+
+  private Provider findPreferredProvider(List<Provider> providers, String preferredNpi, Person person, EncounterType service, long time) {
+    for (Provider provider : providers) { // Iterate the passed-in list
+        // Check if this provider matches the preferred NPI
+        if (preferredNpi.equals(provider.npi)) {
+            System.out.println("FOUND PROVIDER: " + provider.npi + " -- " + preferredNpi);
+
+            // Check if the preferred provider offers the service and accepts the patient
+            if (provider.hasService(service) && provider.accepts(person, time)) {
+                return provider;
+            } else {
+                if (isIgnoringSuitable()) return provider;
+                // Preferred provider found but is not suitable (doesn't offer service or accept patient)
+                // Break the loop and proceed to fallback.
+                break;
+            }
+        }
+    }
+    return null;
+}
+  
+}

--- a/src/main/java/org/mitre/synthea/world/geography/Location.java
+++ b/src/main/java/org/mitre/synthea/world/geography/Location.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.mitre.synthea.export.JSONSkip;
@@ -435,6 +436,18 @@ public class Location implements Serializable {
    */
   public static String getAbbreviation(String state) {
     return stateAbbreviations.get(state);
+  }
+
+  /**
+   * Get the state for an abbreviation.
+   * @param abbreviation State abbreviation. e.g. "MA"
+   * @return state name. e.g. "Massachusetts"
+   */
+  public static String getStateNameFromAbbreviation(String abbreviation) {
+    for(Entry<String, String> entry : stateAbbreviations.entrySet()) {
+      if (entry.getValue().equals(abbreviation)) return entry.getKey();
+    }
+    return null;
   }
 
   /**

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -252,7 +252,13 @@ generate.providers.ihs.primarycare.default_file = providers/ihs_centers.csv
 #  random  - select randomly.
 #  network - select a random provider in your insurance network. same as random except it changes every time the patient switches insurance provider.
 #  medicare - select the nearest provider that can bill Medicare. If no Medicare provider is found, it defaults back to "nearest".
+#  prefer_one - select a specific provider by NPI (generate.providers.prefer_one.npi), falling back to nearest if unavailable/unsuitable.
 generate.providers.selection_behavior = nearest
+# NPI of the provider to prefer when generate.providers.selection_behavior = prefer_one
+generate.providers.prefer_one.npi =
+# only select the provider to prefer when generate.providers.selection_behavior = prefer_one 
+# if set to true then the prefered provider is always used even if not suitable for the encounter type
+generate.providers.prefer_one.ignore_suitable=true
 
 # if a provider cannot be found for a certain type of service,
 # this will default to the nearest hospital.

--- a/src/test/java/org/mitre/synthea/world/agents/behaviors/providerfinder/ProviderFinderPreferOneTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/behaviors/providerfinder/ProviderFinderPreferOneTest.java
@@ -1,0 +1,199 @@
+package org.mitre.synthea.world.agents.behaviors.providerfinder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
+import org.mitre.synthea.world.geography.Location;
+import java.awt.geom.Point2D;
+
+public class ProviderFinderPreferOneTest {
+
+  // Test Constants
+  private static final String PREFERRED_NPI_CONFIG = "generate.providers.prefer_one.npi";
+  private static final String PREFER_ONE_IGNORE_SUITABLE = "generate.providers.prefer_one.ignore_suitable";
+  
+  private static final String PREFERRED_NPI = "1234567890";
+  private static final String NEAREST_NPI = "0987654321";
+  private static final String PREFERRED_CITY = "Bedford";
+  private static final String PREFERRED_STATE = "MA";
+  private static final String NEAREST_CITY = "Albany";
+  private static final String NEAREST_STATE = "NY";
+  private static final String PERSON_INITIAL_CITY = "Schenectady";
+  private static final String PERSON_INITIAL_STATE = "NY";
+
+  private static final Point2D.Double PERSON_COORDS = new Point2D.Double(0.0, 0.0);
+  private static final Point2D.Double NEAREST_PROVIDER_COORDS = new Point2D.Double(0.01, 0.01); // Closer
+  private static final Point2D.Double PREFERRED_PROVIDER_COORDS = new Point2D.Double(0.1, 0.1); // Further
+
+  // Test Objects
+  private Person person;
+  private List<Provider> providers;
+  private Provider preferredProvider;
+  private Provider nearestProvider;
+  private ProviderFinderPreferOne finder;
+  private long time;
+
+
+  @Before
+  public void setUp() {
+    // Clear any previously set config
+    Config.set(PREFERRED_NPI_CONFIG, "");
+    Config.set(PREFER_ONE_IGNORE_SUITABLE, "false");
+
+    person = new Person(0L);
+    // Set initial location and coordinates for the person
+    person.attributes.put(Person.CITY, PERSON_INITIAL_CITY);
+    person.attributes.put(Person.STATE, PERSON_INITIAL_STATE);
+    person.attributes.put(Person.COORDINATE, PERSON_COORDS); // Use static variable
+
+    providers = new ArrayList<>();
+
+    // Preferred Provider Setup
+    preferredProvider = new Provider();
+    preferredProvider.npi = PREFERRED_NPI;
+    preferredProvider.city = PREFERRED_CITY;
+    preferredProvider.state = PREFERRED_STATE;
+    preferredProvider.getLonLat().setLocation(PREFERRED_PROVIDER_COORDS.getX(), PREFERRED_PROVIDER_COORDS.getY()); // Use static variable
+    preferredProvider.servicesProvided.add(EncounterType.AMBULATORY); // Offers the service
+    // Assume accepts patient by default
+
+    // Nearest Provider Setup (for fallback)
+    nearestProvider = new Provider();
+    nearestProvider.npi = NEAREST_NPI;
+    nearestProvider.city = NEAREST_CITY;
+    nearestProvider.state = NEAREST_STATE;
+    nearestProvider.getLonLat().setLocation(NEAREST_PROVIDER_COORDS.getX(), NEAREST_PROVIDER_COORDS.getY()); // Use static variable
+    nearestProvider.servicesProvided.add(EncounterType.AMBULATORY); // Offers the service
+    // Assume accepts patient by default
+
+    providers.add(nearestProvider); // Add nearest first to test preference logic
+    providers.add(preferredProvider);
+
+    finder = new ProviderFinderPreferOne();
+    time = System.currentTimeMillis();
+  }
+
+  @Test
+  public void find_shouldReturnPreferredProvider_whenNpiSetAndProviderAvailableAndSuitable() {
+    Config.set(PREFERRED_NPI_CONFIG, PREFERRED_NPI);
+    Config.set(PREFER_ONE_IGNORE_SUITABLE, "true");
+
+    Provider found = finder.find(providers, person, EncounterType.AMBULATORY, time);
+
+    assertNotNull(found);
+    assertSame("Should find the preferred provider", preferredProvider, found);
+  }
+
+  @Test
+  public void find_shouldReturnNearestProvider_whenPreferredProviderDoesNotOfferService() {
+    Config.set(PREFERRED_NPI_CONFIG, PREFERRED_NPI);
+    preferredProvider.servicesProvided.remove(EncounterType.AMBULATORY); // Does not offer service
+
+    Provider found = finder.find(providers, person, EncounterType.AMBULATORY, time);
+
+    assertNotNull(found);
+    // Since ProviderFinderNearest is the fallback and doesn't have complex logic here,
+    // we expect it to find the 'nearestProvider' based on simple list order in this test setup.
+    // A more robust test would mock ProviderFinderNearest or set up coordinates.
+    assertSame("Should fall back to nearest provider", nearestProvider, found);
+    assertEquals("Person's city should NOT be updated",
+                 PERSON_INITIAL_CITY, person.attributes.get(Person.CITY));
+    assertEquals("Person's state should NOT be updated",
+                 PERSON_INITIAL_STATE, person.attributes.get(Person.STATE));
+  }
+
+  // Mocking Provider.accepts would be ideal, but for simplicity, we'll simulate non-acceptance
+  // by removing the provider from the list before calling find, mimicking a scenario where
+  // accepts() would return false and the provider wouldn't be considered by the fallback.
+  // A better approach involves a custom IProviderFinder mock or modifying Provider for testability.
+  @Test
+  public void find_shouldReturnNearestProvider_whenPreferredProviderDoesNotAcceptPatient() {
+    Config.set(PREFERRED_NPI_CONFIG, PREFERRED_NPI);
+    // Simulate non-acceptance by removing the preferred provider temporarily
+    providers.remove(preferredProvider);
+
+    Provider found = finder.find(providers, person, EncounterType.AMBULATORY, time);
+
+    providers.add(preferredProvider); // Add back for cleanup/other tests
+
+    assertNotNull(found);
+    assertSame("Should fall back to nearest provider", nearestProvider, found);
+    assertEquals("Person's city should NOT be updated",
+                 PERSON_INITIAL_CITY, person.attributes.get(Person.CITY));
+    assertEquals("Person's state should NOT be updated",
+                 PERSON_INITIAL_STATE, person.attributes.get(Person.STATE));
+  }
+
+
+  @Test
+  public void find_shouldReturnNearestProvider_whenPreferredNpiNotFound() {
+    Config.set(PREFERRED_NPI_CONFIG, "NonExistentNPI");
+
+    Provider found = finder.find(providers, person, EncounterType.AMBULATORY, time);
+
+    assertNotNull(found);
+    assertSame("Should fall back to nearest provider", nearestProvider, found);
+    assertEquals("Person's city should NOT be updated",
+                 PERSON_INITIAL_CITY, person.attributes.get(Person.CITY));
+    assertEquals("Person's state should NOT be updated",
+                 PERSON_INITIAL_STATE, person.attributes.get(Person.STATE));
+  }
+
+  @Test
+  public void find_shouldReturnNearestProvider_whenPreferredNpiNotSet() {
+    // Config PREFERRED_NPI_CONFIG is empty by default from setUp()
+
+    Provider found = finder.find(providers, person, EncounterType.AMBULATORY, time);
+
+    assertNotNull(found);
+    assertSame("Should fall back to nearest provider", nearestProvider, found);
+    assertEquals("Person's city should NOT be updated",
+                 PERSON_INITIAL_CITY, person.attributes.get(Person.CITY));
+    assertEquals("Person's state should NOT be updated",
+                 PERSON_INITIAL_STATE, person.attributes.get(Person.STATE));
+  }
+
+  @Test
+  public void find_shouldNotUpdatePersonLocation_whenPreferredProviderLocationNull() {
+    Config.set(PREFERRED_NPI_CONFIG, PREFERRED_NPI);
+    preferredProvider.city = null;
+    preferredProvider.state = null;
+
+    Provider found = finder.find(providers, person, EncounterType.AMBULATORY, time);
+
+    assertNotNull(found);
+    assertSame("Should find the preferred provider", preferredProvider, found);
+    assertEquals("Person's city should NOT be updated",
+                 PERSON_INITIAL_CITY, person.attributes.get(Person.CITY));
+    assertEquals("Person's state should NOT be updated",
+                 PERSON_INITIAL_STATE, person.attributes.get(Person.STATE));
+  }
+
+   @Test
+  public void find_shouldNotUpdatePersonLocation_whenPreferredProviderLocationEmpty() {
+    Config.set(PREFERRED_NPI_CONFIG, PREFERRED_NPI);
+    preferredProvider.city = "";
+    preferredProvider.state = "";
+
+    Provider found = finder.find(providers, person, EncounterType.AMBULATORY, time);
+
+    assertNotNull(found);
+    assertSame("Should find the preferred provider", preferredProvider, found);
+    assertEquals("Person's city should NOT be updated",
+                 PERSON_INITIAL_CITY, person.attributes.get(Person.CITY));
+    assertEquals("Person's state should NOT be updated",
+                 PERSON_INITIAL_STATE, person.attributes.get(Person.STATE));
+  }
+}


### PR DESCRIPTION
Introduces a new provider finding strategy, `ProviderFinderPreferOne`, which allows configuring Synthea to prioritize a specific provider based on their NPI.

Key changes include:
- Added `ProviderFinderPreferOne.java` implementing the new logic.
- Integrated `ProviderFinderPreferOne` into `Generator.java` to:
    - Set the initial simulation state based on the preferred provider's location.
    - Allow overriding patient demographics based on the preferred provider.
- Added the `prefer_one` option to the provider finding mechanism in `Provider.java`.
- Refactored provider file path handling in `Provider.java` for clarity and to support locating the preferred provider.