### PR TITLE
Set MedicationRequest status to COMPLETE instead of STOPPED

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirDstu2.java
+++ b/src/main/java/org/mitre/synthea/export/FhirDstu2.java
@@ -1103,7 +1103,7 @@ public class FhirDstu2 {
 
     medicationResource.setDateWritten(new DateTimeDt(new Date(medication.start)));
     if (medication.stop != 0L) {
-      medicationResource.setStatus(MedicationOrderStatusEnum.STOPPED);
+      medicationResource.setStatus(MedicationOrderStatusEnum.COMPLETED);
     } else {
       medicationResource.setStatus(MedicationOrderStatusEnum.ACTIVE);
     }

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -2336,7 +2336,7 @@ public class FhirR4 {
     medicationResource.setRequester(encounterResource.getParticipantFirstRep().getIndividual());
 
     if (medication.stop != 0L) {
-      medicationResource.setStatus(MedicationRequestStatus.STOPPED);
+      medicationResource.setStatus(MedicationRequestStatus.COMPLETED);
     } else {
       medicationResource.setStatus(MedicationRequestStatus.ACTIVE);
     }

--- a/src/main/java/org/mitre/synthea/export/FhirStu3.java
+++ b/src/main/java/org/mitre/synthea/export/FhirStu3.java
@@ -1759,7 +1759,7 @@ public class FhirStu3 {
     medicationResource.setRequester(requester);
 
     if (medication.stop != 0L) {
-      medicationResource.setStatus(MedicationRequestStatus.STOPPED);
+      medicationResource.setStatus(MedicationRequestStatus.COMPLETED);
     } else {
       medicationResource.setStatus(MedicationRequestStatus.ACTIVE);
     }


### PR DESCRIPTION
This PR fixes a discrepancy in how MedicationRequests are created by the synthea R4 export. The previous code was setting the MedicationRequest to STOPPED if the medication has a valid stop value. But looking at the [MedicationRequest status valueset](https://hl7.org/fhir/R4/valueset-medicationrequest-status.html), stopped means:

> Actions implied by the prescription are to be permanently halted, before all of the administrations occurred. This should not be used if the original order was entered in error

Essentially this seems to mean that the request was stopped rather than that the medication itself was stopped. For most synthea modules, the intent is for medication.stop to get set to something other than 0L when the medication is _completed_. As such, we want to set the MedicationRequest to COMPLETED for this case to capture the intent of those modules.