### PR TITLE
Allow included and excluded files in CSV exporter if there is no overlap

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -193,8 +193,18 @@ public class CSVExporter {
       List<String> excludedFiles = Collections.emptyList();
 
       if (!includedFilesStr.isEmpty() && !excludedFilesStr.isEmpty()) {
-        System.err.println(
-            "CSV exporter: Included and Excluded file settings are both set -- ignoring both");
+        includedFiles = propStringToList(includedFilesStr);
+        excludedFiles = propStringToList(excludedFilesStr);
+
+        // Check if there is any overlap
+        for (String includedFile : includedFiles) {
+          if (excludedFiles.contains(includedFile)) {
+            System.err.println("ERROR! CSV exporter is set to include and exclude the same file: "
+                    + includedFile);
+            throw new IllegalArgumentException(
+                    "CSV exporter cannot include and exclude the same file: " + includedFile);
+          }
+        }
       } else {
         if (!includedFilesStr.isEmpty()) {
           includedFiles = propStringToList(includedFilesStr);

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -1,8 +1,5 @@
 package org.mitre.synthea.export;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.nio.file.Files;
 
@@ -17,6 +14,11 @@ import org.mitre.synthea.engine.Generator.GeneratorOptions;
 import org.mitre.synthea.export.Exporter.ExporterRuntimeOptions;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.SimpleCSV;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 public class CSVExporterTest {
   /**
@@ -235,5 +237,63 @@ public class CSVExporterTest {
 
   }
 
+  @Test
+  public void throwsExceptionWhenFileIncludedAndExcluded() {
+    Config.set("exporter.csv.included_files", "patients.csv,medications.csv");
+    Config.set("exporter.csv.excluded_files", "medications.csv,procedures.csv");
 
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      CSVExporter.getInstance().init();
+    });
+
+    assertEquals("CSV exporter cannot include and exclude the same file: medications.csv", exception.getMessage());
+  }
+
+  @Test
+  public void doesNotThrowWhenNoOverlapBetweenIncludedAndExcludedFiles() {
+    Config.set("exporter.csv.included_files", "patients.csv,medications.csv");
+    Config.set("exporter.csv.excluded_files", "procedures.csv,observations.csv");
+
+    try {
+      CSVExporter.getInstance().init();
+    } catch (IllegalArgumentException e) {
+      fail("CSV exporter should not throw an exception when there is no overlap between included and excluded files");
+    }
+  }
+
+  @Test
+  public void doesNotThrowWhenOnlyIncludedFilesAreSet() {
+    Config.set("exporter.csv.included_files", "patients.csv,medications.csv");
+    Config.set("exporter.csv.excluded_files", "");
+
+    try {
+      CSVExporter.getInstance().init();
+    } catch (IllegalArgumentException e) {
+      fail("CSV exporter should not throw an exception when only included files are set");
+    }
+  }
+
+  @Test
+  public void doesNotThrowWhenOnlyExcludedFilesAreSet() {
+    Config.set("exporter.csv.included_files", "");
+    Config.set("exporter.csv.excluded_files", "patients.csv,medications.csv");
+
+    try {
+      CSVExporter.getInstance().init();
+    } catch (IllegalArgumentException e) {
+      fail("CSV exporter should not throw an exception when only included files are set");
+    }
+  }
+
+  @Test
+  public void doesNotThrowWhenBothIncludedAndExcludedFilesAreEmpty() {
+    Config.set("exporter.csv.included_files", "");
+    Config.set("exporter.csv.excluded_files", "");
+
+    try {
+      CSVExporter.getInstance().init();
+    } catch (IllegalArgumentException e) {
+      fail("CSV exporter should not throw an exception when only included files are set");
+    }
+  }
 }

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -1,5 +1,10 @@
 package org.mitre.synthea.export;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.nio.file.Files;
 
@@ -14,11 +19,6 @@ import org.mitre.synthea.engine.Generator.GeneratorOptions;
 import org.mitre.synthea.export.Exporter.ExporterRuntimeOptions;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.SimpleCSV;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
 
 public class CSVExporterTest {
   /**
@@ -246,7 +246,8 @@ public class CSVExporterTest {
       CSVExporter.getInstance().init();
     });
 
-    assertEquals("CSV exporter cannot include and exclude the same file: medications.csv", exception.getMessage());
+    assertEquals("CSV exporter cannot include and exclude the same file:"
+            + " medications.csv", exception.getMessage());
   }
 
   @Test
@@ -257,7 +258,8 @@ public class CSVExporterTest {
     try {
       CSVExporter.getInstance().init();
     } catch (IllegalArgumentException e) {
-      fail("CSV exporter should not throw an exception when there is no overlap between included and excluded files");
+      fail("CSV exporter should not throw an exception when "
+              + "there is no overlap between included and excluded files");
     }
   }
 
@@ -269,7 +271,8 @@ public class CSVExporterTest {
     try {
       CSVExporter.getInstance().init();
     } catch (IllegalArgumentException e) {
-      fail("CSV exporter should not throw an exception when only included files are set");
+      fail("CSV exporter should not throw an exception when "
+              + "only included files are set");
     }
   }
 
@@ -281,7 +284,8 @@ public class CSVExporterTest {
     try {
       CSVExporter.getInstance().init();
     } catch (IllegalArgumentException e) {
-      fail("CSV exporter should not throw an exception when only included files are set");
+      fail("CSV exporter should not throw an exception when "
+             + "only included files are set");
     }
   }
 


### PR DESCRIPTION
The `CSVExporter` has been updated to support the simultaneous setting of `included_files` and `excluded_files`. The implementation now includes a check for any overlap between these two lists, raising an error if and only if common elements are found.

Fixes:  https://github.com/synthetichealth/synthea/issues/1560
