### PR TITLE
Suppress Javadoc linting errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ jacoco {
   toolVersion '0.8.7'
 }
 
+javadoc {
+    options.addStringOption('Xdoclint:none', '-quiet')
+}
+
 dependencies {
   // This dependency is found on compile classpath of this component and consumers.
   implementation 'com.google.code.gson:gson:2.9.0'


### PR DESCRIPTION
I gave it a good attempt to use Claude to autodocument the Javadoc errors in the [autodocument-javadocs](https://github.com/synthetichealth/synthea/tree/autodocument-javadocs) branch.  After adding maybe 1000 comments for Enums, it became apparent that the Javadoc linting rules want documents on _everything_.  

In the end, it's just easier to suppress the warnings:

```
javadoc {
    options.addStringOption('Xdoclint:none', '-quiet')
}
```

