### PR TITLE
Add labs/reports to clinical notes.

### DIFF
--- a/src/main/java/org/mitre/synthea/export/ClinicalNoteExporter.java
+++ b/src/main/java/org/mitre/synthea/export/ClinicalNoteExporter.java
@@ -126,6 +126,7 @@ public class ClinicalNoteExporter {
     person.attributes.put("ehr_conditions", encounter.conditions);
     person.attributes.put("ehr_allergies", encounter.allergies);
     person.attributes.put("ehr_procedures", encounter.procedures);
+    person.attributes.put("ehr_reports", encounter.reports);
     person.attributes.put("ehr_immunizations", encounter.immunizations);
     person.attributes.put("ehr_medications", encounter.medications);
     person.attributes.put("ehr_careplans", encounter.careplans);

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -10,7 +10,6 @@ import com.google.gson.JsonObject;
 
 import java.awt.geom.Point2D;
 import java.io.IOException;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -143,7 +142,6 @@ import org.mitre.synthea.engine.Components.Attachment;
 import org.mitre.synthea.export.rif.CodeMapper;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.RandomNumberGenerator;
-import org.mitre.synthea.helpers.RandomValueGenerator;
 import org.mitre.synthea.helpers.SimpleCSV;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.identity.Entity;

--- a/src/main/resources/templates/notes/note.ftl
+++ b/src/main/resources/templates/notes/note.ftl
@@ -9,8 +9,7 @@ ${time?number_to_date?string["yyyy-MM-dd"]}
 </#list><#else>No complaints.</#if>
 
 # History of Present Illness
-<#if name??>${name?keep_before_last(" ")}<#else><#if gender=='F'>Jane<#else>John</#if> Doe</#if>
- is a <#if ehr_ageInYears gt 0>${ehr_ageInYears} year-old<#elseif ehr_ageInMonths gt 0>${ehr_ageInMonths} month-old<#else>newborn</#if> ${ethnicity} ${race} <#if gender=='F'>female<#else>male</#if>.<#if ehr_activeConditions?has_content> Patient has a history of <#list ehr_activeConditions as display>${display?lower_case}<#sep>, </#list>.</#if>
+<#if name??>${name?keep_before_last(" ")}<#else><#if gender=='F'>Jane<#else>John</#if> Doe</#if> is a <#if ehr_ageInYears gt 0>${ehr_ageInYears} year-old<#elseif ehr_ageInMonths gt 0>${ehr_ageInMonths} month-old<#else>newborn</#if> ${ethnicity} ${race} <#if gender=='F'>female<#else>male</#if>.<#if ehr_activeConditions?has_content> Patient has a history of <#list ehr_activeConditions as display>${display?lower_case}<#sep>, </#list>.</#if>
 
 # Social History
 <#if ehr_ageInYears gt 18 && marital_status??><#if marital_status=='M'>Patient is married.<#else>Patient is single.</#if></#if><#if ehr_ageInYears gt 18 && homeless?? && homeless> <#if homelessness_category=='chronic'>Patient is chronically homeless.<#else>Patient is temporarily homeless.</#if></#if><#if opioid_addiction_careplan??> Patient has a documented history of opioid addiction.</#if><#if ehr_ageInYears gt 16 && smoker?? && smoker> Patient is an active smoker<#elseif quit_smoking_age??> Patient quit smoking at age ${quit_smoking_age}<#else> Patient has never smoked</#if><#if alcoholic?? && alcoholic> and is an alcoholic.<#else>.</#if>
@@ -36,6 +35,10 @@ Patient currently has ${ehr_insurance?replace("_", " ")}.
 <#list ehr_procedures as entry>
 - ${entry.codes[0].display?lower_case}<#if entry.note??>
   - ${entry.note} </#if>
+</#list></#if>
+<#if ehr_reports?has_content>The following lab reports were completed:
+<#list ehr_reports as entry>
+- ${entry.codes[0].display?lower_case}
 </#list></#if>
 <#if ehr_medications?has_content>The patient was prescribed the following medications:
 <#list ehr_medications as entry>


### PR DESCRIPTION
This is a minor change to add labs/reports to the clinical notes templates, and the removal of two unused imports.

The notes change is useful for downstream enhancements, for example, those provided by [synthetichealth/chatty-notes](https://github.com/synthetichealth/chatty-notes).