### PR TITLE
add thread queue for large sims

### DIFF
--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -117,7 +117,7 @@ generate.thread_pool_size = -1
 # number of jobs exceeds available memory.
 # If running jobs with a huge population, set the queue to a reasonable size
 # like 1000000 to avoid memory issues.
-generate.thread_queue_size = 100
+generate.thread_queue_size = -1
 
 
 generate.log_patients.detail = simple

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -112,6 +112,13 @@ generate.default_population = 1
 # available processors (as per Runtime.getRuntime().availableProcessors())
 # defaults to -1 if not specified
 generate.thread_pool_size = -1
+# the number of jobs to queue up for the thread pool
+# set to -1 to use an unbounded queue, which may cause memory issues if the
+# number of jobs exceeds available memory.
+# If running jobs with a huge population, set the queue to a reasonable size
+# like 1000000 to avoid memory issues.
+generate.thread_queue_size = 100
+
 
 generate.log_patients.detail = simple
 # options are "none", "simple", or "detailed" (without quotes). defaults to simple if another value is used


### PR DESCRIPTION
Fixes #1515 by adding a config option to limit the number of tasks allowed in the thread queue so that memory doesn't fill up with task objects waiting to be run by a thread.  In large sims, this could cause the program to hang when the amount of tasks in the unbounded queue exceeded the available memory.  

Setting `generate.thread_queue_size` to any non-zero number will cap the queue at that number of tasks.  The only difference between these two modes is that the unbounded queue might be slightly faster and have a little less overhead compared to the bounded one, but the bounded one won't freeze up.  This would really only have an effect if the number of threads or available cpu fluctuates over the length of the sim.