### PR TITLE
docs: clarify JDK 11/17 LTS requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+## Build Requirements
+Synthea requires Java 11 LTS or Java 17 LTS. Ensure one of these is installed before building.


### PR DESCRIPTION
Adds explicit note about supported JDK versions (11 and 17 LTS) to README. No code changes.