### PR TITLE
Make default reference time precise to the day

### DIFF
--- a/src/main/java/org/mitre/synthea/engine/Generator.java
+++ b/src/main/java/org/mitre/synthea/engine/Generator.java
@@ -10,12 +10,16 @@ import java.io.ObjectOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -140,7 +144,7 @@ public class Generator {
     /** Number of threads to use */
     public int threadPoolSize = Config.getAsInteger("generate.thread_pool_size", -1);
     /** Reference Time when to start Synthea. By default equal to the current system time. */
-    public long referenceTime = System.currentTimeMillis();
+    public long referenceTime = initializeReferenceTime();
     /** End time of Synthea simulation. By default equal to the current system time. */
     public long endTime = referenceTime;
     /** Actual time the run started. */
@@ -182,6 +186,21 @@ public class Generator {
     public int daysToTravelForward = -1;
     /** Path to a module defining which patients should be kept and exported. */
     public Path keepPatientsModulePath;
+
+    /**
+     * Initialize referenceTime so that it is precise to the day.
+     */
+    private long initializeReferenceTime() {
+      try {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return dateFormat.parse(dateFormat.format(new Date())).getTime();
+      } catch (ParseException ex) {
+        // This will be precise to the millisecond rather than the day, but it
+        // shouldn't be possible for this exception to actually be thrown
+        return System.currentTimeMillis();
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
This PR address #1342. It makes the default reference time precise to the day, so that a run with a default reference time can be reproduced using `-r`.

On master:
```
> ./run_synthea -p 1
Reference Time: 1757076199758
> ./run_synthea -p 1 -r 20250905
Reference Time: 1757030400000
```

On this branch:
```
> ./run_synthea -p 1
Reference Time: 1757030400000
> ./run_synthea -p 1 -r 20250905
Reference Time: 1757030400000
```