### PR TITLE
Limit resources per CSV file

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CSVConstants.java
+++ b/src/main/java/org/mitre/synthea/export/CSVConstants.java
@@ -27,26 +27,6 @@ public class CSVConstants {
   public static final String CLAIM_TRANSACTION_KEY = "claims_transactions";
   public static final String PATIENT_EXPENSE_KEY = "patient_expenses";
 
-  public static final String BASE_PATIENT_FILENAME = "patients.csv";
-  public static final String BASE_ALLERGY_FILENAME = "allergies.csv";
-  public static final String BASE_MEDICATION_FILENAME = "medications.csv";
-  public static final String BASE_CONDITION_FILENAME = "conditions.csv";
-  public static final String BASE_CAREPLAN_FILENAME = "careplans.csv";
-  public static final String BASE_OBSERVATION_FILENAME = "observations.csv";
-  public static final String BASE_PROCEDURE_FILENAME = "procedures.csv";
-  public static final String BASE_IMMUNIZATION_FILENAME = "immunizations.csv";
-  public static final String BASE_ENCOUNTER_FILENAME = "encounters.csv";
-  public static final String BASE_IMAGING_STUDY_FILENAME = "imaging_studies.csv";
-  public static final String BASE_DEVICE_FILENAME = "devices.csv";
-  public static final String BASE_SUPPLY_FILENAME = "supplies.csv";
-  public static final String BASE_ORGANIZATION_FILENAME = "organizations.csv";
-  public static final String BASE_PROVIDER_FILENAME = "providers.csv";
-  public static final String BASE_PAYER_FILENAME = "payers.csv";
-  public static final String BASE_PAYER_TRANSITION_FILENAME = "payer_transitions.csv";
-  public static final String BASE_CLAIM_FILENAME = "claims.csv";
-  public static final String BASE_CLAIM_TRANSACTION_FILENAME = "claims_transactions.csv";
-  public static final String BASE_PATIENT_EXPENSE_FILENAME = "patient_expenses.csv";
-
   public static final String PATIENT_HEADER_LINE =
       "Id,BIRTHDATE,DEATHDATE,SSN,DRIVERS,PASSPORT,"
       + "PREFIX,FIRST,MIDDLE,LAST,SUFFIX,MAIDEN,MARITAL,RACE,ETHNICITY,GENDER,BIRTHPLACE,"
@@ -130,34 +110,7 @@ public class CSVConstants {
       + "HEALTHCARE_EXPENSES,INSURANCE_COSTS,COVERED_COSTS"
       + NEWLINE;
 
-  public static final Map<String, String> BASE_FILENAME_MAP = initializeFilenameMap();
   public static final Map<String, String> HEADER_LINE_MAP = initializeHeaderMap();
-
-  private static Map<String, String> initializeFilenameMap() {
-    Map<String, String> map = new HashMap<>();
-
-    map.put(PATIENT_KEY, BASE_PATIENT_FILENAME);
-    map.put(ALLERGY_KEY, BASE_ALLERGY_FILENAME);
-    map.put(MEDICATION_KEY, BASE_MEDICATION_FILENAME);
-    map.put(CONDITION_KEY, BASE_CONDITION_FILENAME);
-    map.put(CAREPLAN_KEY, BASE_CAREPLAN_FILENAME);
-    map.put(OBSERVATION_KEY, BASE_OBSERVATION_FILENAME);
-    map.put(PROCEDURE_KEY, BASE_PROCEDURE_FILENAME);
-    map.put(IMMUNIZATION_KEY, BASE_IMMUNIZATION_FILENAME);
-    map.put(ENCOUNTER_KEY, BASE_ENCOUNTER_FILENAME);
-    map.put(IMAGING_STUDY_KEY, BASE_IMAGING_STUDY_FILENAME);
-    map.put(DEVICE_KEY, BASE_DEVICE_FILENAME);
-    map.put(SUPPLY_KEY, BASE_SUPPLY_FILENAME);
-    map.put(ORGANIZATION_KEY, BASE_ORGANIZATION_FILENAME);
-    map.put(PROVIDER_KEY, BASE_PROVIDER_FILENAME);
-    map.put(PAYER_KEY, BASE_PAYER_FILENAME);
-    map.put(PAYER_TRANSITION_KEY, BASE_PAYER_TRANSITION_FILENAME);
-    map.put(CLAIM_KEY, BASE_CLAIM_FILENAME);
-    map.put(CLAIM_TRANSACTION_KEY, BASE_CLAIM_TRANSACTION_FILENAME);
-    map.put(PATIENT_EXPENSE_KEY, BASE_PATIENT_EXPENSE_FILENAME);
-
-    return Collections.unmodifiableMap(map);
-  }
 
   private static Map<String, String> initializeHeaderMap() {
     Map<String, String> map = new HashMap<>();

--- a/src/main/java/org/mitre/synthea/export/CSVFileManager.java
+++ b/src/main/java/org/mitre/synthea/export/CSVFileManager.java
@@ -33,6 +33,7 @@ public class CSVFileManager {
   private Map<String, OutputStreamWriter> writerMap = new HashMap<>();
   private Map<String, Integer> resourceCountMap = new HashMap<>();
   private int maxLinesPerFile;
+  private int fileNumberDigits;
 
   /**
    * "No-op" writer to use to prevent writing to excluded files.
@@ -62,6 +63,15 @@ public class CSVFileManager {
     } catch (NumberFormatException ex) {
       // if the property is present but not a numeric string
       maxLinesPerFile = 0;
+    }
+  }
+
+  private void initializeFileNumberDigits() {
+    try {
+      fileNumberDigits = Config.getAsInteger("exporter.csv.file_number_digits", 1);
+    } catch (NumberFormatException ex) {
+      // if the property is present but not a numeric string
+      fileNumberDigits = 1;
     }
   }
 

--- a/src/main/java/org/mitre/synthea/export/CSVFileManager.java
+++ b/src/main/java/org/mitre/synthea/export/CSVFileManager.java
@@ -183,7 +183,8 @@ public class CSVFileManager {
     // file writing may fail if we tell it to append to a file that doesn't already exist
     boolean appendToThisFile = append && file.exists();
 
-    OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(file, appendToThisFile), charset);
+    OutputStreamWriter writer =
+        new OutputStreamWriter(new FileOutputStream(file, appendToThisFile), charset);
     if (!append) {
       writer.write(CSVConstants.HEADER_LINE_MAP.get(resourceKey));
     }
@@ -217,8 +218,8 @@ public class CSVFileManager {
     // file writing may fail if we tell it to append to a file that doesn't already exist
     boolean appendToThisFile = append && file.exists();
 
-    OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(file, appendToThisFile), charset);
-    System.out.println(resourceKey + " - " + resourceCount);
+    OutputStreamWriter writer =
+        new OutputStreamWriter(new FileOutputStream(file, appendToThisFile), charset);
     if (!append || resourceCount % maxLinesPerFile == 1) {
       writer.write(CSVConstants.HEADER_LINE_MAP.get(resourceKey));
     }

--- a/src/main/java/org/mitre/synthea/export/CSVFileManager.java
+++ b/src/main/java/org/mitre/synthea/export/CSVFileManager.java
@@ -211,7 +211,7 @@ public class CSVFileManager {
       resourceCountMap.put(resourceKey, resourceCount);
     }
 
-    int fileNumber = resourceCount / maxLinesPerFile  + 1;
+    int fileNumber = (resourceCount - 1) / maxLinesPerFile  + 1;
     String filename = filename(resourceKey, fileNumber);
 
     File file = outputDirectory.resolve(filename).toFile();

--- a/src/main/java/org/mitre/synthea/export/CSVFileManager.java
+++ b/src/main/java/org/mitre/synthea/export/CSVFileManager.java
@@ -27,17 +27,9 @@ public class CSVFileManager {
   private Path outputDirectory;
   private List<String> includedFiles;
   private List<String> excludedFiles;
-  private Map<String, String> filenameMap = initializeFilenameMap();
+  private Map<String, String> filenameMap = new HashMap<>();
   private Map<String, OutputStreamWriter> writerMap = new HashMap<>();
   private int maxLinesPerFile;
-
-  private Map<String, String> initializeFilenameMap() {
-    HashMap<String, String> map = new HashMap<>();
-
-    map.putAll(CSVConstants.BASE_FILENAME_MAP);
-
-    return map;
-  }
 
   /**
    * "No-op" writer to use to prevent writing to excluded files.
@@ -82,6 +74,14 @@ public class CSVFileManager {
       outputDirectory = outputDirectory.resolve(subfolderName);
       outputDirectory.toFile().mkdirs();
     }
+  }
+
+  private boolean multipleFilesPerResource() {
+    return maxLinesPerFile > 0;
+  }
+
+  private String filename(String resourceKey) {
+    return resourceKey + ".csv";
   }
 
   private void initializeIncludedAndExcludedFiles() {
@@ -147,14 +147,20 @@ public class CSVFileManager {
    * @return OutputStreamWriter for the given resource type's CSV file
    */
   private OutputStreamWriter getResourceWriter(String resourceKey) throws IOException {
-    String baseFilename = CSVConstants.BASE_FILENAME_MAP.get(resourceKey);
+    String baseFilename = filename(resourceKey);
     boolean excluded = (!includedFiles.isEmpty() && !includedFiles.contains(baseFilename))
         || excludedFiles.contains(baseFilename);
     if (excluded) {
       return NO_OP;
     }
 
-    String filename = filenameMap.get(resourceKey);
+    String filename;
+    if (multipleFilesPerResource()) {
+      // TODO
+      filename = null;
+    } else {
+      filename = filename(resourceKey);
+    }
     File file = outputDirectory.resolve(filename).toFile();
     // file writing may fail if we tell it to append to a file that doesn't already exist
     boolean appendToThisFile = append && file.exists();

--- a/src/main/java/org/mitre/synthea/export/CSVFileManager.java
+++ b/src/main/java/org/mitre/synthea/export/CSVFileManager.java
@@ -49,6 +49,7 @@ public class CSVFileManager {
   public CSVFileManager() {
     initializeAppend();
     initializeMaxLinesPerFile();
+    initializeFileNumberDigits();
     initializeOutputDirectory();
     initializeIncludedAndExcludedFiles();
   }
@@ -98,8 +99,13 @@ public class CSVFileManager {
   }
 
   private String filename(String resourceKey, int fileNumber) {
-    // TODO: format with leading zeroes
-    return resourceKey + "-" + fileNumber + ".csv";
+    String formattedNumber = String.valueOf(fileNumber);
+
+    if (fileNumberDigits > 1) {
+      formattedNumber = String.format("%0" + fileNumberDigits + "d", fileNumber);
+    }
+
+    return resourceKey + "-" + formattedNumber + ".csv";
   }
 
   private void initializeIncludedAndExcludedFiles() {

--- a/src/main/java/org/mitre/synthea/export/CSVFileManager.java
+++ b/src/main/java/org/mitre/synthea/export/CSVFileManager.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.lang.NumberFormatException;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -28,6 +29,7 @@ public class CSVFileManager {
   private List<String> excludedFiles;
   private Map<String, String> filenameMap = initializeFilenameMap();
   private Map<String, OutputStreamWriter> writerMap = new HashMap<>();
+  private int maxLinesPerFile;
 
   private Map<String, String> initializeFilenameMap() {
     HashMap<String, String> map = new HashMap<>();
@@ -50,12 +52,22 @@ public class CSVFileManager {
    */
   public CSVFileManager() {
     initializeAppend();
+    initializeMaxLinesPerFile();
     initializeOutputDirectory();
     initializeIncludedAndExcludedFiles();
   }
 
   private void initializeAppend() {
     append = Config.getAsBoolean("exporter.csv.append_mode");
+  }
+
+  private void initializeMaxLinesPerFile() {
+    try {
+      maxLinesPerFile = Config.getAsInteger("exporter.csv.max_lines_per_file", 0);
+    } catch (NumberFormatException ex) {
+      // if the property is present but not a numeric string
+      maxLinesPerFile = 0;
+    }
   }
 
   private void initializeOutputDirectory() {

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -56,6 +56,9 @@ exporter.csv.excluded_files = patient_expenses.csv
 # if set to a number, the output for resource types with more than this number
 # of resources will be split among multiple files
 exporter.csv.max_lines_per_file =
+# When using multiple files, the numbers in the filenames will be zero padded to
+# this many digits.
+exporter.csv.file_number_digits =
 
 exporter.cpcds.export = false
 exporter.cpcds.append_mode = false

--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -53,6 +53,9 @@ exporter.csv.folder_per_run = false
 # NOTE: the csv exporter does not actively delete files, so if Run 1 you included a file, then Run 2 you exclude that file, the version from Run 1 will still be present
 exporter.csv.included_files =
 exporter.csv.excluded_files = patient_expenses.csv
+# if set to a number, the output for resource types with more than this number
+# of resources will be split among multiple files
+exporter.csv.max_lines_per_file =
 
 exporter.cpcds.export = false
 exporter.cpcds.append_mode = false

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -53,6 +53,7 @@ public class CSVExporterTest {
     Config.set("exporter.csv.excluded_files", "");
     Config.set("exporter.csv.max_lines_per_file", "");
     Config.set("exporter.csv.append_mode", "false");
+    Config.set("exporter.csv.file_number_digits", "");
   }
 
   @Test
@@ -403,6 +404,37 @@ public class CSVExporterTest {
     int length3 = patientData3.size();
     assertTrue("Expected one Patient in the third export file, but found " + length3,
                length3 == 1);
+  }
+
+  @Test
+  public void testCSVExportFileNumberDigits() throws Exception {
+    Config.set("exporter.csv.included_files", "patients.csv");
+    Config.set("exporter.csv.max_lines_per_file", "2");
+    Config.set("exporter.csv.file_number_digits", "3");
+    CSVExporter.getInstance().init();
+
+    int numberOfPeople = 1;
+    ExporterRuntimeOptions exportOpts = new ExporterRuntimeOptions();
+    exportOpts.deferExports = true;
+    GeneratorOptions generatorOpts = new GeneratorOptions();
+    generatorOpts.population = numberOfPeople;
+    Generator generator = new Generator(generatorOpts, exportOpts);
+    generator.options.overflow = false;
+    for (int i = 0; i < numberOfPeople; i++) {
+      generator.generatePerson(i);
+    }
+    // Adding post completion exports to generate organizations and providers CSV files
+    Exporter.runPostCompletionExports(generator, exportOpts);
+
+    // if we get here we at least had no exceptions
+
+    File expectedExportFolder = exportDir.toPath().resolve("csv").toFile();
+
+    assertTrue(expectedExportFolder.exists() && expectedExportFolder.isDirectory());
+
+    File patientFile1 = expectedExportFolder.toPath().resolve("patients-001.csv").toFile();
+
+    assertTrue("No patient export file found.", patientFile1.exists());
   }
 
   @Test

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -49,14 +49,14 @@ public class CSVExporterTest {
     exportDir = tempFolder.newFolder();
     Config.set("exporter.baseDirectory", exportDir.toString());
 
-  }
-
-  @Test
-  public void testDeferredCSVExport() throws Exception {
     Config.set("exporter.csv.included_files", "");
     Config.set("exporter.csv.excluded_files", "");
     Config.set("exporter.csv.max_lines_per_file", "");
     Config.set("exporter.csv.append_mode", "false");
+  }
+
+  @Test
+  public void testDeferredCSVExport() throws Exception {
     CSVExporter.getInstance().init();
 
     int numberOfPeople = 10;
@@ -116,9 +116,6 @@ public class CSVExporterTest {
   @Test
   public void testCSVExportIncludes() throws Exception {
     Config.set("exporter.csv.included_files", "patients.csv,medications.csv,procedures.csv");
-    Config.set("exporter.csv.excluded_files", "");
-    Config.set("exporter.csv.max_lines_per_file", "");
-    Config.set("exporter.csv.append_mode", "false");
     CSVExporter.getInstance().init();
 
     int numberOfPeople = 10;
@@ -182,11 +179,8 @@ public class CSVExporterTest {
 
   @Test
   public void testCSVExportExcludes() throws Exception {
-    Config.set("exporter.csv.included_files", "");
     Config.set("exporter.csv.excluded_files", "patients.csv, medications, payers, providers,"
         + "patient_expenses.csv");
-    Config.set("exporter.csv.max_lines_per_file", "");
-    Config.set("exporter.csv.append_mode", "false");
     CSVExporter.getInstance().init();
 
     int numberOfPeople = 10;
@@ -284,8 +278,6 @@ public class CSVExporterTest {
   public void testCSVExportMultipleFiles() throws Exception {
     Config.set("exporter.csv.included_files", "patients.csv");
     Config.set("exporter.csv.max_lines_per_file", "2");
-    Config.set("exporter.csv.excluded_files", "");
-    Config.set("exporter.csv.append_mode", "false");
     CSVExporter.getInstance().init();
 
     int numberOfPeople = 3;
@@ -340,7 +332,6 @@ public class CSVExporterTest {
   public void testCSVExportAppendMultipleFiles() throws Exception {
     Config.set("exporter.csv.included_files", "patients.csv");
     Config.set("exporter.csv.max_lines_per_file", "2");
-    Config.set("exporter.csv.excluded_files", "");
     Config.set("exporter.csv.append_mode", "true");
     CSVExporter.getInstance().init();
 

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -56,6 +56,7 @@ public class CSVExporterTest {
     Config.set("exporter.csv.included_files", "");
     Config.set("exporter.csv.excluded_files", "");
     Config.set("exporter.csv.max_lines_per_file", "");
+    Config.set("exporter.csv.append_mode", "false");
     CSVExporter.getInstance().init();
 
     int numberOfPeople = 10;
@@ -117,6 +118,7 @@ public class CSVExporterTest {
     Config.set("exporter.csv.included_files", "patients.csv,medications.csv,procedures.csv");
     Config.set("exporter.csv.excluded_files", "");
     Config.set("exporter.csv.max_lines_per_file", "");
+    Config.set("exporter.csv.append_mode", "false");
     CSVExporter.getInstance().init();
 
     int numberOfPeople = 10;
@@ -184,6 +186,7 @@ public class CSVExporterTest {
     Config.set("exporter.csv.excluded_files", "patients.csv, medications, payers, providers,"
         + "patient_expenses.csv");
     Config.set("exporter.csv.max_lines_per_file", "");
+    Config.set("exporter.csv.append_mode", "false");
     CSVExporter.getInstance().init();
 
     int numberOfPeople = 10;
@@ -282,6 +285,7 @@ public class CSVExporterTest {
     Config.set("exporter.csv.included_files", "patients.csv");
     Config.set("exporter.csv.max_lines_per_file", "2");
     Config.set("exporter.csv.excluded_files", "");
+    Config.set("exporter.csv.append_mode", "false");
     CSVExporter.getInstance().init();
 
     int numberOfPeople = 3;
@@ -308,8 +312,8 @@ public class CSVExporterTest {
     File patientFile3 = expectedExportFolder.toPath().resolve("patients-3.csv").toFile();
 
     assertTrue("No patient export file found.", patientFile1.exists());
-    assertTrue("Second patient export file found.", patientFile2.exists());
-    assertTrue("Third patient export file should not exist.", !patientFile3.exists());
+    assertTrue("No second patient export file found.", patientFile2.exists());
+    assertTrue("No third patient export file should not exist.", !patientFile3.exists());
 
     String patientDataString1 = new String(Files.readAllBytes(patientFile1.toPath()));
 
@@ -330,6 +334,84 @@ public class CSVExporterTest {
     int length2 = patientData2.size();
     assertTrue("Expected one Patient in the second export file, but found " + length2,
                length2 == 1);
+  }
+
+  @Test
+  public void testCSVExportAppendMultipleFiles() throws Exception {
+    Config.set("exporter.csv.included_files", "patients.csv");
+    Config.set("exporter.csv.max_lines_per_file", "2");
+    Config.set("exporter.csv.excluded_files", "");
+    Config.set("exporter.csv.append_mode", "true");
+    CSVExporter.getInstance().init();
+
+    // Export 3 patients
+    int numberOfPeople = 3;
+    ExporterRuntimeOptions exportOpts = new ExporterRuntimeOptions();
+    exportOpts.deferExports = true;
+    GeneratorOptions generatorOpts = new GeneratorOptions();
+    generatorOpts.population = numberOfPeople;
+    Generator generator = new Generator(generatorOpts, exportOpts);
+    generator.options.overflow = false;
+    for (int i = 0; i < numberOfPeople; i++) {
+      generator.generatePerson(i);
+    }
+    Exporter.runPostCompletionExports(generator, exportOpts);
+
+    // Export 2 patients
+    CSVExporter.getInstance().init();
+    numberOfPeople = 2;
+    exportOpts.deferExports = true;
+    generatorOpts.population = numberOfPeople;
+    generator = new Generator(generatorOpts, exportOpts);
+    generator.options.overflow = false;
+    for (int i = 0; i < numberOfPeople; i++) {
+      generator.generatePerson(i);
+    }
+    Exporter.runPostCompletionExports(generator, exportOpts);
+
+    File expectedExportFolder = exportDir.toPath().resolve("csv").toFile();
+
+    assertTrue(expectedExportFolder.exists() && expectedExportFolder.isDirectory());
+
+    File patientFile1 = expectedExportFolder.toPath().resolve("patients-1.csv").toFile();
+    File patientFile2 = expectedExportFolder.toPath().resolve("patients-2.csv").toFile();
+    File patientFile3 = expectedExportFolder.toPath().resolve("patients-3.csv").toFile();
+    File patientFile4 = expectedExportFolder.toPath().resolve("patients-4.csv").toFile();
+
+    assertTrue("No patient export file found.", patientFile1.exists());
+    assertTrue("No second patient export file found.", patientFile2.exists());
+    assertTrue("No third patient export file found.", patientFile3.exists());
+    assertTrue("Fourth patient export file should not exist.", !patientFile4.exists());
+
+    String patientDataString1 = new String(Files.readAllBytes(patientFile1.toPath()));
+
+    List patientData1 = SimpleCSV.parse(patientDataString1);
+
+    assertTrue("CSV validation: " + patientFile1.getName(), SimpleCSV.isValid(patientDataString1));
+
+    int length1 = patientData1.size();
+    assertTrue("Expected two Patients in the first export file, but found " + length1,
+               length1 == 2);
+
+    String patientDataString2 = new String(Files.readAllBytes(patientFile2.toPath()));
+
+    List patientData2 = SimpleCSV.parse(patientDataString2);
+
+    assertTrue("CSV validation: " + patientFile2.getName(), SimpleCSV.isValid(patientDataString2));
+
+    int length2 = patientData2.size();
+    assertTrue("Expected two Patients in the second export file, but found " + length2,
+               length2 == 2);
+
+    String patientDataString3 = new String(Files.readAllBytes(patientFile3.toPath()));
+
+    List patientData3 = SimpleCSV.parse(patientDataString3);
+
+    assertTrue("CSV validation: " + patientFile3.getName(), SimpleCSV.isValid(patientDataString3));
+
+    int length3 = patientData3.size();
+    assertTrue("Expected one Patient in the third export file, but found " + length3,
+               length3 == 1);
   }
 
   @Test


### PR DESCRIPTION
This branch allows users to limit the number of resources per CSV file.

```
> ./run_synthea -p 250 --exporter.csv.export=true --exporter.csv.max_lines_per_file=100 --exporter.csv.file_number_digits=4
...
> ls output/csv
...
claims_transactions-1269.csv claims_transactions-2552.csv encounters-0049.csv          observations-0904.csv        observations-2187.csv        supplies-0100.csv
claims_transactions-1270.csv claims_transactions-2553.csv encounters-0050.csv          observations-0905.csv        observations-2188.csv
```

`exporter.csv.max_lines_per_file` is the limit for the number of resources per file (there will be one additional line for the header). The filenames will be `basename-###.csv`, with the number padded to the number of digits specified in `exporter.csv.file_number_digits`.

Addresses #1367.