### PR TITLE
Fix Gradle test failures by explicitly configuring test resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,15 @@ repositories {
   }
 }
 
+sourceSets {
+    test {
+        resources {
+            srcDirs = ['src/test/resources']
+        }
+    }
+}
+
+
 // Uncomment to see deprecation warnings
 // tasks.withType(JavaCompile) {
 //   options.compilerArgs << "-Xlint:deprecation"


### PR DESCRIPTION
Fixes issue 1530

Some Gradle tests were failing because test resources under
src/test/resources (including test_mapping.yaml) were not being included
on the test classpath.

This resulted in test initialization issues and caused failures such as
PayerTest.receiveDualEligible.

Explicitly configuring the Gradle test resource source set ensures the
required test resources are available and resolves these test failures.

