### PR TITLE
Reorder condition onset and diagnosing encounter in asthma module

### DIFF
--- a/src/main/resources/modules/asthma.json
+++ b/src/main/resources/modules/asthma.json
@@ -396,12 +396,12 @@
       "type": "SetAttribute",
       "attribute": "asthma_type",
       "value": "lifelong",
-      "direct_transition": "Next_Adult_Welness_Encounter"
+      "direct_transition": "Lifelong_Asthma_Begins"
     },
     "Next_Adult_Welness_Encounter": {
       "type": "Encounter",
       "wellness": true,
-      "direct_transition": "Lifelong_Asthma_Begins",
+      "direct_transition": "End_Wellness_1",
       "reason": "asthma_condition"
     },
     "Lifelong_Asthma_Begins": {
@@ -415,7 +415,7 @@
           "display": "Asthma (disorder)"
         }
       ],
-      "direct_transition": "End_Wellness_1"
+      "direct_transition": "Next_Adult_Welness_Encounter"
     },
     "Potential_Asthma_Attack": {
       "type": "Simple",


### PR DESCRIPTION
Reorder two states in the branch where childhood asthma becomes lifelong asthma. Previously the diagnosing encounter preceded the condition onset, this PR switches the order so the onset is before the diagnosing encounter.

Fixes: #1655