### PR TITLE
Implement sex-specific NHANES sampling for pediatric growth trajectories

### DIFF
--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -217,7 +217,7 @@ public final class LifecycleModule extends Module {
     attributes.put(Person.ACTIVE_WEIGHT_MANAGEMENT, false);
     // TODO: Why are the percentiles a vital sign? Sounds more like an attribute?
     double heightPercentile = person.rand();
-    PediatricGrowthTrajectory pgt = new PediatricGrowthTrajectory(person.getSeed(), time);
+    PediatricGrowthTrajectory pgt = new PediatricGrowthTrajectory(person.getSeed(), time, gender);
     double weightPercentile = pgt.reverseWeightPercentile(gender, heightPercentile);
     // make the head percentile within 5% of the height percentile
     double headPercentile = heightPercentile + person.rand(0.025, 0.025);

--- a/src/main/java/org/mitre/synthea/world/concepts/NHANESSample.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/NHANESSample.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.math3.distribution.EnumeratedDistribution;
 import org.apache.commons.math3.util.Pair;
@@ -88,6 +89,35 @@ public class NHANESSample implements Serializable {
     List<NHANESSample> samples = loadSamples();
     @SuppressWarnings("rawtypes")
     List sampleWeights = samples.stream().map(i -> new Pair(i, i.prob)).collect(toList());
+    return new EnumeratedDistribution<NHANESSample>(sampleWeights);
+  }
+
+  /**
+   * Load a sex-specific NHANES distribution. Filters samples by the given sex code
+   * and re-normalizes the probabilities so they sum to 1.0 within the filtered set.
+   * This produces more realistic BMI distributions for pediatric growth trajectories
+   * since male and female children have different BMI patterns.
+   *
+   * @param sexCode 1 for male, 2 for female (per NHANES convention)
+   * @return the weighted distribution of NHANES Samples filtered by sex
+   */
+  public static EnumeratedDistribution<NHANESSample> loadDistributionBySex(int sexCode) {
+    List<NHANESSample> allSamples = loadSamples();
+    List<NHANESSample> filteredSamples = allSamples.stream()
+        .filter(s -> s.sex == sexCode)
+        .collect(Collectors.toList());
+
+    if (filteredSamples.isEmpty()) {
+      // Fallback to all samples if no sex-specific data available
+      return loadDistribution();
+    }
+
+    // Re-normalize probabilities so they sum to 1.0 within the filtered set
+    double totalProb = filteredSamples.stream().mapToDouble(s -> s.prob).sum();
+    @SuppressWarnings("rawtypes")
+    List sampleWeights = filteredSamples.stream()
+        .map(i -> new Pair(i, i.prob / totalProb))
+        .collect(toList());
     return new EnumeratedDistribution<NHANESSample>(sampleWeights);
   }
 }

--- a/src/main/java/org/mitre/synthea/world/concepts/PediatricGrowthTrajectory.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/PediatricGrowthTrajectory.java
@@ -93,6 +93,10 @@ public class PediatricGrowthTrajectory implements Serializable {
   private static NormalDistribution normalDistribution = new NormalDistribution(null, 0, 1);
   private static EnumeratedDistribution<NHANESSample> nhanesSamples =
       NHANESSample.loadDistribution();
+  private static EnumeratedDistribution<NHANESSample> nhanesMaleSamples =
+      NHANESSample.loadDistributionBySex(1);
+  private static EnumeratedDistribution<NHANESSample> nhanesFemaleSamples =
+      NHANESSample.loadDistributionBySex(2);
 
   /**
    * Container for data on changes between years for BMI information.
@@ -130,13 +134,35 @@ public class PediatricGrowthTrajectory implements Serializable {
 
   /**
    * Starts a new pediatric growth trajectory. Selects a start BMI between 2 and 3 years old by
+   * pulling a weighted sample from NHANES, filtered by the individual's sex for more realistic
+   * BMI distributions.
+   *
+   * @param personSeed The person's seed to allow for repeatable randomization
+   * @param birthTime The time the individual was born in the simulation
+   * @param sex The sex of the individual ("M" or "F")
+   */
+  public PediatricGrowthTrajectory(long personSeed, long birthTime, String sex) {
+    this.seed = personSeed;
+    this.initialSample = getSample(personSeed, sex);
+    this.trajectory = new LinkedList<Point>();
+    Point p = new Point();
+    p.ageInMonths = this.initialSample.agem;
+    p.bmi = this.initialSample.bmi;
+    p.timeInSimulation = birthTime + Utilities.convertTime("months", this.initialSample.agem);
+    this.trajectory.add(p);
+  }
+
+  /**
+   * Starts a new pediatric growth trajectory. Selects a start BMI between 2 and 3 years old by
    * pulling a weighted sample from NHANES.
    *
    * @param personSeed The person's seed to allow for repeatable randomization
    * @param birthTime The time the individual was born in the simulation
+   * @deprecated Use {@link #PediatricGrowthTrajectory(long, long, String)} instead for
+   *     sex-specific sampling which produces more realistic BMI distributions.
    */
+  @Deprecated
   public PediatricGrowthTrajectory(long personSeed, long birthTime) {
-    // TODO: Make the selection sex specific
     this.seed = personSeed;
     this.initialSample = getSample(personSeed);
     this.trajectory = new LinkedList<Point>();
@@ -145,6 +171,21 @@ public class PediatricGrowthTrajectory implements Serializable {
     p.bmi = this.initialSample.bmi;
     p.timeInSimulation = birthTime + Utilities.convertTime("months", this.initialSample.agem);
     this.trajectory.add(p);
+  }
+
+  private static NHANESSample getSample(long personSeed, String sex) {
+    EnumeratedDistribution<NHANESSample> distribution;
+    if ("M".equals(sex)) {
+      distribution = nhanesMaleSamples;
+    } else if ("F".equals(sex)) {
+      distribution = nhanesFemaleSamples;
+    } else {
+      distribution = nhanesSamples;
+    }
+    synchronized (distribution) {
+      distribution.reseedRandomGenerator(personSeed);
+      return distribution.sample();
+    }
   }
 
   private static NHANESSample getSample(long personSeed) {

--- a/src/test/java/org/mitre/synthea/world/concepts/NHANESSampleTest.java
+++ b/src/test/java/org/mitre/synthea/world/concepts/NHANESSampleTest.java
@@ -1,6 +1,8 @@
 package org.mitre.synthea.world.concepts;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +20,64 @@ public class NHANESSampleTest {
     List<NHANESSample> list = NHANESSample.loadSamples();
     NHANESSample first = list.get(0);
     assertEquals(11.9, first.wt, 0.001);
+  }
+
+  @Test
+  public void loadDistributionBySexMale() {
+    EnumeratedDistribution<NHANESSample> maleDist = NHANESSample.loadDistributionBySex(1);
+    assertNotNull(maleDist);
+    // Sample from the male distribution and verify all samples are male
+    maleDist.reseedRandomGenerator(42L);
+    for (int i = 0; i < 100; i++) {
+      NHANESSample sample = maleDist.sample();
+      assertEquals("Male distribution should only contain male samples", 1, sample.sex);
+    }
+  }
+
+  @Test
+  public void loadDistributionBySexFemale() {
+    EnumeratedDistribution<NHANESSample> femaleDist = NHANESSample.loadDistributionBySex(2);
+    assertNotNull(femaleDist);
+    // Sample from the female distribution and verify all samples are female
+    femaleDist.reseedRandomGenerator(42L);
+    for (int i = 0; i < 100; i++) {
+      NHANESSample sample = femaleDist.sample();
+      assertEquals("Female distribution should only contain female samples", 2, sample.sex);
+    }
+  }
+
+  @Test
+  public void loadDistributionBySexProbabilitiesNormalized() {
+    // Verify that the sex-specific distributions produce valid samples
+    // (probabilities are properly re-normalized)
+    EnumeratedDistribution<NHANESSample> maleDist = NHANESSample.loadDistributionBySex(1);
+    EnumeratedDistribution<NHANESSample> femaleDist = NHANESSample.loadDistributionBySex(2);
+
+    // Both distributions should be able to produce samples without error
+    maleDist.reseedRandomGenerator(0L);
+    NHANESSample maleSample = maleDist.sample();
+    assertNotNull(maleSample);
+    assertTrue("Male BMI should be positive", maleSample.bmi > 0);
+
+    femaleDist.reseedRandomGenerator(0L);
+    NHANESSample femaleSample = femaleDist.sample();
+    assertNotNull(femaleSample);
+    assertTrue("Female BMI should be positive", femaleSample.bmi > 0);
+  }
+
+  @Test
+  public void sexSpecificDistributionsAreDeterministic() {
+    // Verify that sex-specific distributions are reproducible with the same seed
+    EnumeratedDistribution<NHANESSample> maleDist = NHANESSample.loadDistributionBySex(1);
+
+    maleDist.reseedRandomGenerator(123L);
+    NHANESSample first = maleDist.sample();
+
+    maleDist.reseedRandomGenerator(123L);
+    NHANESSample second = maleDist.sample();
+
+    assertEquals("Same seed should produce same sample", first.id, second.id);
+    assertEquals("Same seed should produce same BMI", first.bmi, second.bmi, 0.0001);
   }
 
   @Test

--- a/src/test/java/org/mitre/synthea/world/concepts/PediatricGrowthTrajectoryTest.java
+++ b/src/test/java/org/mitre/synthea/world/concepts/PediatricGrowthTrajectoryTest.java
@@ -1,6 +1,8 @@
 package org.mitre.synthea.world.concepts;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 import org.junit.Test;
@@ -26,6 +28,64 @@ public class PediatricGrowthTrajectoryTest {
     double oneYearLaterBMI = pgt.tail().bmi;
     double bmiDiff = oneYearLaterBMI - initialBMI;
     assertEquals(initialBMI + (0.5 * bmiDiff), sixMonthLaterBMI, 0.01);
+  }
+
+  @Test
+  public void sexSpecificConstructorMale() {
+    long birthDay = TestHelper.timestamp(2017, 1, 1, 0, 0, 0);
+    PediatricGrowthTrajectory pgt = new PediatricGrowthTrajectory(0L, birthDay, "M");
+    assertNotNull(pgt.tail());
+    assertTrue("BMI should be positive", pgt.tail().bmi > 0);
+    assertTrue("Age in months should be between 24 and 36",
+        pgt.tail().ageInMonths >= 24 && pgt.tail().ageInMonths <= 36);
+  }
+
+  @Test
+  public void sexSpecificConstructorFemale() {
+    long birthDay = TestHelper.timestamp(2017, 1, 1, 0, 0, 0);
+    PediatricGrowthTrajectory pgt = new PediatricGrowthTrajectory(0L, birthDay, "F");
+    assertNotNull(pgt.tail());
+    assertTrue("BMI should be positive", pgt.tail().bmi > 0);
+    assertTrue("Age in months should be between 24 and 36",
+        pgt.tail().ageInMonths >= 24 && pgt.tail().ageInMonths <= 36);
+  }
+
+  @Test
+  public void sexSpecificConstructorIsDeterministic() {
+    long birthDay = TestHelper.timestamp(2017, 1, 1, 0, 0, 0);
+    // Same seed and sex should produce the same initial BMI
+    PediatricGrowthTrajectory pgt1 = new PediatricGrowthTrajectory(42L, birthDay, "F");
+    PediatricGrowthTrajectory pgt2 = new PediatricGrowthTrajectory(42L, birthDay, "F");
+    assertEquals("Same seed and sex should produce same BMI",
+        pgt1.tail().bmi, pgt2.tail().bmi, 0.0001);
+  }
+
+  @Test
+  public void sexSpecificConstructorDiffersBySex() {
+    long birthDay = TestHelper.timestamp(2017, 1, 1, 0, 0, 0);
+    // Same seed but different sex should produce different initial samples
+    // (since they draw from different distributions)
+    PediatricGrowthTrajectory malePgt = new PediatricGrowthTrajectory(42L, birthDay, "M");
+    PediatricGrowthTrajectory femalePgt = new PediatricGrowthTrajectory(42L, birthDay, "F");
+    // They may occasionally match by chance, but with seed 42 they should differ
+    // We test that at least the trajectory is valid for both
+    assertTrue("Male BMI should be positive", malePgt.tail().bmi > 0);
+    assertTrue("Female BMI should be positive", femalePgt.tail().bmi > 0);
+  }
+
+  @Test
+  public void sexSpecificConstructorGeneratesTrajectory() {
+    long birthDay = TestHelper.timestamp(2017, 1, 1, 0, 0, 0);
+    Person person = new Person(0L);
+    person.attributes.put(Person.BIRTHDATE, birthDay);
+    person.attributes.put(Person.GENDER, "F");
+    PediatricGrowthTrajectory pgt = new PediatricGrowthTrajectory(0L, birthDay, "F");
+    // Verify that the trajectory can generate future BMI values
+    long sampleSimulationTime = pgt.tail().timeInSimulation;
+    long oneYearLater = sampleSimulationTime + Utilities.convertTime("months", 12);
+    double futureBMI = pgt.currentBMI(person, oneYearLater);
+    assertTrue("Future BMI should be positive", futureBMI > 0);
+    assertTrue("Future BMI should be reasonable (< 40)", futureBMI < 40);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Implements sex-specific initial BMI sampling from NHANES data for pediatric 
growth trajectories, producing more clinically realistic synthetic patient data.

## Problem

The `PediatricGrowthTrajectory` constructor selects an initial BMI sample from 
NHANES without considering the child's sex. Since male and female children exhibit 
different BMI distributions (CDC growth charts are sex-specific), this produces 
less realistic synthetic data — particularly problematic for studies examining 
sex-specific obesity prevalence or growth patterns.

Addresses the TODO in `PediatricGrowthTrajectory.java`:
> "Make the selection sex specific"

## Solution

- Added `NHANESSample.loadDistributionBySex(int sexCode)` — filters NHANES samples 
  by sex code (1=male, 2=female per NHANES convention) and re-normalizes probabilities
- Added new constructor `PediatricGrowthTrajectory(seed, birthTime, sex)` that selects 
  from the sex-appropriate distribution
- Updated `LifecycleModule` to pass the person's gender
- Original constructor preserved with `@Deprecated` annotation for backward compatibility

## Clinical Impact

CDC growth charts are sex-specific because male and female children have measurably 
different BMI distributions at ages 2-3. Sampling from a sex-mixed pool could assign 
a female child a BMI statistically more typical of males, producing unrealistic records 
that could mislead downstream clinical analysis or EHR testing.

## Thread Safety

Sex-specific distributions are loaded once at class initialization. Each distribution 
is synchronized independently during sampling, maintaining thread safety for parallel 
patient generation.
