### PR TITLE
Handle --help without NullPointerException

### DIFF
--- a/src/main/java/App.java
+++ b/src/main/java/App.java
@@ -74,9 +74,9 @@ public class App {
         while (!argsQ.isEmpty()) {
           String currArg = argsQ.poll();
 
-          if (currArg.equalsIgnoreCase("-h")) {
+          if (currArg.equalsIgnoreCase("-h") || currArg.equalsIgnoreCase("--help")) {
             usage();
-            System.exit(0);
+            return;
           } else if (currArg.equalsIgnoreCase("-s")) {
             String value = argsQ.poll();
             options.seed = Long.parseLong(value);

--- a/src/test/java/AppTest.java
+++ b/src/test/java/AppTest.java
@@ -232,6 +232,26 @@ public class AppTest {
   }
 
   @Test
+  public void testLongHelpArg() throws Exception {
+    String[] args = {"--help"};
+    final PrintStream original = System.out;
+    final PrintStream originalErr = System.err;
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final PrintStream print = new PrintStream(out, true);
+    System.setOut(print);
+    System.setErr(print);
+    App.main(args);
+    out.flush();
+    String output = out.toString();
+    Assert.assertTrue(output.contains("Usage"));
+    Assert.assertFalse(output.contains("NullPointerException"));
+    Assert.assertFalse(output.contains("Running with options:"));
+    System.setOut(original);
+    System.setErr(originalErr);
+    System.out.println(output);
+  }
+
+  @Test
   public void testInvalidArgs() throws Exception {
     String[] args = {"-s", "foo", "-p", "foo", testStateDefault, testTownDefault};
     final PrintStream original = System.out;


### PR DESCRIPTION
## Summary
- Treat `--help` the same as `-h` before parsing `--` arguments as config overrides
- Return after printing usage instead of calling `System.exit(0)`
- Add a regression test that verifies `--help` prints usage without an NPE or generation output

Fixes #1646.

## Testing
- `./run_synthea --help`
- `./gradlew test --tests AppTest`

I also ran `./gradlew check`; checkstyle passed, but the full test task failed in an unrelated existing path-handling issue in `ActionsTest` because this local checkout path contains a space and the test attempted to open `Open%20Source%20projects/.../test_mapping.yaml`.
