### PR TITLE
Sanitize patient names in export filenames

### DIFF
--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -901,8 +902,19 @@ public abstract class Exporter {
       return person.attributes.get(Person.ID) + tag + "." + extension;
     } else {
       // ensure unique filenames for now
-      return person.attributes.get(Person.NAME).toString().replace(' ', '_') + "_"
+      return safeFilename(person.attributes.get(Person.NAME).toString()) + "_"
           + person.attributes.get(Person.ID) + tag + "." + extension;
     }
+  }
+
+  /**
+   * Sanitize patient names before using them in filenames.
+   * @param name the patient name
+   * @return a filesystem-safe filename segment
+   */
+  private static String safeFilename(String name) {
+    String normalized = Normalizer.normalize(name, Normalizer.Form.NFD)
+        .replaceAll("\\p{M}", "");
+    return normalized.replaceAll("[^A-Za-z0-9._-]", "_");
   }
 }

--- a/src/test/java/org/mitre/synthea/export/ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/ExporterTest.java
@@ -79,6 +79,18 @@ public class ExporterTest {
   }
 
   @Test
+  public void testFilenameSanitizesPatientName() {
+    patient.attributes.put(Person.NAME, "Raquel318 Henríquez109 / Test");
+    patient.attributes.put(Person.ID, "4b33f163-b07b-4ec7-b579-5ac453371d4f");
+    Config.set("exporter.use_uuid_filenames", "false");
+
+    String filename = Exporter.filename(patient, "", "xml");
+
+    assertEquals("Raquel318_Henriquez109___Test_"
+        + "4b33f163-b07b-4ec7-b579-5ac453371d4f.xml", filename);
+  }
+
+  @Test
   public void testExportFilterShouldKeepOldActiveMedication() {
 
     Code code = new Code("SNOMED-CT","705129","Fake Code");


### PR DESCRIPTION
## Summary
- Normalize patient names used in exported filenames to remove diacritics
- Replace filesystem-unfriendly filename characters with underscores
- Preserve UUID filename behavior when `exporter.use_uuid_filenames=true`
- Add a regression test for names like `Henríquez` and path separators

Fixes #1419.

## Testing
- `./gradlew test --tests org.mitre.synthea.export.ExporterTest`
