### PR TITLE
Avoid max timestamp in CCDA coverage fallback

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CCDAExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CCDAExporter.java
@@ -75,7 +75,6 @@ public class CCDAExporter {
       // causes an exception, then we fake an insurance
       // plan for the purposes of creating the super encounter.
       person.coverage.setPlanToNoInsurance(time);
-      person.coverage.setPlanToNoInsurance(Long.MAX_VALUE);
     }
     // create a super encounter... this makes it easier to access
     // all the Allergies (for example) in the export templates,

--- a/src/test/java/org/mitre/synthea/export/CCDAExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CCDAExporterTest.java
@@ -1,6 +1,7 @@
 package org.mitre.synthea.export;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.io.InputStream;
@@ -153,6 +154,21 @@ public class CCDAExporterTest {
     } else {
       System.out.println("There were no people generated that have wellness providers... odd.");
     }
+  }
+
+  @Test
+  public void testExportDoesNotCreateMaxValueCoverageStopTime() throws Exception {
+    PayerManager.clear();
+    PayerManager.loadPayers(new Location(Generator.DEFAULT_STATE, null));
+    TestHelper.loadTestProperties();
+    Person toExport = TestHelper.getGeneratedPeople()[0];
+    long exportTime = System.currentTimeMillis();
+    toExport.coverage.getLastPlanRecord().updateStopTime(exportTime - 1);
+
+    CCDAExporter.export(toExport, exportTime);
+
+    assertFalse(toExport.coverage.getPlanHistory().stream()
+        .anyMatch(planRecord -> planRecord.getStopTime() == Long.MAX_VALUE));
   }
 
   @Ignore("Manual test to debug failed CCDA exports.")


### PR DESCRIPTION
## Summary
- Stop CCDA export from adding a fallback no-insurance coverage record at `Long.MAX_VALUE`
- Keep the existing fallback coverage at export time so CCDA export can continue when no current plan exists
- Add a regression test that verifies CCDA export does not leave a payer history entry ending at `Long.MAX_VALUE`

Fixes #1360.

## Testing
- `./gradlew test --tests org.mitre.synthea.export.CCDAExporterTest`
