### PR TITLE
Use exact decimal for employer premium share

### DIFF
--- a/src/main/java/org/mitre/synthea/world/concepts/healthinsurance/InsurancePlan.java
+++ b/src/main/java/org/mitre/synthea/world/concepts/healthinsurance/InsurancePlan.java
@@ -188,7 +188,7 @@ public class InsurancePlan implements Serializable {
       // If this is a private plan non-ACA plan, then employers will provide coverage.
       double employeeContribution
           = 1.0 - Config.getAsDouble("generate.insurance.employer_coverage", 0.83);
-      premiumPrice = premiumPrice.multiply(new BigDecimal(employeeContribution));
+      premiumPrice = premiumPrice.multiply(BigDecimal.valueOf(employeeContribution));
     }
     return premiumPrice;
   }

--- a/src/test/java/org/mitre/synthea/world/agents/PayerTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/PayerTest.java
@@ -1018,6 +1018,7 @@ public class PayerTest {
         = plan.getMonthlyPremium(0).multiply(BigDecimal.valueOf(0.25));
     employerCovered.checkToPayMonthlyPremium(0L);
     assertEquals(costToCoveredEmployee, employerCovered.coverage.getTotalPremiumExpenses());
+    assertEquals("250.00", employerCovered.coverage.getTotalPremiumExpenses().toPlainString());
     // Patients without a covering occupation level should not get any premium discounts.
     nonEmployerCovered.checkToPayMonthlyPremium(0L);
     assertEquals(plan.getMonthlyPremium(0).setScale(2),


### PR DESCRIPTION
## Summary
- Replace `new BigDecimal(double)` with `BigDecimal.valueOf(double)` for employer premium share calculations
- Preserve clean decimal scale for premium expenses instead of introducing binary floating-point artifacts
- Add a regression assertion for employer-covered premium formatting

Fixes #1425.

## Testing
- `./gradlew test --tests org.mitre.synthea.world.agents.PayerTest.employerPremiumCoverage`
