### PR TITLE
Use interval for CCDA vital signs organizer

### DIFF
--- a/src/main/java/org/mitre/synthea/export/CCDAExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CCDAExporter.java
@@ -115,6 +115,10 @@ public class CCDAExporter {
             .collect(Collectors.toList());
 
     person.attributes.put("ehr_vital_signs", vitalSigns);
+    person.attributes.put("ehr_vital_signs_start", vitalSigns.stream()
+        .mapToLong(vs -> vs.start).min().orElse(time));
+    person.attributes.put("ehr_vital_signs_stop", vitalSigns.stream()
+        .mapToLong(vs -> vs.start).max().orElse(time));
 
     List<Observation> surveyResults = superEncounter.observations
             .stream()

--- a/src/main/resources/templates/ccda/vital_signs.ftl
+++ b/src/main/resources/templates/ccda/vital_signs.ftl
@@ -19,7 +19,10 @@
           <translation code="74728-7" displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
         </code>
         <statusCode code="completed"/>
-        <effectiveTime value="${time?number_to_date?string["yyyyMMddHHmmss"]}"/>
+        <effectiveTime>
+          <low value="${ehr_vital_signs_start?number_to_date?string["yyyyMMddHHmmss"]}"/>
+          <high value="${ehr_vital_signs_stop?number_to_date?string["yyyyMMddHHmmss"]}"/>
+        </effectiveTime>
         <#list ehr_vital_signs as entry>
         <#if entry.value??>
         <component>

--- a/src/test/java/org/mitre/synthea/export/CCDAExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CCDAExporterTest.java
@@ -78,6 +78,12 @@ public class CCDAExporterTest {
     XPathExpression vitalSignsSection = xpath.compile("/ClinicalDocument/component/structuredBody"
             + "/component/section/templateId[@root=\"2.16.840.1.113883.10.20.22.2.4.1\"]");
     sectionExpressions.put("Vital Signs Section", vitalSignsSection);
+    XPathExpression vitalSignsOrganizerInterval = xpath.compile(
+        "/ClinicalDocument/component/structuredBody/component/section"
+        + "/templateId[@root=\"2.16.840.1.113883.10.20.22.2.4.1\"]"
+        + "/../entry/organizer/templateId[@root=\"2.16.840.1.113883.10.20.22.4.26\"]"
+        + "/../effectiveTime/low/../high");
+    sectionExpressions.put("Vital Signs Organizer Interval", vitalSignsOrganizerInterval);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Export CCDA vital signs organizer `effectiveTime` as a low/high interval
- Use the earliest and latest vital sign observation timestamps for the interval bounds
- Add an XPath regression check that the vital signs organizer includes interval bounds

Fixes #995.

## Testing
- `./gradlew test --tests org.mitre.synthea.export.CCDAExporterTest`
