### PR TITLE
Correct heart diagnostic report categories

### DIFF
--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -2550,7 +2550,9 @@ public class FhirR4 {
           BundleEntryComponent personEntry, Bundle bundle, BundleEntryComponent encounterEntry,
           Report report) {
     DiagnosticReport reportResource = new DiagnosticReport();
-    boolean labsOnly = true;
+    boolean cardiacUltrasoundReport = hasLoincCode(report, "55405-5");
+    boolean nyhaAssessmentReport = hasLoincCode(report, "93124-6");
+    boolean labsOnly = !cardiacUltrasoundReport && !nyhaAssessmentReport;
     for (Observation observation : report.observations) {
       labsOnly = labsOnly && observation.category.equalsIgnoreCase("laboratory");
     }
@@ -2567,6 +2569,9 @@ public class FhirR4 {
     if (labsOnly) {
       reportResource.addCategory(new CodeableConcept(
           new Coding("http://terminology.hl7.org/CodeSystem/v2-0074", "LAB", "Laboratory")));
+    } else if (cardiacUltrasoundReport) {
+      reportResource.addCategory(new CodeableConcept(
+          new Coding("http://terminology.hl7.org/CodeSystem/v2-0074", "CUS", "Cardiac Ultrasound")));
     }
     reportResource.setCode(mapCodeToCodeableConcept(report.codes.get(0), LOINC_URI));
     reportResource.setSubject(new Reference(personEntry.getFullUrl()));
@@ -2584,6 +2589,10 @@ public class FhirR4 {
     }
 
     return newEntry(bundle, reportResource, report.uuid.toString());
+  }
+
+  private static boolean hasLoincCode(HealthRecord.Entry entry, String code) {
+    return entry.codes.stream().anyMatch(c -> c.code.equals(code));
   }
 
   /**

--- a/src/main/resources/modules/congestive_heart_failure.json
+++ b/src/main/resources/modules/congestive_heart_failure.json
@@ -1705,7 +1705,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "imaging",
           "unit": "%",
           "codes": [
             {

--- a/src/main/resources/modules/heart/avrr/preoperative.json
+++ b/src/main/resources/modules/heart/avrr/preoperative.json
@@ -447,7 +447,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -476,7 +476,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -505,7 +505,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -534,7 +534,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {

--- a/src/main/resources/modules/heart/cabg/preoperative.json
+++ b/src/main/resources/modules/heart/cabg/preoperative.json
@@ -223,7 +223,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "imaging",
           "unit": "%",
           "codes": [
             {

--- a/src/main/resources/modules/heart/chf_nyha_panel.json
+++ b/src/main/resources/modules/heart/chf_nyha_panel.json
@@ -192,7 +192,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -208,7 +208,7 @@
           }
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -237,7 +237,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -253,7 +253,7 @@
           }
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -282,7 +282,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -298,7 +298,7 @@
           }
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -327,7 +327,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -343,7 +343,7 @@
           }
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -372,7 +372,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -388,7 +388,7 @@
           }
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -417,7 +417,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -433,7 +433,7 @@
           }
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -462,7 +462,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -478,7 +478,7 @@
           }
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -507,7 +507,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -523,7 +523,7 @@
           }
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -552,7 +552,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -568,7 +568,7 @@
           }
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -597,7 +597,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -613,7 +613,7 @@
           }
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -642,7 +642,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -658,7 +658,7 @@
           }
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -687,7 +687,7 @@
       ],
       "observations": [
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {
@@ -703,7 +703,7 @@
           }
         },
         {
-          "category": "laboratory",
+          "category": "survey",
           "unit": "",
           "codes": [
             {

--- a/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/FHIRR4ExporterTest.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.codec.binary.Base64;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.DiagnosticReport;
 import org.hl7.fhir.r4.model.Media;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Quantity;
@@ -520,6 +521,70 @@ public class FHIRR4ExporterTest {
     assertTrue("MedicationRequest missing but should have been included", foundMedications);
     assertTrue("Procedure resource missing but should have been included", foundProcedures);
     assertFalse("Condition resource found but should not have been included", foundConditions);
+  }
+
+  @Test
+  public void testHeartDiagnosticReportCategories() throws Exception {
+    Person p = setupPersonForReportCategoryTest();
+    HealthRecord.Encounter encounter = p.record.encounterStart(0, EncounterType.WELLNESS);
+    encounter.provider = p.record.provider;
+
+    HealthRecord.Observation ejectionFraction = p.record.observation(0,
+        "Left ventricular Ejection fraction", 60.0);
+    ejectionFraction.category = "imaging";
+    ejectionFraction.codes.add(new Code("LOINC", "10230-1",
+        "Left ventricular Ejection fraction"));
+    HealthRecord.Report heartFailureReport = p.record.report(0, "55405-5", 1);
+    heartFailureReport.codes.add(new Code("LOINC", "55405-5", "Heart failure tracking panel"));
+
+    HealthRecord.Observation nyha = p.record.observation(1, "Functional capacity NYHA", "Class I");
+    nyha.category = "survey";
+    nyha.codes.add(new Code("LOINC", "88020-3", "Functional capacity NYHA"));
+    HealthRecord.Report nyhaReport = p.record.report(1, "93124-6", 1);
+    nyhaReport.codes.add(new Code("LOINC", "93124-6",
+        "New York Heart Association Functional Classification panel"));
+
+    Bundle bundle = FhirR4.convertToFHIR(p, 1);
+
+    DiagnosticReport heartFailureFhirReport = findDiagnosticReport(bundle, "55405-5");
+    assertEquals("CUS", heartFailureFhirReport.getCategoryFirstRep().getCodingFirstRep().getCode());
+    DiagnosticReport nyhaFhirReport = findDiagnosticReport(bundle, "93124-6");
+    assertTrue(nyhaFhirReport.getCategory().isEmpty());
+  }
+
+  private Person setupPersonForReportCategoryTest() {
+    Config.set("exporter.fhir.included_resources", "");
+    Config.set("exporter.fhir.excluded_resources", "");
+    FhirR4.reloadIncludeExclude();
+
+    Person p = new Person(0L);
+    p.attributes.put(Person.RACE, "dummy value to prevent NPE");
+    p.attributes.put(Person.ETHNICITY, "dummy value to prevent NPE");
+    p.attributes.put(Person.FIRST_LANGUAGE, "english");
+    p.attributes.put(Person.BIRTHDATE, 0L);
+    p.attributes.put(Person.GENDER, "F");
+    p.coverage.setPlanToNoInsurance(0L);
+
+    Provider stub = new Provider();
+    stub.name = "Fake Provider";
+    stub.npi = "0";
+    Clinician doc = new Clinician(0, p, 0, stub);
+    ArrayList<Clinician> docs = new ArrayList<Clinician>();
+    docs.add(doc);
+    stub.clinicianMap.put(ClinicianSpecialty.GENERAL_PRACTICE, docs);
+    p.setProvider(EncounterType.WELLNESS, stub);
+    p.record.provider = stub;
+    return p;
+  }
+
+  private DiagnosticReport findDiagnosticReport(Bundle bundle, String code) {
+    return (DiagnosticReport) bundle.getEntry().stream()
+        .map(BundleEntryComponent::getResource)
+        .filter(resource -> resource instanceof DiagnosticReport)
+        .map(resource -> (DiagnosticReport) resource)
+        .filter(report -> report.getCode().getCodingFirstRep().getCode().equals(code))
+        .findFirst()
+        .get();
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Emit heart failure tracking DiagnosticReports (LOINC 55405-5) with CUS/Cardiac Ultrasound instead of LAB
- Stop treating NYHA functional classification reports (LOINC 93124-6) as lab reports
- Update source module observation categories for ejection fraction and NYHA observations
- Add an FHIR R4 regression test for both report categories

Fixes #1558.

## Testing
- `./gradlew test --tests org.mitre.synthea.export.FHIRR4ExporterTest.testHeartDiagnosticReportCategories`
