### PR TITLE
Fix: Filter organizations and providers to only include exported patients

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="17" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="25" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -7,13 +7,18 @@ import static org.mitre.synthea.export.ExportHelper.iso8601Timestamp;
 import com.google.common.collect.Table;
 import com.google.gson.JsonObject;
 
-import java.io.File;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Comparator;
+import java.util.GregorianCalendar;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -21,8 +26,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.mitre.synthea.export.CSVConstants;
-import org.mitre.synthea.export.CSVFileManager;
 import org.mitre.synthea.helpers.Config;
 import org.mitre.synthea.helpers.RandomCodeGenerator;
 import org.mitre.synthea.helpers.Utilities;
@@ -135,7 +138,7 @@ public class CSVExporter {
         for (String speciality : providers.keySet()) {
           ArrayList<Clinician> clinicians = providers.get(speciality);
           for (Clinician clinician : clinicians) {
-            if(exportedClinicianIds.contains(clinician.getResourceID())) {
+            if (exportedClinicianIds.contains(clinician.getResourceID())) {
               exportProvider(clinician, org.getResourceID());
             }
           }

--- a/src/main/java/org/mitre/synthea/export/CSVExporter.java
+++ b/src/main/java/org/mitre/synthea/export/CSVExporter.java
@@ -13,14 +13,8 @@ import java.io.OutputStreamWriter;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Comparator;
-import java.util.GregorianCalendar;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -79,6 +73,12 @@ public class CSVExporter {
    */
   private AtomicLong transactionId;
 
+  // Track IDs of providers and clinicians that were actually exported,
+  // so that exportOrganizationsAndProviders can filter out unused records
+  // (e.g. when using a Keep Module that filter many patients)
+  private Set<String> exportedProviderIds;
+  private Set<String> exportedClinicianIds;
+
   /**
    * Constructor for the CSVExporter - initialize the specified files and store
    * the writers in fields.
@@ -91,6 +91,8 @@ public class CSVExporter {
     fileManager = new CSVFileManager();
 
     this.transactionId = new AtomicLong();
+    this.exportedProviderIds = ConcurrentHashMap.newKeySet();
+    this.exportedClinicianIds = ConcurrentHashMap.newKeySet();
   }
 
   /**
@@ -126,13 +128,16 @@ public class CSVExporter {
       Table<Integer, String, AtomicInteger> utilization = org.getUtilization();
       int totalEncounters =
           utilization.column(Provider.ENCOUNTERS).values().stream().mapToInt(ai -> ai.get()).sum();
-      if (totalEncounters > 0) {
+      // Only export organizations and providers linked to exported patients
+      if (totalEncounters > 0 && exportedProviderIds.contains(org.getResourceID())) {
         exportOrganization(org, totalEncounters);
         Map<String, ArrayList<Clinician>> providers = org.clinicianMap;
         for (String speciality : providers.keySet()) {
           ArrayList<Clinician> clinicians = providers.get(speciality);
           for (Clinician clinician : clinicians) {
-            exportProvider(clinician, org.getResourceID());
+            if(exportedClinicianIds.contains(clinician.getResourceID())) {
+              exportProvider(clinician, org.getResourceID());
+            }
           }
         }
       }
@@ -421,12 +426,14 @@ public class CSVExporter {
     // ORGANIZATION
     if (encounter.provider != null) {
       s.append(encounter.provider.getResourceID()).append(',');
+      exportedProviderIds.add(encounter.provider.getResourceID());
     } else {
       s.append(',');
     }
     // PROVIDER
     if (encounter.clinician != null) {
       s.append(encounter.clinician.getResourceID()).append(',');
+      exportedClinicianIds.add(encounter.clinician.getResourceID());
     } else {
       s.append(',');
     }

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -12,6 +12,8 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -540,5 +542,9 @@ public class CSVExporterTest {
 
     assertTrue("Organizations CSV contains organizations not present in any encounter",
             orgIdsInEncounters.containsAll(orgIds));
+
+    CSVExporter.getInstance().init();
+    TestHelper.exportOff();
+    TestHelper.loadTestProperties();
   }
 }

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -7,8 +7,11 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -500,7 +503,7 @@ public class CSVExporterTest {
   }
 
   @Test
-  public void filterOrganizationsAndProviders() throws Exception{
+  public void filterOrganizationsAndProviders() throws Exception {
     CSVExporter.getInstance().init();
 
     int numberOfPeople = 15;
@@ -510,7 +513,7 @@ public class CSVExporterTest {
     generatorOpts.population = numberOfPeople;
     Generator generator = new Generator(generatorOpts, exportOpts);
     generator.options.overflow = false;
-    for(int i = 0; i < numberOfPeople; i++){
+    for (int i = 0; i < numberOfPeople; i++) {
       generator.generatePerson(i);
     }
     Exporter.runPostCompletionExports(generator, exportOpts);
@@ -526,12 +529,12 @@ public class CSVExporterTest {
     List<LinkedHashMap<String, String>> encounterRows = SimpleCSV.parse(encounterData);
 
     Set<String> orgIds = new HashSet<>();
-    for(LinkedHashMap<String, String> row : orgRows){
+    for (LinkedHashMap<String, String> row : orgRows) {
       orgIds.add(row.get("Id"));
     }
 
     Set<String> orgIdsInEncounters = new HashSet<>();
-    for(LinkedHashMap<String, String> row : encounterRows){
+    for (LinkedHashMap<String, String> row : encounterRows) {
       orgIdsInEncounters.add(row.get("ORGANIZATION"));
     }
 

--- a/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
+++ b/src/test/java/org/mitre/synthea/export/CSVExporterTest.java
@@ -7,9 +7,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -499,5 +497,45 @@ public class CSVExporterTest {
     } catch (IllegalArgumentException e) {
       fail("CSV exporter should not throw an exception when only included files are set");
     }
+  }
+
+  @Test
+  public void filterOrganizationsAndProviders() throws Exception{
+    CSVExporter.getInstance().init();
+
+    int numberOfPeople = 15;
+    ExporterRuntimeOptions exportOpts = new ExporterRuntimeOptions();
+    exportOpts.deferExports = true;
+    GeneratorOptions generatorOpts = new GeneratorOptions();
+    generatorOpts.population = numberOfPeople;
+    Generator generator = new Generator(generatorOpts, exportOpts);
+    generator.options.overflow = false;
+    for(int i = 0; i < numberOfPeople; i++){
+      generator.generatePerson(i);
+    }
+    Exporter.runPostCompletionExports(generator, exportOpts);
+
+    File expectedExportFolder = exportDir.toPath().resolve("csv").toFile();
+    File organizationsFile = expectedExportFolder.toPath().resolve("organizations.csv").toFile();
+    File encountersFiles = expectedExportFolder.toPath().resolve("encounters.csv").toFile();
+
+    String orgData = new String(Files.readAllBytes(organizationsFile.toPath()));
+    String encounterData = new String(Files.readAllBytes(encountersFiles.toPath()));
+
+    List<LinkedHashMap<String, String>> orgRows = SimpleCSV.parse(orgData);
+    List<LinkedHashMap<String, String>> encounterRows = SimpleCSV.parse(encounterData);
+
+    Set<String> orgIds = new HashSet<>();
+    for(LinkedHashMap<String, String> row : orgRows){
+      orgIds.add(row.get("Id"));
+    }
+
+    Set<String> orgIdsInEncounters = new HashSet<>();
+    for(LinkedHashMap<String, String> row : encounterRows){
+      orgIdsInEncounters.add(row.get("ORGANIZATION"));
+    }
+
+    assertTrue("Organizations CSV contains organizations not present in any encounter",
+            orgIdsInEncounters.containsAll(orgIds));
   }
 }


### PR DESCRIPTION
Fixes #1378

When using a Keep Module, the hospitalInfo and practitionerInfo files 
included data from patients that were generated but not exported.

This fix tracks exported provider and clinician IDs in a Set within CSVExporter, and uses that to filter exportOrganizationsAndProviders to only include records linked to exported patients.

A regression test was added to verify the fix.