### PR TITLE
Fix timezone-dependent failure in receiveDualEligible test

### DIFF
--- a/src/test/java/org/mitre/synthea/world/agents/PayerTest.java
+++ b/src/test/java/org/mitre/synthea/world/agents/PayerTest.java
@@ -405,8 +405,6 @@ public class PayerTest {
   public void receiveDualEligible() {
     int birthYear = 1950;
     long birthTime = Utilities.convertCalendarYearsToTime(birthYear);
-    Calendar c = Calendar.getInstance();
-    c.setTimeInMillis(birthTime);
 
     // Below Poverty Level and Over 65, thus Dual Eligble.
     Person person = new Person(0L);
@@ -424,14 +422,16 @@ public class PayerTest {
       assertEquals(getGovernmentPayer(PayerManager.MEDICAID),
           person.coverage.getPlanAtTime(currentTime).getPayer());
     }
-    c.setTimeInMillis(birthTime);
-    c.add(Calendar.YEAR, 64);
-    long age64Time = c.getTimeInMillis();
+    // Use Utilities.convertCalendarYearsToTime (UTC-based) for age boundary checks,
+    // consistent with birthTime and the loop above. Using Calendar.getInstance()
+    // (local timezone) caused a timezone/DST mismatch where age64Time could land on
+    // Dec 31 in UTC, making Person.age() return 64 instead of 65 and causing
+    // MedicareEligible to fail (GitHub issue #1530).
+    long age64Time = Utilities.convertCalendarYearsToTime(birthYear + 64);
     assertEquals(PayerManager.MEDICAID,
         person.coverage.getPlanAtTime(age64Time).getPayer().getName());
     // The person is now 65 and qualifies for Medicare in addition to Medicaid.
-    c.add(Calendar.YEAR, 1);
-    long age65Time = c.getTimeInMillis();
+    long age65Time = Utilities.convertCalendarYearsToTime(birthYear + 65);
     healthInsModule.process(person, age65Time);
     assertEquals(PayerManager.DUAL_ELIGIBLE,
         person.coverage.getPlanAtTime(age65Time).getPayer().getName());


### PR DESCRIPTION
## Summary

Fixes #1530 — `PayerTest.receiveDualEligible` fails on hosts in timezones whose UTC offset differed between 1950 and 2015 due to DST history (e.g. `Australia/Sydney`), producing `expected:<[Dual Eligible]> but was:<[Medicaid]>`.

The test constructed the age-64 and age-65 boundary timestamps with `Calendar.getInstance()` (local timezone) then `Calendar.add(YEAR, ...)`. On affected hosts this lands on Dec 31 in UTC. `Person.age()` computes entirely in `ZoneOffset.UTC`, so the instant was interpreted as age 64 rather than 65, causing `MedicareEligible` (age >= 65) to fail. Because `DualEligible = MedicareEligible AND MedicaidEligible`, the plan finder fell back to Medicaid only.

The fix replaces those two `Calendar` calls with `Utilities.convertCalendarYearsToTime()`, which is UTC-based — consistent with `birthTime` and the ages-0-64 loop that was already correct. No production code is changed.

## Test plan

- `./gradlew test --tests "org.mitre.synthea.world.agents.PayerTest.receiveDualEligible"` passes.
- `TZ=Australia/Sydney ./gradlew test --tests "..."` passes (the previously broken timezone).
- `TZ=America/New_York ./gradlew test --tests "..."` passes.
- Full `./gradlew build check test` passes (639 tests, 0 failures).