### PR TITLE
Add mise.toml to pin Temurin JDK 17 for mise users

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+java = "temurin-17"


### PR DESCRIPTION
## Summary

Adds a `mise.toml` at the repo root that pins `java = "temurin-17"` for contributors using [mise](https://mise.jdx.dev/) (formerly `rtx`) as their developer toolchain manager.

## Problem

On macOS, the system Java — or whatever JDK is active in the shell — can be newer than what Synthea's Gradle/Groovy version supports. Running `./gradlew build` with Java 21+ (or system Java 26 as shipped with recent macOS toolchains) produces an immediate hard failure before any code compiles:

```
BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_'
Unsupported class file major version 70
```

The README states the requirement clearly ("Java JDK 17 or newer ... we strongly recommend LTS releases 17 or 25"), but a contributor whose system Java is ahead of that requirement hits a cryptic build error before they ever read it.

## Solution

`mise.toml` pins `temurin-17` — the minimum required and recommended LTS version. When `mise` is active in the project directory, `./gradlew build` automatically uses the correct JDK with no manual `JAVA_HOME` configuration or shell profile editing required. Contributors without `mise` are unaffected; the file is ignored by all other toolchains.

Temurin 17 is chosen specifically because it matches the project's `sourceCompatibility = '17'` in `build.gradle` and is one of the two LTS versions the README explicitly endorses.

## Notes

- mise is a widely-used polyglot toolchain manager (Node, Python, Go, Java, Ruby, etc.) with growing adoption among open-source contributors, particularly on macOS.
- The `mise.toml` does not affect CI, Docker-based builds, or contributors using sdkman, jabba, or manual `JAVA_HOME` setup.
- If the project ever formally endorses Java 25 LTS, this file is a one-line update.