### PR TITLE
fix Patient identifiers (SSN, DRIVERS, PASSPORT) are not unique — collisions at population scale

### DIFF
--- a/src/main/java/org/mitre/synthea/export/rif/identifiers/Passport.java
+++ b/src/main/java/org/mitre/synthea/export/rif/identifiers/Passport.java
@@ -8,27 +8,28 @@ package org.mitre.synthea.export.rif.identifiers;
  */
 public class Passport extends FixedLengthIdentifier {
 
-    private static final char[] FIXED_X = {'X'};
-    private static final char[][] PASSPORT_FORMAT = {FIXED_X, NUMERIC, NUMERIC, NUMERIC, NUMERIC,
-            NUMERIC, NUMERIC, NUMERIC, NUMERIC, FIXED_X};
-    public static final long MIN_PASSPORT = 0;
-    public static final long MAX_PASSPORT = maxValue(PASSPORT_FORMAT);
+  private static final char[] FIXED_X = {'X'};
+  private static final char[][] PASSPORT_FORMAT = {FIXED_X, NUMERIC, NUMERIC, NUMERIC, NUMERIC,
+      NUMERIC, NUMERIC, NUMERIC, NUMERIC, FIXED_X};
+  public static final long MIN_PASSPORT = 0;
+  public static final long MAX_PASSPORT = maxValue(PASSPORT_FORMAT);
 
-    public Passport(long value) {
-        super(value, PASSPORT_FORMAT);
-    }
+  public Passport(long value) {
+    super(value, PASSPORT_FORMAT);
+  }
 
-    /**
-     * Parse a Passport from a String.
-     * @param str the string
-     * @return the Passport
-     */
-    public static Passport parse(String str) {
-        return new Passport(parse(str, PASSPORT_FORMAT));
-    }
+  /**
+   * Parse a Passport from a String.
+   *
+   * @param str the string
+   * @return the Passport
+   */
+  public static Passport parse(String str) {
+    return new Passport(parse(str, PASSPORT_FORMAT));
+  }
 
-    @Override
-    public Passport next() {
-        return new Passport(value + 1);
-    }
+  @Override
+  public Passport next() {
+    return new Passport(value + 1);
+  }
 }

--- a/src/main/java/org/mitre/synthea/export/rif/identifiers/Passport.java
+++ b/src/main/java/org/mitre/synthea/export/rif/identifiers/Passport.java
@@ -1,0 +1,34 @@
+package org.mitre.synthea.export.rif.identifiers;
+
+/**
+ * Utility class for working with synthetic passport numbers.
+ * Format: 'X' + 8 digits + 'X' (e.g. X12345678X), matching the format
+ * originally intended in LifecycleModule but produced incorrectly due to
+ * a dropped offset (see issue #1685).
+ */
+public class Passport extends FixedLengthIdentifier {
+
+    private static final char[] FIXED_X = {'X'};
+    private static final char[][] PASSPORT_FORMAT = {FIXED_X, NUMERIC, NUMERIC, NUMERIC, NUMERIC,
+            NUMERIC, NUMERIC, NUMERIC, NUMERIC, FIXED_X};
+    public static final long MIN_PASSPORT = 0;
+    public static final long MAX_PASSPORT = maxValue(PASSPORT_FORMAT);
+
+    public Passport(long value) {
+        super(value, PASSPORT_FORMAT);
+    }
+
+    /**
+     * Parse a Passport from a String.
+     * @param str the string
+     * @return the Passport
+     */
+    public static Passport parse(String str) {
+        return new Passport(parse(str, PASSPORT_FORMAT));
+    }
+
+    @Override
+    public Passport next() {
+        return new Passport(value + 1);
+    }
+}

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -325,7 +325,7 @@ public final class LifecycleModule extends Module {
         if (person.attributes.get(Person.IDENTIFIER_PASSPORT) == null) {
           Boolean getsPassport = (person.rand() < 0.5);
           if (getsPassport) {
-            String identifierPassport = "X" + (person.randInt(99999999 - 10000000 + 1) + "X");
+            String identifierPassport = "X" + (person.randInt(99999999 - 10000000 + 1) + 10000000) + "X";
             person.attributes.put(Person.IDENTIFIER_PASSPORT, identifierPassport);
           }
         }

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -8,9 +8,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.mitre.synthea.engine.Module;
+import org.mitre.synthea.export.rif.identifiers.FixedLengthIdentifier;
 import org.mitre.synthea.export.rif.identifiers.Passport;
 import org.mitre.synthea.helpers.Attributes;
 import org.mitre.synthea.helpers.Attributes.Inventory;

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.mitre.synthea.engine.Module;
-import org.mitre.synthea.export.rif.identifiers.FixedLengthIdentifier;
 import org.mitre.synthea.export.rif.identifiers.Passport;
 import org.mitre.synthea.helpers.Attributes;
 import org.mitre.synthea.helpers.Attributes.Inventory;

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -8,8 +8,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.mitre.synthea.engine.Module;
+import org.mitre.synthea.export.rif.identifiers.FixedLengthIdentifier;
+import org.mitre.synthea.export.rif.identifiers.Passport;
 import org.mitre.synthea.helpers.Attributes;
 import org.mitre.synthea.helpers.Attributes.Inventory;
 import org.mitre.synthea.helpers.Config;
@@ -66,6 +69,8 @@ public final class LifecycleModule extends Module {
       Config.getAsDouble("generate.middle_names", 0.80);
 
   private static RandomCollection<String> sexualOrientationData = loadSexualOrientationData();
+  private static final AtomicReference<Passport> passportSequence =
+          new AtomicReference<>(new Passport(0));
 
   /**
    * Constructor for LifecycleModule.
@@ -325,7 +330,7 @@ public final class LifecycleModule extends Module {
         if (person.attributes.get(Person.IDENTIFIER_PASSPORT) == null) {
           Boolean getsPassport = (person.rand() < 0.5);
           if (getsPassport) {
-            String identifierPassport = "X" + (person.randInt(99999999 - 10000000 + 1) + 10000000) + "X";
+            String identifierPassport = FixedLengthIdentifier.getAndUpdateId(passportSequence);
             person.attributes.put(Person.IDENTIFIER_PASSPORT, identifierPassport);
           }
         }

--- a/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
+++ b/src/main/java/org/mitre/synthea/modules/LifecycleModule.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.mitre.synthea.engine.Module;
-import org.mitre.synthea.export.rif.identifiers.FixedLengthIdentifier;
 import org.mitre.synthea.export.rif.identifiers.Passport;
 import org.mitre.synthea.helpers.Attributes;
 import org.mitre.synthea.helpers.Attributes.Inventory;
@@ -69,8 +68,6 @@ public final class LifecycleModule extends Module {
       Config.getAsDouble("generate.middle_names", 0.80);
 
   private static RandomCollection<String> sexualOrientationData = loadSexualOrientationData();
-  private static final AtomicReference<Passport> passportSequence =
-          new AtomicReference<>(new Passport(0));
 
   /**
    * Constructor for LifecycleModule.
@@ -330,7 +327,8 @@ public final class LifecycleModule extends Module {
         if (person.attributes.get(Person.IDENTIFIER_PASSPORT) == null) {
           Boolean getsPassport = (person.rand() < 0.5);
           if (getsPassport) {
-            String identifierPassport = FixedLengthIdentifier.getAndUpdateId(passportSequence);
+            int randomValue = person.randInt((int) Passport.MAX_PASSPORT + 1);
+            String identifierPassport = new Passport(randomValue).toString();
             person.attributes.put(Person.IDENTIFIER_PASSPORT, identifierPassport);
           }
         }

--- a/src/test/java/org/mitre/synthea/export/rif/identifiers/PassportTest.java
+++ b/src/test/java/org/mitre/synthea/export/rif/identifiers/PassportTest.java
@@ -1,0 +1,56 @@
+package org.mitre.synthea.export.rif.identifiers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Pattern;
+import org.junit.Test;
+
+public class PassportTest {
+
+    private static final Pattern PASSPORT_PATTERN = Pattern.compile("^X\\d{8}X$");
+
+    @Test
+    public void testFormatIsAlwaysTenCharacters() {
+        Passport passport = new Passport(0);
+        for (int i = 0; i < 10000; i++) {
+            String value = passport.toString();
+            assertTrue("Unexpected format: " + value, PASSPORT_PATTERN.matcher(value).matches());
+            passport = passport.next();
+        }
+    }
+
+    @Test
+    public void testNextIncrementsSequentially() {
+        Passport first = new Passport(0);
+        Passport second = first.next();
+        assertEquals("X00000001X", second.toString());
+    }
+
+    @Test
+    public void testParseRoundTrip() {
+        Passport original = new Passport(12345678L);
+        String str = original.toString();
+        Passport parsed = Passport.parse(str);
+        assertEquals(original, parsed);
+        assertEquals(str, parsed.toString());
+    }
+
+    @Test
+    public void testMinValue() {
+        Passport passport = new Passport(Passport.MIN_PASSPORT);
+        assertEquals("X00000000X", passport.toString());
+    }
+
+    @Test
+    public void testMaxValueDoesNotThrow() {
+        // Should not throw IllegalArgumentException at the upper bound
+        Passport passport = new Passport(Passport.MAX_PASSPORT);
+        assertTrue(PASSPORT_PATTERN.matcher(passport.toString()).matches());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValueBeyondMaxThrows() {
+        new Passport(Passport.MAX_PASSPORT + 1);
+    }
+}

--- a/src/test/java/org/mitre/synthea/export/rif/identifiers/PassportTest.java
+++ b/src/test/java/org/mitre/synthea/export/rif/identifiers/PassportTest.java
@@ -4,53 +4,54 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.regex.Pattern;
+
 import org.junit.Test;
 
 public class PassportTest {
 
-    private static final Pattern PASSPORT_PATTERN = Pattern.compile("^X\\d{8}X$");
+  private static final Pattern PASSPORT_PATTERN = Pattern.compile("^X\\d{8}X$");
 
-    @Test
-    public void testFormatIsAlwaysTenCharacters() {
-        Passport passport = new Passport(0);
-        for (int i = 0; i < 10000; i++) {
-            String value = passport.toString();
-            assertTrue("Unexpected format: " + value, PASSPORT_PATTERN.matcher(value).matches());
-            passport = passport.next();
-        }
+  @Test
+  public void testFormatIsAlwaysTenCharacters() {
+    Passport passport = new Passport(0);
+    for (int i = 0; i < 10000; i++) {
+      String value = passport.toString();
+      assertTrue("Unexpected format: " + value, PASSPORT_PATTERN.matcher(value).matches());
+      passport = passport.next();
     }
+  }
 
-    @Test
-    public void testNextIncrementsSequentially() {
-        Passport first = new Passport(0);
-        Passport second = first.next();
-        assertEquals("X00000001X", second.toString());
-    }
+  @Test
+  public void testNextIncrementsSequentially() {
+    Passport first = new Passport(0);
+    Passport second = first.next();
+    assertEquals("X00000001X", second.toString());
+  }
 
-    @Test
-    public void testParseRoundTrip() {
-        Passport original = new Passport(12345678L);
-        String str = original.toString();
-        Passport parsed = Passport.parse(str);
-        assertEquals(original, parsed);
-        assertEquals(str, parsed.toString());
-    }
+  @Test
+  public void testParseRoundTrip() {
+    Passport original = new Passport(12345678L);
+    String str = original.toString();
+    Passport parsed = Passport.parse(str);
+    assertEquals(original, parsed);
+    assertEquals(str, parsed.toString());
+  }
 
-    @Test
-    public void testMinValue() {
-        Passport passport = new Passport(Passport.MIN_PASSPORT);
-        assertEquals("X00000000X", passport.toString());
-    }
+  @Test
+  public void testMinValue() {
+    Passport passport = new Passport(Passport.MIN_PASSPORT);
+    assertEquals("X00000000X", passport.toString());
+  }
 
-    @Test
-    public void testMaxValueDoesNotThrow() {
-        // Should not throw IllegalArgumentException at the upper bound
-        Passport passport = new Passport(Passport.MAX_PASSPORT);
-        assertTrue(PASSPORT_PATTERN.matcher(passport.toString()).matches());
-    }
+  @Test
+  public void testMaxValueDoesNotThrow() {
+    // Should not throw IllegalArgumentException at the upper bound
+    Passport passport = new Passport(Passport.MAX_PASSPORT);
+    assertTrue(PASSPORT_PATTERN.matcher(passport.toString()).matches());
+  }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testValueBeyondMaxThrows() {
-        new Passport(Passport.MAX_PASSPORT + 1);
-    }
+  @Test(expected = IllegalArgumentException.class)
+  public void testValueBeyondMaxThrows() {
+    new Passport(Passport.MAX_PASSPORT + 1);
+  }
 }

--- a/src/test/java/org/mitre/synthea/modules/LifecycleModuleTest.java
+++ b/src/test/java/org/mitre/synthea/modules/LifecycleModuleTest.java
@@ -10,6 +10,7 @@ import org.mitre.synthea.helpers.PhysiologyValueGenerator;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.VitalSign;
+import java.util.regex.Pattern;
 
 public class LifecycleModuleTest {
   public static boolean deathByNaturalCauses;
@@ -105,4 +106,39 @@ public class LifecycleModuleTest {
 
     LifecycleModule.ENABLE_PHYSIOLOGY_GENERATORS = enablePhysiology;
   }
+
+    @Test
+    public void testPassportFormatIsAlwaysEightDigits() throws Exception {
+        Pattern eightDigitPassport = Pattern.compile("^X\\d{8}X$");
+        int sampleSize = 2000;
+        int issued = 0;
+
+        java.lang.reflect.Method ageMethod = LifecycleModule.class.getDeclaredMethod(
+                "age", Person.class, long.class);
+        ageMethod.setAccessible(true);
+
+        for (int i = 0; i < sampleSize; i++) {
+            Person person = new Person(i);
+            person.attributes.put(Person.GENDER, "F");
+            person.attributes.put(Person.RACE, "white");
+            person.attributes.put(Person.ETHNICITY, "english");
+            long birth = 0L;
+            LifecycleModule.birth(person, birth);
+
+            long candidateTime = birth + Utilities.convertTime("years", 20);
+            while (person.ageInYears(candidateTime) < 20) {
+                candidateTime += Utilities.convertTime("days", 1);
+            }
+
+            ageMethod.invoke(null, person, candidateTime);
+
+            String passport = (String) person.attributes.get(Person.IDENTIFIER_PASSPORT);
+            if (passport != null) {
+                issued++;
+                Assert.assertTrue("Passport not 8 digits: " + passport,
+                        eightDigitPassport.matcher(passport).matches());
+            }
+        }
+        Assert.assertTrue("Expected at least some passports to be issued", issued > 0);
+    }
 }

--- a/src/test/java/org/mitre/synthea/modules/LifecycleModuleTest.java
+++ b/src/test/java/org/mitre/synthea/modules/LifecycleModuleTest.java
@@ -2,6 +2,8 @@ package org.mitre.synthea.modules;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.regex.Pattern;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -10,7 +12,6 @@ import org.mitre.synthea.helpers.PhysiologyValueGenerator;
 import org.mitre.synthea.helpers.Utilities;
 import org.mitre.synthea.world.agents.Person;
 import org.mitre.synthea.world.concepts.VitalSign;
-import java.util.regex.Pattern;
 
 public class LifecycleModuleTest {
   public static boolean deathByNaturalCauses;
@@ -107,38 +108,38 @@ public class LifecycleModuleTest {
     LifecycleModule.ENABLE_PHYSIOLOGY_GENERATORS = enablePhysiology;
   }
 
-    @Test
-    public void testPassportFormatIsAlwaysEightDigits() throws Exception {
-        Pattern eightDigitPassport = Pattern.compile("^X\\d{8}X$");
-        int sampleSize = 2000;
-        int issued = 0;
+  @Test
+  public void testPassportFormatIsAlwaysEightDigits() throws Exception {
+    Pattern eightDigitPassport = Pattern.compile("^X\\d{8}X$");
+    int sampleSize = 2000;
+    int issued = 0;
 
-        java.lang.reflect.Method ageMethod = LifecycleModule.class.getDeclaredMethod(
-                "age", Person.class, long.class);
-        ageMethod.setAccessible(true);
+    java.lang.reflect.Method ageMethod = LifecycleModule.class.getDeclaredMethod(
+        "age", Person.class, long.class);
+    ageMethod.setAccessible(true);
 
-        for (int i = 0; i < sampleSize; i++) {
-            Person person = new Person(i);
-            person.attributes.put(Person.GENDER, "F");
-            person.attributes.put(Person.RACE, "white");
-            person.attributes.put(Person.ETHNICITY, "english");
-            long birth = 0L;
-            LifecycleModule.birth(person, birth);
+    for (int i = 0; i < sampleSize; i++) {
+      Person person = new Person(i);
+      person.attributes.put(Person.GENDER, "F");
+      person.attributes.put(Person.RACE, "white");
+      person.attributes.put(Person.ETHNICITY, "english");
+      long birth = 0L;
+      LifecycleModule.birth(person, birth);
 
-            long candidateTime = birth + Utilities.convertTime("years", 20);
-            while (person.ageInYears(candidateTime) < 20) {
-                candidateTime += Utilities.convertTime("days", 1);
-            }
+      long candidateTime = birth + Utilities.convertTime("years", 20);
+      while (person.ageInYears(candidateTime) < 20) {
+        candidateTime += Utilities.convertTime("days", 1);
+      }
 
-            ageMethod.invoke(null, person, candidateTime);
+      ageMethod.invoke(null, person, candidateTime);
 
-            String passport = (String) person.attributes.get(Person.IDENTIFIER_PASSPORT);
-            if (passport != null) {
-                issued++;
-                Assert.assertTrue("Passport not 8 digits: " + passport,
-                        eightDigitPassport.matcher(passport).matches());
-            }
-        }
-        Assert.assertTrue("Expected at least some passports to be issued", issued > 0);
+      String passport = (String) person.attributes.get(Person.IDENTIFIER_PASSPORT);
+      if (passport != null) {
+        issued++;
+        Assert.assertTrue("Passport not 8 digits: " + passport,
+            eightDigitPassport.matcher(passport).matches());
+      }
     }
+    Assert.assertTrue("Expected at least some passports to be issued", issued > 0);
+  }
 }


### PR DESCRIPTION
Fixes #1685 PASSPORT identifier format losing low-bound offset

SSN/DRIVERS/PASSPORT are not required to be unique per #1685
discussion, so no changes there — this only fixes the format bug.

