### PR TITLE
Honor the configured code system when adding FHIR code translations

### DIFF
--- a/src/main/java/org/mitre/synthea/export/ExportHelper.java
+++ b/src/main/java/org/mitre/synthea/export/ExportHelper.java
@@ -217,32 +217,37 @@ public abstract class ExportHelper {
   private static final String ICD9_URI = "http://hl7.org/fhir/sid/icd-9-cm";
   private static final String ICD10_URI = "http://hl7.org/fhir/sid/icd-10";
   private static final String ICD10_CM_URI = "http://hl7.org/fhir/sid/icd-10-cm";
+  private static final String CPT_URI = "http://www.ama-assn.org/go/cpt";
 
   /**
    * Translate the system name (e.g. SNOMED-CT) into the official
-   * FHIR system URI (e.g. http://snomed.info/sct).
+   * FHIR system URI (e.g. http://snomed.info/sct). The system name is matched
+   * case-insensitively, so that names sourced from configuration keys
+   * (e.g. {@code exporter.code_map.icd10-cm}) resolve as well.
    * @param system SNOMED-CT, LOINC, RxNorm, CVX
    * @return The FHIR system URI for the given system or the input if not found.
    */
   public static String getSystemURI(String system) {
-    if (system.equals("SNOMED-CT")) {
+    if (system.equalsIgnoreCase("SNOMED-CT")) {
       system = SNOMED_URI;
-    } else if (system.equals("LOINC")) {
+    } else if (system.equalsIgnoreCase("LOINC")) {
       system = LOINC_URI;
-    } else if (system.equals("RxNorm")) {
+    } else if (system.equalsIgnoreCase("RxNorm")) {
       system = RXNORM_URI;
-    } else if (system.equals("CVX")) {
+    } else if (system.equalsIgnoreCase("CVX")) {
       system = CVX_URI;
-    } else if (system.equals("DICOM-DCM")) {
+    } else if (system.equalsIgnoreCase("DICOM-DCM")) {
       system = DICOM_DCM_URI;
-    } else if (system.equals("CDT")) {
+    } else if (system.equalsIgnoreCase("CDT")) {
       system = CDT_URI;
-    } else if (system.equals("ICD9")) {
+    } else if (system.equalsIgnoreCase("ICD9")) {
       system = ICD9_URI;
-    } else if (system.equals("ICD10")) {
+    } else if (system.equalsIgnoreCase("ICD10")) {
       system = ICD10_URI;
-    } else if (system.equals("ICD10-CM")) {
+    } else if (system.equalsIgnoreCase("ICD10-CM")) {
       system = ICD10_CM_URI;
+    } else if (system.equalsIgnoreCase("CPT")) {
+      system = CPT_URI;
     }
     return system;
   }
@@ -273,6 +278,8 @@ public abstract class ExportHelper {
         return "ICD10";
       case ICD10_CM_URI:
         return "ICD10-CM";
+      case CPT_URI:
+        return "CPT";
       default:
         return "Unknown";
     }

--- a/src/main/java/org/mitre/synthea/export/Exporter.java
+++ b/src/main/java/org/mitre/synthea/export/Exporter.java
@@ -14,12 +14,12 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.TreeMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -108,9 +108,11 @@ public abstract class Exporter {
    * exporter.code_map.cpt=export/phlebotomy_code_map.json,export/neurology_code_map.json
    * </pre>
    * The above define a single code map for ICD-10 codes and two code maps for CPT codes.
+   * A TreeMap is used so that mappers are always iterated in a deterministic order,
+   * which keeps output reproducible when more than one code system is configured.
    */
   public static void loadCodeMappers() {
-    codeMappers = new HashMap<String, CodeMapper>();
+    codeMappers = new TreeMap<String, CodeMapper>();
     List<String> codeSystemProperties = Config.allPropertyNames()
             .stream()
             .filter((key) -> key.startsWith("exporter.code_map"))
@@ -136,7 +138,18 @@ public abstract class Exporter {
    * @return the corresponding code mapper or null if none configured
    */
   public static CodeMapper getCodeMapper(String codeSystem) {
-    return codeMappers.get(codeSystem);
+    return getCodeMappers().get(codeSystem);
+  }
+
+  /**
+   * Get all configured code mappers, keyed by the code system they map to.
+   * @return the configured code mappers, empty if none are configured
+   */
+  public static Map<String, CodeMapper> getCodeMappers() {
+    if (codeMappers == null) {
+      return Collections.emptyMap();
+    }
+    return codeMappers;
   }
 
   /**

--- a/src/main/java/org/mitre/synthea/export/FhirR4.java
+++ b/src/main/java/org/mitre/synthea/export/FhirR4.java
@@ -865,23 +865,25 @@ public class FhirR4 {
   }
 
   /**
-   * Add a code translation (if available) of the supplied source code to the
-   * supplied CodeableConcept.
-   * @param codeSystem the code system of the translated code
+   * Add code translations (if available) of the supplied source code to the
+   * supplied CodeableConcept. One translation is added for each code system
+   * configured via {@code exporter.code_map.<code system>}, using that code
+   * system's own URI. See {@link Exporter#loadCodeMappers()}.
    * @param from the source code
    * @param to the CodeableConcept to add the translation to
    * @param rand a source of randomness
    */
-  private static void addTranslation(String codeSystem, Code from,
-          CodeableConcept to, RandomNumberGenerator rand) {
-    CodeMapper mapper = Exporter.getCodeMapper(codeSystem);
-    if (mapper != null && mapper.canMap(from)) {
-      Coding coding = new Coding();
-      Map.Entry<String, String> mappedCode = mapper.mapToCodeAndDescription(from, rand);
-      coding.setCode(mappedCode.getKey());
-      coding.setDisplay(mappedCode.getValue());
-      coding.setSystem(ExportHelper.getSystemURI("ICD10-CM"));
-      to.addCoding(coding);
+  private static void addTranslation(Code from, CodeableConcept to, RandomNumberGenerator rand) {
+    for (Map.Entry<String, CodeMapper> entry : Exporter.getCodeMappers().entrySet()) {
+      CodeMapper mapper = entry.getValue();
+      if (mapper != null && mapper.canMap(from)) {
+        Coding coding = new Coding();
+        Map.Entry<String, String> mappedCode = mapper.mapToCodeAndDescription(from, rand);
+        coding.setCode(mappedCode.getKey());
+        coding.setDisplay(mappedCode.getValue());
+        coding.setSystem(ExportHelper.getSystemURI(entry.getKey()));
+        to.addCoding(coding);
+      }
     }
   }
 
@@ -930,8 +932,7 @@ public class FhirR4 {
     if (encounter.reason != null) {
       encounterResource.addReasonCode().addCoding().setCode(encounter.reason.code)
           .setDisplay(encounter.reason.display).setSystem(SNOMED_URI);
-      addTranslation("ICD10-CM", encounter.reason,
-              encounterResource.getReasonCodeFirstRep(), person);
+      addTranslation(encounter.reason, encounterResource.getReasonCodeFirstRep(), person);
     }
 
     Provider provider = encounter.provider;
@@ -1680,7 +1681,7 @@ public class FhirR4 {
 
     Code code = condition.codes.get(0);
     CodeableConcept concept = mapCodeToCodeableConcept(code, SNOMED_URI);
-    addTranslation("ICD10-CM", code, concept, rand);
+    addTranslation(code, concept, rand);
     conditionResource.setCode(concept);
 
     CodeableConcept verification = new CodeableConcept();
@@ -2071,7 +2072,7 @@ public class FhirR4 {
         // we didn't find a matching Condition,
         // fallback to just reason code
         procedureResource.addReasonCode(mapCodeToCodeableConcept(reason, SNOMED_URI));
-        addTranslation("ICD10-CM", reason, procedureResource.getReasonCodeFirstRep(), person);
+        addTranslation(reason, procedureResource.getReasonCodeFirstRep(), person);
       }
     }
 
@@ -2381,8 +2382,7 @@ public class FhirR4 {
         // we didn't find a matching Condition,
         // fallback to just reason code
         medicationResource.addReasonCode(mapCodeToCodeableConcept(reason, SNOMED_URI));
-        addTranslation("ICD10-CM", reason, medicationResource.getReasonCodeFirstRep(),
-                person);
+        addTranslation(reason, medicationResource.getReasonCodeFirstRep(), person);
       }
     }
 
@@ -2535,8 +2535,7 @@ public class FhirR4 {
         // we didn't find a matching Condition,
         // fallback to just reason code
         medicationResource.addReasonCode(mapCodeToCodeableConcept(reason, SNOMED_URI));
-        addTranslation("ICD10-CM", reason, medicationResource.getReasonCodeFirstRep(),
-                person);
+        addTranslation(reason, medicationResource.getReasonCodeFirstRep(), person);
       }
     }
 
@@ -2780,8 +2779,7 @@ public class FhirR4 {
           activityDetailComponent.addReasonReference().setReference(reasonCondition.getFullUrl());
         } else if (reason != null) {
           activityDetailComponent.addReasonCode(mapCodeToCodeableConcept(reason, SNOMED_URI));
-          addTranslation("ICD10-CM", reason, activityDetailComponent.getReasonCodeFirstRep(),
-                  person);
+          addTranslation(reason, activityDetailComponent.getReasonCodeFirstRep(), person);
         }
 
         activityComponent.setDetail(activityDetailComponent);
@@ -2929,7 +2927,7 @@ public class FhirR4 {
     if (carePlan.reasons != null && !carePlan.reasons.isEmpty()) {
       for (Code code : carePlan.reasons) {
         CodeableConcept concept = mapCodeToCodeableConcept(code, SNOMED_URI);
-        addTranslation("ICD10-CM", code, concept, person);
+        addTranslation(code, concept, person);
         careTeam.addReasonCode(concept);
       }
     }

--- a/src/test/java/org/mitre/synthea/export/FhirR4CodeMapTest.java
+++ b/src/test/java/org/mitre/synthea/export/FhirR4CodeMapTest.java
@@ -1,0 +1,144 @@
+package org.mitre.synthea.export;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Coding;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mitre.synthea.TestHelper;
+import org.mitre.synthea.helpers.Config;
+import org.mitre.synthea.world.agents.Clinician;
+import org.mitre.synthea.world.agents.PayerManager;
+import org.mitre.synthea.world.agents.Person;
+import org.mitre.synthea.world.agents.Provider;
+import org.mitre.synthea.world.concepts.ClinicianSpecialty;
+import org.mitre.synthea.world.concepts.HealthRecord;
+import org.mitre.synthea.world.concepts.HealthRecord.Code;
+import org.mitre.synthea.world.concepts.HealthRecord.EncounterType;
+
+/**
+ * Tests the code translations that the FHIR R4 exporter emits for the code maps
+ * configured via {@code exporter.code_map.<code system>}.
+ */
+public class FhirR4CodeMapTest {
+
+  /** Maps SNOMED 10509002 to ABC20.9, see src/test/resources/export/. */
+  private static final String CODE_MAP = "export/unweighted_code_map.json";
+  private static final String CPT_PROPERTY = "exporter.code_map.cpt";
+  private static final String ICD10_PROPERTY = "exporter.code_map.icd10-cm";
+
+  private boolean transactionBundle;
+  private boolean useUsCoreIg;
+
+  /**
+   * Load the test configuration and record the exporter state that this test changes.
+   */
+  @Before
+  public void setUp() throws Exception {
+    TestHelper.loadTestProperties();
+    TestHelper.exportOff();
+    PayerManager.clear();
+    PayerManager.loadNoInsurance();
+    transactionBundle = FhirR4.TRANSACTION_BUNDLE;
+    useUsCoreIg = FhirR4.USE_US_CORE_IG;
+    FhirR4.TRANSACTION_BUNDLE = false;
+    FhirR4.USE_US_CORE_IG = false;
+    FhirR4.reloadIncludeExclude();
+  }
+
+  /**
+   * Put back everything this test changed, so that it cannot affect other tests.
+   */
+  @After
+  public void tearDown() {
+    Config.remove(CPT_PROPERTY);
+    Config.remove(ICD10_PROPERTY);
+    Exporter.loadCodeMappers();
+    FhirR4.TRANSACTION_BUNDLE = transactionBundle;
+    FhirR4.USE_US_CORE_IG = useUsCoreIg;
+    FhirR4.reloadIncludeExclude();
+  }
+
+  /**
+   * A code map configured for a code system other than ICD-10-CM should be applied,
+   * and the resulting translation should carry that code system's URI rather than
+   * the ICD-10-CM URI.
+   */
+  @Test
+  public void testTranslationUsesConfiguredCodeSystem() throws Exception {
+    Config.set(CPT_PROPERTY, CODE_MAP);
+    Exporter.loadCodeMappers();
+
+    Coding translation = translationOfEncounterReason();
+    assertNotNull("Code map configured under exporter.code_map.cpt was not applied", translation);
+    assertEquals("ABC20.9", translation.getCode());
+    assertEquals("http://www.ama-assn.org/go/cpt", translation.getSystem());
+  }
+
+  /**
+   * The pre-existing ICD-10-CM configuration must keep emitting the ICD-10-CM URI.
+   */
+  @Test
+  public void testIcd10TranslationUnchanged() throws Exception {
+    Config.set(ICD10_PROPERTY, CODE_MAP);
+    Exporter.loadCodeMappers();
+
+    Coding translation = translationOfEncounterReason();
+    assertNotNull("Code map configured under exporter.code_map.icd10-cm was not applied",
+        translation);
+    assertEquals("ABC20.9", translation.getCode());
+    assertEquals("http://hl7.org/fhir/sid/icd-10-cm", translation.getSystem());
+  }
+
+  /**
+   * Export a person with a single encounter whose reason is a code the test code map
+   * knows about, and return the translated coding that was added to that reason.
+   *
+   * @return the translated coding, or null if no translation was added
+   */
+  private Coding translationOfEncounterReason() {
+    Person person = new Person(0L);
+    person.attributes.put(Person.RACE, "dummy value to prevent NPE");
+    person.attributes.put(Person.ETHNICITY, "dummy value to prevent NPE");
+    person.attributes.put(Person.FIRST_LANGUAGE, "english");
+    person.attributes.put(Person.BIRTHDATE, 0L);
+    person.attributes.put(Person.GENDER, "F");
+    person.coverage.setPlanToNoInsurance(0L);
+
+    Provider stub = new Provider();
+    stub.name = "Fake Provider";
+    stub.npi = "0";
+    Clinician doc = new Clinician(0, person, 0, stub);
+    ArrayList<Clinician> docs = new ArrayList<Clinician>();
+    docs.add(doc);
+    stub.clinicianMap.put(ClinicianSpecialty.GENERAL_PRACTICE, docs);
+    person.setProvider(EncounterType.AMBULATORY, stub);
+    person.setProvider(EncounterType.WELLNESS, stub);
+    person.record.provider = stub;
+
+    HealthRecord.Encounter encounter = person.record.encounterStart(0, EncounterType.AMBULATORY);
+    encounter.provider = person.record.provider;
+    encounter.reason = new Code("SNOMED-CT", "10509002", "Acute bronchitis (disorder)");
+
+    Bundle bundle = FhirR4.convertToFHIR(person, 0);
+
+    for (BundleEntryComponent entry : bundle.getEntry()) {
+      if (entry.getResource() instanceof org.hl7.fhir.r4.model.Encounter) {
+        org.hl7.fhir.r4.model.Encounter resource =
+            (org.hl7.fhir.r4.model.Encounter) entry.getResource();
+        for (Coding coding : resource.getReasonCodeFirstRep().getCoding()) {
+          if ("ABC20.9".equals(coding.getCode())) {
+            return coding;
+          }
+        }
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
`FhirR4.addTranslation` took a code system, used it to look up a `CodeMapper`, and then always emitted the ICD-10-CM system URI. It also only ever asked for the ICD-10-CM mapper, so a map registered under any other `exporter.code_map.<system>` key was loaded at startup and never consulted, even though `Exporter#loadCodeMappers` documents that usage and gives CPT as its example.

Apply every configured code map and label each translation with its own system URI. Output for the shipped ICD-10-CM configuration is unchanged.

Also add the CPT system URI, match system names case-insensitively so that names derived from configuration keys resolve, and hold the code mappers in a `TreeMap` so that multiple maps are applied in a deterministic order.

Adds some fun and exciting tests!